### PR TITLE
Use ElasticSearch version 7.10.1

### DIFF
--- a/.devcontainer/Dockerfile.elasticsearch
+++ b/.devcontainer/Dockerfile.elasticsearch
@@ -1,3 +1,3 @@
-FROM elasticsearch:7.17.18
+FROM elasticsearch:7.10.1
 
 RUN bin/elasticsearch-plugin install --batch ingest-attachment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - redis
       - elasticsearch
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.1
     restart: always
     volumes:
       - esdata:/usr/share/elasticsearch/data

--- a/src/start-es.sh
+++ b/src/start-es.sh
@@ -6,4 +6,4 @@ docker run \
   --publish 9200:9200 \
   --publish 9300:9300 \
   --env "discovery.type=single-node" \
-  docker.elastic.co/elasticsearch/elasticsearch:7.17.1
+  docker.elastic.co/elasticsearch/elasticsearch:7.10.1


### PR DESCRIPTION
This change is mainly to align the ElasticSearch version we use across environments. This change updates the version in the dev container as well as in the Docker Compose and native installation setups.