### PR TITLE
Implement Amplitude Revenue Tracking

### DIFF
--- a/src/analytics/amplitude.py
+++ b/src/analytics/amplitude.py
@@ -2,8 +2,10 @@ import functools
 import json
 
 import requests
+from typing import Literal
 from ipware import get_client_ip
 
+from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
 from researchhub.settings import AMPLITUDE_API_KEY, DEVELOPMENT
 from utils.parsers import json_serial
 from utils.sentry import log_info
@@ -99,6 +101,36 @@ class Amplitude:
         }
         hit = json.dumps(hit, default=json_serial)
         return self.forward_event(hit)
+    
+    def track_revenue_event(
+        self,
+        user,
+        revenue_type: str,
+        rsc_revenue: str,
+        usd_revenue: str,
+        additional_properties: dict = {},
+    ):
+        user_id, user_properties = self._build_user_properties(user)
+        data = {
+            "user_id": user_id,
+            "event_type": "revenue",
+            "user_properties": user_properties,
+            "event_properties": {
+                "revenue_type": revenue_type,
+                "rsc_revenue": rsc_revenue,
+                "usd_revenue": usd_revenue,
+                **additional_properties,
+            },
+            # Amplitude has specific revenue properties that we can use.
+            "revenue": usd_revenue,
+            "revenueType": revenue_type,
+        }
+        hit = {
+            "api_key": self.api_key,
+            "events": [data],
+        }
+        hit = json.dumps(hit, default=json_serial)
+        return self.forward_event(hit)
 
     def forward_event(self, hit):
         headers = {"Content-Type": "application/json", "Accept": "*/*"}
@@ -124,3 +156,56 @@ def track_event(func):
         return res
 
     return inner
+
+
+def track_revenue_event(
+    user,
+    revenue_type: Literal["BOUNTY_FEE", "FUNDRAISE_CONTRIBUTION_FEE", "SUPPORT_FEE", "DOI_FEE", "WITHDRAWAL_FEE"],
+    rsc_revenue: str,
+    usd_revenue: str = None,
+    transaction_method: Literal["OFF_CHAIN", "ON_CHAIN", "STRIPE"] = None,
+
+    # it's useful to be able to see e.g. how much did we make on paper tips versus comment tips.
+    # so we should use these fields to point to the object that the revenue is associated with.
+    # and not simply the Purchase/Balance/Fundraise object.
+    content_type: str = None,
+    object_id: str = None,
+
+    additional_properties: dict = {},
+):
+    """
+    Helper function to track revenue events.
+    Performs the conversion from RSC to USD if usd_revenue is None.
+    """
+
+    amp = None
+    if DEVELOPMENT:
+        return
+
+    try:
+        if usd_revenue is None:
+            if not isinstance(rsc_revenue, float):
+                rsc_revenue_float = float(rsc_revenue)
+            else:
+                rsc_revenue_float = rsc_revenue
+
+            usd_revenue_float = RscExchangeRate.rsc_to_usd(rsc_revenue_float)
+            usd_revenue = str(usd_revenue_float)
+    except Exception as e:
+        log_info("Error converting RSC to USD", e)
+
+    try:
+        additional_properties["transaction_method"] = transaction_method
+        additional_properties["content_type"] = content_type
+        additional_properties["object_id"] = object_id
+
+        amp = Amplitude()
+        amp.track_revenue_event(
+            user,
+            revenue_type,
+            rsc_revenue,
+            usd_revenue,
+            additional_properties,
+        )
+    except Exception as e:
+        log_info(e, getattr(amp, "revenue_event", None))

