### PR TITLE
RSC Upvote Update + Code Cleanup

### DIFF
--- a/src/discussion/tests/test_integration.py
+++ b/src/discussion/tests/test_integration.py
@@ -1,25 +1,23 @@
 import random
+from unittest import skip
+
+from utils.test_helpers import get_authenticated_post_response, get_user_from_response
 
 from .helpers import create_thread
 from .tests import BaseIntegrationTestCase
-from utils.test_helpers import (
-    get_authenticated_post_response,
-    get_user_from_response,
-)
-from unittest import skip
 
 
+@skip
 class DiscussionIntegrationTests(BaseIntegrationTestCase):
-
     def setUp(self):
-        SEED = 'discussion'
+        SEED = "discussion"
         self.random_generator = random.Random(SEED)
 
     @skip
     def test_discussion_view_shows_threads(self):
         thread = self.create_default_thread()
         paper_id = thread.paper.id
-        url = self.base_url + f'{paper_id}/discussion/'
+        url = self.base_url + f"{paper_id}/discussion/"
         response = self.get_get_response(url)
         text = thread.title
         self.assertContains(response, text, status_code=200)
@@ -49,7 +47,7 @@ class DiscussionIntegrationTests(BaseIntegrationTestCase):
         thread = create_thread()
         user = self.create_user_with_reputation(1)
         response = self.get_upvote_response(user, thread)
-        text = 'vote_type'
+        text = "vote_type"
         self.assertContains(response, text, status_code=201)
 
     def create_user_with_reputation(self, reputation):
@@ -62,13 +60,10 @@ class DiscussionIntegrationTests(BaseIntegrationTestCase):
     def get_thread_submission_response(self, user):
         paper = self.create_paper_without_authors()
         paper_id = paper.id
-        url = self.base_url + f'{paper_id}/discussion/'
+        url = self.base_url + f"{paper_id}/discussion/"
         form_data = self.build_default_thread_form(paper_id)
         response = get_authenticated_post_response(
-            user,
-            url,
-            form_data,
-            content_type='multipart/form-data'
+            user, url, form_data, content_type="multipart/form-data"
         )
         return response
 
@@ -78,29 +73,21 @@ class DiscussionIntegrationTests(BaseIntegrationTestCase):
 
         paper_id = thread.paper.id
 
-        url = self.base_url + f'{paper_id}/discussion/{thread_id}/comment/'
+        url = self.base_url + f"{paper_id}/discussion/{thread_id}/comment/"
 
         form_data = self.build_default_comment_form(thread_id)
 
         response = get_authenticated_post_response(
-            user,
-            url,
-            form_data,
-            content_type='multipart/form-data'
+            user, url, form_data, content_type="multipart/form-data"
         )
         return response
 
     def get_upvote_response(self, user, thread):
-        url = self.base_url + (
-            f'{thread.paper.id}/discussion/{thread.id}/upvote/'
-        )
+        url = self.base_url + (f"{thread.paper.id}/discussion/{thread.id}/upvote/")
 
         data = {}
 
         response = get_authenticated_post_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response

--- a/src/discussion/tests/test_views.py
+++ b/src/discussion/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest import skip
+
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
@@ -9,8 +11,8 @@ from discussion.tests.helpers import (
     create_paper,
     create_reply,
     create_thread,
+    downvote_discussion,
     upvote_discussion,
-    downvote_discussion
 )
 from discussion.views import get_thread_id_from_path
 from user.models import Author
@@ -18,22 +20,21 @@ from user.tests.helpers import create_random_authenticated_user
 from utils.test_helpers import (
     get_authenticated_delete_response,
     get_authenticated_patch_response,
-    get_authenticated_put_response
+    get_authenticated_put_response,
 )
-from unittest import skip
 
 
+@skip
 class DiscussionViewsTests(TestCase):
-
     def setUp(self):
-        self.base_url = '/api/'
-        self.user = create_random_authenticated_user('discussion_views')
+        self.base_url = "/api/"
+        self.user = create_random_authenticated_user("discussion_views")
         self.paper = create_paper(uploaded_by=self.user)
         self.thread = create_thread(paper=self.paper, created_by=self.user)
         self.comment = create_comment(thread=self.thread, created_by=self.user)
         self.reply = create_reply(parent=self.comment, created_by=self.user)
-        self.trouble_maker = create_random_authenticated_user('trouble_maker')
-        self.author = create_random_authenticated_user('author')
+        self.trouble_maker = create_random_authenticated_user("trouble_maker")
+        self.author = create_random_authenticated_user("author")
 
         self.paper.authors.add(Author.objects.get(user=self.author))
         self.paper.save()
@@ -41,16 +42,16 @@ class DiscussionViewsTests(TestCase):
     def test_get_thread_id_from_path(self):
         factory = APIRequestFactory()
 
-        request = factory.get('/api/paper/1/discussion/1/comments')
+        request = factory.get("/api/paper/1/discussion/1/comments")
         thread_id = get_thread_id_from_path(request)
 
-        request = factory.get('/api/paper/1/discussion/2/comments')
+        request = factory.get("/api/paper/1/discussion/2/comments")
         thread_id_2 = get_thread_id_from_path(request)
 
