### PR TITLE
[User Search] Search by fragments, whole words

### DIFF
--- a/src/search/analyzers.py
+++ b/src/search/analyzers.py
@@ -1,9 +1,7 @@
-from elasticsearch_dsl import analyzer, tokenizer, token_filter
+from elasticsearch_dsl import analyzer, token_filter, tokenizer
 
 delimeter_filter = token_filter(
-    'word_delimiter_graph',
-    'word_delimiter',
-    split_on_case_change=False
+    "word_delimiter_graph", "word_delimiter", split_on_case_change=False
 )
 
 title_analyzer = analyzer(
@@ -19,7 +17,7 @@ title_analyzer = analyzer(
         "shingle",
         "kstem",
     ],
-    char_filter=["html_strip"]
+    char_filter=["html_strip"],
 )
 
 content_analyzer = analyzer(
@@ -35,7 +33,7 @@ content_analyzer = analyzer(
         "asciifolding",
         "shingle",
     ],
-    char_filter=["html_strip"]
+    char_filter=["html_strip"],
 )
 
 name_analyzer = analyzer(
@@ -49,5 +47,22 @@ name_analyzer = analyzer(
         "asciifolding",
         "shingle",
     ],
-    char_filter=["html_strip"]
+    char_filter=["html_strip"],
+)
+
+whitespace_edge_ngram_analyzer = analyzer(
+    "whitespace_edge_ngram_analyzer",
+    tokenizer="whitespace",
+    filter=[
+        "lowercase",
+        token_filter("edge_ngram_filter", "edge_ngram", min_gram=1, max_gram=20),
+    ],
+)
+
+whitespace_edge_ngram_tokenizer = tokenizer(
+    "whitespace_edge_ngram_tokenizer",
+    type="edge_ngram",
+    token_chars=["letter", "digit", "punctuation", "symbol", "whitespace"],
+    min_gram=1,
+    max_gram=20,
 )

--- a/src/search/documents/user.py
+++ b/src/search/documents/user.py
@@ -30,18 +30,22 @@ class UserDocument(BaseDocument):
             "id",
             "first_name",
             "last_name",
+            "reputation",
         ]
 
     def prepare_author_profile(self, instance):
         profile = None
 
         try:
-            profile = {"id": instance.author_profile.id}
+            profile = {
+                "id": instance.author_profile.id,
+                "headline": instance.author_profile.headline,
+            }
         except Exception as e:
             return False
 
         try:
-            profile["profile_img"] = instance.author_profile.profile_image.url
+            profile["profile_image"] = instance.author_profile.profile_image.url
         except Exception as e:
             pass
 

--- a/src/search/documents/user.py
+++ b/src/search/documents/user.py
@@ -1,17 +1,35 @@
 from django_elasticsearch_dsl import fields as es_fields
 from django_elasticsearch_dsl.registries import registry
+from elasticsearch_dsl import analyzer, token_filter, tokenizer
 
+from search.analyzers import whitespace_edge_ngram_analyzer
 from user.models import User
 
 from .base import BaseDocument
+
+edge_ngram_filter = token_filter(
+    "edge_ngram_filter",
+    type="edge_ngram",
+    min_gram=1,
+    max_gram=20,
+)
+
+edge_ngram_analyzer = analyzer(
+    "edge_ngram_analyzer",
+    tokenizer="standard",
+    filter=["lowercase", edge_ngram_filter],
+)
 
 
 @registry.register_document
 class UserDocument(BaseDocument):
     auto_refresh = True
-    full_name = es_fields.TextField(attr="full_name")
     profile_img = es_fields.TextField()
     full_name_suggest = es_fields.Completion()
+    full_name = es_fields.TextField(
+        analyzer=edge_ngram_analyzer,
+        search_analyzer="standard",
+    )
     author_profile = es_fields.ObjectField(
         properties={
             "profile_img": es_fields.TextField(),
@@ -62,4 +80,5 @@ class UserDocument(BaseDocument):
     def prepare(self, instance):
         data = super().prepare(instance)
         data["full_name_suggest"] = self.prepare_full_name_suggest(instance)
+
         return data

--- a/src/search/serializers/user.py
+++ b/src/search/serializers/user.py
@@ -9,4 +9,11 @@ from user.serializers import AuthorSerializer, UserSerializer
 class UserDocumentSerializer(DocumentSerializer):
     class Meta:
         document = UserDocument
-        fields = ("full_name", "full_name_suggest", "profile_img")
+        fields = (
+            "id",
+            "full_name",
+            "first_name",
+            "last_name",
+            "reputation",
+            "author_profile",
+        )

--- a/src/search/views/user.py
+++ b/src/search/views/user.py
@@ -1,5 +1,8 @@
 from django_elasticsearch_dsl_drf.constants import SUGGESTER_COMPLETION
-from django_elasticsearch_dsl_drf.filter_backends import SuggesterFilterBackend
+from django_elasticsearch_dsl_drf.filter_backends import (
+    FilteringFilterBackend,
+    SuggesterFilterBackend,
+)
 from django_elasticsearch_dsl_drf.pagination import LimitOffsetPagination
 from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
 from elasticsearch_dsl import Search
@@ -17,8 +20,15 @@ class UserDocumentView(DocumentViewSet):
     pagination_class = LimitOffsetPagination
     lookup_field = "id"
     filter_backends = [
+        MultiMatchSearchFilterBackend,
         SuggesterFilterBackend,
     ]
+    filter_fields = {
+        "full_name": {"field": "full_name", "lookups": ["match"]},
+    }
+    multi_match_search_fields = {
+        "full_name": {"field": "full_name", "boost": 1},
+    }
     suggester_fields = {
         "full_name_suggest": {
             "field": "full_name_suggest",


### PR DESCRIPTION
Updated User search endpoint to support searching for fragments.
e.g.
Entering the following query will return results for user "Kobe Attias"
"ko"
"kobe"
"kobe attias"
"att"
...

Endpoint
`/api/search/user/?search_multi_match={query}`