### PR TITLE
Do not expose user list in dropdown. Filter by explicit ID instead.

### DIFF
--- a/src/user/filters.py
+++ b/src/user/filters.py
@@ -2,6 +2,7 @@ from django.db import models
 from django_filters import rest_framework as filters
 from .models import Author
 from utils.filters import ListExcludeFilter
+from user.models import User
 
 
 class AuthorFilter(filters.FilterSet):
@@ -18,3 +19,11 @@ class AuthorFilter(filters.FilterSet):
                 'filter_class': filters.CharFilter,
             }
         }
+
+class UserFilter(filters.FilterSet):
+    invited_by = filters.NumberFilter()
+    referral_code = filters.Filter()
+
+    class Meta:
+        model = User
+        fields = []

--- a/src/user/views/user_views.py
+++ b/src/user/views/user_views.py
@@ -69,13 +69,15 @@ from utils.http import RequestMethods
 from utils.permissions import CreateOrUpdateIfAllowed
 from utils.throttles import THROTTLE_CLASSES
 from hypothesis.related_models.hypothesis import Hypothesis
+from user.filters import UserFilter
+
 
 class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.filter(is_suspended=False)
     serializer_class = UserEditableSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
     filter_backends = (DjangoFilterBackend,)
-    filterset_fields = ['referral_code', 'invited_by']
+    filter_class = UserFilter
 
     def get_serializer_class(self):
         if self.request.GET.get('referral_code') or self.request.GET.get('invited_by'):


### PR DESCRIPTION
### What?

- Do not expose filterable list of users via a dropdown (see screenshot). Instead, just expose an input field that collects ID.
👍  This is compatible with current web app. No change there is needed.

Before:
![image](https://user-images.githubusercontent.com/802819/152272207-7a232424-aac2-4467-9435-0e4bb3909dec.png)


Do this instead (After):
![image](https://user-images.githubusercontent.com/802819/152272255-976c016a-13ee-4235-bb21-a4c1e8994ccf.png)


