### PR TITLE
Fixes for paper abstracts

### DIFF
--- a/src/paper/management/commands/clean_paper_abstracts.py
+++ b/src/paper/management/commands/clean_paper_abstracts.py
@@ -25,8 +25,8 @@ class Command(BaseCommand):
                     soup = BeautifulSoup(abstract, 'html.parser')
                     strings = soup.strings
                     cleaned_text = ' '.join(strings)
-                    cleaned_text = cleaned_text.replace('\n', '')
-                    cleaned_text = cleaned_text.replace('\r', '')
+                    cleaned_text = cleaned_text.replace('\n', ' ')
+                    cleaned_text = cleaned_text.replace('\r', ' ')
                     paper.abstract = cleaned_text
                     paper.save()
             except Exception as e:

--- a/src/paper/utils.py
+++ b/src/paper/utils.py
@@ -83,8 +83,8 @@ def clean_abstract(abstract):
     soup = BeautifulSoup(abstract, 'html.parser')
     strings = soup.strings
     cleaned_text = ' '.join(strings)
-    cleaned_text = cleaned_text.replace('\n', ' ')
-    cleaned_text = cleaned_text.replace('\r', ' ')
+    #cleaned_text = cleaned_text.replace('\n', ' ')
+    #cleaned_text = cleaned_text.replace('\r', ' ')
     cleaned_text = cleaned_text.lstrip()
     return cleaned_text
 


### PR DESCRIPTION
- We need to run `python manage.py clean_paper_abstracts` to fix the unnecessary newlines issue in the DB.
- Updating paper abstracts through the UI should now preserve newlines.