### PR TITLE
Put verification status into notification payload

### DIFF
--- a/src/notification/models.py
+++ b/src/notification/models.py
@@ -119,6 +119,7 @@ class Notification(models.Model):
                 "action_user",
                 "body",
                 "created_date",
+                "extra",
                 "id",
                 "notification_type",
                 "read",

--- a/src/notification/serializers.py
+++ b/src/notification/serializers.py
@@ -18,6 +18,7 @@ class NotificationSerializer(serializers.ModelSerializer):
         read_only_fields = [
             "id",
             "body",
+            "extra",
             "action_user",
             "recipient",
             "created_date",

--- a/src/notification/views.py
+++ b/src/notification/views.py
@@ -48,6 +48,7 @@ class NotificationViewSet(viewsets.ModelViewSet):
                 "body",
                 "action_user",
                 "created_date",
+                "extra",
                 "id",
                 "navigation_url",
                 "notification_type",

--- a/src/user/tests/test_persona_webhook_view.py
+++ b/src/user/tests/test_persona_webhook_view.py
@@ -120,6 +120,7 @@ class PersonaWebhookViewTests(TestCase):
         self.assertEqual(
             notification.notification_type, Notification.IDENTITY_VERIFICATION_UPDATED
         )
+        self.assertEqual(notification.extra["status"], UserVerification.Status.APPROVED)
         self.assertEqual(notification.item, user_verification)
         send_notification_mock.assert_called_once()
 
@@ -163,6 +164,7 @@ class PersonaWebhookViewTests(TestCase):
         self.assertEqual(
             notification.notification_type, Notification.IDENTITY_VERIFICATION_UPDATED
         )
+        self.assertEqual(notification.extra["status"], UserVerification.Status.DECLINED)
         self.assertEqual(notification.item, user_verification)
         send_notification_mock.assert_called_once()
 
@@ -206,6 +208,7 @@ class PersonaWebhookViewTests(TestCase):
         self.assertEqual(
             notification.notification_type, Notification.IDENTITY_VERIFICATION_UPDATED
         )
+        self.assertEqual(notification.extra["status"], UserVerification.Status.FAILED)
         self.assertEqual(notification.item, user_verification)
         send_notification_mock.assert_called_once()
 
@@ -250,6 +253,9 @@ class PersonaWebhookViewTests(TestCase):
         self.assertIsNotNone(notification)
         self.assertEqual(
             notification.notification_type, Notification.IDENTITY_VERIFICATION_UPDATED
+        )
+        self.assertEqual(
+            notification.extra["status"], UserVerification.Status.MARKED_FOR_REVIEW
         )
         self.assertEqual(notification.item, user_verification)
         send_notification_mock.assert_called_once()

--- a/src/user/views/persona_webhook_view.py
+++ b/src/user/views/persona_webhook_view.py
@@ -110,10 +110,13 @@ class PersonaWebhookView(APIView):
     def _create_notification(self, user_verification: UserVerification):
         user = User.objects.get(id=user_verification.user_id)
         notification = Notification.objects.create(
+            action_user=user,
+            extra={
+                "status": user_verification.status.value,
+            },
             item=user_verification,
             notification_type=Notification.IDENTITY_VERIFICATION_UPDATED,
             recipient=user,
-            action_user=user,
         )
         notification.send_notification()
 


### PR DESCRIPTION
- Add `extra` field to notification serializer.
- Add `status` to user verification notification.