### PR TITLE
Fix bug where preregistrations weren't showing up on /funding

### DIFF
--- a/src/researchhub_document/filters.py
+++ b/src/researchhub_document/filters.py
@@ -208,7 +208,10 @@ class UnifiedDocumentFilter(filters.FilterSet):
             )
             qs = qs.filter(document_filter__has_bounty=True)
         else:
-            qs = qs.exclude(document_type=NOTE)
+            # We do this for preregistrations so that they don't show up in the home feed,
+            # but do show up on the /funding page.
+            # This is a temporary solution as we trial out preregistration funding.
+            qs = qs.exclude(document_type__in=[NOTE, PREREGISTRATION])
 
         return qs.select_related(*selects).prefetch_related(*prefetches)
 


### PR DESCRIPTION
Currently, we set `is_excluded_in_feed=True` in the backend document filter to hide a preregistration from the home page, but this causes preregistrations to not get shown on `/funding` since they don't get returned on the `get_unified_documents` endpoint.

I'm modifying the fetch for all unified documents to exclude preregistrations, and then I'm going to set `is_excluded_in_feed` back to `NULL` for the preregistrations.

So preregistrations will be excluded from `get_unified_documents` results unless you explicitly filter for `type=preregistration`