### PR TITLE
Dev Container | Disable auto forwarding ports

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,10 @@
 		"vscode": {
 			"extensions": [
 				"ms-python.flake8"
-			]
+			],
+			"settings": {
+				"remote.autoForwardPorts": false
+			}
 		}
 	}
 


### PR DESCRIPTION
Use the ports defined in `forwardPorts` instead of automatically discovering port (from processes or even parsed output from the integrated terminal).