### PR TITLE
Crossref Autopull

### DIFF
--- a/src/paper/tasks.py
+++ b/src/paper/tasks.py
@@ -977,7 +977,7 @@ NUM_DUP_STOP = 30
     options={'queue': f'{APP_ENV}_autopull_queue'}
 )
 def pull_crossref_papers(start=0):
-    if not PRODUCTION and False:
+    if not PRODUCTION:
         return
 
     logger.info('Pulling Crossref Papers')
@@ -1053,8 +1053,7 @@ def pull_crossref_papers(start=0):
                     if 'abstract' in item:
                         paper.abstract = clean_abstract(item['abstract'])
                     else:
-                        csl = {'abstract': 'test'}
-                        # csl = get_csl_item(item['URL'])
+                        csl = get_csl_item(item['URL'])
                         abstract = csl.get('abstract', None)
                         if abstract:
                             paper.abstract = abstract


### PR DESCRIPTION
Updated pull time to hours divisible by 6 (4 times a day)
Updated filters to only grab papers uploaded in a given day
Removed stopping after reaching duplicate paper check