### PR TITLE
Cleanup | Use non-deprecated assertion method

### DIFF
--- a/src/institution/tests.py
+++ b/src/institution/tests.py
@@ -17,7 +17,7 @@ class ProcessOpenAlexWorksTests(APITestCase):
         Institution.upsert_from_openalex(institution)
 
         created_inst = Institution.objects.filter(openalex_id=institution["id"]).first()
-        self.assertEquals(created_inst.openalex_id, institution["id"])
+        self.assertEqual(created_inst.openalex_id, institution["id"])
 
     def test_update_institution(self):
         old_institution = self.institutions[0]
@@ -38,4 +38,4 @@ class ProcessOpenAlexWorksTests(APITestCase):
         created_inst = Institution.objects.filter(
             openalex_id=new_institution["id"]
         ).first()
-        self.assertEquals(created_inst.display_name, "new topic")
+        self.assertEqual(created_inst.display_name, "new topic")

--- a/src/paper/tests/test_views.py
+++ b/src/paper/tests/test_views.py
@@ -155,18 +155,18 @@ class PaperViewsTests(TestCase):
             self.base_url,
             {"title": "Paper Uploaded via API Token", "paper_type": "REGULAR"},
         )
-        self.assertEquals(res.status_code, 201)
+        self.assertEqual(res.status_code, 201)
 
     @skip
     def test_search_by_url_arxiv(self):
         url = self.base_url + "search_by_url/"
         data = {"url": "https://arxiv.org/abs/1407.3561v1", "search": True}
         response = get_authenticated_post_response(self.user, url, data)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         result = response.data
-        self.assertEquals(result["url"], data["url"])
+        self.assertEqual(result["url"], data["url"])
         self.assertFalse(result["url_is_pdf"])
