### PR TITLE
Use https for allauth on cloud

### DIFF
--- a/src/oauth/views.py
+++ b/src/oauth/views.py
@@ -1,4 +1,3 @@
-import logging
 from allauth.socialaccount.helpers import render_authentication_error
 from allauth.socialaccount.models import SocialLogin, SocialAccount
 from allauth.socialaccount.providers.base import ProviderException
@@ -30,10 +29,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from oauth.helpers import complete_social_login
 from oauth.exceptions import LoginError
-from researchhub.settings import (
-    GOOGLE_REDIRECT_URL,
-    ORCID_REDIRECT_URL
-)
+from researchhub.settings import GOOGLE_REDIRECT_URL
 from utils import sentry
 
 
@@ -177,13 +173,6 @@ class GoogleLogin(SocialLoginView):
     serializer_class = SocialLoginSerializer
 
 
-class OrcidLogin(SocialLoginView):
-    adapter_class = OrcidOAuth2Adapter
-    callback_url = ORCID_REDIRECT_URL
-    client_class = OAuth2Client
-    serializer_class = SocialLoginSerializer
-
-
 class CallbackView(OAuth2CallbackView):
     """
     This class is copied from allauth/socialaccount/providers/oauth2/views.py
@@ -205,10 +194,8 @@ class CallbackView(OAuth2CallbackView):
                 error=error)
         app = self.adapter.get_provider().get_app(self.request)
         client = self.get_client(request, app)
-        logging.error(request.headers)
         try:
             access_token = client.get_access_token(request.GET['code'])
-            logging.error(access_token)
             token = self.adapter.parse_token(access_token)
             token.app = app
             login = self.adapter.complete_login(request,

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -54,7 +54,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY', keys.SECRET_KEY)
 SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_BROWSER_XSS_FILTER = True
 
-# TODO: Do we need to set this?
+# TODO: Think about setting this so drf uses https
 # SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # SECURITY WARNING: don't run with debug turned on in production!
@@ -276,6 +276,8 @@ ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_VERIFICATION = 'none'
 ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_USERNAME_REQUIRED = False
+if STAGING or PRODUCTION:
+    ACCOUNT_DEFAULT_HTTP_PROTOCOL = 'https'
 LOGIN_REDIRECT_URL = 'http://localhost:3000/orcid'
 if STAGING:
     LOGIN_REDIRECT_URL = 'https://staging-web.reserachhub.com/orcid'
@@ -304,15 +306,6 @@ if STAGING:
         'https://staging-backend.researchhub.com/auth/google/login/callback/'
     )
 
-ORCID_REDIRECT_URL = 'http://localhost:8000/api/auth/orcid/login/'
-if PRODUCTION:
-    ORCID_REDIRECT_URL = (
-        'https://backend.researchhub.com/api/auth/orcid/login/'
-    )
-if STAGING:
-    ORCID_REDIRECT_URL = (
-        'https://staging-backend.researchhub.com/api/auth/orcid/login/'
-    )
 
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases

--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -101,11 +101,6 @@ urlpatterns = [
         name='orcid_callback'
     ),
     path(
-        'api/auth/orcid/login/',
-        oauth.views.OrcidLogin.as_view(),
-        name='orcid_login'
-    ),
-    path(
         'auth/google/login/callback/',
         oauth.views.google_callback,
         name='google_callback'


### PR DESCRIPTION
### Problem

ORCID login was failing with an incorrect redirect url error because django allauth was sending it a url without "https"

### Solution

Update the allauth setting `ACCOUNT_DEFAULT_HTTP_PROTOCOL` to use https if on staging or production

### What code is changing?

- Removed logging and unneeded view class in `src/oauth/views.py`
- Removed unneeded urls to avoid confusion in `src/researchhub/settings.py`
- Removed unneeded url in `src/researchhub/urls.py`