### PR TITLE
Use new staging URL

### DIFF
--- a/src/paper/tests/test_paper_submissions.py
+++ b/src/paper/tests/test_paper_submissions.py
@@ -21,7 +21,7 @@ from user.tests.helpers import create_random_default_user
 class PaperSubmissionViewTests(APITestCase):
     def setUp(self):
         self.url = "https://pubmed.ncbi.nlm.nih.gov/33313563/"
-        self.duplicate_url = "https://researchhub-web-staging.vercel.app/paper/131636/evaluating-and-mapping-grape-color-using-image-based-phenotyping/"
+        self.duplicate_url = "https://www.staging.researchhub.com/paper/131636/evaluating-and-mapping-grape-color-using-image-based-phenotyping/"
         self.true_doi = "10.34133/2020/8086309"
         self.paper_publish_date = "2020-01-01"
         self.concept_display_names = [

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -56,7 +56,7 @@ if DEVELOPMENT or TESTING:
 elif PRODUCTION:
     BASE_FRONTEND_URL = "https://www.researchhub.com"
 elif CLOUD:
-    BASE_FRONTEND_URL = "https://researchhub-web-staging.vercel.app"
+    BASE_FRONTEND_URL = "https://researchhub-web-researchhub.vercel.app"
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
@@ -84,7 +84,6 @@ ALLOWED_HOSTS = [
     ".elasticbeanstalk.com",
     ".quantfive.org",
     ".researchhub-web-researchhub.vercel.app",
-    ".researchhub-web-staging.vercel.app",
     ".researchhub.com",
     "127.0.0.1",  # localhost
     "localhost",
@@ -140,7 +139,7 @@ CORS_ORIGIN_WHITELIST = [
     "https://dev.researchhub.com",
     "https://researchnow.researchhub.com",
     "https://www.researchhub.com",
-    "https://researchhub-web-staging.vercel.app",
+    "https://researchhub-web-researchhub.vercel.app",
     "https://researchhub.com",
     "http://10.0.2.2:3000",
     "http://127.0.0.1:3000",

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -56,7 +56,7 @@ if DEVELOPMENT or TESTING:
 elif PRODUCTION:
     BASE_FRONTEND_URL = "https://www.researchhub.com"
 elif CLOUD:
-    BASE_FRONTEND_URL = "https://researchhub-web-researchhub.vercel.app"
+    BASE_FRONTEND_URL = "https://www.staging.researchhub.com"
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
@@ -87,7 +87,8 @@ ALLOWED_HOSTS = [
     ".researchhub.com",
     "127.0.0.1",  # localhost
     "localhost",
-    "researchhub-web-researchhub.vercel.app",
+    "staging.researchhub.com",
+    "www.staging.researchhub.com",
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
     r"https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}",
     r"researchhub(-[0-9]?)\.ngrok\.io",
@@ -141,6 +142,8 @@ CORS_ORIGIN_WHITELIST = [
     "https://www.researchhub.com",
     "https://researchhub-web-researchhub.vercel.app",
     "https://researchhub.com",
+    "https://staging.researchhub.com",
+    "https://www.staging.researchhub.com",
     "http://10.0.2.2:3000",
     "http://127.0.0.1:3000",
     "https://word.researchhub.com",

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -82,7 +82,6 @@ if not (PRODUCTION or STAGING):
 
 ALLOWED_HOSTS = [
     ".elasticbeanstalk.com",
-    ".quantfive.org",
     ".researchhub-web-researchhub.vercel.app",
     ".researchhub.com",
     "127.0.0.1",  # localhost


### PR DESCRIPTION
In #1626 an incorrect frontend staging URL was set.

This change introduces the new staging URLs staging.researchhub.com and www.staging.researchhub.com.