### PR TITLE
Remove deprecated L10N settings

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -477,8 +477,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 


### PR DESCRIPTION
The default value of the USE_L10N setting is changed to `True`.

See: https://docs.djangoproject.com/en/5.0/releases/4.0/#miscellaneous

This will fix the following warning when running manage commands:

```
/home/vscode/.local/lib/python3.8/site-packages/django/conf/__init__.py:267: RemovedInDjango50Warning: The USE_L10N setting is deprecated. Starting with Django 5.0, localized formatting of data will always be enabled. For example Django will display numbers and dates using the format of the current locale.
```