### PR TITLE
Read S3 storage configuration from properties

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -491,15 +491,14 @@ if TESTING:
 else:
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 AWS_QUERYSTRING_EXPIRE = 604800
+
 AWS_STORAGE_BUCKET_NAME = os.environ.get(
     "AWS_STORAGE_BUCKET_NAME", "researchhub-paper-dev1"
 )
 
-if PRODUCTION:
-    AWS_STORAGE_BUCKET_NAME = "researchhub-paper-prod"
-    AWS_S3_CUSTOM_DOMAIN = "d2ogkcqdn9wsvr.cloudfront.net"
+AWS_S3_CUSTOM_DOMAIN = os.environ.get("AWS_S3_CUSTOM_DOMAIN", None)
 
-AWS_S3_REGION_NAME = "us-west-2"
+AWS_S3_REGION_NAME = os.environ.get("AWS_S3_REGION_NAME", "us-west-2")
 
 AWS_S3_FILE_OVERWRITE = False
 AWS_DEFAULT_ACL = None


### PR DESCRIPTION
Instead of hardcoding values, read the following [Django File Storage API for S3](https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html) configuration properties from the environment:
- `AWS_STORAGE_BUCKET_NAME`
- `AWS_S3_CUSTOM_DOMAIN`
- `AWS_S3_REGION_NAME`