### PR TITLE
[Search] Adding retry logic to bulk paper indexing; increase timeout;

### DIFF
--- a/src/search/management/commands/index_papers_in_es.py
+++ b/src/search/management/commands/index_papers_in_es.py
@@ -34,7 +34,7 @@ def index_papers_in_bulk(es, from_id, to_id, max_attempts=5):
             try:
                 # We would typically not need to create a new instance of a document
                 # and assign data to it, but it is necessary here because we are bypassing
-                # the normal indexing process which normall happens via rebuild_index command.
+                # the normal indexing process which normally happens via rebuild_index command.
                 # NOTE: Any attribute we would need to index will have to be assigned here.
                 doc = PaperDocument()
                 doc.meta.id = paper.id

--- a/src/search/management/commands/index_papers_in_es.py
+++ b/src/search/management/commands/index_papers_in_es.py
@@ -10,7 +10,7 @@ from paper.models import Paper
 from search.documents.paper import PaperDocument
 
 
-def index_papers_in_bulk(es, from_id, to_id, attempt=1, max_attempts=5):
+def index_papers_in_bulk(es, from_id, to_id, max_attempts=5):
     batch_size = 2500
     current_id = from_id or 1
     to_id = to_id or Paper.objects.all().order_by("-id").first().id


### PR DESCRIPTION
Prior attempt to bulk index resulted in connection timeouts. Script has been updated to include retry logic and increase in timeout period.