### PR TITLE
Dev Container | Add workaround for Git permission issues

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,12 @@
 	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "chmod +x .devcontainer/post-create.sh && .devcontainer/post-create.sh"
+	"postCreateCommand": "chmod +x .devcontainer/post-create.sh && .devcontainer/post-create.sh",
+
+	// Use 'postStartCommand' to run commands after the container is started.
+	// Currently setting `safe.directory` to the workspace folder to avoid permission issues.
+	// See: https://github.com/microsoft/vscode-remote-release/issues/7923
+	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
Workaround until this issue is addressed: https://github.com/microsoft/vscode-remote-release/issues/7923.

Without this workaround you might see the following error message when working on the Git repository from within the dev container:

```
fatal: detected dubious ownership in repository at '/workspace'
```