### PR TITLE
Create UserFilter, a class that allows gradual rollouts of backend features

### DIFF
--- a/src/utils/tests/test_user_filter.py
+++ b/src/utils/tests/test_user_filter.py
@@ -1,0 +1,90 @@
+from unittest import TestCase
+from unittest.mock import patch, Mock
+
+from jsonschema.exceptions import ValidationError
+from utils.user_filter import UserFilter
+
+
+class UserFilterTest(TestCase):
+    @staticmethod
+    def test_create_valid_user_filter():
+        UserFilter.create({
+            "allow": {
+                "ids_or_emails": [1, 2, "bot@researchhub.com"],
+                "percent": {
+                    "intervals": [
+                        [0, 10],
+                        [20, 100]
+                    ],
+                    "except": [23, 24, "foo@researchhub.com"]
+                }
+            }
+        })
+
+        UserFilter.create({
+            "deny": {
+                "ids_or_emails": [1, 2, "bot@researchhub.com"],
+                "percent": {
+                    "intervals": [
+                        [0, 10],
+                        [20, 100]
+                    ],
+                    "except": [23, 24, "foo@researchhub.com"]
+                }
+            }
+        })
+
+    def test_create_invalid_user_filter_fails(self):
+        # allow or deny are required
+        with self.assertRaises(ValidationError):
+            UserFilter.create({})
+
+        # only one of allow or deny
+        with self.assertRaises(ValidationError):
+            UserFilter.create({
+                "allow": {},
+                "deny": {}
+            })
+
+        # nothing else except allow or deny
+        with self.assertRaises(ValidationError):
+            UserFilter.create({
+                "foo": {}
+            })
+
+    @patch('user.models.User.objects')
+    def test_filter_correct(self, objects):
+        filter_result = Mock()
+        filter_result.exists.return_value = True
+
+        bot = Mock()
+        bot.id = 1071
+
+        foo = Mock()
+        foo.id = 1052
+
+        filter_result.first.side_effect = [bot, foo]
+        objects.filter.return_value = filter_result
+
+        f = UserFilter.create({
+            "allow": {
+                # allowed ids: 1001, 1002, 1071
+                "ids_or_emails": [1001, 1002, "bot@researchhub.com"],
+                "percent": {
+                    # all ids with the reversed last two digits in range [0, 10) or [20, 100) are also allowed,
+                    # except ids 1023, 1024 and 1052
+                    "intervals": [
+                        [0, 10],
+                        [20, 100]
+                    ],
+                    "except": [1023, 1024, "foo@researchhub.com"]
+                }
+            }
+        })
+        for i in range(1000, 1100):
+            if (i % 10 == 1 and i not in [bot.id, 1001]) or (i in [foo.id, 1023, 1024]):
+                self.assertFalse(f.is_allowed(i), f"{i} shouldn't be allowed")
+            else:
+                self.assertTrue(f.is_allowed(i), f"{i} should be allowed")
+
+

