### PR TITLE
Extend Google Scholar profile search

### DIFF
--- a/src/researchhub_case/tasks.py
+++ b/src/researchhub_case/tasks.py
@@ -75,7 +75,7 @@ def after_rejection_flow(
 
 @app.task(queue=QUEUE_AUTHOR_CLAIM)
 def celery_add_author_citations(author_profile_id, google_scholar_id):
-    lambda_body = {AUTHOR_PROFILE_LOOKUP: [google_scholar_id]}
+    lambda_body = {AUTHOR_PROFILE_LOOKUP: [google_scholar_id, "True"]}
     data_bytes = json.dumps(lambda_body)
     session = Session(
         aws_access_key_id=AWS_ACCESS_KEY_ID,

--- a/src/rh_scholarly/controller.py
+++ b/src/rh_scholarly/controller.py
@@ -19,8 +19,10 @@ def search_for_authors(name, start_index=0):
     return results
 
 
-def author_profile_lookup(scholarly_author_id):
+def author_profile_lookup(scholarly_author_id, fill="False"):
     setup_free_proxy()
     author = scholarly.search_author_id(scholarly_author_id)
-    results = scholarly.fill(author)
-    return results
+    if fill == "True":
+        return scholarly.fill(author)
+    else:
+        return author


### PR DESCRIPTION
[Background](https://docs.google.com/document/d/1XEu9hr0TE1YiKpJEWmlr0zIfHVAuLyADwRLfDGZ9uRs/edit?usp=sharing) for this work.

1. Renames the endpoint for searching Google Scholar profiles (unused afaik)
2. Extends this profile search to support profile URL or scholar ID
3. Makes Scholarly author profile "filling" optional

Leaving questions I have inline..