### PR TITLE
Scripts to backfill OpenAlex and clean-up data

### DIFF
--- a/scripts/backfill_openalex.py
+++ b/scripts/backfill_openalex.py
@@ -1,0 +1,353 @@
+import gzip
+import json
+import pandas as pd
+import os
+from datetime import datetime
+from pathlib import Path
+from unicodedata import normalize
+from slugify import slugify
+import secrets
+import shutil
+
+def check_has_enough_disk_space():
+    """
+    Check if the machine has enough disk space to continue.
+    """
+    # 5 GB
+    min_free_space = 5 * 1024 * 1024 * 1024
+    path_to_check = '/'
+
+    total, used, free = shutil.disk_usage(path_to_check)
+
+    total_in_gb = total / (1024 * 1024 * 1024)
+    used_in_gb = used / (1024 * 1024 * 1024)
+    free_in_gb = free / (1024 * 1024 * 1024)
+
+    print("Disk space:")
+    # Print with only 2 decimal places
+    print(f"\tTotal: {total_in_gb:.2f} GB")
+    print(f"\tUsed: {used_in_gb:.2f} GB")
+    print(f"\tFree: {free_in_gb:.2f} GB")
+
+    if free < min_free_space:
+        print("Low disk space. Stopping the program.")
+        exit()
+
+def get_random_string(length=12):
+    return secrets.token_urlsafe(length)
+
+def get_year_month_from_data(data):
+    """
+    Extract the year and month from the paper's publication date.
+    Returns None if the date is not within the past 5 years.
+    """
+    raw_pub_date = data.get('paper_publish_date', None)
+    if raw_pub_date is None:
+        print(f"Missing paper_publish_date: {data.get('doi', data.get('alternate_ids', None))}")
+        return None, None
+    
+    pub_date = datetime.strptime(raw_pub_date, '%Y-%m-%d').date()
+    cutoff_date = (datetime.now() - pd.DateOffset(years=5)).date()
+    if pub_date < cutoff_date:
+        return None, None
+    return pub_date.year, pub_date.month
+
+def format_raw_authors(raw_authors):
+    for author in raw_authors:
+        if "family" in author:
+            first_name = author.pop("given", "")
+            last_name = author.pop("family", "")
+
+            author["first_name"] = first_name
+            author["last_name"] = last_name
+        elif "literal" in author:
+            name = author.pop("literal", "")
+            names = name.split(" ")
+            first_name = names[0]
+            last_name = names[-1]
+
+            author["first_name"] = first_name
+            author["last_name"] = last_name
+        elif "author" in author:
+            # OpenAlex Cleaning
+            author.pop("author_position", None)
+            author.pop("institutions", None)
+            author.pop("raw_affiliation_string", None)
+
+            author_data = author.pop("author")
+            name = author_data.pop("display_name")
+            open_alex_id = author_data.pop("id")
+            names = name.split(" ")
+            first_name = names[0]
+            last_name = names[-1]
+
+            author_data["open_alex_id"] = open_alex_id
+            author_data["first_name"] = first_name
+            author_data["last_name"] = last_name
+            author.update(author_data)
+        elif "name" in author:
+            author.pop("authorId", None)
+            name = author.pop("name", "")
+            names = name.split(" ")
+            first_name = names[0]
+            last_name = names[-1]
+
+            author["first_name"] = first_name
+            author["last_name"] = last_name
+
+    return raw_authors
+
+def process_json_line(line):
+    """
+    Process and transform each JSON line to match the schema.
+    Return a dictionary of transformed data.
+    """
+    try:
+        data = json.loads(line)
+
+        if data.get('type', data.get('publication_type', '')) != 'article':
+            return "NOT_ARTICLE", "NOT_ARTICLE", "NOT_ARTICLE"
+
+        pdf_url = None
+        pdf_license = None
+
+        best_oa_location = data.get('best_oa_location', {})
+        primary_location = data.get('primary_location', {})
+
+        if best_oa_location:
+            pdf_url = best_oa_location.get('pdf_url')
+            pdf_license = best_oa_location.get('license')
+
+        if pdf_url is None and primary_location:
+            pdf_url = primary_location.get('pdf_url')
+            pdf_license = primary_location.get('license', pdf_license)
+
+        raw_pub_date = data.get('publication_date', None)
+        if raw_pub_date is None:
+            raw_pub_year = data.get('publication_year', None)
+            if raw_pub_year is None:
+                print(f"Missing publication_date and publication_year: {data.get('id', data.get('doi', data.get('ids', None)))}")
+                log_failed_line(line)
+                return None, None, None
+            pub_year = int(raw_pub_year)
+            pub_date = datetime(pub_year, 1, 1).date()
+            # format it like YYYY-MM-DD
+            pub_date = pub_date.strftime('%Y-%m-%d')
+        else:
+            pub_date = datetime.strptime(raw_pub_date, '%Y-%m-%d').date()
+            pub_date = pub_date.strftime('%Y-%m-%d')
+
+        if primary_location is None:
+            if best_oa_location is not None:
+                primary_location = best_oa_location
+            else:
+                primary_location = {}
+    
+        source = primary_location.get("source", {})
+        if source is None:
+            source = {}
+        external_source = source.get("display_name", None) or source.get("name", None) or source.get("publisher", None)
+        url = primary_location.get("landing_page_url", None)
+        oa = data.get("open_access", {})
+        if oa is None:
+            oa = {}
+        raw_title = data.get("title", "") or ""
+        title = normalize("NFKD", raw_title)
+        raw_authors = data.get("authorships", [])
+        concepts = data.get("concepts", [])
+
+        if pdf_license is None:
+            pdf_license = primary_location.get("license", None)
+        if pdf_license is None:
+            pdf_license = data.get("license", None)
+
+        paper_data = {
+            'title': title,
+            'paper_publish_date': pub_date,
+            'doi': data.get('doi', data.get('ids', {}).get('doi', '')),
+            'url': url,
+            'publication_type': data.get('type', ''),
+            'paper_title': title,
+            'pdf_url': pdf_url,
+            'retrieved_from_external_source': True,
+            'is_public': True,
+            'is_removed': False,
+            'external_source': external_source,
+            'pdf_license': pdf_license,
+            'raw_authors': json.dumps(format_raw_authors(raw_authors)),
+            'discussion_count': 0,
+            'alternate_ids': json.dumps(data.get('ids', {})),
+            'slug': slugify(title),
+            # if the slug already exists in the db we can fallback to this alternate slug
+            # this is the same pattern we use in the backend.
+            'alt_slug': slugify(title) + '-' + get_random_string(length=32),
+            'paper_type': 'REGULAR',
+            'completeness': 'INCOMPLETE',
+            'open_alex_raw_json': json.dumps(data),
+            'citations': data.get('cited_by_count', 0),
+            'downloads': 0,
+            'twitter_mentions': 0,
+            'views': 0,
+            'is_open_access': oa.get('is_oa', False),
+            'oa_status': oa.get('oa_status', None),
+        }
+
+        unified_document_data = {
+            'document_type': 'PAPER',
+            'published_date': pub_date,
+            # these fields are so that we can associate the paper and unified_document after
+            # and set paper_paper.unified_document_id correctly.
+            'paper_doi': paper_data['doi'],
+            'paper_url': paper_data['url'],
+        }
+
+        concepts_data = []
+        for concept in concepts:
+            concepts_data.append({
+                'openalex_id': concept.get('id', ''),
+                'display_name': concept.get('display_name', ''),
+                'level': concept.get('level', 0),
+                'score': concept.get('score', 0),
+                # these fields are so that we can associate the paper and concept after
+                # and set unified_document.concepts and unified_document.hubs
+                'paper_doi': paper_data['doi'],
+                'paper_url': paper_data['url'],
+            })
+
+        return paper_data, unified_document_data, concepts_data
+    
+    except Exception as e:
+        print(f"Error processing line: {e}")
+        log_failed_line(line)
+        return None, None, None
+
+def write_to_csv(data, name, year, month):
+    """
+    Write the data to a CSV file named by year and month.
+    Append if the file already exists.
+    """
+    # Expanding the tilde to the user's home directory
+    base_path = os.path.expanduser("~/openalex-snapshot")
+    filename = f"{base_path}/{year}_{name}.csv"
+
+    # Ensure base directory exists
+    os.makedirs(base_path, exist_ok=True)
+
+    data.to_csv(filename, mode='a', header=not os.path.exists(filename), index=False)
+
+def log_failed_line(line):
+    """
+    Write the failed line to a file.
+    """
+    # Expanding the tilde to the user's home directory
+    base_path = os.path.expanduser("~/openalex-snapshot")
+    filename = f"{base_path}/failed_lines.jsonl"
+
+    # Ensure base directory exists
+    os.makedirs(base_path, exist_ok=True)
+
+    with open(filename, 'a') as f:
+        f.write(line)
+
+def write_log(log_data):
+    """
+    Write the log data to JSON lines file.
+    """
+    # Expanding the tilde to the user's home directory
+    base_path = os.path.expanduser("~/openalex-snapshot")
+    filename = f"{base_path}/log.jsonl"
+
+    # Ensure base directory exists
+    os.makedirs(base_path, exist_ok=True)
+
+    with open(filename, 'a') as f:
+        f.write(json.dumps(log_data) + '\n')
+
+def process_file(file_path):
+    """
+    Process a given gzipped JSONL file.
+    """
+    papers_by_month = {}
+    unified_documents_by_month = {}
+    concepts_by_month = {}
+    log_data = {
+        "file_path": str(file_path),
+        "processed": 0,
+        "missing_data": 0,
+        "not_article": 0,
+        "invalid_date": 0,
+    }
+    with gzip.open(file_path, 'rt', encoding='utf-8') as f:
+        for line in f:
+            paper_data, unified_document_data, concepts_data = process_json_line(line)
+            if paper_data is None or unified_document_data is None or concepts_data is None:
+                log_data['missing_data'] = log_data.get('missing_data', 0) + 1
+                continue
+            if paper_data == "NOT_ARTICLE":
+                log_data['not_article'] = log_data.get('not_article', 0) + 1
+                continue
+
+            year, month = get_year_month_from_data(paper_data)
+            if year is None or month is None:
+                log_data['invalid_date'] = log_data.get('invalid_date', 0) + 1
+                continue
+
+            key = f"{year}_{month}"
+            if key not in papers_by_month:
+                papers_by_month[key] = []
+            papers_by_month[key].append(paper_data)
+            if key not in unified_documents_by_month:
+                unified_documents_by_month[key] = []
+            unified_documents_by_month[key].append(unified_document_data)
+            if key not in concepts_by_month:
+                concepts_by_month[key] = []
+            concepts_by_month[key].extend(concepts_data)
+
+            log_data['processed'] = log_data.get('processed', 0) + 1
+
+    # Write Papers
+    for key, data_list in papers_by_month.items():
+        year, month = key.split('_')
+        df = pd.DataFrame(data_list)
+        write_to_csv(df, 'paper_paper', int(year), int(month))
+
+    # Write UnifiedDocuments
+    for key, data_list in unified_documents_by_month.items():
+        year, month = key.split('_')
+        df = pd.DataFrame(data_list)
+        write_to_csv(df, 'researchhub_unified_document', int(year), int(month))
+
+    # Write Concepts
+    for key, data_list in concepts_by_month.items():
+        year, month = key.split('_')
+        df = pd.DataFrame(data_list)
+        write_to_csv(df, 'tag_concept', int(year), int(month))
+
+    # Write log
+    write_log(log_data)
+
+    print(f"Processed {log_data['processed']} entries")
+    print(f"\t{log_data['missing_data']} entries missing data")
+    print(f"\t{log_data['not_article']} entries not articles")
+    print(f"\t{log_data['invalid_date']} entries with invalid date")
+
+    print(f"Deleting {file_path}")
+    os.remove(file_path)
+
+def main():
+    base_snapshot_path = Path(os.path.expanduser("~/openalex-snapshot"))
+    
+    # Iterate over all directories starting with 'updated_date'
+    for date_folder in base_snapshot_path.glob("updated_date*"):
+        print(f"\nProcessing folder: {date_folder}")
+        
+        # Process each gzipped file in the current date folder
+        for file_path in date_folder.glob("part_*.gz"):
+            # Before processing each file, check if there's enough disk space
+            check_has_enough_disk_space()
+
+            print(f"\nProcessing file: {file_path}")
+            process_file(file_path)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backfill_openalex.sql
+++ b/scripts/backfill_openalex.sql
@@ -1,0 +1,274 @@
+-- Make backups of the tables
+CREATE TABLE paper_paper_backup AS TABLE paper_paper;
+CREATE TABLE researchhub_document_researchhubunifieddocument_backup AS TABLE researchhub_document_researchhubunifieddocument;
+CREATE TABLE researchhub_document_unifieddocumentconcepts_backup AS TABLE researchhub_document_unifieddocumentconcepts;
+CREATE TABLE researchhub_document_researchhubunifieddocument_hubs_backup AS TABLE researchhub_document_researchhubunifieddocument_hubs;
+
+-- Create temp tables
+CREATE TABLE backfill_paper_paper (
+  title character varying(1024),
+  paper_publish_date date,
+  doi character varying(255),
+  url character varying(1024),
+  publication_type character varying(255),
+  paper_title character varying(1024),
+  pdf_url character varying(2048),
+  retrieved_from_external_source boolean NOT NULL,
+  is_public boolean NOT NULL,
+  is_removed boolean NOT NULL,
+  external_source character varying(255),
+  pdf_license character varying(255),
+  raw_authors jsonb,
+  discussion_count integer NOT NULL,
+  alternate_ids jsonb NOT NULL,
+  slug character varying(1024),
+  alt_slug character varying(1024),
+  paper_type character varying(32) NOT NULL,
+  completeness character varying(16) NOT NULL,
+  open_alex_raw_json jsonb,
+  citations integer NOT NULL,
+  downloads integer NOT NULL,
+  twitter_mentions integer NOT NULL,
+  views integer NOT NULL,
+  is_open_access boolean,
+  oa_status character varying(8)
+);
+CREATE TABLE backfill_researchhub_unified_document (
+  document_type character varying(32) NOT NULL,
+  published_date date NOT NULL,
+  paper_doi character varying(255),
+  paper_url character varying(1024)
+);
+CREATE TABLE backfill_tag_concept (
+  openalex_id character varying(255),
+  display_name character varying(255),
+  level integer,
+  score double precision,
+  paper_doi character varying(255),
+  paper_url character varying(1024)
+);
+
+-- Load data from CSVs
+\copy backfill_paper_paper FROM '~/openalex-snapshot/2023/2023_paper_paper_part1.csv' DELIMITER ',' CSV HEADER; 
+\copy backfill_researchhub_unified_document FROM '~/openalex-snapshot/2023/2023_researchhub_unified_document_part1.csv' DELIMITER ',' CSV HEADER;
+\copy backfill_tag_concept FROM '~/openalex-snapshot/2023/2023_tag_concept_part1.csv' DELIMITER ',' CSV HEADER;
+
+-- Remove duplicates/invalid
+-- add idx first
+CREATE INDEX idx_backfill_paper_doi ON backfill_paper_paper(doi);
+-- this is an optimized delete
+WITH duplicate_rows AS (
+    SELECT ctid
+    FROM (
+        SELECT ctid, 
+               row_number() OVER (PARTITION BY doi ORDER BY ctid) as rn
+        FROM backfill_paper_paper
+    ) t
+    WHERE rn > 1
+)
+DELETE FROM backfill_paper_paper
+WHERE ctid IN (SELECT ctid FROM duplicate_rows);
+-- delete duplicate rows by url
+CREATE INDEX idx_backfill_paper_url ON backfill_paper_paper(url);
+WITH duplicate_rows AS (
+    SELECT ctid
+    FROM (
+        SELECT ctid, 
+               row_number() OVER (PARTITION BY url ORDER BY ctid) as rn
+        FROM backfill_paper_paper
+    ) t
+    WHERE rn > 1
+)
+DELETE FROM backfill_paper_paper
+WHERE ctid IN (SELECT ctid FROM duplicate_rows);
+-- delete invalid rows
+DELETE FROM backfill_paper_paper
+WHERE doi IS NULL OR doi = '' OR title IS NULL OR title = '' OR slug IS NULL OR slug = '' OR url IS NULL OR url = '';
+-- Truncate url to 1024 characters (there's some with more)
+SELECT id FROM backfill_paper_paper WHERE LENGTH(pdf_url) > 1024;
+ALTER TABLE backfill_paper_paper ALTER COLUMN pdf_url TYPE character varying(1024);
+-- add serial id
+ALTER TABLE backfill_paper_paper
+ADD COLUMN id SERIAL PRIMARY KEY;
+
+
+-- Insert or Update in the main table
+INSERT INTO paper_paper (
+  title, paper_publish_date, doi, url, publication_type, paper_title, pdf_url,
+  retrieved_from_external_source, is_public, is_removed, external_source,
+  pdf_license, raw_authors, discussion_count, alternate_ids, slug,
+  paper_type, completeness, open_alex_raw_json, citations, downloads,
+  twitter_mentions, views, is_open_access, oa_status, created_date, updated_date,
+  is_removed_by_user, bullet_low_quality, summary_low_quality,
+  automated_bounty_created, is_pdf_removed_by_moderator, twitter_score, score
+)
+SELECT title, paper_publish_date, doi, url, publication_type, paper_title, pdf_url,
+  retrieved_from_external_source, is_public, is_removed, external_source,
+  pdf_license, raw_authors, discussion_count, alternate_ids, slug,
+  paper_type, completeness, open_alex_raw_json, citations, downloads,
+  twitter_mentions, views, is_open_access, oa_status, NOW(), NOW(), false,
+  false, false, false, false, 0, 0
+FROM backfill_paper_paper b
+WHERE NOT EXISTS (
+    SELECT 1 FROM paper_paper p WHERE p.url = b.url
+)
+ON CONFLICT (doi)
+DO UPDATE SET
+  paper_publish_date = excluded.paper_publish_date,
+  pdf_license = excluded.pdf_license,
+  alternate_ids = excluded.alternate_ids,
+  citations = excluded.citations,
+  is_open_access = excluded.is_open_access,
+  oa_status = excluded.oa_status,
+  open_alex_raw_json = excluded.open_alex_raw_json,
+  updated_date = NOW()
+WHERE paper_paper.paper_publish_date IS DISTINCT FROM excluded.paper_publish_date
+   OR paper_paper.pdf_license IS DISTINCT FROM excluded.pdf_license
+   OR paper_paper.alternate_ids IS DISTINCT FROM excluded.alternate_ids
+   OR paper_paper.citations IS DISTINCT FROM excluded.citations
+   OR paper_paper.is_open_access IS DISTINCT FROM excluded.is_open_access
+   OR paper_paper.oa_status IS DISTINCT FROM excluded.oa_status
+   OR paper_paper.open_alex_raw_json IS DISTINCT FROM excluded.open_alex_raw_json;
+-- batched version
+DO $$
+DECLARE
+    batch_size int := 5000;
+    offset_val int := 0;
+    rows_affected int;
+BEGIN
+    LOOP
+        INSERT INTO paper_paper (
+          title, paper_publish_date, doi, url, publication_type, paper_title, pdf_url,
+          retrieved_from_external_source, is_public, is_removed, external_source,
+          pdf_license, raw_authors, discussion_count, alternate_ids, slug,
+          paper_type, completeness, open_alex_raw_json, citations, downloads,
+          twitter_mentions, views, is_open_access, oa_status, created_date, updated_date,
+          is_removed_by_user, bullet_low_quality, summary_low_quality,
+          automated_bounty_created, is_pdf_removed_by_moderator, twitter_score, score
+        )
+        SELECT 
+          title, paper_publish_date, doi, url, publication_type, paper_title, pdf_url,
+          retrieved_from_external_source, is_public, is_removed, external_source,
+          pdf_license, raw_authors, discussion_count, alternate_ids, slug,
+          paper_type, completeness, open_alex_raw_json, citations, downloads,
+          twitter_mentions, views, is_open_access, oa_status, NOW(), NOW(), false,
+          false, false, false, false, 0, 0
+        FROM backfill_paper_paper b
+        WHERE NOT EXISTS (
+            SELECT 1 FROM paper_paper p WHERE p.url = b.url
+        )
+        ORDER BY b.id
+        LIMIT batch_size OFFSET offset_val
+        ON CONFLICT (doi) DO UPDATE SET
+          paper_publish_date = excluded.paper_publish_date,
+          pdf_license = excluded.pdf_license,
+          alternate_ids = excluded.alternate_ids,
+          citations = excluded.citations,
+          is_open_access = excluded.is_open_access,
+          oa_status = excluded.oa_status,
+          open_alex_raw_json = excluded.open_alex_raw_json,
+          updated_date = NOW()
+        WHERE paper_paper.paper_publish_date IS DISTINCT FROM excluded.paper_publish_date
+          OR paper_paper.pdf_license IS DISTINCT FROM excluded.pdf_license
+          OR paper_paper.alternate_ids IS DISTINCT FROM excluded.alternate_ids
+          OR paper_paper.citations IS DISTINCT FROM excluded.citations
+          OR paper_paper.is_open_access IS DISTINCT FROM excluded.is_open_access
+          OR paper_paper.oa_status IS DISTINCT FROM excluded.oa_status
+          OR paper_paper.open_alex_raw_json IS DISTINCT FROM excluded.open_alex_raw_json;
+
+        GET DIAGNOSTICS rows_affected = ROW_COUNT;
+        EXIT WHEN rows_affected < batch_size;
+        offset_val := offset_val + batch_size;
+
+        RAISE NOTICE 'Offset: %', offset_val;
+        RAISE NOTICE 'Rows affected: %', rows_affected;
+    END LOOP;
+END $$;
+
+ALTER TABLE backfill_researchhub_unified_document
+ADD COLUMN new_unified_document_id INTEGER;
+
+-- Temporarily add a column to unified doc table
+ALTER TABLE researchhub_document_researchhubunifieddocument
+ADD COLUMN paper_doi character varying(255);
+
+-- Add indexes
+CREATE INDEX idx_backfill_researchhub_unified_document_paper_doi ON backfill_researchhub_unified_document(paper_doi);
+CREATE INDEX idx_backfill_tag_concept_paper_doi ON backfill_tag_concept(paper_doi);
+
+-- Insert unified documents
+-- and update backfill table with new unified_document_id
+WITH inserted AS (
+  INSERT INTO researchhub_document_researchhubunifieddocument (
+    document_type, created_date, updated_date, hot_score, score,
+    is_removed, published_date, is_public, hot_score_v2, is_removed_date,
+    paper_doi
+  )
+  SELECT
+    b.document_type, NOW(), NOW(), 0, 0,
+    false, NOW(), false, 0, NULL, b.paper_doi
+  FROM backfill_researchhub_unified_document b
+  JOIN paper_paper p ON (b.paper_doi = p.doi OR b.paper_url = p.url)
+  WHERE p.unified_document_id IS NULL
+  RETURNING id, paper_doi
+)
+UPDATE backfill_researchhub_unified_document
+SET new_unified_document_id = inserted.id
+FROM inserted
+WHERE backfill_researchhub_unified_document.paper_doi = inserted.paper_doi;
+
+-- let's also update the backfill_tag_concept table with the new unified_document_id
+ALTER TABLE backfill_tag_concept
+ADD COLUMN new_unified_document_id INTEGER;
+-- Set the new unified_document_id to the one we just inserted
+UPDATE backfill_tag_concept
+SET new_unified_document_id = b.new_unified_document_id
+FROM backfill_researchhub_unified_document b
+WHERE backfill_tag_concept.paper_doi = b.paper_doi;
+
+-- Update paper_paper table with unified_document_id
+UPDATE paper_paper
+SET unified_document_id = b.new_unified_document_id
+FROM backfill_researchhub_unified_document b
+WHERE paper_paper.doi = b.paper_doi AND paper_paper.unified_document_id IS NULL;
+
+-- Insert concepts
+INSERT INTO researchhub_document_unifieddocumentconcepts (
+  created_date, updated_date, relevancy_score, level, concept_id, unified_document_id
+)
+SELECT NOW(), NOW(), b.score, b.level, c.id, b.new_unified_document_id
+FROM backfill_tag_concept b
+JOIN tag_concept c ON b.openalex_id = c.openalex_id
+WHERE b.new_unified_document_id IS NOT NULL;
+
+-- Insert hubs
+INSERT INTO researchhub_document_researchhubunifieddocument_hubs (
+  researchhubunifieddocument_id, hub_id
+)
+SELECT b.new_unified_document_id, h.id
+FROM backfill_tag_concept b
+JOIN tag_concept c ON b.openalex_id = c.openalex_id
+JOIN hub_hub h ON c.id = h.concept_id
+WHERE b.new_unified_document_id IS NOT NULL
+ON CONFLICT (researchhubunifieddocument_id, hub_id) 
+DO NOTHING;
+
+-- May be useful to run analyze on the tables
+ANALYZE paper_paper;
+ANALYZE researchhub_document_researchhubunifieddocument;
+ANALYZE researchhub_document_unifieddocumentconcepts;
+ANALYZE researchhub_document_researchhubunifieddocument_hubs;
+
+-- Cleanup
+DROP TABLE backfill_paper_paper;
+DROP TABLE backfill_researchhub_unified_document;
+DROP TABLE backfill_tag_concept;
+
+ALTER TABLE researchhub_document_researchhubunifieddocument
+DROP COLUMN paper_doi;
+
+-- drop backups
+DROP TABLE paper_paper_backup;
+DROP TABLE researchhub_document_researchhubunifieddocument_backup;
+DROP TABLE researchhub_document_unifieddocumentconcepts_backup;
+DROP TABLE researchhub_document_researchhubunifieddocument_hubs_backup;

--- a/src/paper/management/commands/fix_bad_dois.py
+++ b/src/paper/management/commands/fix_bad_dois.py
@@ -1,0 +1,73 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from paper.models import Paper
+
+class Command(BaseCommand):
+    help = 'Correct DOIs for papers with specific invalid DOIs or missing prefixes.'
+
+    def handle(self, *args, **kwargs):
+        self.update_papers_with_malformed_dois_and_arxiv_urls()
+        self.update_papers_with_arxiv_dois()
+        self.stdout.write(self.style.SUCCESS("Finished updating papers with corrected DOIs."))
+
+    def update_papers_with_malformed_dois_and_arxiv_urls(self):
+        """Handles papers with a malformed DOI and an ArXiv URL."""
+        papers = Paper.objects.filter(
+            ~Q(doi__icontains='/'), 
+            ~Q(doi__icontains='arxiv'), 
+            doi__isnull=False, 
+            url__icontains='arxiv.org'
+        )
+        self.process_arxiv_papers(papers)
+
+    def update_papers_with_arxiv_dois(self):
+        """
+        Handles papers where the DOI starts with:
+        - 'arXiv.'
+        - 'arxiv.'
+        - 'arXiv:'
+        - 'arxiv:'
+        """
+        papers = Paper.objects.filter(
+            Q(doi__startswith='arXiv.') |
+            Q(doi__startswith='arxiv.') |
+            Q(doi__startswith='arXiv:') |
+            Q(doi__startswith='arxiv:')
+        )
+        self.process_arxiv_papers(papers)
+
+    def process_arxiv_papers(self, papers):
+        to_update = []
+        for paper in papers.iterator():
+            arxiv_id = self.extract_arxiv_id(paper)
+            if arxiv_id:
+                paper.doi = f"10.48550/arXiv.{arxiv_id}"
+                to_update.append(paper)
+            else:
+                # see if the url is a doi.org link
+                if 'doi.org' in paper.url:
+                    doi = paper.url.split('doi.org/')[-1]
+                    # make sure it's arXiv. and not arXiv:
+                    paper.doi = doi.replace('arXiv:', 'arXiv.')
+                    to_update.append(paper)
+
+            if len(to_update) >= 100:
+                print(f'Updating {len(to_update)} papers...')
+                Paper.objects.bulk_update(to_update, ['doi'])
+                to_update.clear()
+
+        if to_update:
+            print(f'Updating {len(to_update)} papers...')
+            Paper.objects.bulk_update(to_update, ['doi'])
+
+    def extract_arxiv_id(self, paper):
+        """Extracts the ArXiv ID from the paper's DOI or URL."""
+        if paper.doi.startswith('arXiv.') or paper.doi.startswith('arxiv.'):
+            return paper.doi.split('.')[-1]
+        elif paper.doi.startswith('arXiv:') or paper.doi.startswith('arxiv:'):
+            return paper.doi.split(':')[-1]
+        elif 'arxiv.org' in paper.url:
+            parts = paper.url.split('/')
+            if 'abs' in parts or 'pdf' in parts:
+                return parts[-1].replace('.pdf', '')
+        return None

--- a/src/paper/management/commands/fix_empty_titles_and_dates.py
+++ b/src/paper/management/commands/fix_empty_titles_and_dates.py
@@ -1,0 +1,55 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from paper.models import Paper
+from utils.openalex import OpenAlex
+from paper.exceptions import DOINotFoundError
+from dateutil.parser import parse
+
+class Command(BaseCommand):
+    help = 'Update paper titles and publication dates from OpenAlex for papers with NULL or empty titles'
+
+    def handle(self, *args, **kwargs):
+        papers = Paper.objects.filter(
+            (Q(title__isnull=True) | Q(title='')) | Q(paper_publish_date__isnull=True),
+            is_removed=False
+        )
+
+        open_alex = OpenAlex()
+        updated_papers = []
+        batch_size = 100
+
+        for paper in papers.iterator():
+            if not paper.doi:
+                continue  # Skip papers without a DOI
+
+            try:
+                openalex_data = open_alex.get_data_from_doi(paper.doi)
+                title = openalex_data.get('title')
+                publication_date = openalex_data.get('publication_date')
+
+                needs_update = False
+
+                if title and not paper.title:
+                    paper.title = title
+                    needs_update = True
+
+                if publication_date and not paper.paper_publish_date:
+                    paper.paper_publish_date = parse(publication_date).date()
+                    needs_update = True
+
+                # If this paper needs an update, add it to the list
+                if needs_update:
+                    updated_papers.append(paper)
+
+                # When enough papers have been accumulated, update them in batch
+                if len(updated_papers) >= batch_size:
+                    Paper.objects.bulk_update(updated_papers, ['title', 'paper_publish_date'])
+                    updated_papers = []  # Reset the list after updating
+
+            except DOINotFoundError:
+                continue
+
+        if updated_papers:
+            Paper.objects.bulk_update(updated_papers, ['title', 'paper_publish_date'])
+
+        self.stdout.write(self.style.SUCCESS('Batch update completed.'))

--- a/src/paper/management/commands/remove_duplicates_by_doi.py
+++ b/src/paper/management/commands/remove_duplicates_by_doi.py
@@ -1,0 +1,46 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from paper.models import Paper
+
+class Command(BaseCommand):
+    help = 'Mark duplicate papers with 0 discussion_count as removed'
+
+    def handle(self, *args, **kwargs):
+        batch_size = 100
+        papers = Paper.objects.filter(
+            is_removed=False,
+            # must have at least one forward slash to be a valid DOI
+            doi__contains='/',
+        ).only('id', 'doi', 'discussion_count').iterator()
+        to_update_ids = []
+
+        for paper in papers:
+            if paper.doi:
+                normalized_doi = paper.doi.lower().strip().replace('http://', 'https://').replace('https://dx.doi.org/', '').replace('https://doi.org/', '').replace('dx.doi.org/', '').replace('doi.org/', '').strip()
+
+                duplicate_papers = Paper.objects.filter(
+                    Q(doi__iexact=normalized_doi) |
+                    Q(doi__iexact=f'doi.org/{normalized_doi}') |
+                    Q(doi__iexact=f'https://doi.org/{normalized_doi}') |
+                    Q(doi__iexact=f'dx.doi.org/{normalized_doi}') |
+                    Q(doi__iexact=f'https://dx.doi.org/{normalized_doi}'),
+                    is_removed=False
+                ).exclude(id=paper.id)
+
+                # Exclude papers that have non-zero discussion counts or related CitationEntry
+                # Since these are probably (in use)
+                duplicate_papers = duplicate_papers.filter(discussion_count=0).exclude(
+                    unified_document__citation_entries__isnull=False
+                ).values_list('id', flat=True)
+                to_update_ids.extend(duplicate_papers)
+                
+                if len(to_update_ids) >= batch_size:
+                    Paper.objects.filter(id__in=to_update_ids).update(is_removed=True)
+                    self.stdout.write(f'Updated {len(to_update_ids)} papers as removed.')
+                    to_update_ids = []
+
+        if to_update_ids:
+            Paper.objects.filter(id__in=to_update_ids).update(is_removed=True)
+            self.stdout.write(f'Updated {len(to_update_ids)} papers as removed.')
+
+        self.stdout.write(self.style.SUCCESS('Successfully marked duplicate papers with 0 discussion count as removed in batches.'))

--- a/src/paper/management/commands/supplement_paper_with_openalex.py
+++ b/src/paper/management/commands/supplement_paper_with_openalex.py
@@ -1,0 +1,91 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from paper.models import Paper
+from utils.openalex import OpenAlex
+from paper.exceptions import DOINotFoundError
+from dateutil.parser import parse
+
+class Command(BaseCommand):
+    help = 'Supplement paper with OpenAlex data if the discussion count is greater than 0'
+
+    def handle(self, *args, **kwargs):
+        papers = Paper.objects.filter(
+            discussion_count__gt=0,
+        )
+
+        open_alex = OpenAlex()
+        updated_papers = []
+        total_papers_updated = 0
+        batch_size = 10
+
+        for paper in papers.iterator():
+            if not paper.doi:
+                continue  # Skip papers without a DOI
+
+            try:
+                openalex_work = open_alex.get_data_from_doi(paper.doi)
+                data, _ = open_alex.parse_to_paper_format(openalex_work)
+
+                needs_update = False
+                if data.get("abstract") and not paper.abstract:
+                    paper.abstract = data.get("abstract")
+                    needs_update = True
+                if data.get("pdf_license") and not paper.pdf_license:
+                    paper.pdf_license = data.get("pdf_license")
+                    needs_update = True
+                if data.get("oa_status") and not paper.oa_status:
+                    paper.oa_status = data.get("oa_status")
+                    needs_update = True
+                if data.get("is_open_access") and paper.is_open_access is None:
+                    paper.is_open_access = data.get("is_open_access")
+                    needs_update = True
+                if data.get("open_alex_raw_json") and not paper.open_alex_raw_json:
+                    paper.open_alex_raw_json = data.get("open_alex_raw_json")
+                    needs_update = True
+                if data.get("paper_publish_date") and not paper.paper_publish_date:
+                    paper.paper_publish_date = parse(data.get("paper_publish_date")).date()
+                    needs_update = True
+                if data.get("alternate_ids") and not paper.alternate_ids:
+                    paper.alternate_ids = data.get("alternate_ids")
+                    needs_update = True
+
+                # If this paper needs an update, add it to the list
+                if needs_update:
+                    updated_papers.append(paper)
+
+                # When enough papers have been accumulated, update them in batch
+                if len(updated_papers) >= batch_size:
+                    Paper.objects.bulk_update(
+                        updated_papers,
+                        [
+                            'abstract',
+                            'pdf_license',
+                            'oa_status',
+                            'is_open_access',
+                            'open_alex_raw_json',
+                            'paper_publish_date',
+                            'alternate_ids',
+                        ],
+                    )
+                    total_papers_updated += len(updated_papers)
+                    updated_papers = []  # Reset the list after updating
+
+            except DOINotFoundError:
+                continue
+
+        if updated_papers:
+            Paper.objects.bulk_update(
+                updated_papers,
+                [
+                    'abstract',
+                    'pdf_license',
+                    'oa_status',
+                    'is_open_access',
+                    'open_alex_raw_json',
+                    'paper_publish_date',
+                    'alternate_ids',
+                ],
+            )
+            total_papers_updated += len(updated_papers)
+
+        self.stdout.write(self.style.SUCCESS(f'Batch update completed. Updated {total_papers_updated} papers.'))

--- a/src/paper/management/commands/update_abstracts_from_open_alex_json.py
+++ b/src/paper/management/commands/update_abstracts_from_open_alex_json.py
@@ -1,0 +1,23 @@
+from django.core.management.base import BaseCommand
+from paper.models import Paper
+from utils.parsers import rebuild_sentence_from_inverted_index
+
+class Command(BaseCommand):
+    help = 'Update paper abstracts from open_alex_raw_json'
+
+    def handle(self, *args, **kwargs):
+        papers = Paper.objects.filter(abstract__isnull=True, open_alex_raw_json__isnull=False).iterator()
+
+        to_update = []
+        for paper in papers:
+            inverted_index = paper.open_alex_raw_json.get('abstract_inverted_index', None)
+            if inverted_index:
+                paper.abstract = rebuild_sentence_from_inverted_index(inverted_index)
+                to_update.append(paper)
+
+            if len(to_update) >= 100:
+                Paper.objects.bulk_update(to_update, ['abstract'])
+                to_update = []
+
+        if to_update:
+            Paper.objects.bulk_update(to_update, ['abstract'])

--- a/src/paper/management/commands/update_abstracts_from_open_alex_json.py
+++ b/src/paper/management/commands/update_abstracts_from_open_alex_json.py
@@ -16,8 +16,10 @@ class Command(BaseCommand):
                 to_update.append(paper)
 
             if len(to_update) >= 100:
+                print(f'Updating {len(to_update)} papers...')
                 Paper.objects.bulk_update(to_update, ['abstract'])
                 to_update = []
 
         if to_update:
+            print(f'Updating {len(to_update)} papers...')
             Paper.objects.bulk_update(to_update, ['abstract'])


### PR DESCRIPTION
# Cleanup Scripts

### Fix Bad DOIs
Some DOIs aren't properly formatted:
- Base64 string
- Missing host id prefix

So fix them intelligently using `url` field.

### Fix Empty Titles/Dates
There's some papers with empty titles and/or dates, but OpenAlex has that data so just supplement the db rows with OpenAlex data.

### Remove Duplicates by DOI
Some DOIs in db have `https://doi.org` or `doi.org` prefix, so normalize these and find duplicates, then remove duplicate if there's no discussion.

### Update Abstracts
Update papers with missing abstracts by parsing `abstract_inverted_index` in OpenAlex data.

### Supplement with OpenAlex
Supplement papers with non-zero discussion_count with OpenAlex data.

# Backfill Scripts

### Rough Steps
1. Download OpenAlex snapshot (>330GB)
2. Use script to parse/process data and create CSV files
3. Bulk-load CSV files into temp tables in database
4. Update database tables with new data

### More details
1. OpenAlex Snapshot
    - A bunch of compressed `.jsonl` files
    - Only organized by when they were last updated in OpenAlex
2. Processing Scripts
    - Script goes through _all_ compressed files and filters for papers published in last 5 years
    - Excludes objects that aren't articles (e.g. grants, datasets, etc.)
    - Transforms OpenAlex data to our db schema
    - Creates CSV files for `paper`, `unified_document`, and `hubs` / `concepts` data
    - CSV files are split into chunks by year for easier processing
    - Deletes original files after processing to preserve disk space
3. Bulk-load CSV
    - Use `psql` to load CSV files into temp tables for processing
        - Bulk-loading CSV files is the most efficient way to import large data
4. Update tables
    - Add/update entries in the `paper_paper` table
    - Create new `unified_document` entries for all new papers
    - Go back and update the new `paper_paper` entries with new `unified_document_id`
    - Insert document concepts and hubs

---
### Alternatives considered
- Setup a job that queries OpenAlex API
    - Would be much slower and less efficient
- Create python scripts that leverage Django data model and use that to insert data with high data integrity
    - Would also be much slower, and the data model isn't too complex for raw SQL commands

### Concerns
- Large database inserts can lock tables for long amounts of time
    - Will test in staging to see how long these inserts take, if they take a while we can chunk them up