-        request = factory.get('/api/paper/43291/discussion/300/comments')
+        request = factory.get("/api/paper/43291/discussion/300/comments")
         thread_id_3 = get_thread_id_from_path(request)
 
-        request = factory.get('/api/paper/0/discussion/004/comments')
+        request = factory.get("/api/paper/0/discussion/004/comments")
         thread_id_4 = get_thread_id_from_path(request)
 
         self.assertEqual(thread_id, 1)
@@ -60,66 +61,57 @@ class DiscussionViewsTests(TestCase):
 
     @skip
     def test_thread_creator_can_update_thread(self):
-        text = 'update thread with patch'
+        text = "update thread with patch"
         patch_response = self.get_thread_patch_response(self.user, text)
         self.assertContains(patch_response, text, status_code=200)
 
-        text = 'update thread with put'
+        text = "update thread with put"
         put_response = self.get_thread_put_response(self.user, text)
 
         self.assertContains(put_response, text, status_code=200)
 
     @skip
     def test_ONLY_thread_creator_can_update_thread(self):
-        text = 'virus'
-        patch_response = self.get_thread_patch_response(
-            self.trouble_maker,
-            text
-        )
+        text = "virus"
+        patch_response = self.get_thread_patch_response(self.trouble_maker, text)
         put_response = self.get_thread_put_response(self.trouble_maker, text)
 
         self.assertEqual(patch_response.status_code, 403)
         self.assertEqual(put_response.status_code, 403)
 
     def test_comment_creator_can_update_comment(self):
-        text = 'update comment with patch'
+        text = "update comment with patch"
         patch_response = self.get_comment_patch_response(self.user, text)
 
         self.assertContains(patch_response, text, status_code=200)
 
-        text = 'update comment with put'
+        text = "update comment with put"
         put_response = self.get_comment_put_response(self.user, text)
 
         self.assertContains(put_response, text, status_code=200)
 
     def test_ONLY_comment_creator_can_update_comment(self):
-        text = 'virus'
-        patch_response = self.get_comment_patch_response(
-            self.trouble_maker,
-            text
-        )
+        text = "virus"
+        patch_response = self.get_comment_patch_response(self.trouble_maker, text)
         put_response = self.get_comment_put_response(self.trouble_maker, text)
 
         self.assertEqual(patch_response.status_code, 403)
         self.assertEqual(put_response.status_code, 403)
 
     def test_reply_creator_can_update_reply(self):
-        text = 'update reply with patch'
+        text = "update reply with patch"
         patch_response = self.get_reply_patch_response(self.user, text)
 
         self.assertContains(patch_response, text, status_code=200)
 
-        text = 'update reply with put'
+        text = "update reply with put"
         put_response = self.get_reply_put_response(self.user, text)
 
         self.assertContains(put_response, text, status_code=200)
 
     def test_ONLY_reply_creator_can_update_reply(self):
-        text = 'virus'
-        patch_response = self.get_reply_patch_response(
-            self.trouble_maker,
-            text
-        )
+        text = "virus"
+        patch_response = self.get_reply_patch_response(self.trouble_maker, text)
         put_response = self.get_reply_put_response(self.trouble_maker, text)
 
         self.assertEqual(patch_response.status_code, 403)
@@ -127,25 +119,17 @@ class DiscussionViewsTests(TestCase):
 
     @skip
     def test_flag_creator_can_delete_flag(self):
-        user = create_random_authenticated_user('flagger')
+        user = create_random_authenticated_user("flagger")
 
         thread_flag = create_flag(created_by=user, item=self.thread)
         thread_response = self.get_thread_flag_delete_response(user)
 
-        self.assertContains(
-            thread_response,
-            thread_flag.reason,
-            status_code=200
-        )
+        self.assertContains(thread_response, thread_flag.reason, status_code=200)
 
         comment_flag = create_flag(created_by=user, item=self.comment)
         comment_response = self.get_comment_flag_delete_response(user)
 
-        self.assertContains(
-            comment_response,
-            comment_flag.reason,
-            status_code=200
-        )
+        self.assertContains(comment_response, comment_flag.reason, status_code=200)
 
         reply_flag = create_flag(created_by=user, item=self.reply)
         reply_response = self.get_reply_flag_delete_response(user)
@@ -154,7 +138,7 @@ class DiscussionViewsTests(TestCase):
 
     @skip
     def test_ONLY_flag_creator_can_delete_flag(self):
-        user = create_random_authenticated_user('flagger1')
+        user = create_random_authenticated_user("flagger1")
 
         create_flag(created_by=user, item=self.thread)
         response = self.get_thread_flag_delete_response(self.trouble_maker)
@@ -172,80 +156,34 @@ class DiscussionViewsTests(TestCase):
     def test_endorsement_creator_can_delete_endorsement(self):
         user = self.author
 
-        thread_endorsement = create_endorsement(
-            created_by=user,
-            item=self.thread
-        )
+        thread_endorsement = create_endorsement(created_by=user, item=self.thread)
         thread_response = self.get_thread_endorsement_delete_response(user)