--- a/src/analytics/tasks.py
+++ b/src/analytics/tasks.py
@@ -1,0 +1,86 @@
+from typing import Literal
+
+from analytics.amplitude import Amplitude
+from researchhub.celery import QUEUE_EXTERNAL_REPORTING, app
+from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
+from user.models import User
+from researchhub.settings import DEVELOPMENT
+
+from utils.sentry import log_error
+
+
+@app.task(queue=QUEUE_EXTERNAL_REPORTING)
+def track_revenue_event(
+    user_id,
+    revenue_type: Literal["BOUNTY_FEE", "FUNDRAISE_CONTRIBUTION_FEE", "SUPPORT_FEE", "DOI_FEE", "WITHDRAWAL_FEE"],
+    rsc_revenue: str,
+    usd_revenue: str = None,
+    transaction_method: Literal["OFF_CHAIN", "ON_CHAIN", "STRIPE"] = None,
+
+    # it's useful to be able to see e.g. how much did we make on paper tips versus comment tips.
+    # so we should use these fields to point to the object that the revenue is associated with.
+    # and not simply the Purchase/Balance/Fundraise object.
+    content_type: str = None,
+    object_id: str = None,
+
+    additional_properties: dict = {},
+):
+    """
+    Helper function to track revenue events.
+    Performs the conversion from RSC to USD if usd_revenue is None.
+    """
+
+    amp = None
+    user = None
+    if DEVELOPMENT:
+        return
+    
+    def handle_log_error(e, message):
+        """Helper to add useful JSON data to Sentry"""
+        log_error(
+            e,
+            message=message,
+            json_data={
+                "user_id": user_id,
+                "rsc_revenue": rsc_revenue,
+                "usd_revenue": usd_revenue,
+                "revenue_type": revenue_type,
+                "transaction_method": transaction_method,
+                "content_type": content_type,
+                "object_id": object_id,
+            },
+        )
+
+    try:
+        user = User.objects.get(id=user_id)
+    except User.DoesNotExist:
+        handle_log_error(e, "Error tracking revenue event")
+        return
+
+    try:
+        if usd_revenue is None:
+            if not isinstance(rsc_revenue, float):
+                rsc_revenue_float = float(rsc_revenue)
+            else:
+                rsc_revenue_float = rsc_revenue
+
+            usd_revenue_float = RscExchangeRate.rsc_to_usd(rsc_revenue_float)
+            usd_revenue = str(usd_revenue_float)
+    except Exception as e:
+        handle_log_error(e, "Error converting RSC to USD")
+
+    try:
+        additional_properties["transaction_method"] = transaction_method
+        additional_properties["content_type"] = content_type
+        additional_properties["object_id"] = object_id
+
+        amp = Amplitude()
+        amp._track_revenue_event(
+            user,
+            revenue_type,
+            rsc_revenue,
+            usd_revenue,
+            additional_properties,
+        )
+    except Exception as e:
+        handle_log_error(e, "Error tracking revenue event")

--- a/src/purchase/related_models/rsc_exchange_rate_model.py
+++ b/src/purchase/related_models/rsc_exchange_rate_model.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from django.core.cache import cache
 from purchase.related_models.constants.rsc_exchange_currency import (
     MORALIS,
     PRICE_SOURCES,
@@ -44,6 +45,16 @@ class RscExchangeRate(DefaultModel):
     )
 
     @staticmethod
+    def get_latest_exchange_rate(
+        force_refresh=False,
+    ):
+        rate = cache.get('latest_exchange_rate')
+        if rate is None or force_refresh:
+            rate = RscExchangeRate.objects.last().rate
+            cache.set('latest_exchange_rate', rate, timeout=60 * 5) # 5 minutes
+        return rate
+
+    @staticmethod
     def eth_to_rsc(eth_amount):
         from user.rsc_exchange_rate_record_tasks import get_rsc_eth_conversion
 
@@ -51,13 +62,13 @@ class RscExchangeRate(DefaultModel):
         return eth_amount / eth_to_rsc_conversion
 
     @staticmethod
-    def usd_to_rsc(usd_amount):
-        latest_exchange_rate = RscExchangeRate.objects.last().rate
+    def usd_to_rsc(usd_amount, force_refresh=False):
+        latest_exchange_rate = RscExchangeRate.get_latest_exchange_rate(force_refresh=force_refresh)
         return usd_amount / latest_exchange_rate
 
     @staticmethod
