### PR TITLE
Fault tolerant tagging of papers with hubs

### DIFF
--- a/src/hub/models.py
+++ b/src/hub/models.py
@@ -1,6 +1,6 @@
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
-from django.db.models import Sum
+from django.db.models import Q, Sum
 from slugify import slugify
 
 from researchhub_access_group.constants import EDITOR
@@ -127,6 +127,14 @@ class Hub(models.Model):
 
     def get_editor_permission_groups(self):
         return self.permissions.filter(access_type=EDITOR).all()
+
+    # There are a handful of OpenAlex subfields that have duplicate names
+    # but different IDs. This method will ensure that a corresponding hub is returned properly
+    @classmethod
+    def get_from_subfield(cls, subfield):
+        return Hub.objects.get(
+            Q(name=subfield.display_name.lower()) | Q(subfield_id=subfield.id)
+        )
 
     @classmethod
     def create_or_update_hub_from_concept(cls, concept):

--- a/src/paper/paper_upload_tasks.py
+++ b/src/paper/paper_upload_tasks.py
@@ -651,13 +651,10 @@ def create_paper_related_tags(paper_id, openalex_concepts=[], openalex_topics=[]
         topic = None
         try:
             topic = Topic.upsert_from_openalex(openalex_topic)
-
-            # We want to associate the paper with subfield hubs
-            subfield_hub_res = Hub.objects.filter(subfield=topic.subfield)
-            if subfield_hub_res.exists():
-                subfield_hub = subfield_hub_res.first()
-                paper.hubs.add(subfield_hub)
-                paper.unified_document.hubs.add(subfield_hub)
+            # We want to associate the paper with subfield hub
+            subfield_hub = Hub.get_from_subfield(topic.subfield)
+            paper.hubs.add(subfield_hub)
+            paper.unified_document.hubs.add(subfield_hub)
 
         except Exception as e:
             sentry.log_error(

--- a/src/paper/tests/openalex_works.json
+++ b/src/paper/tests/openalex_works.json
@@ -249,6 +249,23 @@
                         "id": "https://openalex.org/domains/3",
                         "display_name": "Physical Sciences"
                     }
+                },
+                {
+                    "id": "https://openalex.org/T11399",
+                    "display_name": "Protein Metabolism in Exercise and Nutrition",
+                    "score": 0.951,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/1307",
+                        "display_name": "Cell Biology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/13",
+                        "display_name": "Biochemistry, Genetics and Molecular Biology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
                 }
             ],
             "keywords": [

--- a/src/topic/management/commands/associate_subfields_to_hubs.py
+++ b/src/topic/management/commands/associate_subfields_to_hubs.py
@@ -18,8 +18,7 @@ class Command(BaseCommand):
 
         for subfield in subfields:
             try:
-                hub = Hub.objects.all()
-                continue
+                hub = Hub.objects.get(subfield=subfield)
             except Hub.DoesNotExist:
                 hub, created = Hub.objects.get_or_create(
                     name=subfield.display_name.lower(),


### PR DESCRIPTION
- Avoiding handful of scenarios of OpenAlex hubs with duplicate names
- e.g. there are two "Neuroscience" subfields. 

We are handling the above scenario by mapping these to a single hub on our end