-        self.assertContains(
-            thread_response,
-            thread_endorsement.id,
-            status_code=200
-        )
+        self.assertContains(thread_response, thread_endorsement.id, status_code=200)
 
-        comment_endorsement = create_endorsement(
-            created_by=user,
-            item=self.comment
-        )
+        comment_endorsement = create_endorsement(created_by=user, item=self.comment)
         comment_response = self.get_comment_endorsement_delete_response(user)
-        self.assertContains(
-            comment_response,
-            comment_endorsement.id,
-            status_code=200
-        )
+        self.assertContains(comment_response, comment_endorsement.id, status_code=200)
 
-        reply_endorsement = create_endorsement(
-            created_by=user,
-            item=self.reply
-        )
+        reply_endorsement = create_endorsement(created_by=user, item=self.reply)
         reply_response = self.get_reply_endorsement_delete_response(user)
-        self.assertContains(
-            reply_response,
-            reply_endorsement.id,
-            status_code=200
-        )
-
+        self.assertContains(reply_response, reply_endorsement.id, status_code=200)
 
     @skip
     def test_ONLY_endorsement_creator_can_delete_endorsement(self):
-        user = create_random_authenticated_user('endorser1')
+        user = create_random_authenticated_user("endorser1")
         self.paper.authors.add(Author.objects.get(user=user))
 
-        create_endorsement(
-            created_by=self.author,
-            item=self.thread
-        )
-        thread_response = self.get_thread_endorsement_delete_response(
-            user
-        )
-        self.assertEqual(
-            thread_response.status_code,
-            400
-        )
+        create_endorsement(created_by=self.author, item=self.thread)
+        thread_response = self.get_thread_endorsement_delete_response(user)
+        self.assertEqual(thread_response.status_code, 400)
 
-        create_endorsement(
-            created_by=self.author,
-            item=self.comment
-        )
-        comment_response = self.get_comment_endorsement_delete_response(
-            user
-        )
-        self.assertEqual(
-            comment_response.status_code,
-            400
-        )
+        create_endorsement(created_by=self.author, item=self.comment)
+        comment_response = self.get_comment_endorsement_delete_response(user)
+        self.assertEqual(comment_response.status_code, 400)
 
-        create_endorsement(
-            created_by=self.author,
-            item=self.reply
-        )
-        reply_response = self.get_reply_endorsement_delete_response(
-            user
-        )
-        self.assertEqual(
-            reply_response.status_code,
-            400
-        )
+        create_endorsement(created_by=self.author, item=self.reply)
+        reply_response = self.get_reply_endorsement_delete_response(user)
+        self.assertEqual(reply_response.status_code, 400)
 
     def test_can_delete_upvote(self):
         comment_vote = upvote_discussion(self.comment, self.user)
@@ -258,142 +196,109 @@ class DiscussionViewsTests(TestCase):
         self.assertContains(response, comment_vote.id, status_code=200)
 
     def get_thread_patch_response(self, user, text):
-        url, data = self.get_request_config('thread', text)
+        url, data = self.get_request_config("thread", text)
         response = get_authenticated_patch_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response
 
     def get_thread_put_response(self, user, text):
-        url = build_discussion_detail_url(self, 'thread')
-        data = {
-            'title': text,
-            'text': text
-        }
+        url = build_discussion_detail_url(self, "thread")
+        data = {"title": text, "text": text}
         response = get_authenticated_put_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response
 
     def get_comment_patch_response(self, user, text):
-        url, data = self.get_request_config('comment', text)
+        url, data = self.get_request_config("comment", text)
         response = get_authenticated_patch_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response
 
     def get_comment_put_response(self, user, text):
-        url, data = self.get_request_config('comment', text)
+        url, data = self.get_request_config("comment", text)
         response = get_authenticated_put_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response
 
     def get_reply_patch_response(self, user, text):
-        url, data = self.get_request_config('reply', text)
+        url, data = self.get_request_config("reply", text)
         response = get_authenticated_patch_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response
 
     def get_reply_put_response(self, user, text):
-        url = build_discussion_detail_url(self, 'reply')
-        data = {
-            'parent': self.comment.id,
-            'text': text
-        }
+        url = build_discussion_detail_url(self, "reply")
+        data = {"parent": self.comment.id, "text": text}
         response = get_authenticated_put_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response
 
     def get_request_config(self, discussion_type, text):
         url = build_discussion_detail_url(self, discussion_type)
-        data = {'text': text}
+        data = {"text": text}
         return url, data
 
     def get_thread_endorsement_delete_response(self, user):
-        url = build_discussion_detail_url(self, 'thread')
+        url = build_discussion_detail_url(self, "thread")
         response = self.get_endorsement_delete_response(user, url)
         return response
 
     def get_comment_endorsement_delete_response(self, user):
-        url = build_discussion_detail_url(self, 'comment')
+        url = build_discussion_detail_url(self, "comment")
         response = self.get_endorsement_delete_response(user, url)
         return response
 
     def get_reply_endorsement_delete_response(self, user):
-        url = build_discussion_detail_url(self, 'reply')
+        url = build_discussion_detail_url(self, "reply")
         response = self.get_endorsement_delete_response(user, url)
         return response
 
     def get_endorsement_delete_response(self, user, url):
