### PR TITLE
Attempt to fix cryptic crayons error on CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
 jobs:
   build:
+    name: build
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -34,14 +35,6 @@ jobs:
         python-version: '3.7'
     - name: elasticsearch plugins
       run: docker exec elasticsearch bin/elasticsearch-plugin install --batch ingest-attachment
-    # # todo: investigate whether the cache is working
-    # - name: cache pipenv
-    #   uses: actions/cache@v1
-    #   with:
-    #     path: ~/.local/share/virtualenvs/
-    #     key: ${{ runner.os }}-pipenv-${{ hashFiles('src/Pipfile.lock') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-pipenv-
     - name: pipenv install
       working-directory: ./src
       run: |


### PR DESCRIPTION
We started getting an error in `pipenv install --dev --deploy` on CI:

https://github.com/ResearchHub/researchhub-backend/commit/fc34c7836f2d72bc952d66b199461912e2df159a/checks?check_suite_id=410729547#step:7:44

```
  File "/opt/hostedtoolcache/Python/3.7.6/x64/lib/python3.7/site-packages/pipenv/core.py", line 590, in ensure_project
    crayons.green(shorten_path(path_to_python)),
TypeError: __str__ returned non-string (type NoneType)
```