### PR TITLE
[Config] Secure Django admin to only be accessible via VPN

### DIFF
--- a/src/.platform/nginx/nginx.conf
+++ b/src/.platform/nginx/nginx.conf
@@ -38,5 +38,16 @@ http {
 
         # Include the Elastic Beanstalk generated locations
         include conf.d/elasticbeanstalk/*.conf;
+
+        # Only allow access to admin panel through VPN IP
+        location ^~ /admin/ { # restrict access to admin section
+            proxy_pass http://127.0.0.1:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            allow 44.231.29.79;
+            deny all;
+        }        
     }
 }


### PR DESCRIPTION
Securing Django admin panel to only be accessible via VPN.