### PR TITLE
Fix document tests

### DIFF
--- a/src/researchhub_document/tests/test_view.py
+++ b/src/researchhub_document/tests/test_view.py
@@ -159,7 +159,7 @@ class ViewTests(APITestCase):
         )
         self.assertEqual(doc.is_removed, True)
 
-    def author_can_create_post(self):
+    def test_author_can_create_post(self):
         author = create_random_default_user("author")
         hub = create_hub()
 
@@ -180,7 +180,7 @@ class ViewTests(APITestCase):
 
         self.assertEqual(doc_response.status_code, 200)
 
-    def author_can_update_post(self):
+    def test_author_can_update_post(self):
         author = create_random_default_user("author")
         hub = create_hub()
 
@@ -215,9 +215,7 @@ class ViewTests(APITestCase):
 
         self.assertEqual(updated_response.data["title"], "updated title")
 
-    def non_author_cannot_update_post(self):
-        author = create_random_default_user("author")
-        nonauthor = create_random_default_user("nonauthor")
+    def test_non_author_cannot_update_post(self):
         hub = create_hub()
 
         self.client.force_authenticate(author)
@@ -252,7 +250,7 @@ class ViewTests(APITestCase):
 
         self.assertEqual(updated_response.status_code, 403)
 
-    def author_can_create_hypothesis(self):
+    def test_author_can_create_hypothesis(self):
         author = create_random_default_user("author")
         hub = create_hub()
 
@@ -273,7 +271,7 @@ class ViewTests(APITestCase):
 
         self.assertEqual(doc_response.status_code, 200)
 
-    def author_can_update_hypothesis(self):
+    def test_author_can_update_hypothesis(self):
         author = create_random_default_user("author")
         hub = create_hub()
 

--- a/src/researchhub_document/tests/test_view.py
+++ b/src/researchhub_document/tests/test_view.py
@@ -301,7 +301,7 @@ class ViewTests(APITestCase):
             },
         )
 
-        self.assertEqual(updated_response.data["full_src"], "updated body")
+        self.assertEqual(updated_response.data["full_markdown"], "updated body")
 
     def test_non_author_cannot_edit_hypothesis(self):
         author = create_random_default_user("author")

--- a/src/user/tests/helpers.py
+++ b/src/user/tests/helpers.py
@@ -9,6 +9,7 @@ from hub.tests.helpers import create_hub
 from researchhub_access_group.constants import EDITOR
 from researchhub_access_group.models import Permission
 from user.models import Action, Author, University, User
+from user.related_models.organization_model import Organization
 
 
 class TestData:
@@ -62,6 +63,14 @@ def create_random_default_user(unique_value, moderator=False):
         first_name=first_name, last_name=last_name, email=email, moderator=moderator
     )
     return user
+
+
+def create_organization(
+    name="Organization", description="Organization description", slug="org"
+):
+    return Organization.objects.create(
+        name=name, description=description, slug=slug
+    )
 
 
 def create_user(


### PR DESCRIPTION
- Some of the test never ran because test methods were not prefixed with `test_`.
- Fix existing texts (update hypothesis, update post with different user than author).