### PR TITLE
Cleanup | Remove distribution endpoint

### DIFF
--- a/src/reputation/distributor.py
+++ b/src/reputation/distributor.py
@@ -1,5 +1,4 @@
 import time
-from datetime import datetime, timedelta
 
 import numpy as np
 from django.contrib.admin.options import get_content_type_for_model
@@ -8,14 +7,12 @@ from django.db import models, transaction
 from django.db.models import Count, FloatField, Func, Q
 from django.db.models.aggregates import Sum
 from django.db.models.functions import Cast
-from django.utils import timezone
 
 import utils.sentry as sentry
 from purchase.models import Balance
 from reputation.distributions import Distribution as dist
 from reputation.exceptions import ReputationDistributorError
 from reputation.models import Contribution, Distribution
-from researchhub.settings import REFERRAL_PROGRAM
 from user.models import User
 from utils.serializers import get_model_serializer
 
@@ -86,65 +83,7 @@ class Distributor:
             error = ReputationDistributorError(e, error_message)
             sentry.log_error(error)
             print(error_message, e)
-
-        # Kobe 12-07-2023
-        # Turning off referral program bonus until further notice
-        # try:
-        #     self._record_referral_distribution_if_applicable(record)
-        # except Exception as error:
-        #     sentry.log_error(error)
-        #     print(error)
-
         return record
-
-    def _record_referral_distribution_if_applicable(self, original_distribution):
-        # Kobe 12-07-2023
-        # Turning off referral program bonus until further notice
-        return False
-
-        if not original_distribution.recipient.invited_by:
-            return False
-
-        referer_rsc_amount = float(original_distribution.amount) * float(
-            REFERRAL_PROGRAM["REFERER_EARN_PCT"]
-        )
-        now = timezone.now()
-        last_day_of_eligible_period = (
-            original_distribution.recipient.created_date
-            + timedelta(days=REFERRAL_PROGRAM["ELIGIBLE_TIME_PERIOD_IN_MONTHS"] * 30)
-        )
-        referrer_is_giver = (
-            original_distribution.giver_id
-            == original_distribution.recipient.invited_by.id
-        )
-
-        should_create = (
-            original_distribution.recipient.invited_by
-            and original_distribution.distribution_type
-            in REFERRAL_PROGRAM["ELIGIBLE_TRANSACTIONS"]
-            and not referrer_is_giver
-            and now < last_day_of_eligible_period
-            and referer_rsc_amount >= 1
-        )
-
-        if should_create:
-            referer_record = Distributor(
-                distribution=dist(
-                    REFERRAL_PROGRAM["REFERER_DISTRIBUTION_TYPE"],
-                    referer_rsc_amount,
-                    False,
-                    0,
-                ),
-                recipient=original_distribution.recipient.invited_by,
-                giver=original_distribution.recipient,
-                db_record=original_distribution.proof_item,
-                hubs=original_distribution.hubs.all(),
-                timestamp=time.time(),
-            ).distribute()
-
-            return referer_record
-
-        return False
 
     def _record_distribution(self):
         record = Distribution.objects.create(

--- a/src/reputation/permissions.py
+++ b/src/reputation/permissions.py
@@ -5,7 +5,6 @@ from django.contrib.contenttypes.models import ContentType
 from rest_framework.permissions import BasePermission
 
 from reputation.models import Bounty
-from researchhub.settings import DIST_WHITELIST
 from researchhub_document.models import ResearchhubUnifiedDocument
 from utils.http import PATCH, POST, RequestMethods
 from utils.permissions import AuthorizationBasedPermission
@@ -37,17 +36,6 @@ class AllowWithdrawalIfNotSuspecious(BasePermission):
         ):
             return False
         return True
-
-
-class DistributionWhitelist(BasePermission):
-    def has_permission(self, request, view):
-        user = request.user
-        if user.is_anonymous:
-            return False
-
-        if user.email in DIST_WHITELIST:
-            return True
-        return False
 
 
 class UserCanApproveBounty(BasePermission):

--- a/src/reputation/views/__init__.py
+++ b/src/reputation/views/__init__.py
@@ -16,7 +16,6 @@ from purchase.models import Balance
 from reputation.distributions import Distribution as Dist
 from reputation.distributor import Distributor
 from reputation.models import PaidStatusModelMixin, Withdrawal
-from reputation.permissions import DistributionWhitelist
 
 # Do not remove these imports
 # Used for urls.py
@@ -37,22 +36,6 @@ EXCLUDED_TOKEN_ADDRS = (
     Web3.to_checksum_address("0xe3648e99b6e68a09e28428790d12b357f081dbe0"),
     Web3.to_checksum_address("0xc4cfa2bdae08416312faa0b72758e1f3750f81e3"),
 )
-
-
-@api_view(http_method_names=[POST])
-@permission_classes([DistributionWhitelist])
-def distribute_rsc(request):
-    data = request.data
-    recipient_id = data.get("recipient_id")
-    amount = data.get("amount")
-
-    user = User.objects.get(id=recipient_id)
-    distribution = Dist("REWARD", amount, give_rep=False)
-    distributor = Distributor(distribution, user, user, time.time(), user)
-    distributor.distribute()
-
-    response = Response({"data": f"Gave {amount} RSC to {user.email}"}, status=200)
-    return response
 
 
 @api_view([GET])

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -565,12 +565,6 @@ EMAIL_WHITELIST = [
     "taki@researchhub.com",
 ]
 
-# Whitelist for distributing RSC
-DIST_WHITELIST = [
-    "pdj7@georgetown.edu",
-    "patricklu@researchhub.com",
-]
-
 SIFT_MODERATION_WHITELIST = [35747, 34581, 36837, 35436, 14, 33287, 34416]
 
 # Sentry

--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -235,7 +235,6 @@ urlpatterns = [
         "api/moderators/get_editors_by_contributions/",
         editor_views.get_editors_by_contributions,
     ),
-    path("api/reputation/distribute_rsc/", reputation.views.distribute_rsc),
     path(
         "api/rsc/get_rsc_circulating_supply",
         reputation.views.get_rsc_circulating_supply,


### PR DESCRIPTION
- Remove referral distribution endpoint and configuration.
- Remove inactive referral distribution code.

**Note:** As a follow up, we might want to remove the `referral` app altogether if that is no longer needed.