### PR TITLE
Fix Github output variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           role_arn_name=${DEPLOY_ENV^^}_DEPLOY_ROLE_ARN
           role_arn=$(eval echo \$$role_arn_name)
-          echo "role_arn=$role_arn" >> "$GITHUB_ENV"
+          echo "role_arn=$role_arn" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials with assume role
         id: aws_credentials


### PR DESCRIPTION
The AWS role ARN is currently written to the wrong `GITHUB` variable. It should be written to `GITHUB_OUTPUT`:

```
${{ steps.get-role-arn.outputs.role_arn }}
```