### PR TITLE
Use new rep for determining if a user can withdraw

### DIFF
--- a/src/reputation/related_models/score.py
+++ b/src/reputation/related_models/score.py
@@ -38,6 +38,14 @@ class Score(DefaultModel):
             return 0.75 + 0.25 * ((self.score - 100000) / 900000)
 
     @classmethod
+    def get_scores(cls, author):
+        return cls.objects.filter(author=author)
+
+    @classmethod
+    def get_max_score(cls, author):
+        return cls.objects.filter(author=author).order_by("-score").first()
+
+    @classmethod
     def get_or_create_score(cls, author, hub):
         try:
             score = cls.objects.get(author=author, hub=hub)

--- a/src/reputation/tests/test_views.py
+++ b/src/reputation/tests/test_views.py
@@ -104,7 +104,6 @@ class ReputationViewsTests(APITestCase):
 
         self.assertEqual(response.status_code, 403)
 
-    @skip  # Skip until withdrawals are reenabled.
     def test_regular_user_can_withdraw_rsc(self):
         user = create_random_authenticated_user_with_reputation("rep_user", 1000)
         user.date_joined = datetime(year=2020, month=1, day=1, tzinfo=utc)

--- a/src/reputation/tests/test_views.py
+++ b/src/reputation/tests/test_views.py
@@ -13,6 +13,8 @@ from reputation.distributor import Distributor
 from reputation.lib import PendingWithdrawal
 from reputation.models import Withdrawal
 from reputation.tests.helpers import create_deposit, create_withdrawals
