### PR TITLE
GitHub | Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners for everything in this repository.
+# They will be automatically requested for review upon opening a pull request.
+*   @researchhub/engineers


### PR DESCRIPTION
Make the new @ResearchHub/engineers team the code owner of this repository. The team will be automatically requested for review when a pull request is opened.