### PR TITLE
Handle `DoesNotExist` errors when fetching contribution

### DIFF
--- a/src/reputation/serializers/contribution_serializer.py
+++ b/src/reputation/serializers/contribution_serializer.py
@@ -122,7 +122,12 @@ class DynamicContributionSerializer(DynamicModelFieldSerializer):
         model_name = contribution.content_type.name
         object_id = contribution.object_id
         model_class = contribution.content_type.model_class()
-        obj = model_class.objects.get(id=object_id)
+        obj = None
+        try:
+            obj = model_class.objects.get(id=object_id)
+        except model_class.DoesNotExist as e:
+            print(f"{model_name} with ID {object_id} does not exist: {e}")
+            return None
 
         if model_name == "paper":
             serializer = DynamicPaperSerializer(obj, context=context, **_context_fields)
@@ -198,6 +203,6 @@ class DynamicContributionSerializer(DynamicModelFieldSerializer):
         serializer = DynamicAuthorSerializer(
             Author.objects.get(user=contribution.user),
             context=context,
-            **_context_fields
+            **_context_fields,
         )
         return serializer.data


### PR DESCRIPTION
Handle `DoesNotExist` exception when fetching contributions. This currently occurs 39k times in the past 7d and is ongoing.

See: https://researchhub.sentry.io/issues/5092332501/events/?project=1797024&referrer=issue-stream&statsPeriod=7d&stream_index=5

<img width="932" alt="image" src="https://github.com/user-attachments/assets/db814cd4-a979-4395-97e0-09aeb8ed26e9">
