### PR TITLE
Removing email field from editor_permissions_group obj

### DIFF
--- a/src/hub/serializers.py
+++ b/src/hub/serializers.py
@@ -34,7 +34,6 @@ class SimpleHubSerializer(serializers.ModelSerializer):
         context['rag_dps_get_user'] = {
             '_include_fields': [
                 'author_profile',
-                'email',
                 'id',
             ]
         }


### PR DESCRIPTION
### What?
- Remove email field from `editor_permissions_group` object. This email field ends up being exposed on the FE
- [Related to report](https://hackerone.com/bugs?subject=researchhub&report_id=1463139&view=assigned&filters%5B%5D=assigned-to-me&substates%5B%5D=new&substates%5B%5D=triaged&substates%5B%5D=pending-program-review&reported_to_team=&text_query=&program_states%5B%5D=2&program_states%5B%5D=3&program_states%5B%5D=4&program_states%5B%5D=5&sort_type=latest_activity&sort_direction=descending&limit=25&page=1#activity-15284897)