### PR TITLE
Fix invite lists, only return invites you have received

### DIFF
--- a/src/invite/tests.py
+++ b/src/invite/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/src/invite/tests/test_views.py
+++ b/src/invite/tests/test_views.py
@@ -74,7 +74,7 @@ class NoteInvitationViewsTest(APITestCaseWithOrg):
 
         # Create note
         self.client.force_authenticate(self.sender)
-        response = self.client.post("/api/note/", {"name": "ORG A"})
+        response = self.client.post("/api/note/", {"name": "NOTE A"})
         self.org = response.data
 
     def test_list_invites_sender(self):

--- a/src/invite/tests/test_views.py
+++ b/src/invite/tests/test_views.py
@@ -3,6 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from rest_framework.test import APITestCase
 
 from invite.related_models.invitation_model import Invitation
+from invite.related_models.note_invitation import NoteInvitation
 from invite.related_models.organization_invitation import OrganizationInvitation
 from researchhub_access_group.models import Permission
 from utils.test_helpers import APITestCaseWithOrg
@@ -52,6 +53,55 @@ class OrganizationInvitationViewsTest(APITestCaseWithOrg):
         # Get org invite as recipient
         self.client.force_authenticate(self.recipient)
         response = self.client.get("/api/invite/organization/")
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(len(response.data["results"]), 1)
+
+
+class NoteInvitationViewsTest(APITestCaseWithOrg):
+    def setUp(self):
+        # Create + auth user
+        self.sender = get_user_model().objects.create_user(
+            username="user1@researchhub_test.com",
+            password="password",
+            email="user1@researchhub_test.com",
+        )
+        self.recipient = get_user_model().objects.create_user(
+            username="user2@researchhub_test.com",
+            password="password",
+            email="user2@researchhub_test.com",
+        )
+
+        # Create org
+        self.client.force_authenticate(self.sender)
+        response = self.client.post("/api/note/", {"name": "ORG A"})
+        self.org = response.data
+
+    def test_list_invites_sender(self):
+        response = NoteInvitation.create(
+            expiration_time=1440,
+            recipient=self.recipient,
+            inviter_id=self.sender.id,
+            note_id=self.org["id"],
+        )
+
+        # Get note invite as sender
+        response = self.client.get("/api/invite/note/")
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(len(response.data["results"]), 0)
+
+    def test_list_invites_receiver(self):
+        response = NoteInvitation.create(
+            expiration_time=1440,
+            recipient=self.recipient,
+            inviter_id=self.sender.id,
+            note_id=self.org["id"],
+        )
+
+        # Get note invite as recipient
+        self.client.force_authenticate(self.recipient)
+        response = self.client.get("/api/invite/note/")
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(len(response.data["results"]), 1)

--- a/src/invite/tests/test_views.py
+++ b/src/invite/tests/test_views.py
@@ -72,7 +72,7 @@ class NoteInvitationViewsTest(APITestCaseWithOrg):
             email="user2@researchhub_test.com",
         )
 
-        # Create org
+        # Create note
         self.client.force_authenticate(self.sender)
         response = self.client.post("/api/note/", {"name": "ORG A"})
         self.org = response.data

