### PR TITLE
Housekeeping | Pin service images in GitHub workflow

### DIFF
--- a/.github/workflows/run-automated-tests.yml
+++ b/.github/workflows/run-automated-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:latest
+        image: postgres:14-alpine
         env:
           POSTGRES_DB: researchhub
           POSTGRES_USER: rh_developer

--- a/.github/workflows/run-automated-tests.yml
+++ b/.github/workflows/run-automated-tests.yml
@@ -31,7 +31,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis
+        image: redis:6.2-alpine
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s


### PR DESCRIPTION
Pin service images to the same tag that is used for the dev container setup, aligning with the version used across all environments.