### PR TITLE
Add Dev Containers Setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.8-bookworm
+
+ENV PYTHONUNBUFFERED 1
+
+# [Optional] If your requirements rarely change, uncomment this section to add them to the image.
+# COPY requirements.txt /tmp/pip-tmp/
+# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#    && rm -rf /tmp/pip-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+
+

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,5 +11,6 @@ ENV PYTHONUNBUFFERED 1
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
+RUN pip --no-cache-dir install --upgrade pip poetry
 
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/postgres
+{
+	"name": "Python 3 & PostgreSQL",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// This can be used to network with other containers or the host.
+	// "forwardPorts": [5000, 5432],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip install --user -r requirements.txt",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// This can be used to network with other containers or the host.
 	"forwardPorts": [
-		"app:8080",
+		"app:8000",
 		"elasticsearch:9200",
 		"postgres:5432",
 		"redis:6379"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,14 +4,17 @@
 	"name": "Python 3 & PostgreSQL",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
-	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// This can be used to network with other containers or the host.
-	// "forwardPorts": [5000, 5432],
+	"forwardPorts": [
+		"app:8080",
+		"postgres:5432"
+	]
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "pip install --user -r requirements.txt",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "sh -c 'poetry install --directory=src && pip install -r src/requirements.txt --no-deps'"
+	"postCreateCommand": "chmod +x .devcontainer/post-create.sh && .devcontainer/post-create.sh"
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/postgres
 {
-	"name": "Python 3 & PostgreSQL",
+	"name": "ResearchHub Backend",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,10 +14,10 @@
 	"forwardPorts": [
 		"app:8080",
 		"postgres:5432"
-	]
+	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pip install --user -r requirements.txt",
+	"postCreateCommand": "sh -c 'poetry install --directory=src && pip install -r src/requirements.txt --no-deps'"
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,9 @@
 	// This can be used to network with other containers or the host.
 	"forwardPorts": [
 		"app:8080",
-		"postgres:5432"
+		"elasticsearch:9200",
+		"postgres:5432",
+		"redis:6379"
 	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: postgres
+
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  postgres-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   app:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data
+      - ./postgres/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -31,5 +31,12 @@ services:
     # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
+  redis:
+    image: redis:6.2
+    restart: unless-stopped
+
+    # Add "forwardPorts": ["6379"] to **devcontainer.json** to forward Redis locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
 volumes:
   postgres-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,6 +18,15 @@ services:
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.18
+    restart: unless-stopped
+    environment:
+      discovery.type: single-node
+
+    # Add "forwardPorts": ["9200", "9300"] to **devcontainer.json** to forward Elasticsearch locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
   postgres:
     image: postgres:14
     restart: unless-stopped

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,11 +23,10 @@ services:
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - ./postgres/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: researchhub
+      POSTGRES_DB: researchhub
+      POSTGRES_PASSWORD: researchhub
 
     # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,6 +13,13 @@ services:
     command: sleep infinity
     volumes:
       - ../..:/workspaces:cached
+    environment:
+      DB_HOST: postgres
+      DB_USER: researchhub
+      DB_PASS: researchhub
+      ELASTICSEARCH_HOST: http://elasticsearch:9200
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
     networks:
       - researchhub
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - researchhub
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.18
+    image: elasticsearch:7.17.18
     restart: unless-stopped
     environment:
       discovery.type: single-node

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,12 +13,12 @@ services:
     command: sleep infinity
 
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:db
+    network_mode: service:postgres
 
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
-  db:
+  postgres:
     image: postgres:latest
     restart: unless-stopped
     volumes:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - researchhub
 
   postgres:
-    image: postgres:14
+    image: postgres:14-alpine
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data
@@ -37,7 +37,7 @@ services:
       - researchhub
 
   redis:
-    image: redis:6.2
+    image: redis:6.2-alpine
     restart: unless-stopped
     networks:
       - researchhub

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   postgres:
-    image: postgres:latest
+    image: postgres:14
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,3 +1,7 @@
+# Note:
+# Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+# (Adding the "ports" property to this file will not forward from a Codespace.)
+
 version: "3.8"
 
 services:
@@ -5,27 +9,20 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-
-    volumes:
-      - ../..:/workspaces:cached
-
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
-
-    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:postgres
-
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
+    volumes:
+      - ../..:/workspaces:cached
+    networks:
+      - researchhub
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.18
     restart: unless-stopped
     environment:
       discovery.type: single-node
-
-    # Add "forwardPorts": ["9200", "9300"] to **devcontainer.json** to forward Elasticsearch locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
+    networks:
+      - researchhub
 
   postgres:
     image: postgres:14
@@ -36,16 +33,18 @@ services:
       POSTGRES_USER: researchhub
       POSTGRES_DB: researchhub
       POSTGRES_PASSWORD: researchhub
-
-    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
+    networks:
+      - researchhub
 
   redis:
     image: redis:6.2
     restart: unless-stopped
+    networks:
+      - researchhub
 
-    # Add "forwardPorts": ["6379"] to **devcontainer.json** to forward Redis locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
+networks:
+  researchhub:
+    driver: bridge
 
 volumes:
   postgres-data:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+# Install dependencies
+poetry install --directory=src
+pip install -r src/requirements.txt --no-deps
+
+# Apply database migrations
+cd src
+python manage.py makemigrations
+python manage.py migrate
+cd -
+
+echo "Post create script complete."

--- a/.devcontainer/postgres/init-db.sql
+++ b/.devcontainer/postgres/init-db.sql
@@ -1,1 +1,0 @@
-CREATE DATABASE researchhub;

--- a/.devcontainer/postgres/init-db.sql
+++ b/.devcontainer/postgres/init-db.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE researchhub;

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/README.md
+++ b/README.md
@@ -28,7 +28,71 @@ We believe that by empowering scientists to independently fund, create, and publ
 
 # Installation
 
-## 1. Quick install using Docker (Not recommended for development)
+There are three different methods for running this project: [Dev Containers with VSCode](#dev-containers-and-vscode), [Docker Compose](#quick-install-using-docker-not-recommended-for-development) and [a native installation](#native-install-slower-recommended-for-development).
+
+## Dev Containers and VSCode
+
+### Prerequisites
+
+Install [Docker](https://www.docker.com/), [Visual Studio Code](https://code.visualstudio.com/) and [the Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). Please review the [Installation section](https://code.visualstudio.com/docs/devcontainers/containers#_installation) in the [Visual Studio Code Dev Container documentation](https://code.visualstudio.com/docs/devcontainers/containers).
+
+On MacOS with [Homebrew](https://brew.sh/), the installation can be achieved with the following commands:
+
+```shell
+brew install docker
+brew install visual-studio-code
+code --install-extension ms-vscode-remote.vscode-remote-extensionpack
+```
+
+### Configuration
+
+Clone the repository and create an initial configuration by copying the sample configuration files to `config_local`:
+
+```shell
+cp db_config.sample.py src/config_local/db.py
+cp keys.sample.py src/config_local/keys.py
+cp twitter_config_sample.py src/config_local/twitter.py
+```
+
+Make adjustments to the new configuration files as needed.
+
+### Start Developing
+
+When opening the code in VSCode, tt will recognize the Dev Containers configuration and will prompt to _Rebuild and Reopen in Container_.
+Alternatively, select _Rebuild and Reopen in Container_ manually from the command palette.
+This will pull and run all necessary auxiliary services including ElasticSearch, PostgreSQL, and Redis.
+
+During the creation of the dev container, all Python dependencies are downloaded and installed and an initial database migration is also performed. After dev container creation, proceed with [seeding the database](#Seed-the-database) as needed.
+
+### Running and Debugging
+
+Run the application by typing the following into integrated terminal:
+
+```shell
+cd src
+python manage.py runserver
+```
+
+Alternatively, debugging of the application is possible with the following launch configuration (in `.vscode/launch.json`):
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Django",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/src/manage.py",
+      "args": ["runserver", "[::]:8000"],
+      "django": true,
+      "autoStartBrowser": false
+    }
+  ]
+}
+```
+
+## Quick install using Docker (Not recommended for development)
 
 1. Download or clone this repository.
 2. Copy local config files. From inside the dir root, run
@@ -49,7 +113,7 @@ docker-compose up
 The backend will now run at localhost:8000  
 4. Setup and run the [web app](https://github.com/ResearchHub/researchhub-web) at localhost:3000
 
-## 2. Native install (Slower, recommended for development)
+## Native install (Slower, recommended for development)
 
 ### Prerequisites
 1. Docker


### PR DESCRIPTION
Add a [Dev Containers](https://containers.dev/) setup that allows developing, running and debugging the project in a self-contained environment. The setup aims to bootstrap a full project environment including all dependencies (Python, Poetry) and services (ElasticSearch, PostgreSQL, ElasticSearch) and making it available by opening it in VSCode using the Dev Containers extension.