### PR TITLE
Update `django-allauth` to 0.50.0

### DIFF
--- a/src/poetry.lock
+++ b/src/poetry.lock
@@ -1370,12 +1370,12 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-allauth"
-version = "0.48.0"
+version = "0.50.0"
 description = "Integrated set of Django applications addressing authentication, registration, account management as well as 3rd party (social) account authentication."
 optional = false
 python-versions = "*"
 files = [
-    {file = "django-allauth-0.48.0.tar.gz", hash = "sha256:531821ce6a2278168054add13421776c9f8e565cf39926e799fa02d6c29da920"},
+    {file = "django-allauth-0.50.0.tar.gz", hash = "sha256:ee3a174e249771caeb1d037e64b2704dd3c56cfec44f2058fae2214b224d35e8"},
 ]
 
 [package.dependencies]
@@ -6008,4 +6008,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "31f6eed59c445955c5930f2e604263aa2c4536b76490e63c7c43972f860b4bf7"
+content-hash = "387efe919a54caeafa821f0b6c0214c36313c023f6f7a5cd749bef56e4763eb1"

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -75,7 +75,7 @@ django-elasticsearch-dsl-drf = "0.20.8"
 q5-django-inlinecss = "0.0.2"
 pdf2doi = "1.5"
 beautifulsoup4 = "4.12.2"
-django-allauth = "0.48.0"
+django-allauth = "0.50.0"
 bibtexparser = {version = "^2.0.0b3", allow-prereleases = true}
 pyyaml = "6.0.1"
 segment-analytics-python = "^2.2.3"

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -716,8 +716,8 @@ distlib==0.3.8 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64
 dj-rest-auth==2.2.8 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:9fb3492888185ede8b2064ad6803120c7b0b83ab08e2347a02e9b44282374242
-django-allauth==0.48.0 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:531821ce6a2278168054add13421776c9f8e565cf39926e799fa02d6c29da920
+django-allauth==0.50.0 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:ee3a174e249771caeb1d037e64b2704dd3c56cfec44f2058fae2214b224d35e8
 django-celery-beat==2.0.0 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:fdf1255eecfbeb770c6521fe3e69989dfc6373cd5a7f0fe62038d37f80f47e48 \
     --hash=sha256:fe0b2a1b31d4a6234fea4b31986ddfd4644a48fab216ce1843f3ed0ddd2e9097


### PR DESCRIPTION
Updating the version of django-allauth due to an error with Python's setup-tools.

With the current version, the build fails with the following errors:

```
 ChefBuildError

  Backend subprocess exited when trying to invoke get_requires_for_build_wheel
  
  Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.8.5/x64/lib/python3.8/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in <module>
      main()
    File "/opt/hostedtoolcache/Python/3.8.5/x64/lib/python3.8/site-packages/pyproject_hooks/_in_process/_in_process.py", line 357, in main
      json_out["return_val"] = hook(**hook_input["kwargs"])
    File "/opt/hostedtoolcache/Python/3.8.5/x64/lib/python3.8/site-packages/pyproject_hooks/_in_process/_in_process.py", line 134, in get_requires_for_build_wheel
      return hook(config_settings)
    File "/tmp/tmpjv8qdtb5/.venv/lib/python3.8/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
      return self._get_build_requires(config_settings, requirements=['wheel'])
    File "/tmp/tmpjv8qdtb5/.venv/lib/python3.8/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
      self.run_setup()
    File "/tmp/tmpjv8qdtb5/.venv/lib/python3.8/site-packages/setuptools/build_meta.py", line 487, in run_setup
      super().run_setup(setup_script=setup_script)
    File "/tmp/tmpjv8qdtb5/.venv/lib/python3.8/site-packages/setuptools/build_meta.py", line 311, in run_setup
      exec(code, locals())
    File "<string>", line 9, in <module>
  ImportError: cannot import name 'convert_path' from 'setuptools' (/tmp/tmpjv8qdtb5/.venv/lib/python3.8/site-packages/setuptools/__init__.py)
```

Also see: https://github.com/actions/setup-python/issues/872