+from reputation.views.withdrawal_view import WithdrawalViewSet
+from user.related_models.user_verification_model import UserVerification
 from user.rsc_exchange_rate_record_tasks import RSC_COIN_GECKO_ID
 from user.tests.helpers import (
     create_random_authenticated_user,
@@ -30,6 +32,7 @@ def mocked_execute_erc20_transfer(w3, sender, sender_signing_key, contract, to, 
 
 class ReputationViewsTests(APITestCase):
     def setUp(self):
+        self.withdrawal_view = WithdrawalViewSet()
         create_withdrawals(10)
         self.all_withdrawals = len(Withdrawal.objects.all())
         self.mocker = requests_mock.Mocker()
@@ -162,6 +165,52 @@ class ReputationViewsTests(APITestCase):
             user, data={"amount": 505, "to_address": "0x0"}
         )
         self.assertEqual(response.status_code, 400)
+
+    def test_can_withdraw_with_sufficient_reputation(self):
+        # Arrange
+        user = create_random_authenticated_user_with_reputation("user1", 1000)
+
+        # Act
+        actual = self.withdrawal_view._can_withdraw(user)
+
+        # Assert
+        self.assertTrue(actual)
+
+    def test_can_withdraw_with_verification(self):
+        # Arrange
+        user = create_random_authenticated_user_with_reputation("user2", 0)
+        UserVerification.objects.create(
+            user=user, status=UserVerification.Status.APPROVED
+        )
+
+        # Act
+        actual = self.withdrawal_view._can_withdraw(user)
+
+        # Assert
+        self.assertTrue(actual)
+
+    def test_can_withdraw_fails_with_declined_status(self):
+        # Arrange
+        user = create_random_authenticated_user_with_reputation("user2", 0)
+        UserVerification.objects.create(
+            user=user, status=UserVerification.Status.DECLINED
+        )
+
+        # Act
+        actual = self.withdrawal_view._can_withdraw(user)
+
+        # Assert
+        self.assertFalse(actual)
+
+    def test_can_withdraw_fails_without_verification_record(self):
+        # Arrange
+        user = create_random_authenticated_user_with_reputation("user2", 0)
+
+        # Act
+        actual = self.withdrawal_view._can_withdraw(user)
+
+        # Assert
+        self.assertFalse(actual)
 
     """
     Helper methods

--- a/src/reputation/views/withdrawal_view.py
+++ b/src/reputation/views/withdrawal_view.py
@@ -61,61 +61,6 @@ class WithdrawalViewSet(viewsets.ModelViewSet):
         else:
             return Withdrawal.objects.filter(user=user)
 
-    @action(
-        detail=False,
-        methods=["POST"],
-        permission_classes=[],
-    )
-    def oz_webhook(self, request):
-        return Response(
-            "Withdrawals are suspended for the time being. Please be patient as we work to turn withdrawals back on",
-            status=400,
-        )
-        body = json.loads(request.body.decode("utf-8"))
-        with sentry_sdk.push_scope() as scope:
-            scope.set_extra("data", body)
-        manual_hook = request.GET.get("manual", False)
-        if not manual_hook:
-            Webhook.objects.create(body=body, from_host=request.headers["Host"])
-        print(body)
-
-        for event in body.get("events", []):
-            transaction_hash = event.get("hash")
-            from_addr = event.get("transaction", {}).get("from")
-            if transaction_hash is None:
-                continue
-
-            transfer = False
-            for reason in event.get("matchReasons", []):
-                if "transfer" in reason.get("signature", "").lower():
-                    transfer = True
-                    break
-
-            if transfer and Web3.to_checksum_address(
-                from_addr
-            ) == Web3.to_checksum_address(WEB3_WALLET_ADDRESS):
-                withdrawal = Withdrawal.objects.get(transaction_hash=transaction_hash)
-                withdrawal.paid_status = PaidStatusModelMixin.PAID
-                withdrawal.save()
-                withdrawal_content_type = get_content_type_for_model(Withdrawal)
-                action, action_created = Action.objects.get_or_create(
-                    user=withdrawal.user,
-                    content_type=withdrawal_content_type,
-                    object_id=withdrawal.id,
-                )
-
-                notification, notification_created = Notification.objects.get_or_create(
-                    content_type=withdrawal_content_type,
-                    object_id=withdrawal.id,
-                    action_user=withdrawal.user,
-                    recipient=withdrawal.user,
-                    notification_type=Notification.RSC_WITHDRAWAL_COMPLETE,
-                )
-
-                notification.send_notification()
-
-        return Response(200)
-
     def create(self, request):
         if LogEntry.objects.filter(
             object_repr="WITHDRAWAL_SWITCH", action_flag=3
@@ -140,9 +85,9 @@ class WithdrawalViewSet(viewsets.ModelViewSet):
                 status=400,
             )
 
-        if user.reputation < 110:
+        if user.author_profile.get_rep_score() < 10:
             return Response(
-                "Your reputation is too low to withdraw. Please contribute to the platform.",
+                "Your reputation is too low to withdraw. Please claim papers you have authored and contribute to the community to increase your reputation.",
                 status=400,
             )
 

--- a/src/reputation/views/withdrawal_view.py
+++ b/src/reputation/views/withdrawal_view.py
@@ -1,14 +1,11 @@
 import decimal
-import json
 import logging
 import os
 from datetime import datetime, timedelta
 
 import pytz
 import requests
-import sentry_sdk
 from django.contrib.admin.models import LogEntry
-from django.contrib.admin.options import get_content_type_for_model
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.utils import timezone
@@ -18,22 +15,15 @@ from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from web3 import Web3
 
 from analytics.tasks import track_revenue_event
-from notification.models import Notification
 from purchase.models import Balance, RscExchangeRate
 from reputation.exceptions import WithdrawalError
 from reputation.lib import WITHDRAWAL_MINIMUM, PendingWithdrawal, gwei_to_eth
-from reputation.models import PaidStatusModelMixin, Webhook, Withdrawal
+from reputation.models import Withdrawal
 from reputation.permissions import AllowWithdrawalIfNotSuspecious
 from reputation.serializers import WithdrawalSerializer
-from researchhub.settings import (
-    ETHERSCAN_API_KEY,
-    WEB3_RSC_ADDRESS,
-    WEB3_WALLET_ADDRESS,
-)
-from user.models import Action
+from researchhub.settings import ETHERSCAN_API_KEY, WEB3_RSC_ADDRESS
 from user.serializers import UserSerializer
 from utils import sentry
 from utils.permissions import CreateOrReadOnly, CreateOrUpdateIfAllowed, UserNotSpammer

--- a/src/user/related_models/author_model.py
+++ b/src/user/related_models/author_model.py
@@ -435,3 +435,10 @@ class Author(models.Model):
             content_type,
             vote.id,
         )
+
+    def get_rep_score(self):
+        score = Score.get_max_score(self)
+        if score is None:
+            return 0
+
+        return score.score

--- a/src/user/related_models/user_model.py
+++ b/src/user/related_models/user_model.py
@@ -75,6 +75,9 @@ class User(AbstractUser):
     )
     is_suspended = models.BooleanField(default=False)
     is_verified = models.BooleanField(default=False)
+    """
+    The old verification status that is being replaced by `UserVerification`.
+    """
     moderator = models.BooleanField(default=False)
     probable_spammer = models.BooleanField(default=False)
     referral_code = models.CharField(max_length=36, default=uuid.uuid4, unique=True)

--- a/src/user/related_models/user_verification_model.py
+++ b/src/user/related_models/user_verification_model.py
@@ -46,4 +46,7 @@ class UserVerification(models.Model):
 
     @property
     def is_verified(self) -> bool:
+        """
+        A simplified boolean status indicating if the user is verified.
+        """
         return self.status == self.Status.APPROVED

--- a/src/user/tests/helpers.py
+++ b/src/user/tests/helpers.py
@@ -6,6 +6,7 @@ from rest_framework.authtoken.models import Token
 from discussion.models import Thread
 from hub.models import Hub
 from hub.tests.helpers import create_hub
+from reputation.related_models.score import Score
 from researchhub_access_group.constants import EDITOR
 from researchhub_access_group.models import Permission
 from user.models import Action, Author, University, User
@@ -105,6 +106,8 @@ def create_moderator(
 def create_random_authenticated_user_with_reputation(unique_value, reputation):
     user = create_random_authenticated_user(unique_value)
     user.reputation = reputation
+    hub = Hub.objects.create(name="Hub")
+    Score.objects.create(author=user.author_profile, hub=hub, score=reputation)
     user.save()
     return user
 


### PR DESCRIPTION
- Re-enable skipped test.
- Add methods for getting scores.
- Remove unused oz webhook endpoint.
- Update check for rep score in withdrawal to use new rep score.