### PR TITLE
Hotfix - Add crossref if external_search param is not true

### DIFF
--- a/src/search/views/combined.py
+++ b/src/search/views/combined.py
@@ -67,7 +67,7 @@ class CombinedView(ListAPIView):
 
     def list(self, request, *args, **kwargs):
         es_response_queryset = self.filter_queryset(self.get_queryset())
-        if request.query_params.get('upload') != 'true':
+        if request.query_params.get('external_search') != 'false':
             es_response_queryset = self._add_crossref_results(
                 request,
                 es_response_queryset


### PR DESCRIPTION
In order to prevent crossref results in the paper upload flow (which also uses the es search view that crossref is built into).