### PR TITLE
Add permission for checking verified users

### DIFF
--- a/src/user/permissions.py
+++ b/src/user/permissions.py
@@ -4,6 +4,8 @@ from rest_framework.permissions import BasePermission
 from utils.http import DELETE, GET, POST, RequestMethods
 from utils.permissions import AuthorizationBasedPermission
 
+from django.conf import settings
+
 
 class UpdateAuthor(AuthorizationBasedPermission):
     message = "Action not permitted."
@@ -152,6 +154,10 @@ class IsVerifiedUser(BasePermission):
 
         if user.is_anonymous:
             return False
+
+        # FIXME: Remove the following condition after releasing to production
+        if settings.PRODUCTION:
+            return True
 
         user_verification = UserVerification.objects.filter(user=user).first()
         if not user_verification:

--- a/src/user/permissions.py
+++ b/src/user/permissions.py
@@ -1,3 +1,4 @@
+from user.models import UserVerification
 from rest_framework.permissions import BasePermission
 
 from utils.http import DELETE, GET, POST, RequestMethods
@@ -137,3 +138,23 @@ class HasVerificationPermission(BasePermission):
             return False
 
         return True
+
+
+class IsVerifiedUser(BasePermission):
+    """
+    Permission class to check if user identity is verified.
+    """
+
+    message = "User identity is not verified"
+
+    def has_permission(self, request, view):
+        user = request.user
+
+        if user.is_anonymous:
+            return False
+
+        user_verification = UserVerification.objects.filter(user=user).first()
+        if not user_verification:
+            return False
+
+        return user_verification.is_verified

--- a/src/user/tests/test_permissions.py
+++ b/src/user/tests/test_permissions.py
@@ -1,0 +1,71 @@
+from django.test import TestCase
+from user.tests.helpers import (
+    create_random_authenticated_user,
+)
+from user.models import UserVerification
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from user.permissions import IsVerifiedUser
+from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
+from rest_framework import status
+
+
+class PermissionsTests(TestCase):
+
+    class TestView(APIView):
+        permission_classes = [IsVerifiedUser]
+
+        def get(self, request):
+            return Response({"noop"})
+
+    def setUp(self):
+        self.verified_user = create_random_authenticated_user("verified_user")
+        UserVerification.objects.create(
+            user=self.verified_user,
+            status=UserVerification.Status.APPROVED,
+        )
+        self.declined_user = create_random_authenticated_user("declined_user")
+        UserVerification.objects.create(
+            user=self.declined_user,
+            status=UserVerification.Status.DECLINED,
+        )
+        self.unverified_user = create_random_authenticated_user("unverified_user")
+
+        self.client = APIClient()
+        self.factory = APIRequestFactory()
+
+    def test_is_verified_user(self):
+        # Arrange
+        request = self.factory.get("/test-view/")
+        force_authenticate(request, user=self.verified_user)
+        view = PermissionsTests.TestView.as_view()
+
+        # Act
+        response = view(request)
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_is_declined_user(self):
+        # Arrange
+        request = self.factory.get("/test-view/")
+        force_authenticate(request, user=self.declined_user)
+        view = PermissionsTests.TestView.as_view()
+
+        # Act
+        response = view(request)
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_is_unverified_user(self):
+        # Arrange
+        request = self.factory.get("/test-view/")
+        force_authenticate(request, user=self.unverified_user)
+        view = PermissionsTests.TestView.as_view()
+
+        # Act
+        response = view(request)
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -95,7 +95,11 @@ class AuthorViewSet(viewsets.ModelViewSet):
 
         return Response(serializer.data)
 
-    @action(detail=True, methods=["post"], permission_classes=[IsVerifiedUser])
+    @action(
+        detail=True,
+        methods=["post"],
+        permission_classes=[IsAuthenticated, IsVerifiedUser],
+    )
     def claim_profile_and_add_publications(self, request, pk=None):
         author = request.user.author_profile
         openalex_ids = request.data.get("openalex_ids", [])

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -71,6 +71,7 @@ from user.permissions import (
     DeleteAuthorPermission,
     DeleteUserPermission,
     HasVerificationPermission,
+    IsVerifiedUser,
     RequestorIsOwnUser,
     UpdateAuthor,
 )
@@ -138,7 +139,7 @@ class AuthorViewSet(viewsets.ModelViewSet):
 
         return Response(serializer.data)
 
-    @action(detail=True, methods=["post"], permission_classes=[IsAuthenticated])
+    @action(detail=True, methods=["post"], permission_classes=[IsVerifiedUser])
     def claim_profile_and_add_publications(self, request, pk=None):
         author = request.user.author_profile
         openalex_ids = request.data.get("openalex_ids", [])

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -110,7 +110,7 @@ class AuthorViewSet(viewsets.ModelViewSet):
             claim_openalex_author_profile(author.id, openalex_author_id)
         except AuthorClaimException as e:
             return Response({"reason": e.reason}, status=status.HTTP_400_BAD_REQUEST)
