### PR TITLE
Default to PENDING status to avoid wrongly marking transaction as FAILED

### DIFF
--- a/src/reputation/lib.py
+++ b/src/reputation/lib.py
@@ -397,7 +397,7 @@ def evaluate_transaction_hash(
     transaction_hash,
 ):
     paid_date = None
-    paid_status = "FAILED"
+    paid_status = "PENDING"
     try:
         timeout = 5 * 1  # 5 second timeout
         transaction_receipt = w3.eth.wait_for_transaction_receipt(


### PR DESCRIPTION
- This might require manual correction but better than allowing double withdrawal.
- This is a temporary solution the actual solution here is to use open zeplin to receive webhooks when transactions land.