### PR TITLE
Only calculate hot score if there is a document

### DIFF
--- a/src/researchhub_document/tasks.py
+++ b/src/researchhub_document/tasks.py
@@ -43,7 +43,8 @@ def recalc_hot_score_task(instance_content_type_id, instance_id):
         elif model_name == "citation":
             uni_doc = model_class.objects.get(id=instance_id).source
 
-        uni_doc.calculate_hot_score_v2(should_save=True)
+        if uni_doc:
+            uni_doc.calculate_hot_score_v2(should_save=True)
     except Exception as error:
         sentry.log_error(error)
 


### PR DESCRIPTION
Fix `AttributeError 'NoneType' object has no attribute 'calculate_hot_score_v2'` that occurred 91k times in the past 7 days and is ongoing.

See: https://researchhub.sentry.io/issues/3759702381/events/?project=1797024&referrer=issue-stream&statsPeriod=7d&stream_index=6