### PR TITLE
Housekeeping | Update GitHub Actions

### DIFF
--- a/.github/workflows/run-automated-tests.yml
+++ b/.github/workflows/run-automated-tests.yml
@@ -41,7 +41,7 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/run-automated-tests.yml
+++ b/.github/workflows/run-automated-tests.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8.5"
       - name: Updating pip


### PR DESCRIPTION
Update GitHub Actions to the latest versions.

This fixes the following warning on each workflow execution:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-python@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```