### PR TITLE
Accept english strings in feed API rather than unix timestamps

### DIFF
--- a/src/researchhub_document/tasks.py
+++ b/src/researchhub_document/tasks.py
@@ -79,26 +79,15 @@ def preload_trending_documents(
       DynamicUnifiedDocumentSerializer
     )
 
-    end_date = datetime.now()
     if time_scope == 'all_time':
         cache_pk = f'{document_type}_{hub_id}_{filtering}_all_time'
-        start_date = datetime(
-            year=2018,
-            month=12,
-            day=31,
-            hour=7
-        )
     elif time_scope == 'year':
         cache_pk = f'{document_type}_{hub_id}_{filtering}_year'
-        start_date = datetime.now() - timedelta(days=365)
     elif time_scope == 'month':
         cache_pk = f'{document_type}_{hub_id}_{filtering}_month'
-        start_date = datetime.now() - timedelta(days=30)
     elif time_scope == 'week':
         cache_pk = f'{document_type}_{hub_id}_{filtering}_week'
-        start_date = datetime.now() - timedelta(days=7)
     else: # Today
-        start_date = datetime.now() - timedelta(hours=24)
         cache_pk = f'{document_type}_{hub_id}_{filtering}_today'
 
     query_string_filtering = 'top_rated'
@@ -124,11 +113,8 @@ def preload_trending_documents(
         http_host = 'localhost:8000'
         protocol = 'http'
 
-    start_date_timestamp = int(start_date.timestamp())
-    end_date_timestamp = int(end_date.timestamp())
-    query_string = 'page=1&start_date__gte={}&end_date__lte={}&ordering={}&hub_id={}&'.format(
-        start_date_timestamp,
-        end_date_timestamp,
+    query_string = 'page=1&time={}&ordering={}&hub_id={}&'.format(
+        time_scope,
         query_string_filtering,
         hub_id
     )
@@ -137,7 +123,7 @@ def preload_trending_documents(
         'HTTP_HOST': http_host,
         'HTTP_X_FORWARDED_PROTO': protocol,
     }
-
+    print('query_string', query_string)
     document_view = ResearchhubUnifiedDocumentViewSet()
     http_req = HttpRequest()
     http_req.META = http_meta
@@ -149,8 +135,7 @@ def preload_trending_documents(
         document_type,
         filtering,
         hub_id,
-        start_date,
-        end_date
+        time_scope
     )
     page = document_view.paginate_queryset(documents)
     context = document_view._get_serializer_context()

--- a/src/researchhub_document/tasks.py
+++ b/src/researchhub_document/tasks.py
@@ -123,7 +123,7 @@ def preload_trending_documents(
         'HTTP_HOST': http_host,
         'HTTP_X_FORWARDED_PROTO': protocol,
     }
-    print('query_string', query_string)
+
     document_view = ResearchhubUnifiedDocumentViewSet()
     http_req = HttpRequest()
     http_req.META = http_meta

--- a/src/researchhub_document/utils.py
+++ b/src/researchhub_document/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from researchhub_document.tasks import (
     preload_trending_documents,
     preload_hub_documents
@@ -51,26 +52,37 @@ def add_default_hub(hub_ids):
         return [0] + list(hub_ids)
     return hub_ids
 
-def get_date_range_key(start_date, end_date):
-    time_difference = end_date - start_date
-
-    if time_difference.days > 365:
-        return "all_time"
-    elif time_difference.days == 365:
-        return "year"
-    elif time_difference.days == 30 or time_difference.days == 31:
-        return "month"
-    elif time_difference.days == 7:
-        return "week"
-    else:
-        return "today"
-
 def get_doc_type_key(document):
     doc_type = document.document_type.lower()
     if doc_type == 'discussion':
         return 'posts'
 
     return doc_type
+
+def get_date_ranges_by_time_scope(time_scope):
+    end_date = datetime.now()
+    if time_scope == 'all_time':
+        start_date = datetime(
+            year=2018,
+            month=12,
+            day=31,
+            hour=0
+        )
+    elif time_scope == 'year':
+        start_date = datetime.now() - timedelta(days=365)
+    elif time_scope == 'month':
+        start_date = datetime.now() - timedelta(days=30)
+    elif time_scope == 'week':
+        start_date = datetime.now() - timedelta(days=7)
+    # Today
+    else:
+        # Given that our "today" results are minimal
+        # it makes sense to have a bit of an extra buffer
+        # for the forseeable future.
+        hours_buffer = 10
+        start_date = datetime.now() - timedelta(hours=(24 + hours_buffer))
+
+    return (start_date, end_date)
 
 def reset_unified_document_cache(
     hub_ids,

--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -286,9 +286,6 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
         start_date = date_ranges[0]
         end_date = date_ranges[1]
 
-        print('start_date', start_date)
-        print('end_date', end_date)
-
         papers = Paper.objects.filter(
             uploaded_by__isnull=False
         ).values_list(
@@ -489,10 +486,6 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
             cache_pk = f'{document_type}_{hub_id}_{filtering}_{time_scope}'
             cache_key_hub = get_cache_key('hub', cache_pk)
             cache_hit = cache.get(cache_key_hub)
-
-        print('cache_hit', cache_hit)
-        print('cache_pk', cache_pk)
-        print('cache_pk_hub', cache_key_hub)
 
         if cache_hit:
             return cache_hit

--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -1,4 +1,3 @@
-import datetime
 from collections import OrderedDict
 
 from django.core.cache import cache
@@ -25,7 +24,7 @@ from researchhub_document.models import (
 )
 from researchhub_document.utils import (
     reset_unified_document_cache,
-    get_date_range_key,
+    get_date_ranges_by_time_scope
 )
 from researchhub_document.serializers import (
     ResearchhubUnifiedDocumentSerializer,
@@ -280,9 +279,16 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
         document_type,
         filtering,
         hub_id,
-        start_date,
-        end_date
+        time_scope,
     ):
+
+        date_ranges = get_date_ranges_by_time_scope(time_scope)
+        start_date = date_ranges[0]
+        end_date = date_ranges[1]
+
+        print('start_date', start_date)
+        print('end_date', end_date)
+
         papers = Paper.objects.filter(
             uploaded_by__isnull=False
         ).values_list(
@@ -476,13 +482,17 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
         filtering,
         hub_id,
         page_number,
-        date_range
+        time_scope
     ):
         cache_hit = None
         if page_number == 1 and 'removed' not in filtering:
-            cache_pk = f'{document_type}_{hub_id}_{filtering}_{date_range}'
+            cache_pk = f'{document_type}_{hub_id}_{filtering}_{time_scope}'
             cache_key_hub = get_cache_key('hub', cache_pk)
             cache_hit = cache.get(cache_key_hub)
+
+        print('cache_hit', cache_hit)
+        print('cache_pk', cache_pk)
+        print('cache_pk_hub', cache_key_hub)
 
         if cache_hit:
             return cache_hit
@@ -497,6 +507,7 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
         is_anonymous = request.user.is_anonymous
         query_params = request.query_params
         subscribed_hubs = query_params.get('subscribed_hubs', 'false')
+        time_scope = query_params.get('time', 'today')
 
         if subscribed_hubs == 'true' and not is_anonymous:
             return self._get_subscribed_unified_documents(request)
@@ -504,23 +515,14 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
         document_request_type = query_params.get('type', 'all')
         hub_id = query_params.get('hub_id', 0)
         page_number = int(query_params.get('page', 1))
-        start_date = datetime.datetime.fromtimestamp(
-            int(request.GET.get('start_date__gte', 0)),
-            datetime.timezone.utc
-        )
-        end_date = datetime.datetime.fromtimestamp(
-            int(request.GET.get('end_date__lte', 0)),
-            datetime.timezone.utc
-        )
-        time_difference = end_date - start_date
+
         filtering = self._get_document_filtering(query_params)
-        date_range = get_date_range_key(start_date, end_date)
         cache_hit = self._get_unifed_document_cache_hit(
             document_request_type,
             filtering,
             hub_id,
             page_number,
-            date_range
+            time_scope
         )
 
         if cache_hit and page_number == 1:
@@ -530,15 +532,14 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
                 hub_ids=[hub_id],
                 document_type=[document_request_type],
                 filters=[filtering],
-                date_ranges=[date_range],
+                date_ranges=[time_scope],
             )
 
         documents = self.get_filtered_queryset(
             document_request_type,
             filtering,
             hub_id,
-            start_date,
-            end_date
+            time_scope,
         )
 
         context = self._get_serializer_context()
@@ -565,15 +566,9 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
         hubs = request.user.subscribed_hubs
         query_params = request.query_params
         document_request_type = query_params.get('type', 'all')
+        time_scope = query_params.get('time', 'today')
+
         page_number = int(query_params.get('page', 1))
-        start_date = datetime.datetime.fromtimestamp(
-            int(request.GET.get('start_date__gte', 0)),
-            datetime.timezone.utc
-        )
-        end_date = datetime.datetime.fromtimestamp(
-            int(request.GET.get('end_date__lte', 0)),
-            datetime.timezone.utc
-        )
         filtering = self._get_document_filtering(query_params)
 
         if filtering == '-hot_score' and page_number == 1:
@@ -622,8 +617,7 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
                     document_request_type,
                     filtering,
                     default_hub_id,
-                    start_date,
-                    end_date
+                    time_scope,
                 )
                 all_documents = all_documents.filter(
                     hubs__in=hubs.all()
@@ -649,37 +643,11 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
                 document_request_type,
                 filtering,
                 default_hub_id,
-                start_date,
-                end_date
+                time_scope,
             )
             all_documents = all_documents.filter(
                 hubs__in=hubs.all()
             ).distinct()
-
-        # if all_documents.count() < 1 and hubs.exists():
-        #     if document_request_type == 'all':
-        #         trending_pk = 'all_0_-hot_score_today'
-        #     elif document_request_type == 'posts':
-        #         trending_pk = 'posts_0_-hot_score_today'
-        #     else:
-        #         trending_pk = 'paper_0_-hot_score_today'
-
-        #     cache_key_hub = get_cache_key('hub', trending_pk)
-        #     cache_hit = cache.get(cache_key_hub)
-
-        #     if cache_hit and page_number == 1:
-        #         return Response(cache_hit)
-
-        #     all_documents = self.get_filtered_queryset(
-        #         document_request_type,
-        #         filtering,
-        #         default_hub_id,
-        #         start_date,
-        #         end_date
-        #     )
-        #     all_documents = all_documents.filter(
-        #         hubs__in=hubs.all()
-        #     ).distinct()
 
         context = self._get_serializer_context()
         page = self.paginate_queryset(all_documents)


### PR DESCRIPTION
### What?
- No longer accept unix timestamps in feed api endpoint. Rather, accept english strings such as "today", "week", ..

Related: https://github.com/ResearchHub/researchhub-web/pull/1131/files