-    def rsc_to_usd(rsc_amount):
-        latest_exchange_rate = RscExchangeRate.objects.last().rate
+    def rsc_to_usd(rsc_amount, force_refresh=False):
+        latest_exchange_rate = RscExchangeRate.get_latest_exchange_rate(force_refresh=force_refresh)
         return rsc_amount * latest_exchange_rate
 
     @staticmethod

--- a/src/purchase/views/fundraise_view.py
+++ b/src/purchase/views/fundraise_view.py
@@ -7,6 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
+from analytics.amplitude import track_revenue_event
 from purchase.models import Balance, Fundraise, Purchase
 from purchase.related_models.constants.currency import RSC, USD
 from purchase.serializers.fundraise_serializer import DynamicFundraiseSerializer
@@ -296,6 +297,14 @@ class FundraiseViewSet(viewsets.ModelViewSet):
                 content_type=ContentType.objects.get_for_model(Purchase),
                 object_id=purchase.id,
                 amount=f"-{amount_str}",
+            )
+
+            # Track in Amplitude
+            track_revenue_event(
+                user=user,
+                revenue_type="FUNDRAISE_CONTRIBUTION_FEE",
+                rsc_revenue=fee_str,
+                transaction_method="OFF_CHAIN",
             )
 
             # Update escrow object

--- a/src/purchase/views/purchase_view.py
+++ b/src/purchase/views/purchase_view.py
@@ -12,7 +12,7 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from analytics.amplitude import track_event
+from analytics.amplitude import track_event, track_revenue_event
 from notification.models import Notification
 from paper.models import Paper
 from paper.utils import get_cache_key
@@ -120,6 +120,16 @@ class PurchaseViewSet(viewsets.ModelViewSet):
                     content_type=source_type,
                     object_id=purchase_id,
                     amount=f"-{amount}",
+                )
+
+                # Track in Amplitude
+                track_revenue_event(
+                    user,
+                    revenue_type="SUPPORT_FEE",
+                    rsc_revenue=fee_str,
+                    transaction_method="OFF_CHAIN",
+                    content_type=content_type.model,
+                    object_id=object_id,
                 )
 
             purchase_hash = purchase.hash()

--- a/src/reputation/views/bounty_view.py
+++ b/src/reputation/views/bounty_view.py
@@ -9,7 +9,7 @@ from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
-from analytics.amplitude import track_event
+from analytics.amplitude import track_event, track_revenue_event
 from purchase.models import Balance
 from reputation.models import Bounty, BountyFee, Contribution, Escrow
 from reputation.permissions import UserCanApproveBounty, UserCanCancelBounty
@@ -128,6 +128,17 @@ def _create_bounty(
             object_id=bounty.id,
             amount=f"-{amount_str}",
         )
+
+    # Track in Amplitude
+    track_revenue_event(
+        user=user,
+        revenue_type="BOUNTY_FEE",
+        rsc_revenue=fee_str,
+        transaction_method="OFF_CHAIN",
+        content_type=content_type.model,
+        object_id=item_object_id,
+    )
+
     return bounty
 
 

--- a/src/reputation/views/deposit_view.py
+++ b/src/reputation/views/deposit_view.py
@@ -19,7 +19,7 @@ from web3 import Web3
 
 import ethereum.lib
 import ethereum.utils
-from analytics.amplitude import track_revenue_event
+from analytics.tasks import track_revenue_event
 from notification.models import Notification
 from purchase.models import Balance
 from reputation.distributions import Distribution as Dist
@@ -221,11 +221,15 @@ class WithdrawalViewSet(viewsets.ModelViewSet):
                 self._pay_withdrawal(withdrawal, amount, transaction_fee)
 
                 # Track in Amplitude
