### PR TITLE
Stop bucket errors

### DIFF
--- a/src/reputation/lib.py
+++ b/src/reputation/lib.py
@@ -9,7 +9,7 @@ from ethereum.lib import RSC_CONTRACT_ADDRESS, execute_erc20_transfer, get_priva
 from mailing_list.lib import base_email_context
 from reputation.models import Withdrawal
 from reputation.related_models.paid_status_mixin import PaidStatusModelMixin
-from researchhub.settings import WEB3_WALLET_ADDRESS, w3
+from researchhub.settings import WEB3_KEYSTORE_BUCKET, WEB3_WALLET_ADDRESS, w3
 from utils.message import send_email_message
 from utils.sentry import log_error
 
@@ -331,7 +331,7 @@ contract_abi = [
 ]
 
 try:
-    PRIVATE_KEY = get_private_key()
+    PRIVATE_KEY = get_private_key() if WEB3_KEYSTORE_BUCKET else None
 except Exception as e:
     print(e)
     PRIVATE_KEY = None

--- a/src/reputation/lib.py
+++ b/src/reputation/lib.py
@@ -333,7 +333,6 @@ contract_abi = [
 try:
     PRIVATE_KEY = get_private_key() if WEB3_KEYSTORE_BUCKET else None
 except Exception as e:
-    print(e)
     PRIVATE_KEY = None
     log_error(e)
 


### PR DESCRIPTION
Currently every `manage.py` invocation will print the following errors:

```
Parameter validation failed:
Invalid bucket name "": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$" or be an ARN matching the regex "^arn:(aws).*:(s3|s3-object-lambda):[a-z\-0-9]*:[0-9]{12}:accesspoint[/:][a-zA-Z0-9\-.]{1,63}$|^arn:(aws).*:s3-outposts:[a-z\-0-9]+:[0-9]{12}:outpost[/:][a-zA-Z0-9\-]{1,63}[/:]accesspoint[/:][a-zA-Z0-9\-]{1,63}$"
Parameter validation failed:
Invalid bucket name "": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$" or be an ARN matching the regex "^arn:(aws).*:(s3|s3-object-lambda):[a-z\-0-9]*:[0-9]{12}:accesspoint[/:][a-zA-Z0-9\-.]{1,63}$|^arn:(aws).*:s3-outposts:[a-z\-0-9]+:[0-9]{12}:outpost[/:][a-zA-Z0-9\-]{1,63}[/:]accesspoint[/:][a-zA-Z0-9\-]{1,63}$" None None
```

This is caused by the attempt to initialize `PRIVATE_KEY` even if no bucket details are configured (locally, when running test, etc.).