### PR TITLE
Verify post authors

### DIFF
--- a/src/researchhub_document/tests/test_view.py
+++ b/src/researchhub_document/tests/test_view.py
@@ -135,7 +135,7 @@ class ViewTests(APITestCase):
         self.client.force_authenticate(author)
 
         doc_response = self.client.post(
-            f"/api/researchhubpost/",
+            "/api/researchhubpost/",
             {
                 "document_type": "DISCUSSION",
                 "created_by": author.id,

--- a/src/researchhub_document/tests/test_view.py
+++ b/src/researchhub_document/tests/test_view.py
@@ -60,6 +60,8 @@ class ViewTests(APITestCase):
         response = self.client.delete(
             f"/api/researchhub_unified_document/{doc_response.data['unified_document_id']}/censor/"
         )
+        self.assertEqual(response.status_code, 200)
+
         doc = ResearchhubUnifiedDocument.all_objects.get(
             id=doc_response.data["unified_document_id"]
         )
@@ -87,6 +89,8 @@ class ViewTests(APITestCase):
         delete_response = self.client.delete(
             f"/api/researchhub_unified_document/{doc_response.data['unified_document_id']}/censor/"
         )
+        self.assertEqual(delete_response.status_code, 200)
+
         restore_response = self.client.patch(
             f"/api/researchhub_unified_document/{doc_response.data['unified_document_id']}/restore/"
         )
@@ -115,6 +119,7 @@ class ViewTests(APITestCase):
         delete_response = self.client.delete(
             f"/api/researchhub_unified_document/{doc_response.data['unified_document_id']}/censor/"
         )
+        self.assertEqual(delete_response.status_code, 200)
 
         self.client.force_authenticate(mod)
         restore_response = self.client.patch(
@@ -147,6 +152,8 @@ class ViewTests(APITestCase):
         response = self.client.delete(
             f"/api/researchhub_unified_document/{doc_response.data['unified_document_id']}/censor/"
         )
+        self.assertEqual(response.status_code, 403)
+
         doc = ResearchhubUnifiedDocument.objects.get(
             id=doc_response.data["unified_document_id"]
         )
@@ -177,6 +184,8 @@ class ViewTests(APITestCase):
         response = self.client.delete(
             f"/api/researchhub_unified_document/{doc_response.data['unified_document_id']}/censor/"
         )
+        self.assertEqual(response.status_code, 200)
+
         doc = ResearchhubUnifiedDocument.all_objects.get(
             id=doc_response.data["unified_document_id"]
         )
@@ -403,6 +412,7 @@ class ViewTests(APITestCase):
                 "hubs": [hub.id],
             },
         )
+        self.assertEqual(doc_response.status_code, 200)
 
         updated_response = self.client.post(
             f"/api/hypothesis/{doc_response.data['id']}/upsert/",
@@ -414,7 +424,7 @@ class ViewTests(APITestCase):
                 "renderable_text": "body",
             },
         )
-
+        self.assertEqual(updated_response.status_code, 200)
         self.assertEqual(updated_response.data["full_markdown"], "updated body")
 
     def test_non_author_cannot_edit_hypothesis(self):
@@ -436,6 +446,7 @@ class ViewTests(APITestCase):
                 "hubs": [hub.id],
             },
         )
+        self.assertEqual(doc_response.status_code, 200)
 
         self.client.force_authenticate(non_author)
 
@@ -449,6 +460,7 @@ class ViewTests(APITestCase):
                 "renderable_text": "body",
             },
         )
+        self.assertEqual(updated_response.status_code, 403)
         self.assertEqual(updated_response.status_code, 403)
 
     def test_hub_editors_can_censor_papers(self):

--- a/src/researchhub_document/tests/test_view.py
+++ b/src/researchhub_document/tests/test_view.py
@@ -12,6 +12,7 @@ from reputation.distributor import Distributor
 from researchhub_access_group.constants import EDITOR
 from researchhub_access_group.models import Permission
 from researchhub_document.models import ResearchhubUnifiedDocument
+from user.related_models.author_model import Author
 from user.related_models.organization_model import Organization
 from user.tests.helpers import create_organization, create_random_default_user
 
@@ -20,8 +21,11 @@ class ViewTests(APITestCase):
     def setUp(self):
         # Create three users - an org admin, and a member of the admin's org, and a non-member:
         self.admin_user = create_random_default_user("admin")
+        self.admin_author = Author.objects.select_related("user").get(id=self.admin_user.id)
         self.member_user = create_random_default_user("member")
