### PR TITLE
Codecov | Fix threshold configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,10 +1,10 @@
-ignore:
-  - "**/tests/*"
-  - "**/tests.py"
-  - "**/test_*.py"
 coverage:
   status:
     patch:
       default:
         target: auto
         threshold: 0.5%
+ignore:
+  - "**/tests/*"
+  - "**/tests.py"
+  - "**/test_*.py"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,8 +2,9 @@ ignore:
   - "**/tests/*"
   - "**/tests.py"
   - "**/test_*.py"
-status:
-  patch:
-    default:
-      target: auto
-      threshold: 0.5%
+coverage:
+  status:
+    patch:
+      default:
+        target: auto
+        threshold: 0.5%


### PR DESCRIPTION
Add necessary `coverage` parent key to configuration.