### PR TITLE
Update deprecated Django settings

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -487,10 +487,19 @@ EMAIL_DOMAIN = (
 DEFAULT_FROM_EMAIL = f"noreply@{EMAIL_DOMAIN}"
 
 # Storage
-if TESTING:
-    DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
-else:
-    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+STORAGES = {
+    "default": {
+        "BACKEND": (
+            "storages.backends.s3boto3.S3Boto3Storage"
+            if not TESTING
+            else "django.core.files.storage.FileSystemStorage"
+        ),
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
 AWS_QUERYSTRING_EXPIRE = 604800
 
 AWS_STORAGE_BUCKET_NAME = os.environ.get(


### PR DESCRIPTION
Update deprecated Django settings (`USE_L10N` and `DEFAULT_FILE_STORAGE`) to address the following warnings:

```
/workspaces/researchhub-backend/src/.venv/lib/python3.8/site-packages/django/conf/__init__.py:267: RemovedInDjango50Warning: The USE_L10N setting is deprecated. Starting with Django 5.0, localized formatting of data will always be enabled. For example Django will display numbers and dates using the format of the current locale.
  warnings.warn(USE_L10N_DEPRECATED_MSG, RemovedInDjango50Warning)
```

And:

```
/workspaces/researchhub-backend/src/.venv/lib/python3.8/site-packages/django/conf/__init__.py:278: RemovedInDjango51Warning: The DEFAULT_FILE_STORAGE setting is deprecated. Use STORAGES instead.
  warnings.warn(DEFAULT_FILE_STORAGE_DEPRECATED_MSG, RemovedInDjango51Warning)
```