### PR TITLE
Specific queues for async jobs

### DIFF
--- a/src/google_analytics/signals.py
+++ b/src/google_analytics/signals.py
@@ -27,6 +27,10 @@ from researchhub_document.related_models.researchhub_post_model \
     import ResearchhubPost
 from summary.models import Summary
 from user.models import User
+from researchhub.celery import (
+    QUEUE_EXTERNAL_REPORTING
+)
+
 ga = GoogleAnalytics()
 
 
@@ -313,7 +317,7 @@ def get_event_hit_response(
     return True
 
 
-@app.task
+@app.task(queue=QUEUE_EXTERNAL_REPORTING)
 def celery_get_event_hit_response(category, action, label, value, date):
     date = datetime.datetime.fromtimestamp(date)
     fields = Hit.build_event_fields(

--- a/src/mailing_list/tasks.py
+++ b/src/mailing_list/tasks.py
@@ -18,9 +18,12 @@ from researchhub.celery import app
 from researchhub_document.models import ResearchhubPost
 from utils.message import send_email_message
 from user.models import Action, User
+from researchhub.celery import (
+    QUEUE_NOTIFICATION
+)
 
 
-@app.task
+@app.task(queue=QUEUE_NOTIFICATION)
 def notify_immediate(action_id):
     actions_notifications([action_id], NotificationFrequencies.IMMEDIATE)
 

--- a/src/profiler/tasks.py
+++ b/src/profiler/tasks.py
@@ -5,9 +5,12 @@ from django.core.files import File
 from researchhub.celery import app
 from profiler.models import Profile, Traceback
 from utils import sentry
+from researchhub.celery import (
+    QUEUE_LOGS,
+)
 
 
-@app.task
+@app.task(queue=QUEUE_LOGS)
 def log_traceback(data, total_view_time, traceback):
     queries = data['queries']
     view_name = data['view_name']

--- a/src/purchase/tasks.py
+++ b/src/purchase/tasks.py
@@ -9,12 +9,16 @@ from purchase.models import Purchase, Support
 from researchhub.settings import APP_ENV, BASE_FRONTEND_URL
 from researchhub_document.utils import reset_unified_document_cache
 from utils.message import send_email_message
+from researchhub.celery import (
+    QUEUE_NOTIFICATION,
+    QUEUE_PURCHASES
+)
 
 
 @periodic_task(
     run_every=crontab(minute='*/30'),
-    priority=2,
-    options={'queue': f'{APP_ENV}_core_queue'}
+    priority=3,
+    queue=QUEUE_PURCHASES,
 )
 def update_purchases():
     PAPER_CONTENT_TYPE = ContentType.objects.get(
@@ -34,7 +38,7 @@ def update_purchases():
     reset_unified_document_cache(with_default_hub=True)
 
 
-@app.task
+@app.task(queue=QUEUE_NOTIFICATION)
 def send_support_email(
     profile_url,
     sender_name,

--- a/src/reputation/tasks.py
+++ b/src/reputation/tasks.py
@@ -25,10 +25,14 @@ from reputation.distributor import RewardDistributor
 from utils.sentry import log_info
 from utils.message import send_email_message
 from mailing_list.lib import base_email_context
+from researchhub.celery import (
+    QUEUE_CONTRIBUTIONS,
+    QUEUE_PURCHASES,
+)
 
 DEFAULT_REWARD = 1000000
 
-@app.task
+@app.task(queue=QUEUE_CONTRIBUTIONS)
 def create_contribution(
     contribution_type,
     instance_type,
@@ -69,7 +73,7 @@ def create_contribution(
     )
 
 
-@app.task
+@app.task(queue=QUEUE_CONTRIBUTIONS)
 def create_author_contribution(
     contribution_type,
     user_id,
@@ -101,7 +105,7 @@ def create_author_contribution(
     Contribution.objects.bulk_create(contributions)
 
 
-@app.task
+@app.task(queue=QUEUE_PURCHASES)
 def distribute_round_robin(paper_id):
     reward_dis = RewardDistributor()
     paper = Paper.objects.get(id=paper_id)

--- a/src/researchhub/celery.py
+++ b/src/researchhub/celery.py
@@ -18,6 +18,21 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 # Loads tasks in `tasks.py` from installed apps.
 app.autodiscover_tasks()
 
+# Queues
+QUEUE_CACHES = 'caches'
+QUEUE_HOT_SCORE = 'hot_score'
+QUEUE_ELASTIC_SEARCH = 'elastic_search'
+QUEUE_EXTERNAL_REPORTING = 'external_reporting'
+QUEUE_NOTIFICATION = 'notifications'
+QUEUE_PAPER_MISC = 'paper_misc'
+QUEUE_CERMINE = 'cermine'
+QUEUE_TWITTER = 'twitter'
+QUEUE_PULL_PAPERS = 'pull_papers'
+QUEUE_LOGS = 'logs'
+QUEUE_PURCHASES = 'purchases'
+QUEUE_CONTRIBUTIONS = 'contributions'
+QUEUE_AUTHOR_CLAIM = 'author_claim'
+
 
 # Celery Debug/Test Functions
 @app.task(bind=True)

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -647,12 +647,7 @@ CELERY_TASK_TRACK_STARTED = True
 CELERY_RESULT_EXTENDED = True
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
-CELERY_TASK_ROUTES = {
-    '*.tasks.*': {
-        'queue': f'{APP_ENV}_core_queue'
-    }
-}
-CELERY_TASK_DEFAULT_QUEUE = f'{APP_ENV}_core_queue'
+CELERY_TASK_DEFAULT_QUEUE = 'default'
 
 REDBEAT_REDIS_URL = 'redis://{}:{}/0'.format(REDIS_HOST, REDIS_PORT)
 REDBEAT_KEY_PREFIX = f'{APP_ENV}_redbeat_'

--- a/src/researchhub_case/tasks.py
+++ b/src/researchhub_case/tasks.py
@@ -11,9 +11,11 @@ from utils import sentry
 from researchhub_case.constants.case_constants import (
     APPROVED, INITIATED, DENIED
 )
+from researchhub.celery import (
+    QUEUE_AUTHOR_CLAIM
+)
 
-
-@app.task
+@app.task(queue=QUEUE_AUTHOR_CLAIM)
 def trigger_email_validation_flow(
     case_id,
 ):
@@ -33,7 +35,7 @@ def trigger_email_validation_flow(
             sentry.log_error(exception)
 
 
-@app.task
+@app.task(queue=QUEUE_AUTHOR_CLAIM)
 def after_approval_flow(
     case_id
 ):
@@ -51,7 +53,7 @@ def after_approval_flow(
         except Exception as exception:
             sentry.log_error(exception)
 
-@app.task
+@app.task(queue=QUEUE_AUTHOR_CLAIM)
 def after_rejection_flow(
     case_id,
     notify_user=False,

--- a/src/start-celery.sh
+++ b/src/start-celery.sh
@@ -1,1 +1,1 @@
-celery -A researchhub worker -Q development_core_queue -l info --concurrency=1 --prefetch-multiplier=1 -P prefork
+celery -A researchhub worker -Q caches,hot_score,elastic_search,external_reporting,notifications,paper_misc,cermine,twitter,pull_papers,logs,purchases,contributions,author_claim -l info --concurrency=1 --prefetch-multiplier=1 -P prefork

--- a/src/start-celery.sh
+++ b/src/start-celery.sh
@@ -1,1 +1,1 @@
-celery -A researchhub worker -Q default_queue,caches,hot_score,elastic_search,external_reporting,notifications,paper_misc,cermine,twitter,pull_papers,logs,purchases,contributions,author_claim -l info --concurrency=1 --prefetch-multiplier=1 -P prefork -n core
+celery -A researchhub worker -B -Q default,caches,hot_score,elastic_search,external_reporting,notifications,paper_misc,cermine,twitter,pull_papers,logs,purchases,contributions,author_claim -l info --concurrency=1 --prefetch-multiplier=1 -P prefork

--- a/src/start-celery.sh
+++ b/src/start-celery.sh
@@ -1,1 +1,1 @@
-celery -A researchhub worker -Q caches,hot_score,elastic_search,external_reporting,notifications,paper_misc,cermine,twitter,pull_papers,logs,purchases,contributions,author_claim -l info --concurrency=1 --prefetch-multiplier=1 -P prefork
+celery -A researchhub worker -Q default_queue,caches,hot_score,elastic_search,external_reporting,notifications,paper_misc,cermine,twitter,pull_papers,logs,purchases,contributions,author_claim -l info --concurrency=1 --prefetch-multiplier=1 -P prefork -n core

--- a/src/user/tasks.py
+++ b/src/user/tasks.py
@@ -32,6 +32,13 @@ from researchhub_document.utils import reset_unified_document_cache
 from researchhub.settings import STAGING, PRODUCTION, APP_ENV
 from user.editor_payout_tasks import editor_daily_payout_task
 from utils.sentry import log_info
+from researchhub.celery import (
+    QUEUE_NOTIFICATION,
+    QUEUE_PAPER_MISC,
+    QUEUE_CACHES,
+    QUEUE_PURCHASES,
+    QUEUE_ELASTIC_SEARCH,
+)
 
 
 @app.task
@@ -96,7 +103,7 @@ def reinstate_user_task(user_id):
     reset_unified_document_cache(hub_ids, {}, None)
 
 
-@app.task
+@app.task(queue=QUEUE_PAPER_MISC)
 def link_author_to_papers(author_id, orcid_account_id):
     Author = apps.get_model('user.Author')
     try:
@@ -119,7 +126,7 @@ def link_author_to_papers(author_id, orcid_account_id):
         )
 
 
-@app.task
+@app.task(queue=QUEUE_PAPER_MISC)
 def link_paper_to_authors(paper_id):
     try:
         paper = Paper.objects.get(pk=paper_id)
@@ -234,7 +241,7 @@ def filter_comments_on_my_threads(comments, threads):
     return [comment for comment in comments if comment.parent in threads]
 
 
-@app.task
+@app.task(queue=QUEUE_CACHES)
 def preload_latest_activity(hub_ids, ordering):
     from user.views import UserViewSet
     from reputation.serializers import DynamicContributionSerializer
@@ -300,7 +307,7 @@ def preload_latest_activity(hub_ids, ordering):
     return paginated_response.data
 
 
-@app.task
+@app.task(queue=QUEUE_ELASTIC_SEARCH)
 def update_elastic_registry(user_id):
     Author = apps.get_model('user.Author')
     user_author = Author.objects.get(user_id=user_id)
@@ -311,7 +318,7 @@ def update_elastic_registry(user_id):
 @periodic_task(
     run_every=crontab(hour=6, minute=0, day_of_week=1),
     priority=5,
-    options={'queue': f'{APP_ENV}_core_queue'}
+    queue=QUEUE_NOTIFICATION
 )
 def notify_editor_inactivity():
     User = apps.get_model('user.User')
@@ -359,7 +366,7 @@ def notify_editor_inactivity():
 @periodic_task(
     run_every=crontab(hour=15, minute=0),  # 3:00 PM PST (pst is system time)
     priority=2,
-    options={'queue': f'{APP_ENV}_core_queue'}
+    queue=QUEUE_PURCHASES,
 )
 def execute_editor_daily_payout_task():
     log_info(f"{APP_ENV}-running payout")

--- a/src/utils/orcid.py
+++ b/src/utils/orcid.py
@@ -8,7 +8,9 @@ from user.models import Author
 from utils import sentry
 from utils.exceptions import OrcidApiError
 from utils.http import http_request, GET, POST
-
+from researchhub.celery import (
+    QUEUE_CERMINE,
+)
 orcid = SOCIALACCOUNT_PROVIDERS['orcid']
 
 
@@ -126,8 +128,8 @@ orcid_api = OrcidApi()
 
 
 # TODO: calvinhlee - temporarily relocating worker
-# @app.task(queue=f'{APP_ENV}_autopull_queue', ignore_result=False)
-@app.task(queue=f'{APP_ENV}_cermine_queue', ignore_result=False)
+# @app.task(queue=QUEUE_PULL_PAPERS, ignore_result=False)
+@app.task(queue=QUEUE_CERMINE, ignore_result=False)
 def celery_add_author(result, authors, attempts=2):
     tries = attempts
     while tries > 0:


### PR DESCRIPTION
### What?
- Mapping async tasks to specific queues. This is done to avoid having everything in a single queue. That way, we can safely purge queues