--- a/src/utils/user_filter.py
+++ b/src/utils/user_filter.py
@@ -1,0 +1,157 @@
+from typing import Mapping, List, Union, Set
+
+from celery.utils.log import get_task_logger
+from jsonschema import validate
+
+logger = get_task_logger(__name__)
+
+
+class UserFilter:
+    """
+    A wrapper around an allow-list/block-list configuration which determines whether a user id should be allowed or not
+    from a specific feature. When releasing a new feature, this class can be used for gradual rollouts. For example, a
+    list of specific users is first allow-listed (e.g. ids [7, 15, 21]); then, 1% of all users, then 10%, 50%, and
+    finally 100%.
+    """
+
+    FILTER_SCHEMA: Mapping = {
+        "type": "object",
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "allow": {
+                        # "type": "integer"
+                        "$ref": "#/$defs/allowlist"
+                    }
+                },
+                "additionalProperties": False,
+                "required": ["allow"]
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "deny": {
+                        "$ref": "#/$defs/allowlist"
+                    }
+                },
+                "additionalProperties": False,
+                "required": ["deny"]
+            }
+        ],
+        "$defs": {
+            "allowlist": {
+                "type": "object",
+                "properties": {
+                    "ids_or_emails": {
+                        "type": "array",
+                        "items": {
+                            "type": ["integer", "string"]
+                        }
+                    },
+                    "percent": {
+                        "type": "object",
+                        "properties": {
+                            "intervals": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": {
+                                        "type": "integer"
+                                    }
+                                }
+                            },
+                            "except": {
+                                "type": "array",
+                                "items": {
+                                    "type": ["integer", "string"]
+                                }
+                            },
+                        },
+                        "additionalProperties": False,
+                    }
+                },
+                "additionalProperties": False,
+            }
+        }
+    }
+    """
+    Defines a JSON Schema that enforces the rules of a user filter.
+    """
+
+    @staticmethod
+    def create(config: dict):
+        """
+        Validates the given user filter configuration and creates a UserFilter instance.
+        """
+        validate(instance=config, schema=UserFilter.FILTER_SCHEMA)
+        return UserFilter(config)
+
+    def __init__(self, config: dict):
+        self._config = config
+        self._usernameToIdMapping: dict = {}
+
+    def is_allowed(self, user_id: int):
+        """
+        Returns True if the given user id is allowed in the user filter configuration, and False otherwise.
+        """
+        filter_action_is_allow = self._config.get("allow") is not None
+        config_data = self._config.get("allow", self._config.get("deny"))
+        ids_or_emails = config_data.get("ids_or_emails")
+
+        if ids_or_emails is not None:
+            ids = self._ids_or_emails_to_ids(ids_or_emails)
+            if user_id in ids:
+                return filter_action_is_allow
+
+        percent = config_data.get("percent")
+        if percent is not None:
+            except_ids_or_emails = percent.get("except")
+            if except_ids_or_emails is not None:
+                except_ids = self._ids_or_emails_to_ids(except_ids_or_emails)
+                if user_id in except_ids:
+                    return not filter_action_is_allow
+
+            intervals = percent.get("intervals")
+            if intervals is None:
+                return not filter_action_is_allow
+
+            pc = UserFilter._user_id_to_percent(user_id)
+            for interval in intervals:
+                if interval[0] <= pc < interval[1]:
+                    return filter_action_is_allow
+            return not filter_action_is_allow
+
+    def _ids_or_emails_to_ids(self, ids_or_emails: List[Union[int, str]]) -> Set[int]:
+        from user.models import User
+        ids = set()
+        for entry in ids_or_emails:
+            # entry is a numeric id
+            if isinstance(entry, int):
+                ids.add(entry)
+                continue
+
+            # entry is an email address; we need to resolve the corresponding id
+            email_id = self._usernameToIdMapping.get(entry)
+            if email_id is None:
+                user_query = User.objects.filter(email=entry)
+                if user_query.exists():
+                    email_id = user_query.first().id
+                    self._usernameToIdMapping[entry] = email_id
+            if email_id is not None:
+                ids.add(email_id)
+        return ids
+
+    @staticmethod
+    def _user_id_to_percent(user_id: int):
+        """
+        Returns the last two digits of the given number in reverse. Examples: 123->32, 7->70, 21->12.
+        This is done so that the ids are more uniformly distributed across percentage intervals. For
+        example, one effect is that consecutive user ids are distributed across different percentage
+        intervals.
+        """
+        last_digit = user_id % 10
+        penultimate_digit = int(user_id / 10) % 10
+        return last_digit * 10 + penultimate_digit


### PR DESCRIPTION
Use cases:

1. Turn off a feature:
```
"allow": {}
```

2. Turn on a feature only for ids `[7, 21, 'bot@researchhub.com']`:
```
"allow": {
  "ids_or_emails": [7, 21, "bot@researchhub.com"]
}
```

3. Turn on a feature for (roughly) 10% of all users in addition to ids `[7, 21, 'bot@researchhub.com']`:
```
"allow": {
  "ids_or_emails": [7, 21, "bot@researchhub.com"],
  "percent": {
    "intervals": [
      [0, 10]
    ]
  }
}
```

4. Turn on a feature for all users:
```
"allow": {
  "percent": {
    "intervals": [
      [0, 100]
    ]
  }
}
```
or:
```
"deny": {}
```

5. Block-list a set of users:
```
"deny": {
  "ids_or_emails": [14, 23, 'vader@empire.com']
}
```

... and more.