### PR TITLE
RSC Tipping for Authors

### DIFF
--- a/src/paper/related_models/paper_model.py
+++ b/src/paper/related_models/paper_model.py
@@ -37,9 +37,9 @@ from paper.utils import (
     populate_pdf_url_from_journal_url,
 )
 from purchase.models import Purchase
-from researchhub_comment.models import RhCommentThreadModel
 from researchhub.lib import CREATED_LOCATIONS
 from researchhub.settings import TESTING
+from researchhub_comment.models import RhCommentThreadModel
 from researchhub_document.related_models.constants.editor_type import (
     EDITOR_TYPES,
     TEXT_FIELD,
@@ -431,6 +431,10 @@ class Paper(AbstractGenericReactionModel):
 
     def true_author_count(self):
         registered_author_count = self.authors.count()
+        raw_author_count = self.raw_author_count()
+        return raw_author_count + registered_author_count
+
+    def raw_author_count(self):
         raw_author_count = 0
 
         if isinstance(self.raw_authors, list):
@@ -441,8 +445,7 @@ class Paper(AbstractGenericReactionModel):
                     last_name=author.get("last_name"),
                 ).exists():
                     raw_author_count -= 1
-
-        return raw_author_count + registered_author_count
+        return raw_author_count
 
     def get_hub_names(self):
         return ",".join(self.hubs.values_list("name", flat=True))

--- a/src/purchase/tests.py
+++ b/src/purchase/tests.py
@@ -76,8 +76,7 @@ class SendRSCTest(APITestCase, TestCase, TestHelper, IntegrationTestHelper):
         self.assertContains(response, "id", status_code=201)
         self.assertTrue(Escrow.objects.filter(hold_type=Escrow.AUTHOR_RSC).count() == 1)
         author_pot = Escrow.objects.filter(hold_type=Escrow.AUTHOR_RSC).first()
-        self.assertTrue(author_pot.amount_holding == amount * 0.75)
-        self.assertTrue(Balance.objects.count() == 3)
+        self.assertTrue(author_pot.amount_holding == amount)
 
     def post_support_response(self, user, paper_id, amount=10):
         url = "/api/purchase/"

--- a/src/purchase/utils.py
+++ b/src/purchase/utils.py
@@ -10,15 +10,16 @@ def distribute_support_to_authors(paper, purchase, amount):
     total_author_count = paper.true_author_count()
 
     rewarded_rsc = 0
-    rsc_per_author = amount / total_author_count
-    for author in registered_authors.iterator():
-        recipient = author.user
-        distribution = create_purchase_distribution(recipient, rsc_per_author)
-        distributor = Distributor(
-            distribution, recipient, purchase, time.time(), purchase.user
-        )
-        distributor.distribute()
-        rewarded_rsc += rsc_per_author
+    if total_author_count:
+        rsc_per_author = amount / total_author_count
+        for author in registered_authors.iterator():
+            recipient = author.user
+            distribution = create_purchase_distribution(recipient, rsc_per_author)
+            distributor = Distributor(
+                distribution, recipient, purchase, time.time(), purchase.user
+            )
+            distributor.distribute()
+            rewarded_rsc += rsc_per_author
 
     store_leftover_paper_support(paper, purchase, amount - rewarded_rsc)
 

--- a/src/purchase/utils.py
+++ b/src/purchase/utils.py
@@ -1,0 +1,32 @@
+import time
+
+from reputation.distributions import create_purchase_distribution
+from reputation.distributor import Distributor
+from reputation.models import Escrow
+
+
+def distribute_support_to_authors(paper, purchase, amount):
+    registered_authors = paper.authors.all()
+    total_author_count = paper.true_author_count()
+
+    rewarded_rsc = 0
+    rsc_per_author = amount / total_author_count
+    for author in registered_authors.iterator():
+        recipient = author.user
+        distribution = create_purchase_distribution(recipient, rsc_per_author)
+        distributor = Distributor(
+            distribution, recipient, purchase, time.time(), purchase.user
+        )
+        distributor.distribute()
+        rewarded_rsc += rsc_per_author
+
+    store_leftover_paper_support(paper, purchase, amount - rewarded_rsc)
+
+
+def store_leftover_paper_support(paper, purchase, leftover_amount):
+    Escrow.objects.create(
+        created_by=purchase.user,
+        amount_holding=leftover_amount,
+        item=paper,
+        hold_type=Escrow.AUTHOR_RSC,
+    )

--- a/src/purchase/views.py
+++ b/src/purchase/views.py
@@ -37,6 +37,7 @@ from purchase.serializers import (
     WalletSerializer,
 )
 from purchase.tasks import send_support_email
+from purchase.utils import distribute_support_to_authors
 from reputation.distributions import Distribution, create_purchase_distribution
 from reputation.distributor import Distributor
 from reputation.models import Contribution, Escrow
@@ -188,12 +189,7 @@ class PurchaseViewSet(viewsets.ModelViewSet):
                 cache.delete(cache_key)
                 transfer_rsc = False
 
