### PR TITLE
Add permission for checking verified users

### DIFF
--- a/src/user/permissions.py
+++ b/src/user/permissions.py
@@ -3,6 +3,7 @@ from rest_framework.permissions import BasePermission
 
 from utils.http import DELETE, GET, POST, RequestMethods
 from utils.permissions import AuthorizationBasedPermission
+from django.conf import settings
 
 
 class UpdateAuthor(AuthorizationBasedPermission):
@@ -152,6 +153,10 @@ class IsVerifiedUser(BasePermission):
 
         if user.is_anonymous:
             return False
+
+        # FIXME: Remove the following condition after releasing to production
+        if settings.PRODUCTION:
+            return True
 
         user_verification = UserVerification.objects.filter(user=user).first()
         if not user_verification:

--- a/src/user/permissions.py
+++ b/src/user/permissions.py
@@ -1,3 +1,4 @@
+from user.models import UserVerification
 from rest_framework.permissions import BasePermission
 
 from utils.http import DELETE, GET, POST, RequestMethods
@@ -137,3 +138,23 @@ class HasVerificationPermission(BasePermission):
             return False
 
         return True
+
+
+class IsVerifiedUser(BasePermission):
+    """
+    Permission class to check if user identity is verified.
+    """
+
+    message = "User identity is not verified"
+
+    def has_permission(self, request, view):
+        user = request.user
+
+        if user.is_anonymous:
+            return False
+
+        user_verification = UserVerification.objects.filter(user=user).first()
+        if not user_verification:
+            return False
+
+        return user_verification.is_verified

--- a/src/user/permissions.py
+++ b/src/user/permissions.py
@@ -3,7 +3,6 @@ from rest_framework.permissions import BasePermission
 
 from utils.http import DELETE, GET, POST, RequestMethods
 from utils.permissions import AuthorizationBasedPermission
-from django.conf import settings
 
 
 class UpdateAuthor(AuthorizationBasedPermission):
@@ -153,10 +152,6 @@ class IsVerifiedUser(BasePermission):
 
         if user.is_anonymous:
             return False
-
-        # FIXME: Remove the following condition after releasing to production
-        if settings.PRODUCTION:
-            return True
 
         user_verification = UserVerification.objects.filter(user=user).first()
         if not user_verification:

--- a/src/user/tests/test_author_claim.py
+++ b/src/user/tests/test_author_claim.py
@@ -49,12 +49,12 @@ class AuthorClaimTests(APITestCase):
 
                 # Get author work Ids first
                 openalex_api = OpenAlex()
-                results, cursor = openalex_api.get_works()
+                results, _ = openalex_api.get_works()
                 work_ids = [work["id"] for work in results]
 
                 # # Add publications to author
                 url = f"/api/author/{self.claiming_user.author_profile.id}/add_publications/"
