### PR TITLE
Dev Containers | Align line length between black and flake

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,6 +38,14 @@
 					"editor.defaultFormatter": "ms-python.black-formatter",
 					"editor.formatOnSave": true
 				},
+				// Align line length between black and flake8 to black's default of 88.
+				// See: https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length
+				"black-formatter.args": [
+					"--line-length=88"
+				],
+				"flake8.args": [
+					"--max-line-length=88"
+				],
 				"remote.autoForwardPorts": false
 			}
 		}

--- a/src/.flake8
+++ b/src/.flake8
@@ -2,3 +2,4 @@
 exclude =
     migrations
 count = True
+max-line-length = 88


### PR DESCRIPTION
Align line length between black and flake to 88 ([black's default](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length))