--- a/src/invite/tests/test_views.py
+++ b/src/invite/tests/test_views.py
@@ -1,0 +1,57 @@
+from allauth.utils import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from rest_framework.test import APITestCase
+
+from invite.related_models.invitation_model import Invitation
+from invite.related_models.organization_invitation import OrganizationInvitation
+from researchhub_access_group.models import Permission
+from utils.test_helpers import APITestCaseWithOrg
+
+
+class OrganizationInvitationViewsTest(APITestCaseWithOrg):
+    def setUp(self):
+        # Create + auth user
+        self.sender = get_user_model().objects.create_user(
+            username="user1@researchhub_test.com",
+            password="password",
+            email="user1@researchhub_test.com",
+        )
+        self.recipient = get_user_model().objects.create_user(
+            username="user2@researchhub_test.com",
+            password="password",
+            email="user2@researchhub_test.com",
+        )
+
+        # Create org
+        self.client.force_authenticate(self.sender)
+        response = self.client.post("/api/organization/", {"name": "ORG A"})
+        self.org = response.data
+
+    def test_list_invites_sender(self):
+        response = OrganizationInvitation.create(
+            expiration_time=1440,
+            recipient=self.recipient,
+            inviter_id=self.sender.id,
+            organization_id=self.org["id"],
+        )
+
+        # Get org invite as sender
+        response = self.client.get("/api/invite/organization/")
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(len(response.data["results"]), 0)
+
+    def test_list_invites_receiver(self):
+        response = OrganizationInvitation.create(
+            expiration_time=1440,
+            recipient=self.recipient,
+            inviter_id=self.sender.id,
+            organization_id=self.org["id"],
+        )
+
+        # Get org invite as recipient
+        self.client.force_authenticate(self.recipient)
+        response = self.client.get("/api/invite/organization/")
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(len(response.data["results"]), 1)

--- a/src/invite/views/note_invite_view.py
+++ b/src/invite/views/note_invite_view.py
@@ -1,11 +1,8 @@
 from django.contrib.contenttypes.models import ContentType
-from rest_framework.viewsets import ModelViewSet
 from rest_framework.decorators import action
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.permissions import (
-    IsAuthenticated,
-    AllowAny
-)
+from rest_framework.viewsets import ModelViewSet
 
 from invite.models import NoteInvitation
 from invite.serializers import NoteInvitationSerializer
@@ -17,37 +14,34 @@ class NoteInvitationViewSet(ModelViewSet):
     permission_classes = [IsAuthenticated]
     serializer_class = NoteInvitationSerializer
 
-    @action(
-        detail=True,
-        methods=['post'],
-        permission_classes=[AllowAny]
-    )
+    def get_queryset(self):
+        return self.queryset.filter(recipient=self.request.user)
+
+    @action(detail=True, methods=["post"], permission_classes=[AllowAny])
     def accept_invite(self, request, pk=None):
         user = request.user
         invite = self.queryset.get(key=pk)
 
         if invite.is_expired() or invite.accepted:
-            return Response({'data': 'Invitation has expired'}, status=403)
+            return Response({"data": "Invitation has expired"}, status=403)
 
         if invite.recipient and user != invite.recipient:
-            return Response({'data': 'Invalid invitation'}, status=400)
+            return Response({"data": "Invalid invitation"}, status=400)
 
         note = invite.note
         invite_type = invite.invite_type
         unified_document = note.unified_document
         permissions = note.unified_document.permissions
-        content_type = ContentType.objects.get_for_model(
-            unified_document
-        )
+        content_type = ContentType.objects.get_for_model(unified_document)
 
         if not permissions.filter(user=user).exists():
             Permission.objects.create(
                 access_type=invite_type,
                 content_type=content_type,
                 object_id=unified_document.id,
-                user=user
+                user=user,
             )
 
         invite.accept()
 
-        return Response({'data': 'User has accepted invitation'}, status=200)
+        return Response({"data": "User has accepted invitation"}, status=200)

--- a/src/invite/views/organization_invite_view.py
+++ b/src/invite/views/organization_invite_view.py
@@ -15,6 +15,9 @@ class OrganizationInvitationViewSet(ModelViewSet):
     permission_classes = [IsAuthenticated]
     serializer_class = OrganizationInvitationSerializer
 
+    def get_queryset(self):
+        return self.queryset.filter(recipient=self.request.user)
+
     @action(detail=True, methods=["post"], permission_classes=[AllowAny])
     def accept_invite(self, request, pk=None):
         user = request.user


### PR DESCRIPTION
- The list view on invites currently returns all invites. These changes limit those invites to the ones you have received.