### PR TITLE
Filter deposits on requesting user

### DIFF
--- a/src/reputation/tests/helpers.py
+++ b/src/reputation/tests/helpers.py
@@ -1,8 +1,18 @@
-from reputation.models import Withdrawal
+from reputation.models import Deposit, Withdrawal
 from user.tests.helpers import create_random_default_user
 
 ADDRESS_1 = "0x0000000000000000000000000000000000000000"
 ADDRESS_2 = "0x1123581321345589144233377610987159725844"
+
+
+def create_deposit(
+    user,
+    amount="1500.0",
+    from_address=ADDRESS_1,
+):
+    Deposit.objects.create(
+        user=user, amount=amount, from_address=from_address
+    )
 
 
 def create_withdrawals(count):

--- a/src/reputation/tests/test_views.py
+++ b/src/reputation/tests/test_views.py
@@ -9,7 +9,7 @@ from rest_framework.test import APITestCase
 from reputation.distributions import Distribution as Dist
 from reputation.distributor import Distributor
 from reputation.models import Withdrawal
-from reputation.tests.helpers import create_withdrawals
+from reputation.tests.helpers import create_deposit, create_withdrawals
 from user.tests.helpers import create_random_authenticated_user
 from utils.test_helpers import (
     get_authenticated_get_response,
@@ -21,6 +21,45 @@ class ReputationViewsTests(APITestCase):
     def setUp(self):
         create_withdrawals(10)
         self.all_withdrawals = len(Withdrawal.objects.all())
+
+    def test_deposit_user_can_list_deposits(self):
+        user = create_random_authenticated_user("deposit_user")
+
+        create_deposit(user)
+
+        self.client.force_authenticate(user)
+        response = self.client.get("/api/deposit/")
+
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.data["count"], 1)
+
+    def test_deposit_user_cannot_list_other_deposits(self):
+        user = create_random_authenticated_user("deposit_user")
+        other_user = create_random_authenticated_user("other_deposit_user")
+
+        create_deposit(user)
+
+        self.client.force_authenticate(other_user)
+        response = self.client.get("/api/deposit/")
+
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.data["count"], 0)
+
+    def test_deposit_deposit_user_can_list_all_deposits(self):
+        user1 = create_random_authenticated_user("user1")
+        user2 = create_random_authenticated_user("user2")
+        staff_user = create_random_authenticated_user("staff_user1")
+        staff_user.is_staff = True
+        staff_user.save()
+
+        create_deposit(user1)
+        create_deposit(user2)
+
+        self.client.force_authenticate(staff_user)
+        response = self.client.get("/api/deposit/")
+
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.data["count"], 2)
 
     def test_suspecious_user_cannot_withdraw_rsc(self):
         user = create_random_authenticated_user("rep_user")

--- a/src/reputation/tests/test_views.py
+++ b/src/reputation/tests/test_views.py
@@ -45,7 +45,7 @@ class ReputationViewsTests(APITestCase):
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.data["count"], 0)
 
-    def test_deposit_deposit_user_can_list_all_deposits(self):
+    def test_deposit_deposit_staff_user_can_list_all_deposits(self):
         user1 = create_random_authenticated_user("user1")
         user2 = create_random_authenticated_user("user2")
         staff_user = create_random_authenticated_user("staff_user1")

--- a/src/reputation/views/deposit_view.py
+++ b/src/reputation/views/deposit_view.py
@@ -54,6 +54,13 @@ class DepositViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = DepositSerializer
     permission_classes = [IsAuthenticated]
 
+    def get_queryset(self):
+        user = self.request.user
+        if user.is_staff:
+            return Deposit.objects.all()
+        else:
+            return Deposit.objects.filter(user=user)
+
     @action(detail=False, methods=["post"], permission_classes=[APIPermission])
     def deposit_rsc(self, request):
         """


### PR DESCRIPTION
Users querying the `/deposit` endpoint should only see their own deposits.
Staff users will be able to query all deposits, aligning with the withdrawal implementation in the same file.