### PR TITLE
Dev Container | Python Formatter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,6 +34,10 @@
 				"ms-python.flake8"
 			],
 			"settings": {
+				"[python]": {
+					"editor.defaultFormatter": "ms-python.black-formatter",
+					"editor.formatOnSave": true
+				},
 				"remote.autoForwardPorts": false
 			}
 		}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,6 +30,7 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
+				"ms-python.black-formatter",
 				"ms-python.flake8"
 			],
 			"settings": {


### PR DESCRIPTION
Add Black Formatter and configure it as the default formatter for Python code.