### PR TITLE
Do not call async service to update deposit status, rely on celery tasks

### DIFF
--- a/src/reputation/views/deposit_view.py
+++ b/src/reputation/views/deposit_view.py
@@ -82,35 +82,17 @@ class DepositViewSet(viewsets.ReadOnlyModelViewSet):
     )
     def start_deposit_rsc(self, request):
         """
-        Ping the async-service to start the process of depositing RSC
+        Create a pending deposit that will be updated by a celery task
         """
 
-        url = ASYNC_SERVICE_HOST + "/ethereum/deposit"
-        deposit = Deposit.objects.create(
+        Deposit.objects.create(
             user=request.user,
             amount=request.data.get("amount"),
             from_address=request.data.get("from_address"),
             transaction_hash=request.data.get("transaction_hash"),
         )
-        message_raw = {
-            "deposit_id": deposit.id,
-            "tx_hash": deposit.transaction_hash,
-            "amount": deposit.amount,
-            "from_address": deposit.from_address,
-            "user_id": deposit.user.id,
-        }
-        signature, message, public_key = ethereum.utils.sign_message(
-            message_raw, WEB3_SHARED_SECRET
-        )
-        data = {
-            "signature": signature,
-            "message": message.hex(),
-            "public_key": public_key,
-        }
-        response = http_request(POST, url, data=json.dumps(data), timeout=10)
-        response.raise_for_status()
-        logging.info(response.content)
-        return Response(status=response.status_code)
+
+        return Response(200)
 
 
 class WithdrawalViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
- No longer call the async service to update the status of a deposit. Rely on celery tasks run every 5 minutes.
- The async service interacts with the db directly to update the deposit status to PAID and then calls the API to finalize the update. This is very unreliable.