### PR TITLE
Update Pagination Logic on Hubs

### DIFF
--- a/src/config/ci/keys.py
+++ b/src/config/ci/keys.py
@@ -59,3 +59,7 @@ TRANSPOSE_KEY = os.environ.get("TRANSPOSE_KEY", "")
 
 SERP_API_KEY = os.environ.get("SERP_API_KEY", "")
 OPENALEX_KEY = os.environ.get("OPENALEX_KEY", "")
+LINKEDIN_CLIENT_ID = os.environ.get("LINKEDIN_CLIENT_ID", "")
+LINKEDIN_CLIENT_SECRET = os.environ.get("LINKEDIN_CLIENT_SECRET", "")
+LINKEDIN_CALLBACK_URL = os.environ.get("LINKEDIN_CALLBACK_URL", "")
+ORCID_REDIRECT_URL = os.environ.get("ORCID_REDIRECT_URL", "")

--- a/src/hub/filters.py
+++ b/src/hub/filters.py
@@ -1,55 +1,11 @@
-from datetime import timedelta
-
 from django.contrib.postgres.search import TrigramSimilarity
-from django.db.models import Count, F, FileField, Q
-from django.utils import timezone
+from django.db.models import FileField
 from django_filters import rest_framework as filters
-
-from discussion.reaction_models import Vote
 
 from .models import Hub
 
-
-class ScoreOrderingFilter(filters.OrderingFilter):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.extra["choices"] += ["score", "-score"]
-
-    def filter(self, qs, value):
-        if value and any(v in ["score", "-score"] for v in value):
-            two_weeks_ago = timezone.now().date() - timedelta(days=14)
-            num_upvotes = Count(
-                "papers__votes__vote_type",
-                filter=Q(
-                    papers__votes__vote_type=Vote.UPVOTE,
-                    papers__votes__created_date__gte=two_weeks_ago,
-                ),
-            )
-            num_downvotes = Count(
-                "papers__votes__vote_type",
-                filter=Q(
-                    papers__votes__vote_type=Vote.DOWNVOTE,
-                    papers__votes__created_date__gte=two_weeks_ago,
-                ),
-            )
-
-            DISCUSSION_FACTOR = 10
-            score = (
-                (num_upvotes - num_downvotes)
-                + DISCUSSION_FACTOR * F("discussion_count")
-                + F("paper_count")
-            )
-
-            qs = qs.annotate(score=score).order_by(*value, "id")
-            return qs
-
-        else:
-            return super().filter(qs, value)
-
-
 class HubFilter(filters.FilterSet):
     name__iexact = filters.Filter(field_name="name", lookup_expr="iexact")
-    ordering = ScoreOrderingFilter(fields=["name", "score"])
     name__fuzzy = filters.Filter(
         field_name="name", method="name_trigram_similarity_search"
     )

--- a/src/hub/filters.py
+++ b/src/hub/filters.py
@@ -40,7 +40,7 @@ class ScoreOrderingFilter(filters.OrderingFilter):
                 + F("paper_count")
             )
 
-            qs = qs.annotate(score=score).order_by("-score")
+            qs = qs.annotate(score=score).order_by(*value, "id")
             return qs
 
         else:

--- a/src/hub/tests/test_views.py
+++ b/src/hub/tests/test_views.py
@@ -63,16 +63,17 @@ class HubViewsTests(APITestCase):
 
         self.assertTrue(response.status_code, 401)
 
-    def test_hub_order_by_score(self):
-        hub = create_hub('High Score Hub')
-        hub2 = create_hub('Low Score Hub')
+    def test_hub_order_by_paper_count(self):
+        hub = create_hub('High Paper Count Hub')
+        hub2 = create_hub('Low Paper Count Hub')
 
         paper = create_paper()
         hub.papers.add(paper)
         hub.paper_count = 1
         hub.save()
 
-        url = self.base_url + '?ordering=-score'
+        # this is a specific ordering used for the front end
+        url = self.base_url + '?ordering=-paper_count,-discussion_count,id'
         response = get_get_response(url)
         response_data = response.data['results']
 

