### PR TITLE
Run websockets on all servers

### DIFF
--- a/src/researchhub/asgi.py
+++ b/src/researchhub/asgi.py
@@ -30,17 +30,18 @@ routing = {}
 if not CELERY_WORKER:
     routing["http"] = django_asgi_app
 
-if CELERY_WORKER or DEVELOPMENT:
-    routing["websocket"] = AllowedHostsOriginValidator(
-        TokenAuthMiddlewareStack(
-            URLRouter(
-                [
-                    *note.routing.websocket_urlpatterns,
-                    *notification.routing.websocket_urlpatterns,
-                    *user.routing.websocket_urlpatterns,
-                    *citation.routing.websocket_urlpatterns,
-                ]
-            )
+# FIXME: Runs on workers in the old accounts, but on webservers in the new account.
+# Add the condition `not CELERY_WORKER` once migrated into the new account.
+routing["websocket"] = AllowedHostsOriginValidator(
+    TokenAuthMiddlewareStack(
+        URLRouter(
+            [
+                *note.routing.websocket_urlpatterns,
+                *notification.routing.websocket_urlpatterns,
+                *user.routing.websocket_urlpatterns,
+                *citation.routing.websocket_urlpatterns,
+            ]
         )
     )
+)
 application = ProtocolTypeRouter(routing)


### PR DESCRIPTION
The websocket server is currently running on workers in the old account. In the new account, websockets will be running in the public facing webservers. This change makes the websocket server run on all instances. A `FIXME` is added to fix this post-migration.