### PR TITLE
Make user ID for user `popover` endpoint mandatory

### DIFF
--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -287,8 +287,8 @@ urlpatterns = [
         note_views.note_view.ckeditor_webhook_document_removed,
     ),
     path("api/ckeditor/token/", note_views.note_view.ckeditor_token),
-    re_path(
-        r"api/popover/(?P<pk>[^/.]+)/get_user/",
+    path(
+        "api/popover/<int:pk>/get_user/",
         user.views.get_user_popover,
         name="popover_user",
     ),

--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -288,7 +288,7 @@ urlpatterns = [
     ),
     path("api/ckeditor/token/", note_views.note_view.ckeditor_token),
     path(
-        "api/popover/<int:pk>/get_user/",
+        "api/popover/<int:user_id>/get_user/",
         user.views.get_user_popover,
         name="popover_user",
     ),

--- a/src/user/tests/test_views.py
+++ b/src/user/tests/test_views.py
@@ -252,3 +252,7 @@ class UserPopoverTests(APITestCase):
         res = self.client.get("/api/popover/1000/get_user/")
         self.assertEqual(res.status_code, 404)
         self.assertEqual(res.data["detail"], "Not found.")
+
+    def test_popover_for_invalid_id(self):
+        res = self.client.get("/api/popover/INVALID/get_user/")
+        self.assertEqual(res.status_code, 404)


### PR DESCRIPTION
- Make user ID mandatory and assert integer type.
- Return HTTP 400 if invalid user ID is provided.