### PR TITLE
Add operation for deleting authorships

### DIFF
--- a/src/user/tests/test_views.py
+++ b/src/user/tests/test_views.py
@@ -48,7 +48,7 @@ class UserApiTests(APITestCase):
 
             # Get author work Ids first
             openalex_api = OpenAlex()
-            author_works, cursor = openalex_api.get_works()
+            author_works, _ = openalex_api.get_works()
             work_ids = [work["id"] for work in author_works]
 
             # Add publications to author
@@ -145,7 +145,7 @@ class UserApiTests(APITestCase):
 
             # Get author work Ids first
             openalex_api = OpenAlex()
-            author_works, cursor = openalex_api.get_works()
+            author_works, _ = openalex_api.get_works()
             work_ids = [work["id"] for work in author_works]
 
             # Add publications to author

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -730,17 +730,15 @@ class AuthorViewSet(viewsets.ModelViewSet):
     def delete_publications(self, request, pk=None):
         paper_ids = request.data.get("paper_ids", [])
 
-        try:
-            authorship = Authorship.objects.get(paper__id__in=paper_ids)
+        authorships = Authorship.objects.filter(paper__id__in=paper_ids)
 
+        for authorship in authorships:
             if authorship.author != request.user.author_profile:
                 return Response(status=status.HTTP_403_FORBIDDEN)
 
-            authorship.delete()
-        except Authorship.DoesNotExist:
-            return Response(status=status.HTTP_404_NOT_FOUND)
+        count, _ = authorships.delete()
 
-        return Response(status=status.HTTP_200_OK)
+        return Response({"count": count}, status=status.HTTP_200_OK)
 
     @action(
         detail=True,

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -724,6 +724,26 @@ class AuthorViewSet(viewsets.ModelViewSet):
 
     @action(
         detail=True,
+        permission_classes=[IsAuthenticated, IsVerifiedUser],
+    )
+    @publications.mapping.delete
+    def delete_publications(self, request, pk=None):
+        paper_ids = request.data.get("paper_ids", [])
+
+        try:
+            authorship = Authorship.objects.get(paper__id__in=paper_ids)
+
+            if authorship.author != request.user.author_profile:
+                return Response(status=status.HTTP_403_FORBIDDEN)
+
+            authorship.delete()
+        except Authorship.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        return Response(status=status.HTTP_200_OK)
+
+    @action(
+        detail=True,
         methods=["get"],
     )
     def overview(self, request, pk=None):


### PR DESCRIPTION
Add a new operation for deleting authorships (author-paper associations) on the `/author/<ID>/publications` resource using the HTTP `DELETE` method. The operation support deletion of multiple authorships by submitting multiple `paper_ids` in the request payload.