### PR TITLE
Only return sub in linkedin_data

### DIFF
--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -7,6 +7,7 @@ from rest_framework.serializers import (
     IntegerField,
     ModelSerializer,
     PrimaryKeyRelatedField,
+    Serializer,
     SerializerMethodField,
 )
 
@@ -50,10 +51,15 @@ class UniversitySerializer(ModelSerializer):
         fields = "__all__"
 
 
+class LinkedinDataSerializer(Serializer):
+    sub = CharField(required=False)
+
+
 class AuthorSerializer(ModelSerializer):
     added_as_editor_date = SerializerMethodField()
     is_hub_editor_of = SerializerMethodField()
     is_hub_editor = SerializerMethodField()
+    linkedin_data = LinkedinDataSerializer(required=False)
     num_posts = SerializerMethodField()
     orcid_id = SerializerMethodField()
     reputation = SerializerMethodField()
@@ -71,6 +77,7 @@ class AuthorSerializer(ModelSerializer):
             "is_claimed",
             "is_hub_editor_of",
             "is_hub_editor",
+            "linkedin_data",
             "num_posts",
             "orcid_id",
             "reputation",

--- a/src/user/tests/test_serializers.py
+++ b/src/user/tests/test_serializers.py
@@ -3,22 +3,67 @@ import json
 from django.test import TestCase
 
 from user.serializers import AuthorSerializer
-from user.tests.helpers import create_user, create_university
+from user.tests.helpers import create_university, create_user
 
 
 class UserSerializersTests(TestCase):
-
     def setUp(self):
-        self.user = create_user(first_name='Serializ')
+        self.user = create_user(first_name="Serializ")
         self.university = create_university()
 
     def test_author_serializer_succeeds_without_user_or_university(self):
         data = {
-            'first_name': 'Ray',
-            'last_name': 'Man',
+            "first_name": "Ray",
+            "last_name": "Man",
         }
         serializer = AuthorSerializer(data=data)
-        self.assertTrue(serializer.is_valid())
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_author_serializer_linkedin_data(self):
+        data = {
+            "first_name": "Ray",
+            "last_name": "Man",
+            "linkedin_data": {
+                "sub": "Sub",
+                "name": "Name",
+                "email": "name@email.com",
+                "locale": {
+                    "country": "US",
+                    "language": "en",
+                },
+                "picture": "img.jpg",
+                "given_name": "Given",
+                "family_name": "Family",
+                "email_verified": True,
+            },
+        }
+        serializer = AuthorSerializer(data=data)
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        author = serializer.save()
+        self.assertEqual(author.first_name, data["first_name"])
+        self.assertEqual(author.last_name, data["last_name"])
+        self.assertEqual(
+            author.linkedin_data,
+            {
+                "sub": "Sub",
+            },
+        )
+
+    def test_author_serializer_without_linkedin_data_returns_none(self):
+        data = {
+            "first_name": "Ray",
+            "last_name": "Man",
+        }
+        serializer = AuthorSerializer(data=data)
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        author = serializer.save()
+        self.assertEqual(author.first_name, data["first_name"])
+        self.assertEqual(author.last_name, data["last_name"])
+        self.assertEqual(author.linkedin_data, None)
 
     def test_author_serializer_without_orcid_sends_null(self):
         serializer = AuthorSerializer(self.user.author_profile)


### PR DESCRIPTION
- linkedin_data currently returns email and other identifying information that isn't being used by the front end. The only field that looks to be used is the sub field.