### PR TITLE
get dehydrated concepts from openalex, then sort them by level & score

### DIFF
--- a/src/paper/tests/test_paper_submissions.py
+++ b/src/paper/tests/test_paper_submissions.py
@@ -12,6 +12,8 @@ class PaperSubmissionViewTests(APITestCase):
         self.duplicate_url = "https://www.vitisgen2.org/research-in-plain-english/evaluating-and-mapping-grape-color-using-image-based-phenotyping/"
         self.true_doi = "10.34133/2020/8086309"
         self.paper_publish_date = "2020-04-24"
+        self.concept_display_names = ['Computer science', 'Mathematics', 'Artificial intelligence', 'Hue',
+                                      'RGB color model', 'Population', 'Berry', 'Lightness', 'Quantitative trait locus', 'Color space']
         self.submitter = create_random_default_user("submitter")
         self.client.force_authenticate(self.submitter)
 
@@ -44,6 +46,9 @@ class PaperSubmissionViewTests(APITestCase):
         celery_data_after_openalex = celery_openalex.apply((celery_data,)).result
         paper_publish_date = celery_data_after_openalex[0]["paper_publish_date"]
         self.assertEqual(self.paper_publish_date, paper_publish_date)
+        concepts = celery_data_after_openalex[0]["concepts"]
+        self.assertEqual(self.concept_display_names,
+                    [concept["display_name"] for concept in concepts])
 
         celery_data_after_crossref = celery_crossref.apply((celery_data,)).result
         doi = celery_data_after_crossref[0]["doi"]

--- a/src/utils/openalex.py
+++ b/src/utils/openalex.py
@@ -13,25 +13,40 @@ class OpenAlex:
         }
         self.timeout = timeout
 
-    def _get_works(self, filters, headers=None):
+    def _get(self, url, filters=None, headers=None):
         if not headers:
             headers = {}
+        if not filters:
+            filters = {}
 
-        filters = {**filters, **self.base_params}
+        params = {**filters, **self.base_params}
         headers = {**headers, **self.base_headers}
-        url = f"{self.base_url}/works"
+        url = f"{self.base_url}/{url}"
         response = requests.get(
-            url, params=filters, headers=headers, timeout=self.timeout
+            url, params=params, headers=headers, timeout=self.timeout
         )
         response.raise_for_status()
         return response.json()
 
     def get_data_from_doi(self, doi):
         filters = {"filter": f"doi:{doi}"}
-        works = self._get_works(filters)
+        works = self._get("works", filters)
         meta = works["meta"]
         count = meta["count"]
         results = works["results"]
         if count == 0:
             raise DOINotFoundError(f"No OpenAlex works found for doi: {doi}")
         return results[0]
+
+    # fetch a hydrated concept by id: https://docs.openalex.org/about-the-data/concept#id
+    def get_hydrated_concept(self, concept_id_url):
+        # e.g. https://api.openalex.org/concepts/C126537357 -> C126537357
+        concept_id = concept_id_url.split("/")[-1]
+        concept = self._get(f"concepts/{concept_id}")
+        return {
+            "openalex_id":           concept["id"],
+            "display_name":          concept["display_name"],
+            "description":           concept["description"],
+            "openalex_created_date": concept["created_date"],
+            "openalex_updated_date": concept["updated_date"]
+        }


### PR DESCRIPTION
Use the id from each dehydrated concept returned from OpenAlex's /works endpoint to fetch hydrated concepts from the /concepts endpoint.

Refactor OpenAlex class to share code between _get_works and get_hydrated_concept.