-                response = self.client.post(
+                self.client.post(
                     url,
                     {
                         "openalex_ids": work_ids,
@@ -93,7 +93,7 @@ class AuthorClaimTests(APITestCase):
 
                 # # Add publications to author
                 url = f"/api/author/{self.claiming_user.author_profile.id}/add_publications/"
-                response = self.client.post(
+                self.client.post(
                     url,
                     {
                         "openalex_ids": work_ids,
@@ -134,7 +134,7 @@ class AuthorClaimTests(APITestCase):
 
                 # # Add publications to author
                 url = f"/api/author/{self.claiming_user.author_profile.id}/add_publications/"
-                response = self.client.post(
+                self.client.post(
                     url,
                     {
                         "openalex_ids": work_ids,
@@ -189,7 +189,7 @@ class AuthorClaimTests(APITestCase):
 
                 self.client.force_authenticate(self.claiming_user)
                 url = f"/api/author/{self.claiming_user.author_profile.id}/add_publications/"
-                response = self.client.post(
+                self.client.post(
                     url,
                     {
                         "openalex_ids": work_ids,

--- a/src/user/tests/test_author_claim.py
+++ b/src/user/tests/test_author_claim.py
@@ -4,10 +4,8 @@ from unittest.mock import patch
 from rest_framework.test import APITestCase
 
 from paper.openalex_util import process_openalex_works
-from paper.related_models.paper_model import Paper
 from user.models import UserVerification
 from user.tests.helpers import create_user
-from user.utils import AuthorClaimException
 from utils.openalex import OpenAlex
 
 

--- a/src/user/tests/test_author_claim.py
+++ b/src/user/tests/test_author_claim.py
@@ -5,6 +5,7 @@ from rest_framework.test import APITestCase
 
 from paper.openalex_util import process_openalex_works
 from paper.related_models.paper_model import Paper
+from user.models import UserVerification
 from user.tests.helpers import create_user
 from user.utils import AuthorClaimException
 from utils.openalex import OpenAlex
@@ -12,7 +13,24 @@ from utils.openalex import OpenAlex
 
 class AuthorClaimTests(APITestCase):
     def setUp(self):
-        self.user = create_user(email="random@example.com")
+        self.claiming_user = create_user(
+            email="random@example.com",
+            first_name="Yang",
+            last_name="Wang",
+        )
+        UserVerification.objects.create(
+            user=self.claiming_user,
+            status=UserVerification.Status.APPROVED,
+        )
+        self.second_claiming_user = create_user(
+            first_name="Yang",
+            last_name="Wang",
+            email="random_author2@researchhub.com",
+        )
+        UserVerification.objects.create(
+            user=self.second_claiming_user,
+            status=UserVerification.Status.APPROVED,
+        )
 
     @patch.object(OpenAlex, "get_authors")
     @patch.object(OpenAlex, "get_works")
@@ -28,13 +46,8 @@ class AuthorClaimTests(APITestCase):
                 mock_get_authors.return_value = (authors_data, None)
 
                 claiming_user_openalex_id = "https://openalex.org/A5068835581"
-                claiming_user = create_user(
-                    first_name="Yang",
-                    last_name="Wang",
-                    email="random_author@researchhub.com",
-                )
 
-                self.client.force_authenticate(claiming_user)
+                self.client.force_authenticate(self.claiming_user)
 
                 # Get author work Ids first
                 openalex_api = OpenAlex()
@@ -42,7 +55,7 @@ class AuthorClaimTests(APITestCase):
                 work_ids = [work["id"] for work in results]
 
                 # # Add publications to author
-                url = f"/api/author/{claiming_user.author_profile.id}/add_publications/"
+                url = f"/api/author/{self.claiming_user.author_profile.id}/add_publications/"
                 response = self.client.post(
                     url,
                     {
@@ -51,10 +64,10 @@ class AuthorClaimTests(APITestCase):
                     },
                 )
 
-                claiming_user.refresh_from_db()
+                self.claiming_user.refresh_from_db()
                 self.assertEquals(
                     claiming_user_openalex_id
-                    in claiming_user.author_profile.openalex_ids,
+                    in self.claiming_user.author_profile.openalex_ids,
                     True,
                 )
 
@@ -72,13 +85,8 @@ class AuthorClaimTests(APITestCase):
                 mock_get_authors.return_value = (authors_data, None)
 
                 claiming_user_openalex_id = "https://openalex.org/A5068835581"
-                claiming_user = create_user(
-                    first_name="Yang",
-                    last_name="Wang",
-                    email="random_author@researchhub.com",
-                )
 
-                self.client.force_authenticate(claiming_user)
+                self.client.force_authenticate(self.claiming_user)
 
                 # Get author work Ids first
                 openalex_api = OpenAlex()
@@ -86,7 +94,7 @@ class AuthorClaimTests(APITestCase):
                 work_ids = [work["id"] for work in results]
 
                 # # Add publications to author
-                url = f"/api/author/{claiming_user.author_profile.id}/add_publications/"
+                url = f"/api/author/{self.claiming_user.author_profile.id}/add_publications/"
                 response = self.client.post(
                     url,
                     {
@@ -95,11 +103,11 @@ class AuthorClaimTests(APITestCase):
                     },
                 )
 
-                claiming_user.refresh_from_db()
+                self.claiming_user.refresh_from_db()
                 self.assertCountEqual(
                     [
                         p.openalex_id
-                        for p in claiming_user.author_profile.authored_papers.all()
+                        for p in self.claiming_user.author_profile.authored_papers.all()
                     ],
                     work_ids,
                 )
@@ -118,13 +126,8 @@ class AuthorClaimTests(APITestCase):
                 mock_get_authors.return_value = (authors_data, None)
 
                 claiming_user_openalex_id = "https://openalex.org/A5068835581"
-                claiming_user = create_user(
-                    first_name="Yang",
-                    last_name="Wang",
-                    email="random_author@researchhub.com",
-                )
 
-                self.client.force_authenticate(claiming_user)
+                self.client.force_authenticate(self.claiming_user)
 
                 # Get author work Ids first
                 openalex_api = OpenAlex()
@@ -132,7 +135,7 @@ class AuthorClaimTests(APITestCase):
                 work_ids = [work["id"] for work in results]
 
                 # # Add publications to author
-                url = f"/api/author/{claiming_user.author_profile.id}/add_publications/"
+                url = f"/api/author/{self.claiming_user.author_profile.id}/add_publications/"
                 response = self.client.post(
                     url,
                     {
@@ -141,17 +144,18 @@ class AuthorClaimTests(APITestCase):
                     },
                 )
 
-                claiming_user.refresh_from_db()
+                self.claiming_user.refresh_from_db()
                 openalex_author = authors_data[0]
                 self.assertEquals(
-                    claiming_user.author_profile.orcid_id, openalex_author.get("orcid")
+                    self.claiming_user.author_profile.orcid_id,
+                    openalex_author.get("orcid"),
                 )
                 self.assertEquals(
-                    claiming_user.author_profile.two_year_mean_citedness,
+                    self.claiming_user.author_profile.two_year_mean_citedness,
                     openalex_author.get("summary_stats", {}).get("2yr_mean_citedness"),
                 )
                 self.assertEquals(
-                    claiming_user.author_profile.h_index,
+                    self.claiming_user.author_profile.h_index,
                     openalex_author.get("summary_stats", {}).get("h_index"),
                 )
 
@@ -180,20 +184,13 @@ class AuthorClaimTests(APITestCase):
                 )
                 self.assertEquals(unclaimed_author.user, None)
 
-                # Now let's try to claim this user
-                claiming_user = create_user(
-                    first_name="Yang",
-                    last_name="Wang",
-                    email="random_author@researchhub.com",
-                )
-
                 # Get author work Ids first
                 openalex_api = OpenAlex()
                 results, cursor = openalex_api.get_works()
                 work_ids = [work["id"] for work in results]
 
-                self.client.force_authenticate(claiming_user)
-                url = f"/api/author/{claiming_user.author_profile.id}/add_publications/"
+                self.client.force_authenticate(self.claiming_user)
+                url = f"/api/author/{self.claiming_user.author_profile.id}/add_publications/"
                 response = self.client.post(
                     url,
                     {
@@ -202,9 +199,9 @@ class AuthorClaimTests(APITestCase):
                     },
                 )
 
-                claiming_user.refresh_from_db()
+                self.claiming_user.refresh_from_db()
                 unclaimed_author.refresh_from_db()
                 self.assertEquals(
-                    claiming_user.author_profile.id,
+                    self.claiming_user.author_profile.id,
                     unclaimed_author.merged_with_author.id,
                 )

--- a/src/user/tests/test_permissions.py
+++ b/src/user/tests/test_permissions.py
@@ -1,0 +1,71 @@
+from django.test import TestCase
+from user.tests.helpers import (
+    create_random_authenticated_user,
+)
+from user.models import UserVerification
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from user.permissions import IsVerifiedUser
+from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
+from rest_framework import status
+
+
+class PermissionsTests(TestCase):
+
+    class TestView(APIView):
+        permission_classes = [IsVerifiedUser]
+
+        def get(self, request):
+            return Response({"noop"})
+
+    def setUp(self):
+        self.verified_user = create_random_authenticated_user("verified_user")
+        UserVerification.objects.create(
+            user=self.verified_user,
+            status=UserVerification.Status.APPROVED,
+        )
+        self.declined_user = create_random_authenticated_user("declined_user")
+        UserVerification.objects.create(
+            user=self.declined_user,
+            status=UserVerification.Status.DECLINED,
+        )
+        self.unverified_user = create_random_authenticated_user("unverified_user")
+
+        self.client = APIClient()
+        self.factory = APIRequestFactory()
+
+    def test_is_verified_user(self):
+        # Arrange
+        request = self.factory.get("/test-view/")
+        force_authenticate(request, user=self.verified_user)
+        view = PermissionsTests.TestView.as_view()
+
+        # Act
+        response = view(request)
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_is_declined_user(self):
+        # Arrange
+        request = self.factory.get("/test-view/")
+        force_authenticate(request, user=self.declined_user)
+        view = PermissionsTests.TestView.as_view()
+
+        # Act
+        response = view(request)
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_is_unverified_user(self):
+        # Arrange
+        request = self.factory.get("/test-view/")
+        force_authenticate(request, user=self.unverified_user)
+        view = PermissionsTests.TestView.as_view()
+
+        # Act
+        response = view(request)
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/src/user/tests/test_views.py
+++ b/src/user/tests/test_views.py
@@ -52,7 +52,7 @@ class UserApiTests(APITestCase):
 
             # Add publications to author
             url = f"/api/author/{self.user_with_published_works.author_profile.id}/add_publications/"
-            response = self.client.post(
+            self.client.post(
                 url,
                 {
                     "openalex_ids": work_ids,
@@ -87,7 +87,7 @@ class UserApiTests(APITestCase):
 
             # Add publications to author
             url = f"/api/author/{self.user_with_published_works.author_profile.id}/add_publications/"
-            response = self.client.post(
+            self.client.post(
                 url,
                 {
                     "openalex_ids": work_ids,

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -149,7 +149,7 @@ class AuthorViewSet(viewsets.ModelViewSet):
         openalex_ids = request.data.get("openalex_ids", [])
         openalex_author_id = request.data.get("openalex_author_id", None)
 
-        # Esnsure the openalex author id is a full url since it is the format stored in our system
+        # Ensure the openalex author id is a full url since it is the format stored in our system
         if "openalex.org" not in openalex_author_id:
             openalex_author_id = f"https://openalex.org/authors/{openalex_author_id}"
 

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -111,9 +111,9 @@ class AuthorViewSet(viewsets.ModelViewSet):
         # Attempt to associate the openalex author id with the RH author
         try:
             claim_openalex_author_profile(author.id, openalex_author_id)
-        except AuthorClaimException as e:
+        except AuthorClaimException:
             pass
-        except Exception as e:
+        except Exception:
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         if len(openalex_ids) > 0:

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -1,23 +1,8 @@
-import hmac
-from datetime import datetime, timedelta
-from hashlib import sha1
-
-from allauth.account.models import EmailAddress
 from django.contrib.contenttypes.models import ContentType
-from django.core.cache import cache
-from django.core.exceptions import ValidationError
-from django.db import IntegrityError, models, transaction
-from django.db.models import Exists, F, OuterRef, Q, Sum
-from django.db.models.functions import Coalesce
-from django.shortcuts import get_object_or_404
-from django.utils import timezone
-from django.utils.decorators import method_decorator
-from django.utils.timezone import now
-from django.views.decorators.cache import cache_page
+from django.db.models import Q, Sum
 from django_filters.rest_framework import DjangoFilterBackend
-from requests.exceptions import HTTPError
 from rest_framework import status, viewsets
-from rest_framework.decorators import action, api_view, permission_classes
+from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import (
     AllowAny,
@@ -25,32 +10,18 @@ from rest_framework.permissions import (
     IsAuthenticatedOrReadOnly,
 )
 from rest_framework.response import Response
-from rest_framework.utils.urls import replace_query_param
-from simple_history.utils import bulk_update_with_history
 
-import utils.sentry as sentry
-from discussion.models import Comment, Reply, Thread
 from discussion.serializers import DynamicThreadSerializer
 from hypothesis.related_models.hypothesis import Hypothesis
 from paper.models import Paper
-from paper.openalex_util import merge_openalex_author_with_researchhub_author
 from paper.serializers import DynamicPaperSerializer
-from paper.tasks import pull_openalex_author_works, pull_openalex_author_works_batch
-from paper.utils import PAPER_SCORE_Q_ANNOTATION, get_cache_key
+from paper.tasks import pull_openalex_author_works_batch
+from paper.utils import PAPER_SCORE_Q_ANNOTATION
 from paper.views import PaperViewSet
-from reputation.models import Bounty, BountySolution, Contribution, Distribution
-from reputation.serializers import (
-    DynamicBountySerializer,
-    DynamicBountySolutionSerializer,
-    DynamicContributionSerializer,
-)
-from reputation.views import BountyViewSet
-from researchhub.settings import (
-    EMAIL_WHITELIST,
-    SIFT_MODERATION_WHITELIST,
-    SIFT_WEBHOOK_SECRET_KEY,
-    TESTING,
-)
+from reputation.models import Bounty, BountySolution, Contribution
+from reputation.serializers import DynamicContributionSerializer
+
+from researchhub.settings import TESTING
 from researchhub_comment.models import RhCommentModel
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 from researchhub_document.related_models.researchhub_unified_document_model import (
@@ -64,39 +35,23 @@ from researchhub_document.views.researchhub_unified_document_views import (
     ResearchhubUnifiedDocumentViewSet,
 )
 from review.models.review_model import Review
-from user.filters import AuthorFilter, UserFilter
-from user.models import Author, Follow, Major, University, User, UserApiToken
+from user.filters import AuthorFilter
+from user.models import Author
 from user.permissions import (
-    Censor,
     DeleteAuthorPermission,
-    DeleteUserPermission,
-    HasVerificationPermission,
     IsVerifiedUser,
-    RequestorIsOwnUser,
     UpdateAuthor,
 )
 from user.serializers import (
     AuthorEditableSerializer,
     AuthorSerializer,
     DynamicAuthorProfileSerializer,
-    DynamicUserSerializer,
-    MajorSerializer,
-    UniversitySerializer,
-    UserActions,
-    UserEditableSerializer,
-    UserSerializer,
 )
-from user.tasks import handle_spam_user_task, reinstate_user_task
 from user.utils import (
     AuthorClaimException,
-    calculate_show_referral,
     claim_openalex_author_profile,
-    reset_latest_acitvity_cache,
 )
-from utils.http import POST, RequestMethods
-from utils.openalex import OpenAlex
 from utils.permissions import CreateOrUpdateIfAllowed
-from utils.sentry import log_error, log_info
 from utils.throttles import THROTTLE_CLASSES
 
 

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -71,6 +71,7 @@ from user.permissions import (
     DeleteAuthorPermission,
     DeleteUserPermission,
     HasVerificationPermission,
+    IsVerifiedUser,
     RequestorIsOwnUser,
     UpdateAuthor,
 )
@@ -138,7 +139,11 @@ class AuthorViewSet(viewsets.ModelViewSet):
 
         return Response(serializer.data)
 
-    @action(detail=True, methods=["post"], permission_classes=[IsAuthenticated])
+    @action(
+        detail=True,
+        methods=["post"],
+        permission_classes=[IsAuthenticated, IsVerifiedUser],
+    )
     def add_publications(self, request, pk=None):
         author = request.user.author_profile
         openalex_ids = request.data.get("openalex_ids", [])


### PR DESCRIPTION
- Add a new permission class `IsVerifiedUser` for checking a user if KYC verified.
- Add the permission to the existing claiming endpoint.

**Note:**
The permission is not active in production (see code change). The conditional logic that is checking for `PRODUCTION` needs to be removed for releasing this feature.