### PR TITLE
Dev Container | Copy static content after container creation

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,10 +5,12 @@ set -e
 poetry install --directory=src
 pip install -r src/requirements.txt --no-deps
 
-# Apply database migrations
 cd src
+# Apply database migrations
 python manage.py makemigrations
 python manage.py migrate
+# Copy static conent
+python manage.py collectstatic --no-input
 cd -
 
 echo "Post create script complete."


### PR DESCRIPTION
After container creation, copy static assets to avoid issues resolving includes in template files and similar issues.