### PR TITLE
Make changes to copy of automated peer review bounty

### DIFF
--- a/src/discussion/reaction_views.py
+++ b/src/discussion/reaction_views.py
@@ -456,7 +456,17 @@ def create_automated_bounty(item):
                     {
                         "insert": "If you have any questions you may join our discord (https://discord.gg/researchhub) or email our Editor Lead, Maulik Dhandha (maulik.editor@researchhub.foundation)"
                     },
-                    {"attributes": {"list": "ordered"}, "insert": "\n"},
+                    {"attributes": {"list": "ordered"}, "insert": "\n\n"},
+                    {
+                        "insert": "We will award $150 in ResearchCoin (RSC) each for up to "
+                    },
+                    {
+                        "attributes": {"bold": True},
+                        "insert": "3 high quality and rigorous peer reviews ",
+                    },
+                    {
+                        "insert": "on this preprint.",
+                    },
                 ]
             }
 


### PR DESCRIPTION
Adds the additional line of text to the automated peer review bounty text:

"We will award $150 in ResearchCoin (RSC) each for up to **3 high quality and rigorous peer reviews** on this preprint."

Closes ResearchHub/issues/issues/71