-        url += 'endorse/'
+        url += "endorse/"
         data = None
         response = get_authenticated_delete_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response
 
     def get_thread_flag_delete_response(self, user):
-        url = build_discussion_detail_url(self, 'thread')
+        url = build_discussion_detail_url(self, "thread")
         response = self.get_flag_delete_response(user, url)
         return response
 
     def get_comment_flag_delete_response(self, user):
-        url = build_discussion_detail_url(self, 'comment')
+        url = build_discussion_detail_url(self, "comment")
         response = self.get_flag_delete_response(user, url)
         return response
 
     def get_reply_flag_delete_response(self, user):
-        url = build_discussion_detail_url(self, 'reply')
+        url = build_discussion_detail_url(self, "reply")
         response = self.get_flag_delete_response(user, url)
         return response
 
     def get_flag_delete_response(self, user, url):
-        url += 'flag/'
+        url += "flag/"
         data = None
         response = get_authenticated_delete_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response
 
     def get_comment_vote_delete_response(self, user):
-        url = build_discussion_detail_url(self, 'comment')
+        url = build_discussion_detail_url(self, "comment")
         response = self.get_vote_delete_response(user, url)
         return response
 
     def get_vote_delete_response(self, user, url):
-        url += 'user_vote/'
+        url += "user_vote/"
         data = None
         response = get_authenticated_delete_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response

--- a/src/reputation/distributions.py
+++ b/src/reputation/distributions.py
@@ -1,4 +1,5 @@
 import datetime
+import decimal
 from time import time
 
 import pytz
@@ -98,9 +99,13 @@ def create_upvote_distribution(vote_type, paper=None, vote=None):
         from reputation.distributor import Distributor
         from researchhub_case.models import AuthorClaimCase
 
-        author_distribution_amount = distribution_amount * 0.95
-        distribution_amount *= 0.05  # authors get 95% of the upvote score
-        distributed_amount = 0
+        author_distribution_amount = round(
+            decimal.Decimal(distribution_amount * 0.95), 10
+        )
+        distribution_amount *= round(
+            decimal.Decimal(0.05), 10
+        )  # authors get 95% of the upvote score
+        distributed_amount = decimal.Decimal(0)
         author_count = paper.true_author_count()
 
         for author in paper.authors.all():

--- a/src/reputation/distributions.py
+++ b/src/reputation/distributions.py
@@ -98,8 +98,8 @@ def create_upvote_distribution(vote_type, paper=None, vote=None):
         from reputation.distributor import Distributor
         from researchhub_case.models import AuthorClaimCase
 
-        author_distribution_amount = distribution_amount * 0.75
-        distribution_amount *= 0.25  # authors get 75% of the upvote score
+        author_distribution_amount = distribution_amount * 0.95
+        distribution_amount *= 0.05  # authors get 95% of the upvote score
         distributed_amount = 0
         author_count = paper.true_author_count()
 

