### PR TITLE
Remove deprecated hosts

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -94,7 +94,7 @@ ALLOWED_HOSTS = [
 
 
 if not (PRODUCTION or STAGING):
-    ALLOWED_HOSTS += [".ngrok.io", "localhost", "10.0.2.2", "10.0.3.2"]
+    ALLOWED_HOSTS += [".ngrok.io", "localhost"]
 
 if ELASTIC_BEANSTALK:
     # This is for health checks
@@ -155,7 +155,6 @@ CORS_ORIGIN_WHITELIST = [
     "https://researchhub.com",
     "https://staging.researchhub.com",
     "https://www.staging.researchhub.com",
-    "http://10.0.2.2:3000",
     "http://127.0.0.1:3000",
     "https://word.researchhub.com",
 ]

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -89,12 +89,7 @@ ALLOWED_HOSTS = [
     "www.staging.researchhub.com",
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
     r"https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}",
-    r"researchhub(-[0-9]?)\.ngrok\.io",
 ]
-
-
-if not (PRODUCTION or STAGING):
-    ALLOWED_HOSTS += [".ngrok.io", "localhost"]
 
 if ELASTIC_BEANSTALK:
     # This is for health checks

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -82,7 +82,6 @@ if not (PRODUCTION or STAGING):
 
 ALLOWED_HOSTS = [
     ".elasticbeanstalk.com",
-    ".researchhub-web-researchhub.vercel.app",
     ".researchhub.com",
     "127.0.0.1",  # localhost
     "localhost",
@@ -153,7 +152,6 @@ CORS_ORIGIN_WHITELIST = [
     "https://dev.researchhub.com",
     "https://researchnow.researchhub.com",
     "https://www.researchhub.com",
-    "https://researchhub-web-researchhub.vercel.app",
     "https://researchhub.com",
     "https://staging.researchhub.com",
     "https://www.staging.researchhub.com",


### PR DESCRIPTION
Remove deprecated hosts from `ALLOWED_HOSTS` and CORS including:
- The Vercel former staging environment host researchhub-web-researchhub.vercel.app
- Some range 10.0.x.x IP addresses used in the previous AWS environment.
- Remove ngrok.