-                track_revenue_event(
-                    user=user,
-                    revenue_type="WITHDRAWAL_FEE",
-                    rsc_revenue=str(transaction_fee),
-                    transaction_method="ON_CHAIN",
+                track_revenue_event.apply_async(
+                    (
+                        user.id,
+                        "WITHDRAWAL_FEE",
+                        str(transaction_fee),
+                        None,
+                        "ON_CHAIN",
+                    ),
+                    priority=1,
                 )
 
                 serialized = WithdrawalSerializer(withdrawal)

--- a/src/reputation/views/deposit_view.py
+++ b/src/reputation/views/deposit_view.py
@@ -19,6 +19,7 @@ from web3 import Web3
 
 import ethereum.lib
 import ethereum.utils
+from analytics.amplitude import track_revenue_event
 from notification.models import Notification
 from purchase.models import Balance
 from reputation.distributions import Distribution as Dist
@@ -218,6 +219,14 @@ class WithdrawalViewSet(viewsets.ModelViewSet):
                 )
 
                 self._pay_withdrawal(withdrawal, amount, transaction_fee)
+
+                # Track in Amplitude
+                track_revenue_event(
+                    user=user,
+                    revenue_type="WITHDRAWAL_FEE",
+                    rsc_revenue=str(transaction_fee),
+                    transaction_method="ON_CHAIN",
+                )
 
                 serialized = WithdrawalSerializer(withdrawal)
                 return Response(serialized.data, status=201)

--- a/src/reputation/views/withdrawal_view.py
+++ b/src/reputation/views/withdrawal_view.py
@@ -20,6 +20,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from web3 import Web3
 
+from analytics.amplitude import track_revenue_event
 from notification.models import Notification
 from purchase.models import Balance, RscExchangeRate
 from reputation.exceptions import WithdrawalError
@@ -164,6 +165,14 @@ class WithdrawalViewSet(viewsets.ModelViewSet):
                 )
 
                 self._pay_withdrawal(withdrawal, amount, transaction_fee)
+
+                # Track in Amplitude
+                track_revenue_event(
+                    user=user,
+                    revenue_type="WITHDRAWAL_FEE",
+                    rsc_revenue=str(transaction_fee),
+                    transaction_method="ON_CHAIN",
+                )
 
                 serialized = WithdrawalSerializer(withdrawal)
                 return Response(serialized.data, status=201)

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -13,7 +13,7 @@ from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
-from analytics.amplitude import track_event
+from analytics.amplitude import track_event, track_revenue_event
 from discussion.reaction_views import ReactionViewActionMixin
 from hub.models import Hub
 from note.models import NoteContent
@@ -353,4 +353,12 @@ def charge_doi_fee(created_by, rh_post):
         content_type=ContentType.objects.get_for_model(purchase),
         object_id=purchase.id,
         amount=-CROSSREF_DOI_RSC_FEE,
+    )
+
+    # Track in Amplitude
+    track_revenue_event(
+        user=created_by,
+        revenue_type="DOI_FEE",
+        rsc_revenue=str(CROSSREF_DOI_RSC_FEE),
+        transaction_method="OFF_CHAIN",
     )

--- a/src/utils/sentry.py
+++ b/src/utils/sentry.py
@@ -3,13 +3,14 @@ import traceback
 from sentry_sdk import capture_exception, capture_message, configure_scope
 
 
-def log_error(e, base_error=None, message=None):
+def log_error(e, base_error=None, message=None, json_data=None):
     """Captures an exception with the sentry sdk.
 
     Arguments:
         e (Exception)
         base_error (Exception) -- Exception that triggered e
         message (str) -- Optional message for additional info
+        json_data (dict) -- Optional json data to send with the error
     """
     from researchhub.settings import PRODUCTION
 
@@ -28,6 +29,13 @@ def log_error(e, base_error=None, message=None):
             scope.set_extra("base_error", message)
         if message is not None:
             scope.set_extra("message", message)
+        if json_data is not None:
+            for k, v in json_data.items():
+                if isinstance(v, dict):
+                    for k2, v2 in v.items():
+                        scope.set_extra(f"{k}_{k2}", v2)
+                elif v is not None:
+                    scope.set_extra(k, v)
         capture_exception(e)
 
 


### PR DESCRIPTION
Created a separate `track_revenue_event` that we should call whenever we earn revenue.

Will have to wait til it's in prod to test whether it fires correctly. 

Tested:
- Manually logged data to make sure we're tracking accurate/correct numbers
- Tipping still works
- Creating bounties still works