--- a/src/hub/tests/test_views.py
+++ b/src/hub/tests/test_views.py
@@ -16,6 +16,7 @@ from utils.test_helpers import (
 from unittest import skip
 from hub.models import Hub
 
+
 class HubViewsTests(APITestCase):
 
     def setUp(self):
@@ -62,13 +63,14 @@ class HubViewsTests(APITestCase):
 
         self.assertTrue(response.status_code, 401)
 
-    @skip
     def test_hub_order_by_score(self):
         hub = create_hub('High Score Hub')
         hub2 = create_hub('Low Score Hub')
 
-        actions = create_actions(10, hub=hub)
-        actions = create_actions(5, hub=hub2)
+        paper = create_paper()
+        hub.papers.add(paper)
+        hub.paper_count = 1
+        hub.save()
 
         url = self.base_url + '?ordering=-score'
         response = get_get_response(url)
@@ -97,6 +99,60 @@ class HubViewsTests(APITestCase):
                 h1_second = True
 
         self.assertTrue(h2_first and h1_second)
+
+    def test_hub_order_by_name(self):
+        hub = create_hub('Hub A')
+        hub2 = create_hub('Hub B')
+
+        url = self.base_url + '?ordering=name'
+        response = get_get_response(url)
+        response_data = response.data['results']
+
+        h1_first = False
+        h2_second = False
+        for h in response_data:
+            if h['id'] == hub.id:
+                h1_first = True
+            elif h1_first and h['id'] == hub2.id:
+                h2_second = True
+
+        self.assertTrue(h1_first and h2_second)
+
+        url = self.base_url + '?ordering=-name'
+        response = get_get_response(url)
+        response_data = response.data['results']
+
+        h2_first = False
+        h1_second = False
+        for h in response_data:
+            if h['id'] == hub2.id:
+                h2_first = True
+            elif h2_first and h['id'] == hub.id:
+                h1_second = True
+
+        self.assertTrue(h2_first and h1_second)
+
+    def test_hub_is_paginated(self):
+        for x in range(11):
+            create_hub(name=f'Hub {x}')
+
+        page = 1
+        url = self.base_url + f'?page={page}&page_limit=10'
+        response = get_get_response(url)
+        result_count = len(response.data['results'])
+        page1_ids = [h['id'] for h in response.data['results']]
+
+        self.assertEqual(result_count, 10)
+
+        page = 2
+        url = self.base_url + f'?page={page}&page_limit=10'
+        response = get_get_response(url)
+        result_count = len(response.data['results'])
+        page2_ids = [h['id'] for h in response.data['results']]
+
+        self.assertLess(result_count, 10)
+        for id in page1_ids:
+            self.assertNotIn(id, page2_ids)
 
     def test_can_subscribe_to_hub(self):
         start_state = self.is_subscribed(self.user, self.hub)

--- a/src/hub/views.py
+++ b/src/hub/views.py
@@ -77,7 +77,12 @@ class HubViewSet(viewsets.ModelViewSet):
         }
 
     def list(self, request):
-        if request.query_params.get("ordering", None) == "score":
+        page = request.query_params.get("page", 1)
+        ordering = request.query_params.get("ordering", None)
+
+        # only cache the first page of trending hubs,
+        # since it's the most frequently queried
+        if ordering == "-score" and page == 1:
             cache_key = get_cache_key("hubs", "trending")
             cache_hit = cache.get(cache_key)
 

--- a/src/hub/views.py
+++ b/src/hub/views.py
@@ -82,7 +82,7 @@ class HubViewSet(viewsets.ModelViewSet):
 
         # only cache the first page of trending hubs,
         # since it's the most frequently queried
-        if ordering == "-score" and page == 1:
+        if ordering == "-paper_count,-discussion_count,id" and page == 1:
             cache_key = get_cache_key("hubs", "trending")
             cache_hit = cache.get(cache_key)
 


### PR DESCRIPTION
Had to make some changes to the backend to make pagination work properly.

- Ensure the `ordering` param is actually getting used
- Add "id" as an ordering field to break ties for hubs that have identical scores
- Added tests for ordering and pagination