### PR TITLE
Fixed bug where profile page comments always showed a date of "just now"

### DIFF
--- a/src/user/views.py
+++ b/src/user/views.py
@@ -690,6 +690,7 @@ class AuthorViewSet(viewsets.ModelViewSet):
                 'id',
                 'comment_count',
                 'created_by',
+                'created_date',
                 'paper',
                 'post',
                 'score',


### PR DESCRIPTION
<img width="499" alt="Screen Shot 2021-08-27 at 7 19 27 PM" src="https://user-images.githubusercontent.com/22990196/131201909-54a4d1b7-efb1-4ce7-b722-4ce8664b6d46.png">