### PR TITLE
Accept `ALLOWED_HOSTS` from environment

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -122,6 +122,10 @@ if ELASTIC_BEANSTALK:
     except requests.exceptions.RequestException:
         pass
 
+    DJANGO_ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "")
+    if DJANGO_ALLOWED_HOSTS:
+        ALLOWED_HOSTS += DJANGO_ALLOWED_HOSTS.split(",")
+
 CORS_ALLOW_HEADERS = (
     *default_headers,
     "X-organization-id",


### PR DESCRIPTION
Accept additional hosts via the environment variable `ALLOWED_HOSTS`. This will be used to e.g. add the Beanstalk load balancers after provisioning.