### PR TITLE
add prefix api to analytics/forward_event route

### DIFF
--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -127,7 +127,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('email_notifications/', mailing_list.views.email_notifications),
     path('health/', researchhub.views.healthcheck),
-    path('api/analytics/forward_event/', google_analytics.views.forward_event),
+    path('api/google_analytics/forward_event/', google_analytics.views.forward_event),
     re_path(r'^api/', include(router.urls)),
     path('api/ethereum/', include(ethereum.urls)),
     path(


### PR DESCRIPTION
**Feature**

1. Adds `api` prefix to `analytics/forward_event` route*


*Frontend Base URL includes the prefix /api/