-        self.assertEquals(
+        self.assertEqual(
             result["csl_item"]["title"],
             "IPFS - Content Addressed, Versioned, P2P File System",
         )
@@ -181,12 +181,12 @@ class PaperViewsTests(TestCase):
         url = self.base_url + "search_by_url/"
         data = {"url": "https://arxiv.org/pdf/1407.3561.pdf"}
         response = get_authenticated_post_response(self.user, url, data)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         result = response.data
-        self.assertEquals(result["url"], data["url"])
+        self.assertEqual(result["url"], data["url"])
         self.assertTrue(result["url_is_pdf"])
         self.assertFalse(result["url_is_unsupported_pdf"])
-        self.assertEquals(
+        self.assertEqual(
             result["csl_item"]["title"],
             "IPFS - Content Addressed, Versioned, P2P File System",
         )
@@ -205,33 +205,33 @@ class PaperViewsTests(TestCase):
         url = self.base_url + "search_by_url/"
         data = {"url": "https://www.nature.com/articles/s41586-019-1099-1"}
         response = get_authenticated_post_response(self.user, url, data)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         result = response.data
-        self.assertEquals(result["url"], data["url"])
+        self.assertEqual(result["url"], data["url"])
         self.assertFalse(result["url_is_pdf"])
         self.assertFalse(result["url_is_unsupported_pdf"])
-        self.assertEquals(
+        self.assertEqual(
             result["csl_item"]["title"],
             "Restoration of brain circulation and cellular functions hours post-mortem",
         )  # noqa E501
-        self.assertEquals(result["csl_item"]["DOI"], "10.1038/s41586-019-1099-1")
+        self.assertEqual(result["csl_item"]["DOI"], "10.1038/s41586-019-1099-1")
 
     @skip
     def test_search_by_url_doi(self):
         url = self.base_url + "search_by_url/"
         data = {"url": "https://doi.org/10.1038/ng.3259"}
         response = get_authenticated_post_response(self.user, url, data)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         result = response.data
-        self.assertEquals(result["url"], data["url"])
+        self.assertEqual(result["url"], data["url"])
         self.assertFalse(result["url_is_pdf"])
         self.assertFalse(result["url_is_unsupported_pdf"])
-        self.assertEquals(
+        self.assertEqual(
             result["csl_item"]["title"],
             "Understanding multicellular function and disease with human tissue-specific networks",
         )  # noqa E501
-        self.assertEquals(result["csl_item"]["DOI"], "10.1038/ng.3259")
-        self.assertEquals(
+        self.assertEqual(result["csl_item"]["DOI"], "10.1038/ng.3259")
+        self.assertEqual(
             result["oa_pdf_location"]["url_for_pdf"],
             "http://europepmc.org/articles/pmc4828725?pdf=render",
         )
@@ -244,12 +244,12 @@ class PaperViewsTests(TestCase):
         url = self.base_url + "search_by_url/"
         data = {"url": "https://www.ncbi.nlm.nih.gov/pubmed/18888140"}
         response = get_authenticated_post_response(self.user, url, data)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         result = response.data
-        self.assertEquals(result["url"], data["url"])
+        self.assertEqual(result["url"], data["url"])
         self.assertFalse(result["url_is_pdf"])
         self.assertFalse(result["url_is_unsupported_pdf"])
-        self.assertEquals(
+        self.assertEqual(
             result["csl_item"]["title"],
             "[Major achievements in the second plan year in the Soviet Union].",
         )  # noqa E501
@@ -260,7 +260,7 @@ class PaperViewsTests(TestCase):
         url = self.base_url + "search_by_url/"
         data = {"url": "https://bitcoin.org/bitcoin.pdf"}
         response = get_authenticated_post_response(self.user, url, data)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         result = response.data
         self.assertTrue(result["url_is_pdf"])
         self.assertTrue(result["url_is_unsupported_pdf"])

--- a/src/paper/tests/tests.py
+++ b/src/paper/tests/tests.py
@@ -168,14 +168,14 @@ class JournalPdfTests(TestCase):
             pdf_url, exists = convert_journal_url_to_pdf_url(url)
             if exists:
                 print(pdf_url)
-                self.assertEquals(pdf_url, self.pdf_test_urls[i])
+                self.assertEqual(pdf_url, self.pdf_test_urls[i])
 
     def test_pdf_to_journal(self):
         for i, url in enumerate(self.pdf_test_urls):
             journal_url, exists = convert_pdf_url_to_journal_url(url)
             if exists:
                 print(journal_url)
-                self.assertEquals(journal_url, self.journal_test_urls[i])
+                self.assertEqual(journal_url, self.journal_test_urls[i])
 
 
 class PaperPatchTest(TestCase, TestHelper, IntegrationTestHelper):
@@ -197,9 +197,9 @@ class PaperPatchTest(TestCase, TestHelper, IntegrationTestHelper):
         url = f"{self.base_url}{paper.id}/?make_public=true"
         response = client.patch(url, form, content_type="application/json")
         data = response.data
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(data["title"], updated_title)
-        self.assertEquals(
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["title"], updated_title)
+        self.assertEqual(
             data["raw_authors"], [{"first_name": "First", "last_name": "Last"}]
         )
 

--- a/src/paper/tests/tests.py
+++ b/src/paper/tests/tests.py
@@ -5,7 +5,7 @@ from django.db import IntegrityError
 from django.test import TestCase, TransactionTestCase, tag
 from psycopg2.errors import UniqueViolation
 
-from paper.serializers import DynamicPaperSerializer, PaperSerializer
+from paper.serializers import DynamicPaperSerializer
 from paper.tasks import handle_duplicate_doi
 from paper.utils import (
     convert_journal_url_to_pdf_url,

--- a/src/reputation/tests/test_upvote_rsc_distribution.py
+++ b/src/reputation/tests/test_upvote_rsc_distribution.py
@@ -65,8 +65,8 @@ class BaseTests(TestCase, TestHelper):
         comment = create_rh_comment(created_by=new_user, paper=self.original_paper)
         GrmVote.objects.create(item=comment, vote_type=1, created_by=voter_user)
         distribution = distributions.Distribution(1, 1, 1)
-        self.assertEquals(Distribution.objects.count(), 1)
-        self.assertEquals(distribution.amount, Distribution.objects.first().amount)
+        self.assertEqual(Distribution.objects.count(), 1)
+        self.assertEqual(distribution.amount, Distribution.objects.first().amount)
 
     def test_upvote_downvote_upvote(self):
         if Distribution.objects.count() > 0:
@@ -99,14 +99,14 @@ class BaseTests(TestCase, TestHelper):
         )
 
         distribution = distributions.Distribution(1, 1, 1)
-        self.assertEquals(Distribution.objects.count(), 1)
-        self.assertEquals(distribution.amount, Distribution.objects.first().amount)
+        self.assertEqual(Distribution.objects.count(), 1)
+        self.assertEqual(distribution.amount, Distribution.objects.first().amount)
         reply_vote.vote_type = 2
         reply_vote.save()
         reply_vote.vote_type = 1
         reply_vote.save()
-        self.assertEquals(Distribution.objects.count(), 1)
-        self.assertEquals(distribution.amount, Distribution.objects.first().amount)
+        self.assertEqual(Distribution.objects.count(), 1)
+        self.assertEqual(distribution.amount, Distribution.objects.first().amount)
 
     def test_upvote_distribution(self):
         if Distribution.objects.count() > 0:
@@ -128,4 +128,4 @@ class BaseTests(TestCase, TestHelper):
         eligible_user.save()
 
         distribution = distributions.Distribution(1, 1, 1)
-        self.assertEquals(distribution.amount, 1)
+        self.assertEqual(distribution.amount, 1)

--- a/src/reputation/tests/test_upvote_rsc_distribution.py
+++ b/src/reputation/tests/test_upvote_rsc_distribution.py
@@ -1,6 +1,3 @@
-import decimal
-import math
-
 from django.contrib.admin.options import get_content_type_for_model
 from django.test import TestCase
 
@@ -8,9 +5,6 @@ import reputation.distributions as distributions
 from discussion.models import Vote as GrmVote
 from discussion.tests.helpers import create_rh_comment
 from reputation.models import Distribution, Escrow
-from researchhub_case.constants.case_constants import APPROVED
-from researchhub_case.models import AuthorClaimCase
-from researchhub_case.tasks import after_approval_flow
 from user.models import Author
 from utils.test_helpers import TestHelper
 

--- a/src/reputation/tests/test_views.py
+++ b/src/reputation/tests/test_views.py
@@ -56,8 +56,8 @@ class ReputationViewsTests(APITestCase):
         self.client.force_authenticate(user)
         response = self.client.get("/api/deposit/")
 
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.data["count"], 1)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 1)
 
     def test_deposit_user_cannot_list_other_deposits(self):
         user = create_random_authenticated_user("deposit_user")
@@ -68,8 +68,8 @@ class ReputationViewsTests(APITestCase):
         self.client.force_authenticate(other_user)
         response = self.client.get("/api/deposit/")
 
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.data["count"], 0)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 0)
 
     def test_deposit_deposit_staff_user_can_list_all_deposits(self):
         user1 = create_random_authenticated_user("user1")
@@ -84,8 +84,8 @@ class ReputationViewsTests(APITestCase):
         self.client.force_authenticate(staff_user)
         response = self.client.get("/api/deposit/")
 
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.data["count"], 2)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 2)
 
     def test_suspecious_user_cannot_withdraw_rsc(self):
         user = create_random_authenticated_user("rep_user")

