### PR TITLE
added spam/suspension labeling in admin console

### DIFF
--- a/src/user/admin.py
+++ b/src/user/admin.py
@@ -13,6 +13,21 @@ from django.urls import path
 from .models import User, Action
 
 
+class CustomUserAdmin(UserAdmin):
+    fieldsets = UserAdmin.fieldsets + (
+            ('Labels', {'fields': ('probable_spammer', 'is_suspended')}),
+    )
+
+    def save_model(self, request, obj, form, change):
+        user = request.user
+        changed_spam_status = 'probable_spammer' in form.changed_data
+        changed_suspended_status = 'is_suspended' in form.changed_data
+        if changed_spam_status or changed_suspended_status:
+            user.set_probable_spammer(obj.probable_spammer)  
+            user.set_suspended(obj.is_suspended) 
+        super().save_model(request, obj, form, change)
+
+
 class AnalyticModel(models.Model):
 
     class Meta:
@@ -186,4 +201,4 @@ class AnalyticAdminPanel(admin.ModelAdmin):
 
 
 admin.site.register(AnalyticModel, AnalyticAdminPanel)
-admin.site.register(User, UserAdmin)
+admin.site.register(User, CustomUserAdmin)


### PR DESCRIPTION
<img width="1680" alt="Screen Shot 2020-11-06 at 3 35 03 PM" src="https://user-images.githubusercontent.com/35616708/98424148-b10a3300-2045-11eb-8cac-4edc972b9a3f.png">
toggles under 'Labels' section