### PR TITLE
HotScore V2 - Add time points instead of time penalty

### DIFF
--- a/src/researchhub_document/signals/researchhub_unified_document_signals.py
+++ b/src/researchhub_document/signals/researchhub_unified_document_signals.py
@@ -41,8 +41,8 @@ def recalc_hot_score(instance, sender, **kwargs):
                     instance.object_id,
 
                 ),
-                priority=1,
-                countdown=1
+                priority=2,
+                countdown=5
             )
         elif type(instance) is PaperVote:
             paper = instance.paper
@@ -53,8 +53,20 @@ def recalc_hot_score(instance, sender, **kwargs):
                     paper.id
 
                 ),
-                priority=1,
-                countdown=1
+                priority=2,
+                countdown=5
+            )
+        elif type(instance) is ResearchhubUnifiedDocument:
+            inner_doc = instance.get_document()
+            content_type_id = ContentType.objects.get_for_model(inner_doc).id
+
+            recalc_hot_score_task.apply_async(
+                (
+                    content_type_id,
+                    inner_doc.id
+                ),
+                priority=2,
+                countdown=5
             )
     except Exception as error:
         print('recalc_hot_score error', error)


### PR DESCRIPTION
### What?
- Add time points given the number of seconds elapsed since epoch rather than time penalty. This way we do not have to recalculate the hot score for the entire feed every day.