### PR TITLE
Remove prefix from AWS environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,8 @@ jobs:
         id: aws_credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.NEW_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.NEW_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ steps.get-role-arn.outputs.role_arn }}
           role-session-name: github-actions-beanstalk-session
           role-duration-seconds: 1200


### PR DESCRIPTION
The environment variables prefixed with `NEW_` were used for the AWS migration for the new account. The non-prefixed were updated to point to the new account. Cleaning up the temporary variables now.