--- a/src/researchhub_case/tests/test_approval_flow.py
+++ b/src/researchhub_case/tests/test_approval_flow.py
@@ -23,7 +23,7 @@ class ApprovalFlowTests(TestCase):
 
         after_approval_flow(case.id)
         requesting_user.refresh_from_db()
-        self.assertEquals(requesting_user.is_verified, True)
+        self.assertEqual(requesting_user.is_verified, True)
 
     def attribute_paper_to_author(self):
         requesting_user = create_random_default_user("2")
@@ -34,4 +34,4 @@ class ApprovalFlowTests(TestCase):
         after_approval_flow(case.id)
         requesting_user.refresh_from_db()
         self.paper.refresh_from_db()
-        self.assertEquals(self.paper.authors.first().id, requesting_user.id)
+        self.assertEqual(self.paper.authors.first().id, requesting_user.id)

--- a/src/topic/tests.py
+++ b/src/topic/tests.py
@@ -19,7 +19,7 @@ class ProcessOpenAlexWorksTests(APITestCase):
         Topic.upsert_from_openalex(topic)
 
         created_topic = Topic.objects.filter(openalex_id=topic["id"]).first()
-        self.assertEquals(created_topic.openalex_id, topic["id"])
+        self.assertEqual(created_topic.openalex_id, topic["id"])
 
     def test_update_topic(self):
         old_topic = self.topics[0]