+        self.member_author = Author.objects.select_related("user").get(id=self.member_user.id)
         self.non_member = create_random_default_user("non_member")
+        self.non_member_author = Author.objects.select_related("user").get(id=self.non_member.id)
 
         # Make `member_user` a member of `admin_user`'s organization
         self.organization = Organization.objects.get(user_id=self.admin_user.id)
@@ -207,7 +211,7 @@ class ViewTests(APITestCase):
         doc_response = self.client.post(
             "/api/researchhubpost/",
             {
-                "authors": [self.admin_user.id, self.member_user.id],
+                "authors": [self.admin_author.id, self.member_author.id],
                 "created_by": self.admin_user.id,
                 "document_type": "DISCUSSION",
                 "full_src": "body",
@@ -229,7 +233,7 @@ class ViewTests(APITestCase):
         doc_response = self.client.post(
             "/api/researchhubpost/",
             {
-                "authors": [self.admin_user.id, self.non_member.id],
+                "authors": [self.admin_author.id, self.non_member_author.id],
                 "created_by": self.admin_user.id,
                 "document_type": "DISCUSSION",
                 "full_src": "body",
@@ -304,7 +308,7 @@ class ViewTests(APITestCase):
         updated_response = self.client.post(
             "/api/researchhubpost/",
             {
-                "authors": [self.admin_user.id, self.non_member.id],
+                "authors": [self.admin_author.id, self.non_member_author.id],
                 "post_id": doc_response.data["id"],
                 "title": "updated title",
                 "document_type": "DISCUSSION",

--- a/src/researchhub_document/tests/test_view.py
+++ b/src/researchhub_document/tests/test_view.py
@@ -244,23 +244,25 @@ class ViewTests(APITestCase):
         self.assertEqual(doc_response.status_code, 403)
 
     def test_author_can_update_post(self):
-        author = create_random_default_user("author")
-        hub = create_hub()
+        note = create_note(self.admin_user, self.organization)
 
-        self.client.force_authenticate(author)
+        self.client.force_authenticate(self.admin_user)
 
         doc_response = self.client.post(
             "/api/researchhubpost/",
             {
                 "document_type": "DISCUSSION",
-                "created_by": author.id,
+                "created_by": self.admin_user.id,
                 "full_src": "body",
                 "is_public": True,
+                "note_id": note[0].id,
                 "renderable_text": "body",
                 "title": "title",
-                "hubs": [hub.id],
+                "hubs": [self.hub.id],
             },
         )
+
+        self.assertEqual(doc_response.status_code, 200)
 
         updated_response = self.client.post(
             "/api/researchhubpost/",
@@ -268,11 +270,11 @@ class ViewTests(APITestCase):
                 "post_id": doc_response.data["id"],
                 "title": "updated title",
                 "document_type": "DISCUSSION",
-                "created_by": author.id,
+                "created_by": self.admin_user.id,
                 "full_src": "body",
                 "is_public": True,
                 "renderable_text": "body",
-                "hubs": [hub.id],
+                "hubs": [self.hub.id],
             },
         )
 

--- a/src/researchhub_document/tests/test_view.py
+++ b/src/researchhub_document/tests/test_view.py
@@ -280,6 +280,44 @@ class ViewTests(APITestCase):
 
         self.assertEqual(updated_response.data["title"], "updated title")
 
+    def test_author_cannot_update_post_with_non_members(self):
+        note = create_note(self.admin_user, self.organization)
+
+        self.client.force_authenticate(self.admin_user)
+
+        doc_response = self.client.post(
+            "/api/researchhubpost/",
+            {
+                "document_type": "DISCUSSION",
+                "created_by": self.admin_user.id,
+                "full_src": "body",
+                "is_public": True,
+                "note_id": note[0].id,
+                "renderable_text": "body",
+                "title": "title",
+                "hubs": [self.hub.id],
+            },
+        )
+
+        self.assertEqual(doc_response.status_code, 200)
+
+        updated_response = self.client.post(
+            "/api/researchhubpost/",
+            {
+                "authors": [self.admin_user.id, self.non_member.id],
+                "post_id": doc_response.data["id"],
+                "title": "updated title",
+                "document_type": "DISCUSSION",
+                "created_by": self.admin_user.id,
+                "full_src": "body",
+                "is_public": True,
+                "renderable_text": "body",
+                "hubs": [self.hub.id],
+            },
+        )
+
+        self.assertEqual(updated_response.status_code, 403)
+
     def test_non_author_cannot_update_post(self):
         hub = create_hub()
 

--- a/src/researchhub_document/tests/test_view.py
+++ b/src/researchhub_document/tests/test_view.py
@@ -21,11 +21,11 @@ class ViewTests(APITestCase):
     def setUp(self):
         # Create three users - an org admin, and a member of the admin's org, and a non-member:
         self.admin_user = create_random_default_user("admin")
-        self.admin_author = Author.objects.select_related("user").get(id=self.admin_user.id)
+        self.admin_author, _ = Author.objects.get_or_create(user=self.admin_user)
         self.member_user = create_random_default_user("member")
-        self.member_author = Author.objects.select_related("user").get(id=self.member_user.id)
+        self.member_author, _ = Author.objects.get_or_create(user=self.member_user)
         self.non_member = create_random_default_user("non_member")
-        self.non_member_author = Author.objects.select_related("user").get(id=self.non_member.id)
+        self.non_member_author, _ = Author.objects.get_or_create(user=self.non_member)
 
         # Make `member_user` a member of `admin_user`'s organization
         self.organization = Organization.objects.get(user_id=self.admin_user.id)

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -21,10 +21,6 @@ from note.models import NoteContent
 from note.related_models.note_model import Note
 from peer_review.serializers import PeerReviewRequestSerializer
 from purchase.models import Balance, Purchase
-from reputation.views.bounty_view import (
-    _create_bounty,
-    _create_bounty_checks,
-)
 from researchhub.settings import (
     BASE_FRONTEND_URL,
     CROSSREF_API_URL,

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -57,7 +57,7 @@ from researchhub_document.serializers.researchhub_post_serializer import (
     ResearchhubPostSerializer,
 )
 from researchhub_document.utils import reset_unified_document_cache
-from user.related_models.user_model import User
+from user.related_models.author_model import Author
 from utils.sentry import log_error
 from utils.siftscience import SIFT_POST, sift_track
 from utils.throttles import THROTTLE_CLASSES
@@ -103,8 +103,8 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
 
     def _check_authors_in_org(self, authors, organization):
         for author_id in authors:
-            author = User.objects.get(id=author_id)
-            if not organization.org_has_user(author):
+            author = Author.objects.select_related("user").get(id=author_id)
+            if not organization.org_has_user(author.user):
                 return False
         return True
 

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -133,27 +133,10 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
                 title = data.get("title", "")
                 assign_doi = data.get("assign_doi", False)
                 peer_review_is_requested = data.get("request_peer_review", False)
-                # amount = data.pop("amount", None)
                 doi = generate_doi() if assign_doi else None
 
                 if assign_doi and created_by.get_balance() - CROSSREF_DOI_RSC_FEE < 0:
                     return Response("Insufficient Funds", status=402)
-
-                # if amount:
-                #     item_content_type = ResearchhubPost.__name__.lower()
-                #     response = _create_bounty_checks(
-                #         created_by, amount, item_content_type
-                #     )
-                #     if not isinstance(response, tuple):
-                #         return response
-                #     else:
-                #         (
-                #             amount,
-                #             fee_amount,
-                #             rh_fee,
-                #             dao_fee,
-                #             current_bounty_fee,
-                #         ) = response
 
                 # logical ordering & not using signals to avoid race-conditions
                 access_group = self.create_access_group(request)
@@ -181,26 +164,6 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
                 full_src_file = ContentFile(data["full_src"].encode())
                 rh_post.authors.set(authors)
                 self.add_upvote(created_by, rh_post)
-
-                # if amount:
-                #     bounty_data = {
-                #         "item_content_type": item_content_type,
-                #         "item": rh_post,
-                #         "item_object_id": rh_post.id,
-                #         "bounty_type": "ANSWER",
-                #     }
-                #     _deduct_fees(
-                #         created_by, fee_amount, rh_fee, dao_fee, current_bounty_fee
-                #     )
-                #     _create_bounty(
-                #         created_by,
-                #         bounty_data,
-                #         amount,
-                #         fee_amount,
-                #         current_bounty_fee,
-                #         item_content_type,
-                #         rh_post.id,
-                #     )
 
                 if not TESTING:
                     if document_type in RESEARCHHUB_POST_DOCUMENT_TYPES:


### PR DESCRIPTION
Verify that all provided authors are all part of the organization under which the post is published. This check is added to the publish post and republish post use cases.