--- a/src/reputation/signals.py
+++ b/src/reputation/signals.py
@@ -356,7 +356,6 @@ def distribute_for_discussion_vote(sender, instance, created, update_fields, **k
     if (
         created or vote_type_updated(update_fields)
     ) and is_eligible_for_discussion_vote(recipient, voter):
-
         hubs = None
         item = instance.item
         if isinstance(item, RhCommentModel):
@@ -439,13 +438,14 @@ def get_discussion_vote_item_distribution(instance):
     item_type = type(item)
 
     error = TypeError(f"Instance of type {item_type} is not supported")
-
+    paper = None
     if vote_type == GrmVote.UPVOTE:
         if isinstance(item, RhCommentModel):
             vote_type = distributions.RhCommentUpvoted.name
         elif isinstance(item, ResearchhubPost):
             vote_type = distributions.ResearchhubPostUpvoted.name
         elif isinstance(item, Paper):
+            paper = item
             vote_type = distributions.PaperUpvoted.name
         elif isinstance(item, Hypothesis):
             vote_type = distributions.HypothesisUpvoted.name
@@ -454,7 +454,7 @@ def get_discussion_vote_item_distribution(instance):
         else:
             raise error
 
-        return distributions.create_upvote_distribution(vote_type, None, instance)
+        return distributions.create_upvote_distribution(vote_type, paper, instance)
     elif vote_type == GrmVote.DOWNVOTE:
         if isinstance(item, RhCommentModel):
             vote_type = distributions.RhCommentDownvoted

--- a/src/reputation/tests/test_upvote_rsc_distribution.py
+++ b/src/reputation/tests/test_upvote_rsc_distribution.py
@@ -52,7 +52,7 @@ class BaseTests(TestCase, TestHelper):
         self.assertEquals(Escrow.objects.filter(hold_type=Escrow.AUTHOR_RSC).count(), 1)
         self.assertEquals(
             Escrow.objects.filter(hold_type=Escrow.AUTHOR_RSC).first().amount_holding,
-            decimal.Decimal(distribution_amount * 0.95),
+            round(decimal.Decimal(distribution_amount * 0.95), 10),
         )
 
     def test_no_verified_author_distribution(

--- a/src/reputation/tests/test_upvote_rsc_distribution.py
+++ b/src/reputation/tests/test_upvote_rsc_distribution.py
@@ -87,7 +87,9 @@ class BaseTests(TestCase, TestHelper):
         )
         distribution_amount = calculate_rsc_per_upvote()
         self.assertEquals(Distribution.objects.count(), 0)
-        self.assertEquals(distribution.amount, distribution_amount * 0.05)
+        self.assertEquals(
+            distribution.amount, round(decimal.Decimal(distribution_amount * 0.05), 10)
+        )
 
     def test_author_claim_distribution(
         self,

--- a/src/reputation/tests/test_upvote_rsc_distribution.py
+++ b/src/reputation/tests/test_upvote_rsc_distribution.py
@@ -51,7 +51,7 @@ class BaseTests(TestCase, TestHelper):
         self.assertEquals(Escrow.objects.filter(hold_type=Escrow.AUTHOR_RSC).count(), 1)
         self.assertEquals(
             Escrow.objects.filter(hold_type=Escrow.AUTHOR_RSC).first().amount_holding,
-            distribution_amount * 0.75,
+            distribution_amount * 0.95,
         )
 
     def test_no_verified_author_distribution(
@@ -86,7 +86,7 @@ class BaseTests(TestCase, TestHelper):
         )
         distribution_amount = calculate_rsc_per_upvote()
         self.assertEquals(Distribution.objects.count(), 0)
-        self.assertEquals(distribution.amount, distribution_amount * 0.25)
+        self.assertEquals(distribution.amount, distribution_amount * 0.05)
 
     def test_author_claim_distribution(
         self,
@@ -125,7 +125,7 @@ class BaseTests(TestCase, TestHelper):
         self.assertEquals(Distribution.objects.count(), 1)
         self.assertEquals(
             Distribution.objects.first().amount,
-            math.floor(distribution_amount * 0.75 / 3),
+            math.floor(distribution_amount * 0.95 / 3),
         )
 
     def test_comment_upvote_distribution(self):
@@ -274,5 +274,5 @@ class BaseTests(TestCase, TestHelper):
             Distribution.objects.filter(distribution_type="STORED_PAPER_POT")
             .first()
             .amount,
-            math.floor(distribution_amount * 0.75 / 3),
+            math.floor(distribution_amount * 0.95 / 3),
         )

--- a/src/reputation/tests/test_upvote_rsc_distribution.py
+++ b/src/reputation/tests/test_upvote_rsc_distribution.py
@@ -1,3 +1,4 @@
+import decimal
 import math
 
 from django.contrib.admin.options import get_content_type_for_model
@@ -51,7 +52,7 @@ class BaseTests(TestCase, TestHelper):
         self.assertEquals(Escrow.objects.filter(hold_type=Escrow.AUTHOR_RSC).count(), 1)
         self.assertEquals(
             Escrow.objects.filter(hold_type=Escrow.AUTHOR_RSC).first().amount_holding,
-            distribution_amount * 0.95,
+            decimal.Decimal(distribution_amount * 0.95),
         )
 
     def test_no_verified_author_distribution(

--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -16,7 +16,6 @@ from django.urls import include, path, re_path
 from rest_framework import routers
 
 import analytics.views
-import discussion.views
 import google_analytics.views
 import hub.views
 import hypothesis.views as hypothesis_views
@@ -44,7 +43,6 @@ from peer_review.views import (
 )
 from referral.referral_invite_view import ReferralInviteViewSet
 from researchhub.settings import INSTALLED_APPS, USE_DEBUG_TOOLBAR
-from researchhub_comment.views.rh_comment_thread_view import RhCommentThreadViewSet
 from researchhub_comment.views.rh_comment_view import RhCommentViewSet
 from review.views.review_view import ReviewViewSet
 from user.views import editor_views
@@ -55,106 +53,6 @@ router.register(
     r"new_feature_release",
     new_feature_release.views.NewFeatureViewSet,
     basename="new_feature_release",
-)
-
-# NOTE: calvinhlee - the way coments are handled is very inefficient. We need to refactor this
-
-router.register(r"discussion", discussion.views.ThreadViewSet, basename="discussion")
-router.register(
-    r"paper/([0-9]+)/discussion/([0-9]+)/comment/([0-9]+)/reply",
-    discussion.views.ReplyViewSet,
-    basename="discussion_thread_comment_replies",
-)
-
-router.register(
-    r"paper/([0-9]+)/discussion/([0-9]+)/comment",
-    discussion.views.CommentViewSet,
-    basename="discussion_thread_comments",
-)
-
-router.register(
-    r"paper/([0-9]+)/discussion",
-    discussion.views.ThreadViewSet,
-    basename="discussion_threads",
-)
-
-router.register(
-    r"researchhub_post/([0-9]+)/discussion/([0-9]+)/comment/([0-9]+)/reply",
-    discussion.views.ReplyViewSet,
-    basename="post_discussion_thread_comment_replies",
-)
-
-router.register(
-    r"researchhub_post/([0-9]+)/discussion/([0-9]+)/comment",
-    discussion.views.CommentViewSet,
-    basename="post_discussion_thread_comments",
-)
-
-router.register(
-    r"researchhub_post/([0-9]+)/discussion",
-    discussion.views.ThreadViewSet,
-    basename="post_discussion_threads",
-)
-
-router.register(
-    r"hypothesis/([0-9]+)/discussion/([0-9]+)/comment/([0-9]+)/reply",
-    discussion.views.ReplyViewSet,
-    basename="hypothesis_discussion_thread_comment_replies",
-)
-
-router.register(
-    r"hypothesis/([0-9]+)/discussion/([0-9]+)/comment",
-    discussion.views.CommentViewSet,
-    basename="hypothesis_discussion_thread_comments",
-)
-
-router.register(
-    r"hypothesis/([0-9]+)/discussion",
-    discussion.views.ThreadViewSet,
-    basename="hypothesis_discussion_threads",
-)
-
-router.register(
-    r"citation/([0-9]+)/discussion/([0-9]+)/comment/([0-9]+)/reply",
-    discussion.views.ReplyViewSet,
-    basename="citation_discussion_thread_comment_replies",
-)
-
-router.register(
-    r"citation/([0-9]+)/discussion/([0-9]+)/comment",
-    discussion.views.CommentViewSet,
-    basename="citation_discussion_thread_comments",
-)
-
-router.register(
-    r"citation/([0-9]+)/discussion",
-    discussion.views.ThreadViewSet,
-    basename="citation_discussion_threads",
-)
-
-router.register(
-    r"peer_review/([0-9]+)/discussion/([0-9]+)/comment/([0-9]+)/reply",
-    discussion.views.ReplyViewSet,
-    basename="post_discussion_thread_comment_replies",
-)
-
-router.register(
-    r"peer_review/([0-9]+)/discussion/([0-9]+)/comment",
-    discussion.views.CommentViewSet,
-    basename="post_discussion_thread_comments",
-)
-
-router.register(
-    r"peer_review/([0-9]+)/discussion",
-    discussion.views.ThreadViewSet,
-    basename="post_discussion_threads",
-)
-
-
-router.register(
-    r"paper/discussion/file",
-    discussion.views.CommentFileUpload,
-    basename="discussion_file_upload",
 )
 
 router.register(
@@ -178,8 +76,6 @@ router.register(
 )
 
 router.register(r"author", user.views.AuthorViewSet, basename="author")
-
-router.register(r"summary", summary.views.SummaryViewSet, basename="summary")
 
 router.register(r"hub", hub.views.HubViewSet, basename="hub")
 
@@ -228,21 +124,6 @@ router.register(
 )
 
 router.register(r"purchase", purchase.views.PurchaseViewSet, basename="purchase")
-
-
-# Deprecated endpoints
-
-# router.register(
-#     r'support',
-#     purchase.views.SupportViewSet,
-#     basename='support'
-# )
-
-# router.register(
-#     r'stripe',
-#     purchase.views.StripeViewSet,
-#     basename='stripe'
-# )
 
 router.register(r"transactions", purchase.views.BalanceViewSet, basename="transactions")
 

--- a/src/summary/tests/test_permissions.py
+++ b/src/summary/tests/test_permissions.py
@@ -1,34 +1,31 @@
+from unittest import skip
+
 from django.test import TestCase
 
-from .helpers import build_summary_data, create_summary
 from paper.tests.helpers import create_paper
 from user.tests.helpers import (
     create_random_authenticated_user,
-    create_random_authenticated_user_with_reputation
+    create_random_authenticated_user_with_reputation,
 )
 from utils.test_helpers import (
     get_authenticated_delete_response,
     get_authenticated_patch_response,
     get_authenticated_post_response,
-    get_authenticated_put_response
+    get_authenticated_put_response,
 )
-from unittest import skip
+
+from .helpers import build_summary_data, create_summary
 
 
+@skip
 class SummaryPermissionsTests(TestCase):
-
     def setUp(self):
-        self.base_url = '/api/summary/'
-        self.user = create_random_authenticated_user('summary_user')
-        self.paper = create_paper(title='Summary Permissions Tests')
-        self.summary_text = 'This is a summary for the permissions tests'
-        self.summary = create_summary(
-            self.summary_text,
-            self.user,
-            self.paper.id
-        )
+        self.base_url = "/api/summary/"
+        self.user = create_random_authenticated_user("summary_user")
+        self.paper = create_paper(title="Summary Permissions Tests")
+        self.summary_text = "This is a summary for the permissions tests"
+        self.summary = create_summary(self.summary_text, self.user, self.paper.id)
 
-    @skip
     def test_can_propose_summary_edit_with_minimum_reputation(self):
         # TODO: Get reputation from json
         user = create_random_authenticated_user_with_reputation(1, 1)
@@ -42,175 +39,125 @@ class SummaryPermissionsTests(TestCase):
 
     @skip
     def test_can_propose_first_summary_if_user_is_uploader(self):
-        uploader = create_random_authenticated_user_with_reputation(
-            'uploader',
-            0
-        )
-        paper = create_paper(
-            title='Summary Paper With Uploader',
-            uploaded_by=uploader
-        )
-        response = self.get_first_summary_post_response(
-            uploader,
-            paper_id=paper.id
-        )
+        uploader = create_random_authenticated_user_with_reputation("uploader", 0)
+        paper = create_paper(title="Summary Paper With Uploader", uploaded_by=uploader)
+        response = self.get_first_summary_post_response(uploader, paper_id=paper.id)
         self.assertEqual(response.status_code, 201)
 
     def test_can_NOT_propose_first_summary_if_user_is_not_uploader(self):
-        user = create_random_authenticated_user_with_reputation(
-            'not_uploader',
-            0
-        )
-        response = self.get_first_summary_post_response(
-            user
-        )
+        user = create_random_authenticated_user_with_reputation("not_uploader", 0)
+        response = self.get_first_summary_post_response(user)
         self.assertEqual(response.status_code, 403)
 
     def test_can_patch_unapproved_summary_when_user_is_proposer(self):
-        proposer = create_random_authenticated_user('patch_proposer')
-        summary = create_summary('patch summary', proposer, self.paper.id)
+        proposer = create_random_authenticated_user("patch_proposer")
+        summary = create_summary("patch summary", proposer, self.paper.id)
         response = self.get_summary_patch_response(proposer, summary=summary)
         self.assertEqual(response.status_code, 200)
 
     def test_can_NOT_patch_unapproved_summary_when_not_proposer(self):
-        user = create_random_authenticated_user('not_patch_proposer')
+        user = create_random_authenticated_user("not_patch_proposer")
         response = self.get_summary_patch_response(user)
         self.assertEqual(response.status_code, 403)
 
     def test_uploader_can_patch_approved_summary_without_approver(self):
-        user = create_random_authenticated_user('patch_uploader')
+        user = create_random_authenticated_user("patch_uploader")
         paper = create_paper(uploaded_by=user)
         approver = None
-        summary = self.create_approved_summary(
-            user,
-            approver,
-            paper_id=paper.id
-        )
+        summary = self.create_approved_summary(user, approver, paper_id=paper.id)
         response = self.get_summary_patch_response(user, summary=summary)
         self.assertEqual(response.status_code, 200)
 
     def test_can_NOT_patch_approved_summary_without_approver(self):
-        user = create_random_authenticated_user('fail_patch_uploader')
+        user = create_random_authenticated_user("fail_patch_uploader")
         approver = None
-        summary = self.create_approved_summary(
-            user,
-            approver
-        )
+        summary = self.create_approved_summary(user, approver)
         response = self.get_summary_patch_response(user, summary=summary)
         self.assertEqual(response.status_code, 403)
 
     def test_can_NOT_patch_summary_if_approved_by_user(self):
-        user = create_random_authenticated_user('fail_patch')
+        user = create_random_authenticated_user("fail_patch")
         paper = create_paper(uploaded_by=user)
         approver = self.user
-        summary = self.create_approved_summary(
-            user,
-            approver,
-            paper_id=paper.id
-        )
+        summary = self.create_approved_summary(user, approver, paper_id=paper.id)
         response = self.get_summary_patch_response(user, summary=summary)
         self.assertEqual(response.status_code, 403)
 
     def test_can_put_unapproved_summary_when_user_is_proposer(self):
-        proposer = create_random_authenticated_user('put_proposer')
-        summary = create_summary('put summary', proposer, self.paper.id)
+        proposer = create_random_authenticated_user("put_proposer")
+        summary = create_summary("put summary", proposer, self.paper.id)
         response = self.get_summary_put_response(proposer, summary=summary)
         self.assertEqual(response.status_code, 200)
 
     def test_can_NOT_put_unapproved_summary_when_not_proposer(self):
-        user = create_random_authenticated_user('not_put_proposer')
+        user = create_random_authenticated_user("not_put_proposer")
         response = self.get_summary_put_response(user)
         self.assertEqual(response.status_code, 403)
 
     def test_uploader_can_put_approved_summary_without_approver(self):
-        user = create_random_authenticated_user('put_uploader')
+        user = create_random_authenticated_user("put_uploader")
         paper = create_paper(uploaded_by=user)
         approver = None
-        summary = self.create_approved_summary(
-            user,
-            approver,
-            paper_id=paper.id
-        )
+        summary = self.create_approved_summary(user, approver, paper_id=paper.id)
         response = self.get_summary_put_response(user, summary=summary)
         self.assertEqual(response.status_code, 200)
 
     def test_can_NOT_put_approved_summary_without_approver(self):
-        user = create_random_authenticated_user('fail_put_uploader')
+        user = create_random_authenticated_user("fail_put_uploader")
         approver = None
-        summary = self.create_approved_summary(
-            user,
-            approver
-        )
+        summary = self.create_approved_summary(user, approver)
         response = self.get_summary_put_response(user, summary=summary)
         self.assertEqual(response.status_code, 403)
 
     def test_can_NOT_put_summary_if_approved_by_user(self):
-        user = create_random_authenticated_user('fail_put')
+        user = create_random_authenticated_user("fail_put")
         paper = create_paper(uploaded_by=user)
         approver = self.user
-        summary = self.create_approved_summary(
-            user,
-            approver,
-            paper_id=paper.id
-        )
+        summary = self.create_approved_summary(user, approver, paper_id=paper.id)
         response = self.get_summary_put_response(user, summary=summary)
         self.assertEqual(response.status_code, 403)
 
     def test_can_delete_unapproved_summary_when_user_is_proposer(self):
-        proposer = create_random_authenticated_user('delete_proposer')
-        summary = create_summary('delete summary', proposer, self.paper.id)
+        proposer = create_random_authenticated_user("delete_proposer")
+        summary = create_summary("delete summary", proposer, self.paper.id)
         response = self.get_summary_delete_response(proposer, summary=summary)
         self.assertEqual(response.status_code, 204)
 
     def test_can_NOT_delete_unapproved_summary_when_not_proposer(self):
-        user = create_random_authenticated_user('not_delete_proposer')
+        user = create_random_authenticated_user("not_delete_proposer")
         response = self.get_summary_delete_response(user)
         self.assertEqual(response.status_code, 403)
 
     def test_uploader_can_delete_approved_summary_without_approver(self):
-        user = create_random_authenticated_user('delete_uploader')
+        user = create_random_authenticated_user("delete_uploader")
         paper = create_paper(uploaded_by=user)
         approver = None
-        summary = self.create_approved_summary(
-            user,
-            approver,
-            paper_id=paper.id
-        )
+        summary = self.create_approved_summary(user, approver, paper_id=paper.id)
         response = self.get_summary_delete_response(user, summary=summary)
         self.assertEqual(response.status_code, 204)
 
     def test_can_NOT_delete_approved_summary_without_approver(self):
-        user = create_random_authenticated_user('fail_delete_uploader')
+        user = create_random_authenticated_user("fail_delete_uploader")
         approver = None
-        summary = self.create_approved_summary(
-            user,
-            approver
-        )
+        summary = self.create_approved_summary(user, approver)
         response = self.get_summary_delete_response(user, summary=summary)
         self.assertEqual(response.status_code, 403)
 
     def test_can_NOT_delete_summary_if_approved_by_user(self):
-        user = create_random_authenticated_user('fail_delete')
+        user = create_random_authenticated_user("fail_delete")
         paper = create_paper(uploaded_by=user)
         approver = self.user
-        summary = self.create_approved_summary(
-            user,
-            approver,
-            paper_id=paper.id
-        )
+        summary = self.create_approved_summary(user, approver, paper_id=paper.id)
         response = self.get_summary_delete_response(user, summary=summary)
         self.assertEqual(response.status_code, 403)
 
     def get_first_summary_post_response(self, user, paper_id=None):
         if paper_id is None:
             paper_id = self.paper.id
-        url = self.base_url + 'first/'
+        url = self.base_url + "first/"
         data = build_summary_data(self.summary_text, paper_id, None)
         response = get_authenticated_post_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response
 
@@ -220,49 +167,37 @@ class SummaryPermissionsTests(TestCase):
         url = self.base_url
         data = build_summary_data(self.summary_text, paper_id, None)
         response = get_authenticated_post_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response
 
     def get_summary_patch_response(self, user, summary=None):
         if summary is None:
             summary = self.summary
-        url = self.base_url + f'{summary.id}/'
-        data = {'summary': 'A patch update'}
+        url = self.base_url + f"{summary.id}/"
+        data = {"summary": "A patch update"}
         response = get_authenticated_patch_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response
 
     def get_summary_put_response(self, user, summary=None):
         if summary is None:
             summary = self.summary
-        url = self.base_url + f'{summary.id}/'
-        data = build_summary_data('A put update', self.paper.id, None)
+        url = self.base_url + f"{summary.id}/"
+        data = build_summary_data("A put update", self.paper.id, None)
         response = get_authenticated_put_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response
 
     def get_summary_delete_response(self, user, summary=None):
         if summary is None:
             summary = self.summary
-        url = self.base_url + f'{summary.id}/'
+        url = self.base_url + f"{summary.id}/"
         data = None
         response = get_authenticated_delete_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )
         return response
 

--- a/src/summary/tests/test_views.py
+++ b/src/summary/tests/test_views.py
@@ -1,13 +1,15 @@
+from unittest import skip
+
 from django.test import TestCase
 
 from user.tests.helpers import create_random_authenticated_user
 from utils.test_helpers import get_authenticated_post_response
 
 
+@skip
 class SummaryViewsTests(TestCase):
-
     def setUp(self):
-        self.user = create_random_authenticated_user('summary_views')
+        self.user = create_random_authenticated_user("summary_views")
 
     def test_post_propose_edit_route_gives_405(self):
         # Because you can't post to a detail route
@@ -15,11 +17,8 @@ class SummaryViewsTests(TestCase):
         self.assertEqual(response.status_code, 405)
 
     def get_propose_edit_post_response(self, user):
-        url = '/api/summary/propose_edit/'
+        url = "/api/summary/propose_edit/"
         data = None
         return get_authenticated_post_response(
-            user,
-            url,
-            data,
-            content_type='application/json'
+            user, url, data, content_type="application/json"
         )


### PR DESCRIPTION
Fixed bug where upvoting a paper was not correctly allocating to author claim pot
Updated amount of RSC that goes to authors from 75% to 95%
Removed legacy discussion APIs and other deprecated APIs