### PR TITLE
Fix error fetching prediction market votes

### DIFF
--- a/src/prediction_market/serializers/prediction_market_vote_serializer.py
+++ b/src/prediction_market/serializers/prediction_market_vote_serializer.py
@@ -28,7 +28,7 @@ class DynamicPredictionMarketVoteSerializer(DynamicModelFieldSerializer):
 
     def get_created_by(self, obj):
         context = self.context
-        _context_fields = context.get("rhc_dcs_get_created_by", {})
+        _context_fields = context.get("pm_dpmvs_get_created_by", {})
         serializer = DynamicUserSerializer(
             obj.created_by, context=context, **_context_fields
         )

--- a/src/prediction_market/views/pred_market_votes_view.py
+++ b/src/prediction_market/views/pred_market_votes_view.py
@@ -157,13 +157,12 @@ class PredictionMarketVoteViewSet(viewsets.ModelViewSet):
 
     def _get_retrieve_context(self):
         context = {
-            "rhc_dcs_get_created_by": {
+            "pm_dpmvs_get_created_by": {
                 "_include_fields": (
                     "id",
                     "author_profile",
                     "first_name",
                     "last_name",
-                    "editor_of",
                 )
             },
             "usr_dus_get_author_profile": {
@@ -176,10 +175,6 @@ class PredictionMarketVoteViewSet(viewsets.ModelViewSet):
                     "profile_image",
                     "is_verified",
                 )
-            },
-            "usr_dus_get_editor_of": {"_include_fields": ("source",)},
-            "rag_dps_get_source": {
-                "_include_fields": ("id", "name", "hub_image", "slug")
             },
         }
         return context

--- a/src/prediction_market/views/pred_market_votes_view.py
+++ b/src/prediction_market/views/pred_market_votes_view.py
@@ -174,7 +174,12 @@ class PredictionMarketVoteViewSet(viewsets.ModelViewSet):
                     "created_date",
                     "updated_date",
                     "profile_image",
+                    "is_verified",
                 )
+            },
+            "usr_dus_get_editor_of": {"_include_fields": ("source",)},
+            "rag_dps_get_source": {
+                "_include_fields": ("id", "name", "hub_image", "slug")
             },
         }
         return context

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -563,24 +563,20 @@ class DynamicUserSerializer(DynamicModelFieldSerializer):
     def get_editor_of(self, user):
         context = self.context
         _context_fields = context.get("usr_dus_get_editor_of", {})
-        try:
-            if hasattr(user, "created_by_permissions"):
-                # This comes from prefetching
-                permissions = user.created_by_permissions
-            else:
-                hub_content_type = ContentType.objects.get_for_model(Hub)
-                permissions = user.permissions.prefetch_related("source").filter(
-                    access_type=EDITOR,
-                    content_type=hub_content_type,
-                )
-            serializer = DynamicPermissionSerializer(
-                permissions, many=True, context=context, **_context_fields
+
+        if hasattr(user, "created_by_permissions"):
+            # This comes from prefetching
+            permissions = user.created_by_permissions
+        else:
+            hub_content_type = ContentType.objects.get_for_model(Hub)
+            permissions = user.permissions.prefetch_related("source").filter(
+                access_type=EDITOR,
+                content_type=hub_content_type,
             )
-            return serializer.data
-        except Exception as e:
-            print(e)
-            sentry.log_error(e)
-            return []
+        serializer = DynamicPermissionSerializer(
+            permissions, many=True, context=context, **_context_fields
+        )
+        return serializer.data
 
 
 class UserActions:

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -563,20 +563,24 @@ class DynamicUserSerializer(DynamicModelFieldSerializer):
     def get_editor_of(self, user):
         context = self.context
         _context_fields = context.get("usr_dus_get_editor_of", {})
-
-        if hasattr(user, "created_by_permissions"):
-            # This comes from prefetching
-            permissions = user.created_by_permissions
-        else:
-            hub_content_type = ContentType.objects.get_for_model(Hub)
-            permissions = user.permissions.prefetch_related("source").filter(
-                access_type=EDITOR,
-                content_type=hub_content_type,
+        try:
+            if hasattr(user, "created_by_permissions"):
+                # This comes from prefetching
+                permissions = user.created_by_permissions
+            else:
+                hub_content_type = ContentType.objects.get_for_model(Hub)
+                permissions = user.permissions.prefetch_related("source").filter(
+                    access_type=EDITOR,
+                    content_type=hub_content_type,
+                )
+            serializer = DynamicPermissionSerializer(
+                permissions, many=True, context=context, **_context_fields
             )
-        serializer = DynamicPermissionSerializer(
-            permissions, many=True, context=context, **_context_fields
-        )
-        return serializer.data
+            return serializer.data
+        except Exception as e:
+            print(e)
+            sentry.log_error(e)
+            return []
 
 
 class UserActions:


### PR DESCRIPTION
Jeff was unable to submit/retrieve prediction market votes.

I compared the retrieve context with the one in CommentView and realized it doesn't have the right fields/values set.

I also added a `try/catch` when getting `editor_of` details to make it more robust, and also because we have a similar `try/catch` when getting the author profile.