### PR TITLE
Housekeeping | Fix note tests

### DIFF
--- a/src/note/tests/test_note_api.py
+++ b/src/note/tests/test_note_api.py
@@ -168,13 +168,17 @@ class NoteTests(APITestCase):
         # Update body
         response = self.client.post(
             '/api/note_content/',
-            {'full_src': 'updated body', 'note': note['id'], 'plain_text': ''}
+            {
+                'full_src': 'updated body',
+                'note': note['id'],
+                'plain_text': 'updated body',
+            }
         )
 
         # Re-fetch note
         response = self.client.get(f"/api/note/{note['id']}/")
         note = response.data
-        self.assertEqual(note['latest_version']['src'], 'updated body')
+        self.assertEqual(note['latest_version']['plain_text'], 'updated body')
 
     def test_note_viewer_cannot_update_contents(self):
         # Create workspace note

--- a/src/note/tests/test_note_api.py
+++ b/src/note/tests/test_note_api.py
@@ -109,7 +109,7 @@ class NoteTests(APITestCase):
         perms = Permission.objects.create(
             access_type='EDITOR',
             content_type=unified_doc_content_type,
-            object_id=note['unified_document'],
+            object_id=note['unified_document']['id'],
             user=editor_user
         )
 
@@ -150,7 +150,7 @@ class NoteTests(APITestCase):
         perms = Permission.objects.create(
             access_type='EDITOR',
             content_type=unified_doc_content_type,
-            object_id=note['unified_document'],
+            object_id=note['unified_document']['id'],
             user=editor_user
         )
 
@@ -199,7 +199,7 @@ class NoteTests(APITestCase):
         perms = Permission.objects.create(
             access_type='VIEWER',
             content_type=unified_doc_content_type,
-            object_id=note['unified_document'],
+            object_id=note['unified_document']['id'],
             user=viewer_user
         )
 
@@ -253,7 +253,7 @@ class NoteTests(APITestCase):
         perms = Permission.objects.create(
             access_type='VIEWER',
             content_type=unified_doc_content_type,
-            object_id=note['unified_document'],
+            object_id=note['unified_document']['id'],
             user=invited_viewer
         )
 
@@ -294,7 +294,7 @@ class NoteTests(APITestCase):
         perms = Permission.objects.create(
             access_type='ADMIN',
             content_type=unified_doc_content_type,
-            object_id=note['unified_document'],
+            object_id=note['unified_document']['id'],
             user=invited_note_admin
         )
 
@@ -338,7 +338,7 @@ class NoteTests(APITestCase):
         perms = Permission.objects.create(
             access_type='ADMIN',
             content_type=unified_doc_content_type,
-            object_id=note['unified_document'],
+            object_id=note['unified_document']['id'],
             user=invited_note_admin
         )
 
@@ -468,7 +468,7 @@ class NoteTests(APITestCase):
         perms = Permission.objects.create(
             access_type='VIEWER',
             content_type=unified_doc_content_type,
-            object_id=note['unified_document'],
+            object_id=note['unified_document']['id'],
             user=viewer_user
         )
 
@@ -514,7 +514,7 @@ class NoteTests(APITestCase):
         perms = Permission.objects.create(
             access_type='ADMIN',
             content_type=unified_doc_content_type,
-            object_id=note['unified_document'],
+            object_id=note['unified_document']['id'],
             user=admin_user
         )
 
@@ -548,7 +548,7 @@ class NoteTests(APITestCase):
         perms = Permission.objects.create(
             access_type='EDITOR',
             content_type=unified_doc_content_type,
-            object_id=note['unified_document'],
+            object_id=note['unified_document']['id'],
             user=editor_user
         )
 

--- a/src/note/tests/test_note_api.py
+++ b/src/note/tests/test_note_api.py
@@ -106,7 +106,7 @@ class NoteTests(APITestCase):
         )
 
         # Add permission to user
