### PR TITLE
Add caching on client id for purchases

### DIFF
--- a/src/purchase/tests/test_send_rsc.py
+++ b/src/purchase/tests/test_send_rsc.py
@@ -247,10 +247,11 @@ class SendRSCTest(APITestCase, TestCase, TestHelper, IntegrationTestHelper):
         self.assertContains(response, "id", status_code=201)
 
         # make a second request with the same client_id which should fail.
-        response = self._post_support_response(
+        response_repeat_call = self._post_support_response(
             user, comment.id, client_id, "rhcommentmodel", tip_amount
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, response_repeat_call.data)
+        self.assertEqual(response_repeat_call.status_code, 201)
 
     def _post_support_response(
         self, user, object_id, client_id, content_type, amount=10

--- a/src/purchase/views/purchase_view.py
+++ b/src/purchase/views/purchase_view.py
@@ -212,10 +212,10 @@ class PurchaseViewSet(viewsets.ModelViewSet):
                 )
                 distributor.distribute()
 
-        serializer = self.serializer_class(purchase, context=context)
-        serializer_data = serializer.data
+            serializer = self.serializer_class(purchase, context=context)
+            serializer_data = serializer.data
 
-        cache.set(f"purchase_client_id_{client_id}", serializer_data, timeout=3600)
+            cache.set(f"purchase_client_id_{client_id}", serializer_data, timeout=3600)
 
         if recipient and user:
             self.send_purchase_notification(


### PR DESCRIPTION
- To prevent accidental double purchases such as tipping.
- All requests to this endpoint will require a client id.
