### PR TITLE
Filter author claim query

### DIFF
--- a/src/researchhub_case/tests/test_approval_flow.py
+++ b/src/researchhub_case/tests/test_approval_flow.py
@@ -4,8 +4,7 @@ from paper.tests.helpers import create_paper
 from researchhub_case.constants.case_constants import APPROVED
 from researchhub_case.models import AuthorClaimCase
 from researchhub_case.tasks import after_approval_flow
-from user.tests.helpers import create_moderator, create_random_default_user
-from user.utils import move_paper_to_author
+from user.tests.helpers import create_random_default_user
 
 
 class ApprovalFlowTests(TestCase):

--- a/src/researchhub_case/views/author_claim_case_view.py
+++ b/src/researchhub_case/views/author_claim_case_view.py
@@ -28,6 +28,9 @@ class AuthorClaimCaseViewSet(ModelViewSet):
     queryset = AuthorClaimCase.objects.all()
     serializer_class = AuthorClaimCaseSerializer
 
+    def get_queryset(self):
+        return self.queryset.filter(requestor=self.request.user.id)
+
     def create(self, request, *args, **kwargs):
         if not self._can_claim_case(request):
             return Response("Author cannot claim case", status=403)


### PR DESCRIPTION
Users querying the `/author_claim_case` endpoint should only see their own claims.