### PR TITLE
Allow org access for users with permission to a note within the org but not the org itself.

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -585,6 +585,7 @@ EMAIL_WHITELIST = [
     "pat@researchhub.com",
     "lightning.lu7@gmail.com",
     "contact@notesalong.com",
+    "taki@researchhub.com",
 ]
 
 # Whitelist for distributing RSC

--- a/src/user/views/organization_view.py
+++ b/src/user/views/organization_view.py
@@ -43,7 +43,8 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         user = self.request.user
         organizations = self.queryset.filter(
-            permissions__user=user,
+            Q(permissions__user=user)
+            | Q(created_notes__unified_document__permissions__user=user)
         ).distinct()
         return organizations
 


### PR DESCRIPTION
- Allow org access for users with permission to a note within the org but not the org itself. A user currently can't access notes that they don't have org access to. 