### PR TITLE
Use `Authorship` model for author profile stats

### DIFF
--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -1089,8 +1089,6 @@ class DynamicAuthorProfileSerializer(DynamicModelFieldSerializer):
     reputation = SerializerMethodField()
     reputation_list = SerializerMethodField()
     activity_by_year = SerializerMethodField()
-    works_count = SerializerMethodField()
-    citation_count = SerializerMethodField()
     summary_stats = SerializerMethodField()
     open_access_pct = SerializerMethodField()
     achievements = SerializerMethodField()

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -1114,7 +1114,10 @@ class DynamicAuthorProfileSerializer(DynamicModelFieldSerializer):
         sorted_topics = sorted(topic_counts.items(), key=lambda x: x[1], reverse=True)
 
         # Extract topics from sorted list
-        sorted_topics = [topic for topic, count in sorted_topics]
+        sorted_topics = [topic for topic, _ in sorted_topics]
+
+        if not sorted_topics:
+            return None
 
         return "Author with expertise in " + sorted_topics[0].display_name
 

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -760,14 +760,10 @@ class UserActions:
                     data["paper_id"] = thread_paper.id
                 elif thread_post:
                     data["parent_content_type"] = "post"
-                    data[
-                        "paper_title"
-                    ] = (
+                    data["paper_title"] = (
                         thread_post.title
                     )  # paper_title instead of post_title for symmetry on the FE
-                    data[
-                        "paper_id"
-                    ] = (
+                    data["paper_id"] = (
                         thread_post.id
                     )  # paper_id instead of post_id to temporarily reduce refactoring on FE
 

--- a/src/user/tests/test_serializers.py
+++ b/src/user/tests/test_serializers.py
@@ -3,9 +3,15 @@ import json
 from django.test import TestCase
 
 from hub.models import Hub
+from paper.related_models.authorship_model import Authorship
+from paper.related_models.paper_model import Paper
 from reputation.models import Score
 from user.models import UserVerification
-from user.serializers import AuthorSerializer, UserEditableSerializer
+from user.serializers import (
+    AuthorSerializer,
+    DynamicAuthorProfileSerializer,
+    UserEditableSerializer,
+)
 from user.tests.helpers import create_university, create_user
 
 
@@ -13,6 +19,18 @@ class UserSerializersTests(TestCase):
     def setUp(self):
         self.user = create_user(first_name="Serializ")
         self.university = create_university()
+        paper1 = Paper.objects.create(
+            title="title1",
+            citations=10,
+        )
+        paper2 = Paper.objects.create(
+            title="title2",
+            citations=20,
+        )
+        Authorship.objects.create(author=self.user.author_profile, paper=paper1)
+        Authorship.objects.create(author=self.user.author_profile, paper=paper2)
+
+        self.user_without_papers = create_user(email="email1@researchhub.com")
 
     def test_author_serializer_succeeds_without_user_or_university(self):
         data = {
@@ -72,3 +90,27 @@ class UserSerializersTests(TestCase):
         )
         serializer = UserEditableSerializer(self.user)
         self.assertFalse(serializer.data["is_verified_v2"])
+
+    def test_dynamic_author_serializer_summary_stats(self):
+        serializer = DynamicAuthorProfileSerializer(self.user.author_profile)
+        self.assertEqual(
+            serializer.data["summary_stats"],
+            {
+                "citation_count": 30,
+                "two_year_mean_citedness": 0,
+                "works_count": 2,
+            },
+        )
+
+    def test_dynamic_author_serializer_summary_stats_without_papers(self):
+        serializer = DynamicAuthorProfileSerializer(
+            self.user_without_papers.author_profile
+        )
+        self.assertEqual(
+            serializer.data["summary_stats"],
+            {
+                "citation_count": 0,
+                "two_year_mean_citedness": 0,
+                "works_count": 0,
+            },
+        )

--- a/src/user/tests/test_serializers.py
+++ b/src/user/tests/test_serializers.py
@@ -91,8 +91,28 @@ class UserSerializersTests(TestCase):
         serializer = UserEditableSerializer(self.user)
         self.assertFalse(serializer.data["is_verified_v2"])
 
-    def test_dynamic_author_serializer_summary_stats(self):
+    def test_dynamic_author_serializer_headline(self):
+        # Arrange
+        self.user.author_profile.headline = "headline1"
+
+        # Act
         serializer = DynamicAuthorProfileSerializer(self.user.author_profile)
+
+        # Assert
+        self.assertEqual(serializer.data["headline"], "headline1")
+
+    def test_dynamic_author_serializer_headline_without_headline_and_topics(self):
+        # Act
+        serializer = DynamicAuthorProfileSerializer(self.user.author_profile)
+
+        # Assert
+        self.assertIsNone(serializer.data["headline"])
+
+    def test_dynamic_author_serializer_summary_stats(self):
+        # Act
+        serializer = DynamicAuthorProfileSerializer(self.user.author_profile)
+
+        # Assert
         self.assertEqual(
             serializer.data["summary_stats"],
             {
@@ -103,9 +123,12 @@ class UserSerializersTests(TestCase):
         )
 
     def test_dynamic_author_serializer_summary_stats_without_papers(self):
+        # Act
         serializer = DynamicAuthorProfileSerializer(
             self.user_without_papers.author_profile
         )
+
+        # Assert
         self.assertEqual(
             serializer.data["summary_stats"],
             {


### PR DESCRIPTION
- Use the `Authorship` model to get summary stats (paper count, citation count) instead from the `authored_papers` relation.
- Remove invalid root level serializer fields (`citation_count`, `works_count`).