### PR TITLE
Enforce email allowlist for all new AWS accounts

### DIFF
--- a/src/utils/message.py
+++ b/src/utils/message.py
@@ -4,15 +4,20 @@ from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from sentry_sdk import capture_exception
 
-from mailing_list.models import EmailRecipient
-from researchhub.settings import EMAIL_WHITELIST, PRODUCTION, TESTING
+from researchhub.settings import (
+    AWS_ACCOUNT_ID,
+    EMAIL_WHITELIST,
+    PRODUCTION,
+    TESTING,
+)
 
 
 def is_valid_email(email):
     if TESTING:
         return True
 
-    if not PRODUCTION:
+    # Temporarily enforce the email allowlist for all environments in the new accounts:
+    if not PRODUCTION or AWS_ACCOUNT_ID != "794128250202":
         return email in EMAIL_WHITELIST
     else:
         return True

--- a/src/utils/message.py
+++ b/src/utils/message.py
@@ -22,19 +22,6 @@ def is_valid_email(email):
     else:
         return True
 
-    # # TODO: Add regex validation
-    # try:
-    # recipient, created = EmailRecipient.objects.get_or_create(
-    # email=email
-    # )
-    # except Exception as e:
-    # print(e)
-
-    # return (email in EMAIL_WHITELIST) or (
-    # (not recipient.do_not_email)
-    # and (not recipient.is_opted_out)
-    # )
-
 
 def send_email_message(
     recipients,


### PR DESCRIPTION
While testing the new AWS accounts, enforce the email allowslist (`EMAIL_WHITELIST`) for all environments.