### PR TITLE
Restructure Paper Serializer

### DIFF
--- a/src/hub/serializers.py
+++ b/src/hub/serializers.py
@@ -3,6 +3,15 @@ from rest_framework import serializers
 from .models import Hub
 from utils.http import get_user_from_request
 
+class SimpleHubSerializer(serializers.ModelSerializer):
+    class Meta:
+        fields = [
+            'id',
+            'name',
+            'is_locked',
+            'slug',
+        ]
+        model = Hub
 
 class HubSerializer(serializers.ModelSerializer):
     subscriber_count = serializers.SerializerMethodField()

--- a/src/paper/views.py
+++ b/src/paper/views.py
@@ -90,9 +90,6 @@ class PaperViewSet(viewsets.ModelViewSet):
             'votes',
             'flags',
             'threads',
-            'referenced_by',
-            'referenced_by__hubs__subscribers',
-            'references',
             'threads__comments',
             Prefetch(
                 'figures',
@@ -261,20 +258,26 @@ class PaperViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=[GET])
     def referenced_by(self, request, pk=None):
         paper = self.get_object()
-        serialized = PaperReferenceSerializer(
-            paper.referenced_by.all(),
-            many=True
-        )
-        return Response(serialized.data, status=status.HTTP_200_OK)
+        queryset = paper.referenced_by.all()
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = PaperReferenceSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=[GET])
     def references(self, request, pk=None):
         paper = self.get_object()
-        serialized = PaperReferenceSerializer(
-            paper.references.all(),
-            many=True
-        )
-        return Response(serialized.data, status=status.HTTP_200_OK)
+        queryset = paper.references.all()
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = PaperReferenceSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=['get'])
     def user_vote(self, request, pk=None):


### PR DESCRIPTION
Optimizing the call to the paper page by restructuring the serializer.

We're removing all references into a separate call because it's slower.