### PR TITLE
[Search] Updating ES suggesters to account for more phrases (e.g. DOI, author, ..) 

### DIFF
--- a/src/search/documents/paper.py
+++ b/src/search/documents/paper.py
@@ -69,7 +69,7 @@ class PaperDocument(BaseDocument):
         return False
 
     # Used specifically for "autocomplete" style suggest feature.
-    # Inlcudes a bunch of phrases the user may search by.
+    # Includes a bunch of phrases the user may search by.
     def prepare_suggestion_phrases(self, instance):
         phrases = []
 

--- a/src/search/documents/paper.py
+++ b/src/search/documents/paper.py
@@ -98,7 +98,7 @@ class PaperDocument(BaseDocument):
             phrases.append(joined_kewords)
             phrases.extend(keywords)
 
-        except:
+        except Exception:
             pass
 
         # Variation of author names which may be searched by users
@@ -113,7 +113,7 @@ class PaperDocument(BaseDocument):
 
             phrases.append(all_authors_as_str)
             phrases.extend(author_names_only)
-        except:
+        except Exception:
             pass
 
         # Assign weight based on how "hot" the paper is

--- a/src/search/documents/paper.py
+++ b/src/search/documents/paper.py
@@ -1,3 +1,5 @@
+import math
+
 from django_elasticsearch_dsl import Document, Index
 from django_elasticsearch_dsl import fields
 from django_elasticsearch_dsl import fields as es_fields
@@ -114,9 +116,16 @@ class PaperDocument(BaseDocument):
         except:
             pass
 
+        # Assign weight based on how "hot" the paper is
+        weight = 1
+        if instance.unified_document.hot_score_v2 > 0:
+            # Scale down the hot score from 1 - 100 to avoid a huge range
+            # of values that could result in bad suggestions
+            weight = int(math.log(instance.unified_document.hot_score_v2, 10) * 10)
+
         return {
             "input": list(set(phrases)),  # Dedupe using set
-            "weight": 1,
+            "weight": weight,
         }
 
     def prepare(self, instance):

--- a/src/search/documents/post.py
+++ b/src/search/documents/post.py
@@ -87,7 +87,7 @@ class PostDocument(BaseDocument):
             phrases.append(all_authors_as_str)
             phrases.append(created_by)
             phrases.extend(author_names_only)
-        except:
+        except Exception:
             pass
 
         # Assign weight based on how "hot" the paper is

--- a/src/search/management/commands/index_papers_in_es.py
+++ b/src/search/management/commands/index_papers_in_es.py
@@ -44,7 +44,7 @@ def index_papers_in_bulk(es, from_id, to_id):
                     "hubs": paper.hubs_indexing or [],
                     "slug": paper.slug or None,
                     "title": paper.title or None,
-                    "title_suggest": doc.prepare_title_suggest(paper),
+                    "suggestion_phrases": doc.prepare_suggestion_phrases(paper),
                     "updated_date": paper.updated_date or None,
                     "is_open_access": paper.is_open_access or None,
                     "oa_status": paper.oa_status,

--- a/src/search/views/combined_suggester.py
+++ b/src/search/views/combined_suggester.py
@@ -19,7 +19,7 @@ class CombinedSuggestView(APIView):
         suggestion_types = [
             {
                 "document": PaperDocument,
-                "suggester_field": "title_suggest",
+                "suggester_field": "suggestion_phrases",
             },
             {
                 "document": PostDocument,

--- a/src/search/views/combined_suggester.py
+++ b/src/search/views/combined_suggester.py
@@ -23,7 +23,7 @@ class CombinedSuggestView(APIView):
             },
             {
                 "document": PostDocument,
-                "suggester_field": "title_suggest",
+                "suggester_field": "suggestion_phrases",
             },
             {
                 "document": UserDocument,


### PR DESCRIPTION
- Allow users to search by more phases.
- More specifically, Updating ElasticSearch suggesters to account for more input phrases that would yield results. These new input phrases are DOI, authors, keywords. 
- Assign weights to documents in such a way that documents with higher `hot_score_v2` show up first
