### PR TITLE
Add configuration for email domain

### DIFF
--- a/src/mailing_list/tasks.py
+++ b/src/mailing_list/tasks.py
@@ -16,7 +16,7 @@ from mailing_list.lib import base_email_context
 from mailing_list.models import EmailRecipient, EmailTaskLog, NotificationFrequencies
 from paper.models import Paper
 from researchhub.celery import QUEUE_NOTIFICATION, app
-from researchhub.settings import PRODUCTION, STAGING
+from researchhub.settings import EMAIL_DOMAIN, PRODUCTION, STAGING
 from researchhub_document.models import ResearchhubPost, ResearchhubUnifiedDocument
 from researchhub_document.views import ResearchhubUnifiedDocumentViewSet
 from user.models import Action, User
@@ -88,7 +88,7 @@ def send_bounty_digest(frequency):
             subject,
             email_context,
             "bounty_digest.html",
-            "ResearchHub Bounty Digest <digest@researchhub.com>",
+            f"ResearchHub Bounty Digest <digest@{EMAIL_DOMAIN}>",
         )
         emails += recipient
 
@@ -159,7 +159,7 @@ def send_editor_hub_digest(frequency):
                 subject,
                 email_context,
                 "editor_digest.html",
-                "ResearchHub Digest <digest@researchhub.com>",
+                f"ResearchHub Digest <digest@{EMAIL_DOMAIN}>",
             )
             emails += recipient
 
@@ -229,7 +229,7 @@ def send_hub_digest(frequency):
                 "preview_text": documents[0],
             },
             "weekly_digest_email.html",
-            "ResearchHub Digest <digest@researchhub.com>",
+            f"ResearchHub Digest <digest@{EMAIL_DOMAIN}>",
         )
         emails += recipient
     etl.emails = ",".join(emails)

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -492,7 +492,10 @@ GHOSTSCRIPT_LAMBDA_ARN = os.environ.get(
 ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 7
 ACCOUNT_EMAIL_SUBJECT_PREFIX = "ResearchHub | "
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"
-DEFAULT_FROM_EMAIL = "noreply@researchhub.com"
+EMAIL_DOMAIN = (
+    "researchhub.com" if APP_ENV == "production" else f"{APP_ENV}.researchhub.com"
+)
+DEFAULT_FROM_EMAIL = f"noreply@{EMAIL_DOMAIN}"
 
 # Storage
 if TESTING:

--- a/src/researchhub_case/utils/author_claim_case_utils.py
+++ b/src/researchhub_case/utils/author_claim_case_utils.py
@@ -71,7 +71,6 @@ def send_validation_email(case):
         "Please Verify Your Paper Claim",
         email_context,
         "author_claim_validation_email.html",
-        "ResearchHub <noreply@researchhub.com>",
     )
 
 
@@ -96,7 +95,6 @@ def send_verification_email(case, context):
         "Your account has been verified",
         email_context,
         "account_verified_email.html",
-        "ResearchHub <noreply@researchhub.com>",
     )
 
 
@@ -135,7 +133,6 @@ def send_approval_email(case, context):
         "Your paper claim request has been approved",
         email_context,
         "author_approval_email.html",
-        "ResearchHub <noreply@researchhub.com>",
     )
 
 
@@ -154,7 +151,6 @@ def send_rejection_email(case):
         "Your paper claim request has been denied",
         email_context,
         "author_rejection_email.html",
-        "ResearchHub <noreply@researchhub.com>",
     )
 
 

--- a/src/user/views/audit_views.py
+++ b/src/user/views/audit_views.py
@@ -16,6 +16,7 @@ from mailing_list.lib import base_email_context
 from notification.models import Notification
 from researchhub_comment.models import RhCommentModel
 from researchhub_comment.views.rh_comment_view import censor_comment
+from researchhub.settings import EMAIL_DOMAIN
 from user.filters import AuditDashboardFilterBackend
 from user.models import Action, User
 from user.permissions import IsModerator, UserIsEditor
@@ -506,5 +507,5 @@ class AuditViewSet(viewsets.GenericViewSet):
             subject,
             email_context,
             "flagged_and_removed_content.html",
-            "ResearchHub Digest <digest@researchhub.com>",
+            f"ResearchHub Digest <digest@{EMAIL_DOMAIN}>",
         )

--- a/src/user/views/audit_views.py
+++ b/src/user/views/audit_views.py
@@ -399,8 +399,7 @@ class AuditViewSet(viewsets.GenericViewSet):
                 {},
                 status=200,
             )
-        
-    
+
     @action(detail=False, methods=["post"])
     def remove_flagged_paper_pdf(self, request):
         flagger = request.user
@@ -413,7 +412,9 @@ class AuditViewSet(viewsets.GenericViewSet):
         with transaction.atomic():
             flags = Flag.objects.filter(id__in=data.get("flag_ids", []))
             for flag in flags.iterator():
-                if flag.content_type != ContentType.objects.get(app_label="paper", model="paper"):
+                if flag.content_type != ContentType.objects.get(
+                    app_label="paper", model="paper"
+                ):
                     continue
 
                 available_reasons = list(map(lambda r: r[0], FLAG_REASON_CHOICES))
@@ -437,7 +438,7 @@ class AuditViewSet(viewsets.GenericViewSet):
                 {},
                 status=200,
             )
-        
+
     def _remove_flagged_paper_pdf(self, flag):
         with transaction.atomic():
             paper = flag.item

--- a/src/utils/message.py
+++ b/src/utils/message.py
@@ -6,6 +6,7 @@ from sentry_sdk import capture_exception
 
 from researchhub.settings import (
     AWS_ACCOUNT_ID,
+    DEFAULT_FROM_EMAIL,
     EMAIL_WHITELIST,
     PRODUCTION,
     TESTING,
@@ -29,7 +30,7 @@ def send_email_message(
     subject,
     email_context,
     html_template=None,
-    sender="ResearchHub <noreply@researchhub.com>",
+    sender=f"ResearchHub <{DEFAULT_FROM_EMAIL}>",
 ):
     """Emails `message` to `recipients` and returns a dict with results in the
     following form:


### PR DESCRIPTION
- Create a new setting variable for the environment-specific email domain. For production, this is researchhub.com, for other environments it is the environment-specific subdomain, e.g. staging.researchhub.com.
- Use the new setting throughout the code base where email addresses are used.