### PR TITLE
Reduce transaction sampling rate to 10%

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -670,6 +670,7 @@ if elastic_token:
         "ENVIRONMENT": APP_ENV,
         "DJANGO_AUTOINSERT_MIDDLEWARE": False,
         "DISABLE_SEND": CELERY_WORKER or TESTING,
+        "TRANSACTION_SAMPLE_RATE": 0.1,
         "PROCESSORS": (
             "utils.elastic_apm.filter_processor",
             "elasticapm.processors.sanitize_stacktrace_locals",


### PR DESCRIPTION
Only sample 10% of transactions, the rest will be sent to Elastic without span data. This should be sufficient to get representative performance metrics.

Also see: https://www.elastic.co/guide/en/apm/get-started/7.15/trace-sampling.html