### PR TITLE
Paper Reference Serializer

### DIFF
--- a/src/paper/serializers.py
+++ b/src/paper/serializers.py
@@ -163,7 +163,6 @@ class BasePaperSerializer(serializers.ModelSerializer):
             many=True,
             context=context
         )
-        print(serialized.data)
         return serialized.data
 
     def get_references(self, paper):


### PR DESCRIPTION
Reduced serializer fields for reference papers
Serializes:
1. id
2. hubs
3. title
4. first pdf preview