@@ -36,7 +36,7 @@ class ProcessOpenAlexWorksTests(APITestCase):
         Topic.upsert_from_openalex(new_topic)
 
         created_topic = Topic.objects.filter(openalex_id=new_topic["id"]).first()
-        self.assertEquals(created_topic.display_name, "new topic")
+        self.assertEqual(created_topic.display_name, "new topic")
 
     def test_create_topic_should_create_related_entities(self):
         topic = self.topics[0]
@@ -46,6 +46,6 @@ class ProcessOpenAlexWorksTests(APITestCase):
         field = subfield.field
         domain = field.domain
 
-        self.assertEquals(domain.openalex_id, topic["domain"]["id"])
-        self.assertEquals(subfield.openalex_id, topic["subfield"]["id"])
-        self.assertEquals(field.openalex_id, topic["field"]["id"])
+        self.assertEqual(domain.openalex_id, topic["domain"]["id"])
+        self.assertEqual(subfield.openalex_id, topic["subfield"]["id"])
+        self.assertEqual(field.openalex_id, topic["field"]["id"])

--- a/src/topic/tests.py
+++ b/src/topic/tests.py
@@ -3,8 +3,6 @@ from datetime import datetime
 
 from rest_framework.test import APITestCase
 
-from paper.models import Paper
-from paper.openalex_util import process_openalex_works
 from topic.models import Topic
 
 

--- a/src/user/tests/test_audit_view.py
+++ b/src/user/tests/test_audit_view.py
@@ -110,7 +110,7 @@ class AuditViewTests(APITestCase):
                 "send_email": False,
             },
         )
-        self.assertEquals(http_response.status_code, 403)
+        self.assertEqual(http_response.status_code, 403)
 
     def test_editor_can_dismiss_flag(self):
         self.client.force_authenticate(self.test_editor)
@@ -121,7 +121,7 @@ class AuditViewTests(APITestCase):
         http_response = self.client.post(
             DISMISS_FLAGGED_CONTENT_URL, {"flag_ids": [target_flag.id]}
         )
-        self.assertEquals(http_response.status_code, 200)
+        self.assertEqual(http_response.status_code, 200)
 
     def test_reg_user_cannot_dismiss_flag(self):
         self.client.force_authenticate(self.reg_user)
@@ -132,4 +132,4 @@ class AuditViewTests(APITestCase):
         http_response = self.client.post(
             DISMISS_FLAGGED_CONTENT_URL, {"flag_ids": [target_flag.id]}
         )
-        self.assertEquals(http_response.status_code, 403)
+        self.assertEqual(http_response.status_code, 403)


### PR DESCRIPTION
Fix warning message while running unit tests, e.g.:
```
[...]
/workspaces/researchhub-backend/src/institution/tests.py:20: DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(created_inst.openalex_id, institution["id"])
.testing123
/workspaces/researchhub-backend/src/institution/tests.py:41: DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(created_inst.display_name, "new topic")
[...]
```