### PR TITLE
Add launch configuration for debugging tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,20 @@
             ],
             "django": true,
             "autoStartBrowser": false
-        }
+        },
+        {
+            // Configuration options for debugging:
+            // https://code.visualstudio.com/docs/python/debugging#_set-configuration-options
+            "name": "Python: Django Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/manage.py",
+            "args": [
+                "test",
+                "${fileDirname}",
+                "--keepdb"
+            ],
+            "django": true
+        },
     ]
 }


### PR DESCRIPTION
Add a new launch configuration for debugging tests. It will run all tests in the module of the currently opened file.

<img width="1322" alt="image" src="https://github.com/user-attachments/assets/778bf516-e3a5-414d-8a4f-52e1b1acd2ce">
