### PR TITLE
Replace deprecated set-output command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           role_arn_name=${DEPLOY_ENV^^}_DEPLOY_ROLE_ARN
           role_arn=$(eval echo \$$role_arn_name)
-          echo "::set-output name=role_arn::$role_arn"
+          echo "role_arn=$role_arn" >> "$GITHUB_ENV"
 
       - name: Configure AWS credentials with assume role
         id: aws_credentials


### PR DESCRIPTION
`set-output` is deprecated (see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and currently triggers the following warning on every build:

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. [...]
```