### PR TITLE
Dev Container | ElasticSearch Ingest Attachment support

### DIFF
--- a/.devcontainer/Dockerfile.elasticsearch
+++ b/.devcontainer/Dockerfile.elasticsearch
@@ -1,0 +1,3 @@
+FROM elasticsearch:7.17.18
+
+RUN bin/elasticsearch-plugin install --batch ingest-attachment

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,7 +24,9 @@ services:
       - researchhub
 
   elasticsearch:
-    image: elasticsearch:7.17.18
+    build:
+      context: .
+      dockerfile: Dockerfile.elasticsearch
     restart: unless-stopped
     environment:
       discovery.type: single-node


### PR DESCRIPTION
With the dev container setup, create a custom ElasticSearch container that includes the [Ingest Attachment plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/ingest-attachment.html).

This solves this ElasticSearch errors in the dev container:

```
{"error":{"root_cause":[{"type":"parse_exception","reason":"No processor type exists with name [attachment]","processor_type":"attachment"}],"type":"parse_exception","reason":"No processor type exists with name [attachment]","processor_type":"attachment"},"status":400} Request to Elasticsearch failed with400 None
```

**Note:**
The [Ingest Attachment plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/ingest-attachment.html) plugin is part of newer ElasticSearch releases, starting with 8.x. As we're still based on 7.x, installing the plugin is still necessary. 