### PR TITLE
Devcontainers | Organize imports

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,8 @@
 		"vscode": {
 			"extensions": [
 				"ms-python.black-formatter",
-				"ms-python.flake8"
+				"ms-python.flake8",
+				"ms-python.isort"
 			],
 			"settings": {
 				"[python]": {
@@ -46,6 +47,8 @@
 				"flake8.args": [
 					"--max-line-length=88"
 				],
+				// Import sorting, see: https://github.com/microsoft/vscode-isort?tab=readme-ov-file#usage-and-features
+				"isort.args":["--profile", "black"],
 				"remote.autoForwardPorts": false
 			}
 		}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,11 @@
 			"settings": {
 				"[python]": {
 					"editor.defaultFormatter": "ms-python.black-formatter",
-					"editor.formatOnSave": true
+					"editor.formatOnSave": true,
+					"editor.codeActionsOnSave": {
+						"source.organizeImports": "explicit",
+						"source.unusedImports": "never"
+					}
 				},
 				// Align line length between black and flake8 to black's default of 88.
 				// See: https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length


### PR DESCRIPTION
- Add [Microsoft's isort Python extension](https://github.com/microsoft/vscode-isort) for organizing imports. 
- Add configuration to sort imports on every save action without removing any unused imports.