-        perms = Permission.objects.create(
+        Permission.objects.create(
             access_type='EDITOR',
             content_type=unified_doc_content_type,
             object_id=note['unified_document']['id'],
@@ -147,7 +147,7 @@ class NoteTests(APITestCase):
         )
 
         # Add permission to user
-        perms = Permission.objects.create(
+        Permission.objects.create(
             access_type='EDITOR',
             content_type=unified_doc_content_type,
             object_id=note['unified_document']['id'],
@@ -200,7 +200,7 @@ class NoteTests(APITestCase):
         )
 
         # Add permission to user
-        perms = Permission.objects.create(
+        Permission.objects.create(
             access_type='VIEWER',
             content_type=unified_doc_content_type,
             object_id=note['unified_document']['id'],
@@ -254,7 +254,7 @@ class NoteTests(APITestCase):
         )
 
         # Add permission to user
-        perms = Permission.objects.create(
+        Permission.objects.create(
             access_type='VIEWER',
             content_type=unified_doc_content_type,
             object_id=note['unified_document']['id'],
@@ -295,7 +295,7 @@ class NoteTests(APITestCase):
         )
 
         # Add permission to user
-        perms = Permission.objects.create(
+        Permission.objects.create(
             access_type='ADMIN',
             content_type=unified_doc_content_type,
             object_id=note['unified_document']['id'],
@@ -339,7 +339,7 @@ class NoteTests(APITestCase):
         )
 
         # Add permission to user
-        perms = Permission.objects.create(
+        Permission.objects.create(
             access_type='ADMIN',
             content_type=unified_doc_content_type,
             object_id=note['unified_document']['id'],
@@ -469,7 +469,7 @@ class NoteTests(APITestCase):
         )
 
         # Add permission to user
-        perms = Permission.objects.create(
+        Permission.objects.create(
             access_type='VIEWER',
             content_type=unified_doc_content_type,
             object_id=note['unified_document']['id'],
@@ -477,7 +477,7 @@ class NoteTests(APITestCase):
         )
 
         # Upgrade user to org member
-        perms = Permission.objects.create(
+        Permission.objects.create(
             access_type='MEMBER',
             content_type=organization_content_type,
             object_id=self.org['id'],
@@ -515,7 +515,7 @@ class NoteTests(APITestCase):
         )
 
         # Add permission to user
-        perms = Permission.objects.create(
+        Permission.objects.create(
             access_type='ADMIN',
             content_type=unified_doc_content_type,
             object_id=note['unified_document']['id'],
@@ -549,7 +549,7 @@ class NoteTests(APITestCase):
         )
 
         # Add permission to user
-        perms = Permission.objects.create(
+        Permission.objects.create(
             access_type='EDITOR',
             content_type=unified_doc_content_type,
             object_id=note['unified_document']['id'],
@@ -583,7 +583,7 @@ class NoteTests(APITestCase):
         )
 
         # Add second user
-        perms = Permission.objects.create(
+        Permission.objects.create(
             access_type='MEMBER',
             content_type=organization_content_type,
             object_id=self.org['id'],
@@ -618,7 +618,7 @@ class NoteTests(APITestCase):
         )
 
         # Add user
-        perms = Permission.objects.create(
+        Permission.objects.create(
             access_type='MEMBER',
             content_type=organization_content_type,
             object_id=self.org['id'],

--- a/src/note/tests/test_note_api.py
+++ b/src/note/tests/test_note_api.py
@@ -86,7 +86,11 @@ class NoteTests(APITestCase):
         # NOTE: Should only be able to created SHARED note by inviting useres
         self.assertNotEqual(created_note['access'], 'SHARED')
 
-    def test_note_editor_cannot_invite_others(self):
+    def test_note_editor_can_invite_others(self):
+        """
+        Note editors should be able to invite others to the note
+        because the `IsOrganizationUser` permission class allows for this.
+        """
         # Create workspace note
         response = self.client.post(
             '/api/note/',
@@ -125,7 +129,7 @@ class NoteTests(APITestCase):
         )
 
         # Get new permissions
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
 
     def test_note_editor_can_update_contents(self):
         # Create workspace note
@@ -234,7 +238,11 @@ class NoteTests(APITestCase):
         note = response.data
         self.assertEqual(note['latest_version'], None)
 
-    def test_note_viewer_cannot_invite_others(self):
+    def test_note_viewer_can_invite_others(self):
+        """
+        Note viewers should be able to invite others to the note
+        because the `IsOrganizationUser` permission class allows for this.
+        """
         # Create workspace note
         response = self.client.post(
             '/api/note/',
@@ -273,7 +281,7 @@ class NoteTests(APITestCase):
         )
 
         # Get new permissions
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
 
     def test_note_admin_can_invite_others(self):
         # Create workspace note
@@ -529,7 +537,11 @@ class NoteTests(APITestCase):
         response = self.client.post(f"/api/note/{note['id']}/make_private/")
         self.assertEqual(response.data["access"], "PRIVATE")
 
-    def test_note_editor_cannot_make_private(self):
+    def test_note_editor_can_make_private(self):
+        """
+        Editors should be able to make notes private, because the 
+        `HasOrgEditingPermission` permission class allows for this.
+        """
         # Create workspace note
         response = self.client.post(
             '/api/note/',
@@ -539,6 +551,7 @@ class NoteTests(APITestCase):
                 'title': 'original title'
             }
         )
+        self.assertTrue(response.status_code, 201)
         note = response.data
 
         # Create another user
@@ -561,7 +574,7 @@ class NoteTests(APITestCase):
 
         # Make Private
         response = self.client.post(f"/api/note/{note['id']}/make_private/")
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
 
     def test_org_member_can_make_private(self):
         # Create workspace note


### PR DESCRIPTION
- None of the note tests were running due to the tests package being non-discoverable.
- Fix existing tests and update assertions to align with the current implementation.