### PR TITLE
Reduce database load from Unified Doc fetch

### DIFF
--- a/src/researchhub_document/views/custom/unified_document_pagination.py
+++ b/src/researchhub_document/views/custom/unified_document_pagination.py
@@ -1,31 +1,58 @@
 from collections import OrderedDict
 
 from django.db import connection
+from django.core.paginator import Paginator
+from django.utils.functional import cached_property
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
 UNIFIED_DOC_PAGE_SIZE = 20
 
+class PaginatorWithApproximateCount(Paginator):
+    """
+    Adapted from: https://gist.github.com/noviluni/d86adfa24843c7b8ed10c183a9df2afe
+    """
+    @cached_property
+    def count(self):
+        """
+        Returns an approximate number of objects, across all pages.
+        """
+        try:
+            with connection.cursor() as cursor:
+                # Obtain estimated values
+                # reltuples is a cached value that approximates the number of rows in the table
+                cursor.execute(
+                    "SELECT reltuples FROM pg_class WHERE relname = %s",
+                    [self.object_list.query.model._meta.db_table]
+                )
+                estimate = int(cursor.fetchone()[0])
+                return estimate
+        except Exception:
+            # If any other exception occurred fall back to default behaviour
+            pass
+
+        # We can fallback to a very large number,
+        # because if Django receives a page number over the actual number of pages,
+        # it will default to the last page.
+        return 9999999999
+
 
 class UnifiedDocPagination(PageNumberPagination):
+    # We use a custom paginator to get an approximate count,
+    # because the unified document table is very large
+    # so the COUNT(*) ends up being very slow.
+    # Also, we don't show an exact page count to the user,
+    # we mainly use pagination to go to the next page.
+    django_paginator_class = PaginatorWithApproximateCount
     page_size_query_param = "page_limit"
     max_page_size = 200  # NOTE: arbitrary size for security
     page_size = UNIFIED_DOC_PAGE_SIZE
-
-    def _get_estimated_count(self):
-        cursor = connection.cursor()
-        cursor.execute(
-            "SELECT reltuples FROM pg_class WHERE relname = 'researchhub_document_researchhubunifieddocument'"
-        )
-        n = int(cursor.fetchone()[0])
-        connection.close()
-        return n
 
     def get_paginated_response(self, data):
         return Response(
             OrderedDict(
                 [
-                    ("count", self._get_estimated_count()),
+                    ("count", self.page.paginator.count),
                     ("next", self.get_next_link()),
                     ("previous", self.get_previous_link()),
                     ("results", data),


### PR DESCRIPTION
## Context
There were a lot of `SELECT COUNT(*)` queries on Unified Document table, after investigating it became clear that basically all of them were from requests to the `get_unified_documents` endpoint.

When I logged the raw SQL run by Django, and tried requests to this endpoint locally, the raw SQL queries exactly matched the queries in the slow query log.

It seems like the `SELECT COUNT(*)` would get called from the underlying `Paginator` object when fetching the unified documents.

## Fix

We already had some logic to use a "cached" version of the row count for speed, but the underlying `Paginator` object was still calling the `SELECT COUNT(*)`.

I modified the custom paginator to correctly use the cached row count in all cases.

## Testing

Tested locally by logging the raw SQL that Django runs, and didn't see any `SELECT COUNT(*)` on the Unified Document table.