-                Escrow.objects.create(
-                    created_by=user,
-                    amount_holding=amount,
-                    item=paper,
-                    hold_type=Escrow.AUTHOR_RSC,
-                )
+                distribute_support_to_authors(paper, purchase, amount)
 
                 hub_ids = paper.hubs.values_list("id", flat=True)
                 reset_unified_document_cache(

--- a/src/reputation/distributions.py
+++ b/src/reputation/distributions.py
@@ -208,47 +208,8 @@ ReferralInvitedBonus = Distribution(
 )
 
 
-def create_purchase_distribution(user, amount, paper=None, purchaser=None):
-
-    distribution_amount = amount
-
-    if paper:
-        from reputation.distributor import Distributor
-        from reputation.models import Escrow
-        from researchhub_case.models import AuthorClaimCase
-
-        author_distribution_amount = distribution_amount * 0.75
-        distribution_amount *= 0.25  # authors get 75% of the upvote score
-        distributed_amount = 0
-        author_count = paper.true_author_count()
-
-        for author in paper.authors.all():
-            if (
-                author.user
-                and AuthorClaimCase.objects.filter(
-                    target_paper=paper, requestor=author.user, status=APPROVED
-                ).exists()
-            ):
-                timestamp = time()
-                amt = author_distribution_amount / author_count
-                distributor = Distributor(
-                    Distribution("PURCHASE", amt),
-                    author.user,
-                    paper,
-                    timestamp,
-                    purchaser,
-                    paper.hubs.all(),
-                )
-                record = distributor.distribute()
-                distributed_amount += amt
-
-        Escrow.objects.create(
-            created_by=user,
-            item=paper,
-            amount_holding=author_distribution_amount - distributed_amount,
-            hold_type=Escrow.AUTHOR_RSC,
-        )
-    return Distribution("PURCHASE", distribution_amount, False)
+def create_purchase_distribution(user, amount):
+    return Distribution("PURCHASE", amount, False)
 
 
 def create_bounty_rh_fee_distribution(amount):

--- a/src/reputation/distributions.py
+++ b/src/reputation/distributions.py
@@ -232,6 +232,11 @@ def create_bounty_refund_distribution(amount):
     return distribution
 
 
+def create_stored_paper_pot(amount):
+    distribution = Distribution("STORED_PAPER_POT", amount, give_rep=False)
+    return distribution
+
+
 DISTRIBUTION_TYPE_CHOICES = [
     (FlagPaper.name, FlagPaper.name),
     (PaperUpvoted.name, PaperUpvoted.name),
@@ -259,6 +264,7 @@ DISTRIBUTION_TYPE_CHOICES = [
     (HypothesisDownvoted.name, HypothesisDownvoted.name),
     (ReferralInvitedBonus.name, ReferralInvitedBonus.name),
     ("UPVOTE_RSC_POT", "UPVOTE_RSC_POT"),
+    ("STORED_PAPER_POT", "STORED_PAPER_POT"),
     ("REWARD", "REWARD"),
     ("PURCHASE", "PURCHASE"),
     (

--- a/src/reputation/tests/test_upvote_rsc_distribution.py
+++ b/src/reputation/tests/test_upvote_rsc_distribution.py
@@ -271,7 +271,7 @@ class BaseTests(TestCase, TestHelper):
 
         self.assertEquals(Distribution.objects.count(), 2)
         self.assertEquals(
-            Distribution.objects.filter(distribution_type="UPVOTE_RSC_POT")
+            Distribution.objects.filter(distribution_type="STORED_PAPER_POT")
             .first()
             .amount,
             math.floor(distribution_amount * 0.75 / 3),

--- a/src/researchhub_case/serializers/author_claim_case_serializer.py
+++ b/src/researchhub_case/serializers/author_claim_case_serializer.py
@@ -1,12 +1,10 @@
-from django.contrib.contenttypes.models import ContentType
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
 
 from paper.models import Paper
-from researchhub_case.constants.case_constants import APPROVED
 from researchhub_case.models import AuthorClaimCase
 from researchhub_case.tasks import trigger_email_validation_flow
-from user.models import Author, User
-from user.serializers import AuthorSerializer, UserSerializer
+from user.models import User
+from user.serializers import UserSerializer
 
 from .researchhub_case_abstract_serializer import EXPOSABLE_FIELDS
 

--- a/src/researchhub_case/tasks.py
+++ b/src/researchhub_case/tasks.py
@@ -53,11 +53,15 @@ def after_approval_flow(case_id):
         try:
             requestor_author = instance.requestor.author_profile
 
-            reward_author_claim_case(requestor_author, instance.target_paper, instance)
+            total_amount_paid = reward_author_claim_case(
+                requestor_author, instance.target_paper, instance
+            )
             if instance.target_paper is None:
                 raise Exception("Cannot approve claim because paper was not found")
 
-            send_approval_email(instance)
+            send_approval_email(
+                instance, context={"total_amount_paid": total_amount_paid}
+            )
             instance.target_paper.unified_document.update_filter(FILTER_AUTHOR_CLAIMED)
         except Exception as exception:
             sentry.log_error(exception)


### PR DESCRIPTION
Supporting papers with RSC will now go to the authors instead of the uploader
- Authors with an account are tipped (total support amount / total authors)
- Leftover RSC is stored in Escrow that can be claimed via AuthorClaim