-        except Exception as e:
+        except Exception:
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         if len(openalex_ids) > 0:

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -145,7 +145,7 @@ class AuthorViewSet(viewsets.ModelViewSet):
         openalex_ids = request.data.get("openalex_ids", [])
         openalex_author_id = request.data.get("openalex_author_id", None)
 
-        # Esnsure the openalex author id is a full url since it is the format stored in our system
+        # Ensure the openalex author id is a full url since it is the format stored in our system
         if "openalex.org" not in openalex_author_id:
             raise Exception("Invalid OpenAlex author ID")
 

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -1,23 +1,8 @@
-import hmac
-from datetime import datetime, timedelta
-from hashlib import sha1
-
-from allauth.account.models import EmailAddress
 from django.contrib.contenttypes.models import ContentType
-from django.core.cache import cache
-from django.core.exceptions import ValidationError
-from django.db import IntegrityError, models, transaction
-from django.db.models import Exists, F, OuterRef, Q, Sum
-from django.db.models.functions import Coalesce
-from django.shortcuts import get_object_or_404
-from django.utils import timezone
-from django.utils.decorators import method_decorator
-from django.utils.timezone import now
-from django.views.decorators.cache import cache_page
+from django.db.models import Q, Sum
 from django_filters.rest_framework import DjangoFilterBackend
-from requests.exceptions import HTTPError
 from rest_framework import status, viewsets
-from rest_framework.decorators import action, api_view, permission_classes
+from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import (
     AllowAny,
@@ -25,32 +10,19 @@ from rest_framework.permissions import (
     IsAuthenticatedOrReadOnly,
 )
 from rest_framework.response import Response
-from rest_framework.utils.urls import replace_query_param
-from simple_history.utils import bulk_update_with_history
 
-import utils.sentry as sentry
-from discussion.models import Comment, Reply, Thread
 from discussion.serializers import DynamicThreadSerializer
 from hypothesis.related_models.hypothesis import Hypothesis
 from paper.models import Paper
-from paper.openalex_util import merge_openalex_author_with_researchhub_author
 from paper.serializers import DynamicPaperSerializer
-from paper.tasks import pull_openalex_author_works, pull_openalex_author_works_batch
-from paper.utils import PAPER_SCORE_Q_ANNOTATION, get_cache_key
+from paper.tasks import pull_openalex_author_works_batch
+from paper.utils import PAPER_SCORE_Q_ANNOTATION
 from paper.views import PaperViewSet
-from reputation.models import Bounty, BountySolution, Contribution, Distribution
+from reputation.models import Bounty, BountySolution, Contribution
 from reputation.serializers import (
-    DynamicBountySerializer,
-    DynamicBountySolutionSerializer,
     DynamicContributionSerializer,
 )
-from reputation.views import BountyViewSet
-from researchhub.settings import (
-    EMAIL_WHITELIST,
-    SIFT_MODERATION_WHITELIST,
-    SIFT_WEBHOOK_SECRET_KEY,
-    TESTING,
-)
+from researchhub.settings import TESTING
 from researchhub_comment.models import RhCommentModel
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 from researchhub_document.related_models.researchhub_unified_document_model import (
@@ -64,39 +36,23 @@ from researchhub_document.views.researchhub_unified_document_views import (
     ResearchhubUnifiedDocumentViewSet,
 )
 from review.models.review_model import Review
-from user.filters import AuthorFilter, UserFilter
-from user.models import Author, Follow, Major, University, User, UserApiToken
+from user.filters import AuthorFilter
+from user.models import Author
 from user.permissions import (
-    Censor,
     DeleteAuthorPermission,
-    DeleteUserPermission,
-    HasVerificationPermission,
     IsVerifiedUser,
-    RequestorIsOwnUser,
     UpdateAuthor,
 )
 from user.serializers import (
     AuthorEditableSerializer,
     AuthorSerializer,
     DynamicAuthorProfileSerializer,
-    DynamicUserSerializer,
-    MajorSerializer,
-    UniversitySerializer,
-    UserActions,
-    UserEditableSerializer,
-    UserSerializer,
 )
-from user.tasks import handle_spam_user_task, reinstate_user_task
 from user.utils import (
     AuthorClaimException,
-    calculate_show_referral,
     claim_openalex_author_profile,
-    reset_latest_acitvity_cache,
 )
-from utils.http import POST, RequestMethods
-from utils.openalex import OpenAlex
 from utils.permissions import CreateOrUpdateIfAllowed
-from utils.sentry import log_error, log_info
 from utils.throttles import THROTTLE_CLASSES
 
 


### PR DESCRIPTION
- Add a new permission class `IsVerifiedUser` for checking a user if KYC verified.
- Add the permission to the existing claiming endpoint.

**Note:**
The permission is not active in production (see code change). The conditional logic that is checking for `PRODUCTION` needs to be removed for releasing this feature.