### PR TITLE
Updating nginx config to allow 15MB files (PDF upload error)

### DIFF
--- a/src/.platform/nginx/nginx.conf
+++ b/src/.platform/nginx/nginx.conf
@@ -1,0 +1,42 @@
+#Elastic Beanstalk Nginx Configuration File
+
+user                    nginx;
+error_log               /var/log/nginx/error.log warn;
+pid                     /var/run/nginx.pid;
+worker_processes        auto;
+worker_rlimit_nofile    65874;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    include       conf.d/*.conf;
+
+    map $http_upgrade $connection_upgrade {
+        default     "upgrade";
+    }
+
+    server {
+        listen        80 default_server;
+        access_log    /var/log/nginx/access.log main;
+
+        client_header_timeout 60;
+        client_body_timeout   60;
+        keepalive_timeout     60;
+        gzip                  off;
+        gzip_comp_level       4;
+        client_max_body_size 15M;
+        gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+        # Include the Elastic Beanstalk generated locations
+        include conf.d/elasticbeanstalk/*.conf;
+    }
+}


### PR DESCRIPTION
A 400 level error results in frontend alerting: 

> "You are not allowed to upload papers"

This error occurs due to very low PDF upload limits on nginx of about 1MB.

Safari incorrectly throws a CORS error when this happens (known Safari bug) https://github.com/adamchainz/django-cors-headers/issues/595

The fix is to override the nginx config and include `client_max_body_size 15M` directive. 

Related Sentry error:
https://sentry.io/organizations/quantfive/issues/2868387209/events/d1462ca68c0a41a7918df3f1ae672ec8/?project=1817918&query=&statsPeriod=14d 