### PR TITLE
Exclude votes from hubs popularity score

### DIFF
--- a/src/config/ci/keys.py
+++ b/src/config/ci/keys.py
@@ -59,3 +59,7 @@ TRANSPOSE_KEY = os.environ.get("TRANSPOSE_KEY", "")
 
 SERP_API_KEY = os.environ.get("SERP_API_KEY", "")
 OPENALEX_KEY = os.environ.get("OPENALEX_KEY", "")
+LINKEDIN_CLIENT_ID = os.environ.get("LINKEDIN_CLIENT_ID", "")
+LINKEDIN_CLIENT_SECRET = os.environ.get("LINKEDIN_CLIENT_SECRET", "")
+LINKEDIN_CALLBACK_URL = os.environ.get("LINKEDIN_CALLBACK_URL", "")
+ORCID_REDIRECT_URL = os.environ.get("ORCID_REDIRECT_URL", "")

--- a/src/hub/filters.py
+++ b/src/hub/filters.py
@@ -1,11 +1,7 @@
-from datetime import timedelta
-
 from django.contrib.postgres.search import TrigramSimilarity
-from django.db.models import Count, F, FileField, Q
-from django.utils import timezone
+from django.db.models import F, FileField
 from django_filters import rest_framework as filters
 
-from discussion.reaction_models import Vote
 
 from .models import Hub
 
@@ -17,26 +13,9 @@ class ScoreOrderingFilter(filters.OrderingFilter):
 
     def filter(self, qs, value):
         if value and any(v in ["score", "-score"] for v in value):
-            two_weeks_ago = timezone.now().date() - timedelta(days=14)
-            num_upvotes = Count(
-                "papers__votes__vote_type",
-                filter=Q(
-                    papers__votes__vote_type=Vote.UPVOTE,
-                    papers__votes__created_date__gte=two_weeks_ago,
-                ),
-            )
-            num_downvotes = Count(
-                "papers__votes__vote_type",
-                filter=Q(
-                    papers__votes__vote_type=Vote.DOWNVOTE,
-                    papers__votes__created_date__gte=two_weeks_ago,
-                ),
-            )
-
             DISCUSSION_FACTOR = 10
             score = (
-                (num_upvotes - num_downvotes)
-                + DISCUSSION_FACTOR * F("discussion_count")
+                DISCUSSION_FACTOR * F("discussion_count")
                 + F("paper_count")
             )
 


### PR DESCRIPTION
Our hubs endpoint was taking a long time to compute scores because it fetched upvotes/downvotes for the past two weeks across all papers in the hub.

We opted to remove the votes from the final score count for simplicity.

Alternatives considered:
- Reducing two week threshold down
- Setting up a cron job that periodically updated votes (perhaps for top X hubs)
- Setup signals for votes that auto-updates hub score