### PR TITLE
Filter out works published on ResearchHub

### DIFF
--- a/src/paper/tests/test_views.py
+++ b/src/paper/tests/test_views.py
@@ -21,88 +21,85 @@ class PaperApiTests(APITestCase):
     def test_fetches_author_works_by_doi_if_name_matches(
         self, mock_get_works, mock_get_data_from_doi
     ):
-        with open("./paper/tests/openalex_author_works.json", "r") as works_file:
-            with open(
-                "./paper/tests/openalex_single_work.json", "r"
-            ) as single_work_file:
-                # Set up a user that has a matching name to the one in the mocked response
-                user_with_published_works = create_user(
-                    first_name="Yang",
-                    last_name="Wang",
-                    email="random_author@researchhub.com",
-                )
-                self.client.force_authenticate(user_with_published_works)
+        with open("./paper/tests/openalex_author_works.json", "r") as works_file, open(
+            "./paper/tests/openalex_single_work.json", "r"
+        ) as single_work_file:
+            # Set up a user that has a matching name to the one in the mocked response
+            user_with_published_works = create_user(
+                first_name="Yang",
+                last_name="Wang",
+                email="random_author@researchhub.com",
+            )
+            self.client.force_authenticate(user_with_published_works)
 
-                # Mock responses for OpenAlex API calls
-                mock_data = json.load(works_file)
-                mock_get_works.return_value = (mock_data["results"], None)
-                mock_get_data_from_doi.return_value = json.load(single_work_file)
+            # Mock responses for OpenAlex API calls
+            mock_data = json.load(works_file)
+            mock_get_works.return_value = (mock_data["results"], None)
+            mock_get_data_from_doi.return_value = json.load(single_work_file)
 
-                response = self.client.get(
-                    f"/api/paper/fetch_publications_by_doi/?doi=10.1371/journal.pone.0305345",
-                )
+            response = self.client.get(
+                "/api/paper/fetch_publications_by_doi/?doi=10.1371/journal.pone.0305345",
+            )
 
-                self.assertGreater(len(response.data["works"]), 0)
+            self.assertGreater(len(response.data["works"]), 0)
 
     @patch.object(OpenAlex, "get_data_from_doi")
     @patch.object(OpenAlex, "get_works")
     def test_cannot_fetch_author_works_by_doi_if_name_mismatch(
         self, mock_get_works, mock_get_data_from_doi
     ):
-        with open("./paper/tests/openalex_author_works.json", "r") as works_file:
-            with open(
-                "./paper/tests/openalex_single_work.json", "r"
-            ) as single_work_file:
-                # Set up a user that has a matching name to the one in the mocked response
-                user_with_published_works = create_user(
-                    first_name="Name",
-                    last_name="Mismatch",
-                    email="random_author@researchhub.com",
-                )
-                self.client.force_authenticate(user_with_published_works)
+        with open("./paper/tests/openalex_author_works.json", "r") as works_file, open(
+            "./paper/tests/openalex_single_work.json", "r"
+        ) as single_work_file:
+            # Set up a user that has a matching name to the one in the mocked response
+            user_with_published_works = create_user(
+                first_name="Name",
+                last_name="Mismatch",
+                email="random_author@researchhub.com",
+            )
+            self.client.force_authenticate(user_with_published_works)
 
-                # Mock responses for OpenAlex API calls
-                mock_data = json.load(works_file)
-                mock_get_works.return_value = (mock_data["results"], None)
-                mock_get_data_from_doi.return_value = json.load(single_work_file)
+            # Mock responses for OpenAlex API calls
+            mock_data = json.load(works_file)
+            mock_get_works.return_value = (mock_data["results"], None)
+            mock_get_data_from_doi.return_value = json.load(single_work_file)
 
-                response = self.client.get(
-                    f"/api/paper/fetch_publications_by_doi/?doi=10.1371/journal.pone.0305345",
-                )
+            response = self.client.get(
+                "/api/paper/fetch_publications_by_doi/?doi=10.1371/journal.pone.0305345",
+            )
 
-                self.assertEqual(len(response.data["works"]), 0)
-                self.assertGreater(len(response.data["available_authors"]), 0)
+            self.assertEqual(len(response.data["works"]), 0)
+            self.assertGreater(len(response.data["available_authors"]), 0)
 
     @patch.object(OpenAlex, "get_data_from_doi")
     @patch.object(OpenAlex, "get_works")
     def test_fetch_author_works_by_doi_can_accept_optional_author_id(
         self, mock_get_works, mock_get_data_from_doi
     ):
-        with open("./paper/tests/openalex_author_works.json", "r") as works_file:
-            with open(
-                "./paper/tests/openalex_single_work.json", "r"
-            ) as single_work_file:
-                # Set up a user that has a matching name to the one in the mocked response
-                user_with_published_works = create_user(
-                    first_name="Name",
-                    last_name="Mismatch",
-                    email="random_author@researchhub.com",
-                )
-                self.client.force_authenticate(user_with_published_works)
+        with open("./paper/tests/openalex_author_works.json", "r") as works_file, open(
+            "./paper/tests/openalex_single_work.json", "r"
+        ) as single_work_file:
+            # Set up a user that has a matching name to the one in the mocked response
+            user_with_published_works = create_user(
+                first_name="Name",
+                last_name="Mismatch",
+                email="random_author@researchhub.com",
+            )
+            self.client.force_authenticate(user_with_published_works)
 
-                # Mock responses for OpenAlex API calls
-                mock_data = json.load(works_file)
-                mock_get_works.return_value = (mock_data["results"], None)
-                mock_get_data_from_doi.return_value = json.load(single_work_file)
+            # Mock responses for OpenAlex API calls
+            mock_data = json.load(works_file)
+            mock_get_works.return_value = (mock_data["results"], None)
+            mock_get_data_from_doi.return_value = json.load(single_work_file)
 
-                # Override author guessing by explicilty providing author_id
-                author_id = "A5075662890"
+            # Override author guessing by explicilty providing author_id
+            author_id = "A5075662890"
 
-                response = self.client.get(
-                    f"/api/paper/fetch_publications_by_doi/?doi=10.1371/journal.pone.0305345&author_id={author_id}",
-                )
+            response = self.client.get(
+                f"/api/paper/fetch_publications_by_doi/?doi=10.1371/journal.pone.0305345&author_id={author_id}",
+            )
 
-                self.assertEqual(response.data["selected_author_id"], author_id)
+            self.assertEqual(response.data["selected_author_id"], author_id)
 
 
 class PaperViewsTests(TestCase):

--- a/src/paper/views/paper_views.py
+++ b/src/paper/views/paper_views.py
@@ -701,7 +701,7 @@ class PaperViewSet(ReactionViewActionMixin, viewsets.ModelViewSet):
         try:
             open_alex = OpenAlex()
             open_alex_json = open_alex.get_data_from_doi(doi_string)
-        except Exception as e:
+        except Exception:
             return Response(status=404)
 
         return Response(open_alex_json, status=200)
@@ -724,7 +724,7 @@ class PaperViewSet(ReactionViewActionMixin, viewsets.ModelViewSet):
                 # Fetch data from OpenAlex
                 open_alex_api = OpenAlex()
                 work = open_alex_api.get_data_from_doi(doi_string)
-            except DOINotFoundError as e:
+            except DOINotFoundError:
                 return Response(status=404)
 
             # Next we want to try and guess the author in the list of authors associated with the work.
@@ -747,12 +747,12 @@ class PaperViewSet(ReactionViewActionMixin, viewsets.ModelViewSet):
                     ):
                         found_openalex_author = openalex_author
                     elif (
-                        found_openalex_author == None
+                        found_openalex_author is None
                         and rh_author_last_name == openalex_author_name[0]
                     ):
                         found_openalex_author = openalex_author
                     elif (
-                        found_openalex_author == None
+                        found_openalex_author is None
                         and rh_author_first_name == openalex_author_name[-1]
                     ):
                         found_openalex_author = openalex_author
@@ -764,7 +764,7 @@ class PaperViewSet(ReactionViewActionMixin, viewsets.ModelViewSet):
             author_works = []
             if openalex_author_id:
                 openalex_author_id = openalex_author_id.split("/")[-1]
-                author_works, cursor = open_alex_api.get_works(
+                author_works, _ = open_alex_api.get_works(
                     openalex_author_id=openalex_author_id, batch_size=200
                 )
 

--- a/src/paper/views/paper_views.py
+++ b/src/paper/views/paper_views.py
@@ -101,20 +101,6 @@ class PaperViewSet(ReactionViewActionMixin, viewsets.ModelViewSet):
             "uploaded_by__subscribed_hubs",
             "authors",
             "authors__user",
-            # Prefetch(
-            #     'bullet_points',
-            #     queryset=BulletPoint.objects.filter(
-            #         is_head=True,
-            #         is_removed=False,
-            #         ordinal__isnull=False
-            #     ).order_by('ordinal')
-            # ),
-            # 'summary',
-            # 'summary__previous',
-            # 'summary__proposed_by__bookmarks',
-            # 'summary__proposed_by__subscribed_hubs',
-            # 'summary__proposed_by__author_profile',
-            # 'summary__paper',
             "moderators",
             "hubs",
             "hubs__subscribers",
@@ -131,7 +117,6 @@ class PaperViewSet(ReactionViewActionMixin, viewsets.ModelViewSet):
         queryset = self.queryset
         ordering = query_params.get("ordering", None)
         external_source = query_params.get("external_source", False)
-        # queryset = queryset.filter(pdf_license__isnull=False)
 
         if (
             query_params.get("make_public")
@@ -261,17 +246,6 @@ class PaperViewSet(ReactionViewActionMixin, viewsets.ModelViewSet):
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
         context = self._get_paper_context(request)
-
-        # Commenting out paper cache
-        # cache_key = get_cache_key("paper", instance.id)
-        # cache_hit = cache.get(cache_key)
-        # if cache_hit is not None:
-        #     vote = self.dynamic_serializer_class(context=context).get_user_vote(
-        #         instance
-        #     )
-        #     cache_hit["user_vote"] = vote
-        #     return Response(cache_hit)
-
         serializer = self.dynamic_serializer_class(
             instance,
             context=context,
@@ -337,8 +311,6 @@ class PaperViewSet(ReactionViewActionMixin, viewsets.ModelViewSet):
             instance = self.get_object()
             self._send_created_location_ga_event(instance, request.user)
 
-        # Commenting out paper cache
-        # instance.reset_cache(use_celery=False)
         return response
 
     def _send_created_location_ga_event(self, instance, user):
@@ -450,9 +422,6 @@ class PaperViewSet(ReactionViewActionMixin, viewsets.ModelViewSet):
             pass
         paper.is_removed = False
         paper.save()
-
-        # Commenting out paper cache
-        # paper.reset_cache(use_celery=False)
 
         reset_unified_document_cache(
             filters=[HOT, UPVOTED, DISCUSSED, NEW],

--- a/src/paper/views/paper_views.py
+++ b/src/paper/views/paper_views.py
@@ -29,7 +29,6 @@ from discussion.models import Vote as GrmVote
 from discussion.reaction_serializers import VoteSerializer as GrmVoteSerializer
 from discussion.reaction_views import ReactionViewActionMixin
 from google_analytics.signals import get_event_hit_response
-from notification.models import Notification
 from paper.exceptions import DOINotFoundError, PaperSerializerError
 from paper.filters import PaperFilter
 from paper.models import AdditionalFile, Figure, Paper, PaperSubmission
@@ -37,7 +36,6 @@ from paper.paper_upload_tasks import celery_process_paper
 from paper.permissions import (
     CreatePaper,
     IsAuthor,
-    IsModeratorOrVerifiedAuthor,
     UpdateOrDeleteAdditionalFile,
     UpdatePaper,
 )
@@ -52,7 +50,6 @@ from paper.serializers import (
 )
 from paper.tasks import censored_paper_cleanup
 from paper.utils import (
-    add_default_hub,
     clean_abstract,
     get_cache_key,
     get_csl_item,
@@ -70,7 +67,6 @@ from researchhub_document.related_models.constants.filters import (
     UPVOTED,
 )
 from researchhub_document.utils import reset_unified_document_cache
-from user.related_models.author_model import Author
 from utils.http import GET, POST, check_url_contains_pdf
 from utils.openalex import OpenAlex
 from utils.permissions import CreateOrUpdateIfAllowed, HasAPIKey, PostOnly

--- a/src/utils/openalex.py
+++ b/src/utils/openalex.py
@@ -102,9 +102,9 @@ class OpenAlex:
                         if isinstance(value, str):
                             output_json[mapped_key] = value
                         else:
-                            output_json[
-                                mapped_key
-                            ] = rebuild_sentence_from_inverted_index(value)
+                            output_json[mapped_key] = (
+                                rebuild_sentence_from_inverted_index(value)
+                            )
                     else:
                         output_json[mapped_key] = value
             else:

--- a/src/utils/openalex.py
+++ b/src/utils/openalex.py
@@ -387,7 +387,7 @@ class OpenAlex:
         # have a `researchhub` namespace in the DOI.
         filtered_works = list(
             filter(
-                lambda w: "/researchhub." not in w.get("doi", ""),
+                lambda w: "/researchhub." not in w.get("doi", "").lower(),
                 works,
             )
         )

--- a/src/utils/openalex.py
+++ b/src/utils/openalex.py
@@ -1,4 +1,3 @@
-import datetime
 import math
 from unicodedata import normalize
 
@@ -6,7 +5,7 @@ from dateutil import parser
 from django.utils.timezone import get_current_timezone, is_aware, make_aware
 
 from paper.exceptions import DOINotFoundError
-from paper.utils import check_url_contains_pdf, format_raw_authors
+from paper.utils import format_raw_authors
 from researchhub.settings import OPENALEX_KEY
 from utils.aws import download_pdf
 from utils.parsers import rebuild_sentence_from_inverted_index

--- a/src/utils/openalex.py
+++ b/src/utils/openalex.py
@@ -350,6 +350,11 @@ class OpenAlex:
         source_id=None,
         openalex_author_id=None,
     ):
+        """
+        Fetches works from OpenAlex based on the given criteria.
+
+        Works published on ResearchHub are filtered out (by DOI).
+        """
         # Build the filter
         oa_filters = []
         if isinstance(types, list):
@@ -377,9 +382,19 @@ class OpenAlex:
 
         response = self._get("works", filters=filters)
         works = response.get("results", [])
+
+        # Filter out works that were published on ResearchHub,
+        # have a `researchhub` namespace in the DOI.
+        filtered_works = list(
+            filter(
+                lambda w: "/researchhub." not in w.get("doi", ""),
+                works,
+            )
+        )
+
         next_cursor = response.get("meta", {}).get("next_cursor")
         cursor = next_cursor if next_cursor != "*" else None
-        return works, cursor
+        return filtered_works, cursor
 
     @classmethod
     def normalize_dates(self, generic_openalex_object):

--- a/src/utils/tests/openalex_with_researchhub_works.json
+++ b/src/utils/tests/openalex_with_researchhub_works.json
@@ -1,0 +1,21656 @@
+{
+    "meta": {
+        "count": 13,
+        "db_response_time_ms": 44,
+        "page": 1,
+        "per_page": 25,
+        "groups_count": null
+    },
+    "results": [
+        {
+            "id": "https://openalex.org/W2594873390",
+            "title": "Targeting Signaling Pathways in Cancer Stem Cells for Cancer Treatment",
+            "display_name": "Targeting Signaling Pathways in Cancer Stem Cells for Cancer Treatment",
+            "publication_year": 2017,
+            "publication_date": "2017-01-01",
+            "ids": {
+                "openalex": "https://openalex.org/W2594873390",
+                "doi": "https://doi.org/10.1155/2017/2925869",
+                "mag": "2594873390",
+                "pmid": "https://pubmed.ncbi.nlm.nih.gov/28356914",
+                "pmcid": "https://www.ncbi.nlm.nih.gov/pmc/articles/5357538"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1155/2017/2925869",
+                "pdf_url": "http://downloads.hindawi.com/journals/sci/2017/2925869.pdf",
+                "source": {
+                    "id": "https://openalex.org/S27922360",
+                    "display_name": "Stem cells international",
+                    "issn_l": "1687-966X",
+                    "issn": [
+                        "1687-966X",
+                        "1687-9678"
+                    ],
+                    "is_oa": true,
+                    "is_in_doaj": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310319869",
+                    "host_organization_name": "Hindawi Publishing Corporation",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310319869"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Hindawi Publishing Corporation"
+                    ],
+                    "type": "journal"
+                },
+                "license": "cc-by",
+                "license_id": "https://openalex.org/licenses/cc-by",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "type": "review",
+            "type_crossref": "journal-article",
+            "indexed_in": [
+                "crossref",
+                "doaj",
+                "pubmed"
+            ],
+            "open_access": {
+                "is_oa": true,
+                "oa_status": "gold",
+                "oa_url": "http://downloads.hindawi.com/journals/sci/2017/2925869.pdf",
+                "any_repository_has_fulltext": true
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5081987607",
+                        "display_name": "Jeffrey Koury",
+                        "orcid": "https://orcid.org/0000-0002-7368-4891"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jeffrey Koury",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5050507251",
+                        "display_name": "Li Zhong",
+                        "orcid": "https://orcid.org/0000-0003-3815-6484"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43337087",
+                            "display_name": "Hebei University",
+                            "ror": "https://ror.org/01p884a79",
+                            "country_code": "CN",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I43337087"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN",
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Li Zhong",
+                    "raw_affiliation_strings": [
+                        "Department of Basic Medical Sciences, College of Osteopathic Medicine of the Pacific, Western University of Health Sciences, Pomona, CA, USA",
+                        "Department of Cell Biology, College of Life Sciences, Hebei University, Baoding, Hebei, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Department of Basic Medical Sciences, College of Osteopathic Medicine of the Pacific, Western University of Health Sciences, Pomona, CA, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Department of Cell Biology, College of Life Sciences, Hebei University, Baoding, Hebei, China",
+                            "institution_ids": [
+                                "https://openalex.org/I43337087"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "last",
+                    "author": {
+                        "id": "https://openalex.org/A5046138088",
+                        "display_name": "Jijun Hao",
+                        "orcid": "https://orcid.org/0000-0002-6769-9069"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Jijun Hao",
+                    "raw_affiliation_strings": [
+                        "College of Veterinary Medicine, Western University of Health Sciences, Pomona, CA 91766, USA",
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "College of Veterinary Medicine, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": []
+                        }
+                    ]
+                }
+            ],
+            "countries_distinct_count": 2,
+            "institutions_distinct_count": 2,
+            "corresponding_author_ids": [
+                "https://openalex.org/A5046138088"
+            ],
+            "corresponding_institution_ids": [
+                "https://openalex.org/I93393672"
+            ],
+            "apc_list": {
+                "value": 2150,
+                "currency": "USD",
+                "value_usd": 2150,
+                "provenance": "doaj"
+            },
+            "apc_paid": {
+                "value": 2150,
+                "currency": "USD",
+                "value_usd": 2150,
+                "provenance": "doaj"
+            },
+            "fwci": 6.24,
+            "has_fulltext": true,
+            "fulltext_origin": "ngrams",
+            "cited_by_count": 126,
+            "cited_by_percentile_year": {
+                "min": 98,
+                "max": 99
+            },
+            "biblio": {
+                "volume": "2017",
+                "issue": null,
+                "first_page": "1",
+                "last_page": "10"
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T12009",
+                "display_name": "Hedgehog Signaling in Development and Cancer",
+                "score": 1,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/1312",
+                    "display_name": "Molecular Biology"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/13",
+                    "display_name": "Biochemistry, Genetics and Molecular Biology"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/1",
+                    "display_name": "Life Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T12009",
+                    "display_name": "Hedgehog Signaling in Development and Cancer",
+                    "score": 1,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/1312",
+                        "display_name": "Molecular Biology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/13",
+                        "display_name": "Biochemistry, Genetics and Molecular Biology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T10269",
+                    "display_name": "Epigenetic Modifications and Their Functional Implications",
+                    "score": 0.9961,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/1312",
+                        "display_name": "Molecular Biology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/13",
+                        "display_name": "Biochemistry, Genetics and Molecular Biology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T10336",
+                    "display_name": "Cancer Stem Cells and Tumor Metastasis",
+                    "score": 0.983,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2730",
+                        "display_name": "Oncology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/cancer-stem-cells",
+                    "display_name": "Cancer Stem Cells",
+                    "score": 0.552376
+                },
+                {
+                    "id": "https://openalex.org/keywords/stem-cell-niches",
+                    "display_name": "Stem Cell Niches",
+                    "score": 0.549979
+                },
+                {
+                    "id": "https://openalex.org/keywords/hedgehog-signaling",
+                    "display_name": "Hedgehog Signaling",
+                    "score": 0.546855
+                },
+                {
+                    "id": "https://openalex.org/keywords/cancer-epigenetics",
+                    "display_name": "Cancer Epigenetics",
+                    "score": 0.511333
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C137620995",
+                    "wikidata": "https://www.wikidata.org/wiki/Q155769",
+                    "display_name": "Wnt signaling pathway",
+                    "level": 3,
+                    "score": 0.8665985
+                },
+                {
+                    "id": "https://openalex.org/C2778539099",
+                    "wikidata": "https://www.wikidata.org/wiki/Q6120",
+                    "display_name": "Hedgehog",
+                    "level": 3,
+                    "score": 0.7948922
+                },
+                {
+                    "id": "https://openalex.org/C55427017",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1638475",
+                    "display_name": "Cancer stem cell",
+                    "level": 3,
+                    "score": 0.72448665
+                },
+                {
+                    "id": "https://openalex.org/C502942594",
+                    "wikidata": "https://www.wikidata.org/wiki/Q3421914",
+                    "display_name": "Cancer research",
+                    "level": 1,
+                    "score": 0.63540137
+                },
+                {
+                    "id": "https://openalex.org/C88498014",
+                    "wikidata": "https://www.wikidata.org/wiki/Q14859918",
+                    "display_name": "Hedgehog signaling pathway",
+                    "level": 3,
+                    "score": 0.63114816
+                },
+                {
+                    "id": "https://openalex.org/C161879069",
+                    "wikidata": "https://www.wikidata.org/wiki/Q904082",
+                    "display_name": "Notch signaling pathway",
+                    "level": 3,
+                    "score": 0.5477681
+                },
+                {
+                    "id": "https://openalex.org/C62478195",
+                    "wikidata": "https://www.wikidata.org/wiki/Q828130",
+                    "display_name": "Signal transduction",
+                    "level": 2,
+                    "score": 0.5221555
+                },
+                {
+                    "id": "https://openalex.org/C86803240",
+                    "wikidata": "https://www.wikidata.org/wiki/Q420",
+                    "display_name": "Biology",
+                    "level": 0,
+                    "score": 0.50667745
+                },
+                {
+                    "id": "https://openalex.org/C121608353",
+                    "wikidata": "https://www.wikidata.org/wiki/Q12078",
+                    "display_name": "Cancer",
+                    "level": 2,
+                    "score": 0.4737754
+                },
+                {
+                    "id": "https://openalex.org/C2778287671",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7852676",
+                    "display_name": "Tumor initiation",
+                    "level": 4,
+                    "score": 0.43800285
+                },
+                {
+                    "id": "https://openalex.org/C28328180",
+                    "wikidata": "https://www.wikidata.org/wiki/Q48196",
+                    "display_name": "Stem cell",
+                    "level": 2,
+                    "score": 0.43304068
+                },
+                {
+                    "id": "https://openalex.org/C95444343",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7141",
+                    "display_name": "Cell biology",
+                    "level": 1,
+                    "score": 0.34946513
+                },
+                {
+                    "id": "https://openalex.org/C71924100",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11190",
+                    "display_name": "Medicine",
+                    "level": 0,
+                    "score": 0.33313787
+                },
+                {
+                    "id": "https://openalex.org/C555283112",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1637543",
+                    "display_name": "Carcinogenesis",
+                    "level": 3,
+                    "score": 0.2687298
+                },
+                {
+                    "id": "https://openalex.org/C54355233",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7162",
+                    "display_name": "Genetics",
+                    "level": 1,
+                    "score": 0.094659805
+                }
+            ],
+            "mesh": [],
+            "locations_count": 5,
+            "locations": [
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://doi.org/10.1155/2017/2925869",
+                    "pdf_url": "http://downloads.hindawi.com/journals/sci/2017/2925869.pdf",
+                    "source": {
+                        "id": "https://openalex.org/S27922360",
+                        "display_name": "Stem cells international",
+                        "issn_l": "1687-966X",
+                        "issn": [
+                            "1687-966X",
+                            "1687-9678"
+                        ],
+                        "is_oa": true,
+                        "is_in_doaj": true,
+                        "is_core": true,
+                        "host_organization": "https://openalex.org/P4310319869",
+                        "host_organization_name": "Hindawi Publishing Corporation",
+                        "host_organization_lineage": [
+                            "https://openalex.org/P4310319869"
+                        ],
+                        "host_organization_lineage_names": [
+                            "Hindawi Publishing Corporation"
+                        ],
+                        "type": "journal"
+                    },
+                    "license": "cc-by",
+                    "license_id": "https://openalex.org/licenses/cc-by",
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://doaj.org/article/3ec2311db55a4fd2a5636998d37fb826",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306401280",
+                        "display_name": "DOAJ (DOAJ: Directory of Open Access Journals)",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": null,
+                        "host_organization_name": null,
+                        "host_organization_lineage": [],
+                        "host_organization_lineage_names": [],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://europepmc.org/articles/pmc5357538",
+                    "pdf_url": "https://europepmc.org/articles/pmc5357538?pdf=render",
+                    "source": {
+                        "id": "https://openalex.org/S4306400806",
+                        "display_name": "Europe PMC (PubMed Central)",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1303153112",
+                        "host_organization_name": "European Bioinformatics Institute",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1303153112"
+                        ],
+                        "host_organization_lineage_names": [
+                            "European Bioinformatics Institute"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": "cc-by",
+                    "license_id": "https://openalex.org/licenses/cc-by",
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5357538",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S2764455111",
+                        "display_name": "PubMed Central",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://pubmed.ncbi.nlm.nih.gov/28356914",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306525036",
+                        "display_name": "PubMed",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1155/2017/2925869",
+                "pdf_url": "http://downloads.hindawi.com/journals/sci/2017/2925869.pdf",
+                "source": {
+                    "id": "https://openalex.org/S27922360",
+                    "display_name": "Stem cells international",
+                    "issn_l": "1687-966X",
+                    "issn": [
+                        "1687-966X",
+                        "1687-9678"
+                    ],
+                    "is_oa": true,
+                    "is_in_doaj": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310319869",
+                    "host_organization_name": "Hindawi Publishing Corporation",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310319869"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Hindawi Publishing Corporation"
+                    ],
+                    "type": "journal"
+                },
+                "license": "cc-by",
+                "license_id": "https://openalex.org/licenses/cc-by",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "sustainable_development_goals": [
+                {
+                    "id": "https://metadata.un.org/sdg/3",
+                    "display_name": "Good health and well-being",
+                    "score": 0.82
+                }
+            ],
+            "grants": [
+                {
+                    "funder": "https://openalex.org/F4320321001",
+                    "funder_display_name": "National Natural Science Foundation of China",
+                    "award_id": "81472744"
+                },
+                {
+                    "funder": "https://openalex.org/F4320321001",
+                    "funder_display_name": "National Natural Science Foundation of China",
+                    "award_id": "81272444"
+                }
+            ],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 94,
+            "referenced_works": [
+                "https://openalex.org/W1655178001",
+                "https://openalex.org/W1756165953",
+                "https://openalex.org/W1760611117",
+                "https://openalex.org/W1861001175",
+                "https://openalex.org/W1935464246",
+                "https://openalex.org/W1965431780",
+                "https://openalex.org/W1968861372",
+                "https://openalex.org/W1971526515",
+                "https://openalex.org/W1971707325",
+                "https://openalex.org/W1973329885",
+                "https://openalex.org/W1974083062",
+                "https://openalex.org/W1974943679",
+                "https://openalex.org/W1982087641",
+                "https://openalex.org/W1994029539",
+                "https://openalex.org/W1997379399",
+                "https://openalex.org/W2001544973",
+                "https://openalex.org/W2009886857",
+                "https://openalex.org/W2010653264",
+                "https://openalex.org/W2019264784",
+                "https://openalex.org/W2020579083",
+                "https://openalex.org/W2023427658",
+                "https://openalex.org/W2031986169",
+                "https://openalex.org/W2036041106",
+                "https://openalex.org/W2040087348",
+                "https://openalex.org/W2041935553",
+                "https://openalex.org/W2046483038",
+                "https://openalex.org/W2050754241",
+                "https://openalex.org/W2051055358",
+                "https://openalex.org/W2051385741",
+                "https://openalex.org/W2051859926",
+                "https://openalex.org/W2055296003",
+                "https://openalex.org/W2056628299",
+                "https://openalex.org/W2057881265",
+                "https://openalex.org/W2060710804",
+                "https://openalex.org/W2061965920",
+                "https://openalex.org/W2072569544",
+                "https://openalex.org/W2078510083",
+                "https://openalex.org/W2080316304",
+                "https://openalex.org/W2082210456",
+                "https://openalex.org/W2083425643",
+                "https://openalex.org/W2083812545",
+                "https://openalex.org/W2087205490",
+                "https://openalex.org/W2090982381",
+                "https://openalex.org/W2095424699",
+                "https://openalex.org/W2100553819",
+                "https://openalex.org/W2100639629",
+                "https://openalex.org/W2101616608",
+                "https://openalex.org/W2107394975",
+                "https://openalex.org/W2107503279",
+                "https://openalex.org/W2107648723",
+                "https://openalex.org/W2109805795",
+                "https://openalex.org/W2113557972",
+                "https://openalex.org/W2115001053",
+                "https://openalex.org/W2116261578",
+                "https://openalex.org/W2118453722",
+                "https://openalex.org/W2124936055",
+                "https://openalex.org/W2128175263",
+                "https://openalex.org/W2128937038",
+                "https://openalex.org/W2130552015",
+                "https://openalex.org/W2131232783",
+                "https://openalex.org/W2133117291",
+                "https://openalex.org/W2139945482",
+                "https://openalex.org/W2140350596",
+                "https://openalex.org/W2143234817",
+                "https://openalex.org/W2149154780",
+                "https://openalex.org/W2149858252",
+                "https://openalex.org/W2150014036",
+                "https://openalex.org/W2153382986",
+                "https://openalex.org/W2154861644",
+                "https://openalex.org/W2158021558",
+                "https://openalex.org/W2165908624",
+                "https://openalex.org/W2167414381",
+                "https://openalex.org/W2187201134",
+                "https://openalex.org/W2269814587",
+                "https://openalex.org/W2275077398",
+                "https://openalex.org/W2284711770",
+                "https://openalex.org/W2311462071",
+                "https://openalex.org/W2334577496",
+                "https://openalex.org/W2339187372",
+                "https://openalex.org/W2410495669",
+                "https://openalex.org/W2412509206",
+                "https://openalex.org/W2416238130",
+                "https://openalex.org/W2418808650",
+                "https://openalex.org/W2443178225",
+                "https://openalex.org/W2482151002",
+                "https://openalex.org/W2505288790",
+                "https://openalex.org/W2509039608",
+                "https://openalex.org/W2509794319",
+                "https://openalex.org/W2520112765",
+                "https://openalex.org/W2520132464",
+                "https://openalex.org/W2522404881",
+                "https://openalex.org/W2554806785",
+                "https://openalex.org/W2573357394",
+                "https://openalex.org/W4213058179"
+            ],
+            "related_works": [
+                "https://openalex.org/W3139447365",
+                "https://openalex.org/W3082835005",
+                "https://openalex.org/W2766051584",
+                "https://openalex.org/W2127247587",
+                "https://openalex.org/W2122598160",
+                "https://openalex.org/W2116707180",
+                "https://openalex.org/W2064272569",
+                "https://openalex.org/W2039762497",
+                "https://openalex.org/W2009400743",
+                "https://openalex.org/W1585922331"
+            ],
+            "ngrams_url": "https://api.openalex.org/works/W2594873390/ngrams",
+            "abstract_inverted_index": {
+                "The": [
+                    0,
+                    59
+                ],
+                "Wnt,": [
+                    1,
+                    77
+                ],
+                "Hedgehog,": [
+                    2,
+                    78
+                ],
+                "and": [
+                    3,
+                    14,
+                    27,
+                    53,
+                    67,
+                    79,
+                    85,
+                    87,
+                    97
+                ],
+                "Notch": [
+                    4,
+                    80
+                ],
+                "pathways": [
+                    5,
+                    9,
+                    20,
+                    34,
+                    81,
+                    93
+                ],
+                "are": [
+                    6,
+                    21,
+                    61
+                ],
+                "inherent": [
+                    7
+                ],
+                "signaling": [
+                    8
+                ],
+                "in": [
+                    10,
+                    23,
+                    37,
+                    82
+                ],
+                "normal": [
+                    11
+                ],
+                "embryogenesis,": [
+                    12
+                ],
+                "development,": [
+                    13
+                ],
+                "hemostasis.": [
+                    15
+                ],
+                "However,": [
+                    16
+                ],
+                "dysfunctions": [
+                    17
+                ],
+                "of": [
+                    18,
+                    32,
+                    39,
+                    47,
+                    51,
+                    76
+                ],
+                "these": [
+                    19,
+                    33,
+                    92
+                ],
+                "evident": [
+                    22
+                ],
+                "multiple": [
+                    24
+                ],
+                "tumor": [
+                    25,
+                    57,
+                    64
+                ],
+                "types": [
+                    26
+                ],
+                "malignancies.": [
+                    28
+                ],
+                "Specifically,": [
+                    29
+                ],
+                "aberrant": [
+                    30
+                ],
+                "activation": [
+                    31
+                ],
+                "is": [
+                    35
+                ],
+                "implicated": [
+                    36
+                ],
+                "modulation": [
+                    38
+                ],
+                "cancer": [
+                    40,
+                    48,
+                    100
+                ],
+                "stem": [
+                    41
+                ],
+                "cells": [
+                    42,
+                    49
+                ],
+                "(CSCs),": [
+                    43
+                ],
+                "a": [
+                    44
+                ],
+                "small": [
+                    45
+                ],
+                "subset": [
+                    46
+                ],
+                "capable": [
+                    50
+                ],
+                "self-renewal": [
+                    52
+                ],
+                "differentiation": [
+                    54
+                ],
+                "into": [
+                    55
+                ],
+                "heterogeneous": [
+                    56
+                ],
+                "cells.": [
+                    58
+                ],
+                "CSCs": [
+                    60,
+                    96
+                ],
+                "accountable": [
+                    62
+                ],
+                "for": [
+                    63
+                ],
+                "initiation,": [
+                    65
+                ],
+                "growth,": [
+                    66
+                ],
+                "recurrence.": [
+                    68
+                ],
+                "In": [
+                    69
+                ],
+                "this": [
+                    70
+                ],
+                "review,": [
+                    71
+                ],
+                "we": [
+                    72
+                ],
+                "focus": [
+                    73
+                ],
+                "on": [
+                    74
+                ],
+                "roles": [
+                    75
+                ],
+                "CSCs’": [
+                    83
+                ],
+                "stemness": [
+                    84
+                ],
+                "functions": [
+                    86
+                ],
+                "summarize": [
+                    88
+                ],
+                "therapeutic": [
+                    89
+                ],
+                "studies": [
+                    90
+                ],
+                "targeting": [
+                    91
+                ],
+                "to": [
+                    94
+                ],
+                "eliminate": [
+                    95
+                ],
+                "improve": [
+                    98
+                ],
+                "overall": [
+                    99
+                ],
+                "treatment": [
+                    101
+                ],
+                "outcomes.": [
+                    102
+                ]
+            },
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W2594873390",
+            "counts_by_year": [
+                {
+                    "year": 2024,
+                    "cited_by_count": 3
+                },
+                {
+                    "year": 2023,
+                    "cited_by_count": 5
+                },
+                {
+                    "year": 2022,
+                    "cited_by_count": 24
+                },
+                {
+                    "year": 2021,
+                    "cited_by_count": 24
+                },
+                {
+                    "year": 2020,
+                    "cited_by_count": 15
+                },
+                {
+                    "year": 2019,
+                    "cited_by_count": 25
+                },
+                {
+                    "year": 2018,
+                    "cited_by_count": 19
+                },
+                {
+                    "year": 2017,
+                    "cited_by_count": 5
+                }
+            ],
+            "updated_date": "2024-07-22T12:39:25.022125",
+            "created_date": "2017-03-16"
+        },
+        {
+            "id": "https://openalex.org/W2790067792",
+            "doi": "https://doi.org/10.1155/2018/9585614",
+            "title": "Immunotherapies: Exploiting the Immune System for Cancer Treatment",
+            "display_name": "Immunotherapies: Exploiting the Immune System for Cancer Treatment",
+            "publication_year": 2018,
+            "publication_date": "2018-01-01",
+            "ids": {
+                "openalex": "https://openalex.org/W2790067792",
+                "doi": "https://doi.org/10.1155/2018/9585614",
+                "mag": "2790067792",
+                "pmid": "https://pubmed.ncbi.nlm.nih.gov/29725606",
+                "pmcid": "https://www.ncbi.nlm.nih.gov/pmc/articles/5872614"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1155/2018/9585614",
+                "pdf_url": "http://downloads.hindawi.com/journals/jir/2018/9585614.pdf",
+                "source": {
+                    "id": "https://openalex.org/S4210178340",
+                    "display_name": "Journal of immunology research",
+                    "issn_l": "2314-7156",
+                    "issn": [
+                        "2314-7156",
+                        "2314-8861"
+                    ],
+                    "is_oa": true,
+                    "is_in_doaj": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310319869",
+                    "host_organization_name": "Hindawi Publishing Corporation",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310319869"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Hindawi Publishing Corporation"
+                    ],
+                    "type": "journal"
+                },
+                "license": "cc-by",
+                "license_id": "https://openalex.org/licenses/cc-by",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "type": "review",
+            "type_crossref": "journal-article",
+            "indexed_in": [
+                "crossref",
+                "pubmed"
+            ],
+            "open_access": {
+                "is_oa": true,
+                "oa_status": "gold",
+                "oa_url": "http://downloads.hindawi.com/journals/jir/2018/9585614.pdf",
+                "any_repository_has_fulltext": true
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5081987607",
+                        "display_name": "Jeffrey Koury",
+                        "orcid": "https://orcid.org/0000-0002-7368-4891"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Jeffrey Koury",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5065378021",
+                        "display_name": "Mariana Lucero",
+                        "orcid": "https://orcid.org/0000-0002-9173-4768"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Mariana Lucero",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5009132382",
+                        "display_name": "Caleb Cato",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Caleb Cato",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5102915448",
+                        "display_name": "Lawrence Chang",
+                        "orcid": "https://orcid.org/0000-0002-2938-5309"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Lawrence Chang",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5047055383",
+                        "display_name": "Joseph Geiger",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Joseph Geiger",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5051358243",
+                        "display_name": "Denise Henry",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Denise Henry",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5103143402",
+                        "display_name": "Jennifer Hernandez",
+                        "orcid": "https://orcid.org/0000-0001-8836-4455"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jennifer Hernandez",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5082366496",
+                        "display_name": "Fion Hung",
+                        "orcid": "https://orcid.org/0000-0003-0829-2223"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Fion Hung",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5030450466",
+                        "display_name": "Preet Kaur",
+                        "orcid": "https://orcid.org/0000-0002-1125-3201"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Preet Kaur",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5083188567",
+                        "display_name": "Garrett Teskey",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Garrett Teskey",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "last",
+                    "author": {
+                        "id": "https://openalex.org/A5018896272",
+                        "display_name": "Andrew Tran",
+                        "orcid": "https://orcid.org/0000-0001-5777-4611"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Andrew Tran",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, CA 91766, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "countries_distinct_count": 1,
+            "institutions_distinct_count": 1,
+            "corresponding_author_ids": [
+                "https://openalex.org/A5081987607"
+            ],
+            "corresponding_institution_ids": [
+                "https://openalex.org/I93393672"
+            ],
+            "apc_list": {
+                "value": 2100,
+                "currency": "USD",
+                "value_usd": 2100,
+                "provenance": "doaj"
+            },
+            "apc_paid": {
+                "value": 2100,
+                "currency": "USD",
+                "value_usd": 2100,
+                "provenance": "doaj"
+            },
+            "fwci": 4.003,
+            "has_fulltext": true,
+            "fulltext_origin": "pdf",
+            "cited_by_count": 109,
+            "cited_by_percentile_year": {
+                "min": 98,
+                "max": 99
+            },
+            "biblio": {
+                "volume": "2018",
+                "issue": null,
+                "first_page": "1",
+                "last_page": "16"
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T11491",
+                "display_name": "Chimeric Antigen Receptor T Cell Therapy",
+                "score": 1,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/2730",
+                    "display_name": "Oncology"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/27",
+                    "display_name": "Medicine"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/4",
+                    "display_name": "Health Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T11491",
+                    "display_name": "Chimeric Antigen Receptor T Cell Therapy",
+                    "score": 1,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2730",
+                        "display_name": "Oncology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T10580",
+                    "display_name": "Immunobiology of Dendritic Cells",
+                    "score": 0.9993,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2403",
+                        "display_name": "Immunology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/24",
+                        "display_name": "Immunology and Microbiology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T10158",
+                    "display_name": "Cancer Immunotherapy",
+                    "score": 0.9993,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2730",
+                        "display_name": "Oncology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/cancer-immunotherapy",
+                    "display_name": "Cancer Immunotherapy",
+                    "score": 0.57845
+                },
+                {
+                    "id": "https://openalex.org/keywords/biomarkers-for-immunotherapy",
+                    "display_name": "Biomarkers for Immunotherapy",
+                    "score": 0.538321
+                },
+                {
+                    "id": "https://openalex.org/keywords/cancer-immunoediting",
+                    "display_name": "Cancer Immunoediting",
+                    "score": 0.532582
+                },
+                {
+                    "id": "https://openalex.org/keywords/immunotherapy",
+                    "display_name": "Immunotherapy",
+                    "score": 0.523741
+                },
+                {
+                    "id": "https://openalex.org/keywords/t-cell-therapy",
+                    "display_name": "T Cell Therapy",
+                    "score": 0.517915
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C71924100",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11190",
+                    "display_name": "Medicine",
+                    "level": 0,
+                    "score": 0.64416474
+                },
+                {
+                    "id": "https://openalex.org/C2777701055",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1427096",
+                    "display_name": "Immunotherapy",
+                    "level": 3,
+                    "score": 0.59873086
+                },
+                {
+                    "id": "https://openalex.org/C2780674031",
+                    "wikidata": "https://www.wikidata.org/wiki/Q2012719",
+                    "display_name": "Cancer immunotherapy",
+                    "level": 4,
+                    "score": 0.58399385
+                },
+                {
+                    "id": "https://openalex.org/C535046627",
+                    "wikidata": "https://www.wikidata.org/wiki/Q30612",
+                    "display_name": "Clinical trial",
+                    "level": 2,
+                    "score": 0.539713
+                },
+                {
+                    "id": "https://openalex.org/C3019816032",
+                    "wikidata": "https://www.wikidata.org/wiki/Q2575340",
+                    "display_name": "Cancer treatment",
+                    "level": 3,
+                    "score": 0.50484186
+                },
+                {
+                    "id": "https://openalex.org/C90375314",
+                    "wikidata": "https://www.wikidata.org/wiki/Q3537484",
+                    "display_name": "Adoptive cell transfer",
+                    "level": 4,
+                    "score": 0.50269055
+                },
+                {
+                    "id": "https://openalex.org/C121608353",
+                    "wikidata": "https://www.wikidata.org/wiki/Q12078",
+                    "display_name": "Cancer",
+                    "level": 2,
+                    "score": 0.49972105
+                },
+                {
+                    "id": "https://openalex.org/C2983331546",
+                    "wikidata": "https://www.wikidata.org/wiki/Q12078",
+                    "display_name": "Cancer therapy",
+                    "level": 3,
+                    "score": 0.46402174
+                },
+                {
+                    "id": "https://openalex.org/C8891405",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1059",
+                    "display_name": "Immune system",
+                    "level": 2,
+                    "score": 0.4366026
+                },
+                {
+                    "id": "https://openalex.org/C203014093",
+                    "wikidata": "https://www.wikidata.org/wiki/Q101929",
+                    "display_name": "Immunology",
+                    "level": 1,
+                    "score": 0.34464398
+                },
+                {
+                    "id": "https://openalex.org/C2776090121",
+                    "wikidata": "https://www.wikidata.org/wiki/Q193529",
+                    "display_name": "T cell",
+                    "level": 3,
+                    "score": 0.20665848
+                },
+                {
+                    "id": "https://openalex.org/C126322002",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11180",
+                    "display_name": "Internal medicine",
+                    "level": 1,
+                    "score": 0.16132566
+                }
+            ],
+            "mesh": [
+                {
+                    "descriptor_ui": "D000911",
+                    "descriptor_name": "Antibodies, Monoclonal",
+                    "qualifier_ui": "Q000627",
+                    "qualifier_name": "therapeutic use",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D007167",
+                    "descriptor_name": "Immunotherapy",
+                    "qualifier_ui": "Q000379",
+                    "qualifier_name": "methods",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D009369",
+                    "descriptor_name": "Neoplasms",
+                    "qualifier_ui": "Q000628",
+                    "qualifier_name": "therapy",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D013601",
+                    "descriptor_name": "T-Lymphocytes",
+                    "qualifier_ui": "Q000276",
+                    "qualifier_name": "immunology",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D000818",
+                    "descriptor_name": "Animals",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000911",
+                    "descriptor_name": "Antibodies, Monoclonal",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D002986",
+                    "descriptor_name": "Clinical Trials as Topic",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D061025",
+                    "descriptor_name": "Costimulatory and Inhibitory T-Cell Receptors",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D061025",
+                    "descriptor_name": "Costimulatory and Inhibitory T-Cell Receptors",
+                    "qualifier_ui": "Q000276",
+                    "qualifier_name": "immunology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D006801",
+                    "descriptor_name": "Humans",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D007167",
+                    "descriptor_name": "Immunotherapy",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D009369",
+                    "descriptor_name": "Neoplasms",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D009369",
+                    "descriptor_name": "Neoplasms",
+                    "qualifier_ui": "Q000276",
+                    "qualifier_name": "immunology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D013601",
+                    "descriptor_name": "T-Lymphocytes",
+                    "qualifier_ui": "Q000637",
+                    "qualifier_name": "transplantation",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D013601",
+                    "descriptor_name": "T-Lymphocytes",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                }
+            ],
+            "locations_count": 4,
+            "locations": [
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://doi.org/10.1155/2018/9585614",
+                    "pdf_url": "http://downloads.hindawi.com/journals/jir/2018/9585614.pdf",
+                    "source": {
+                        "id": "https://openalex.org/S4210178340",
+                        "display_name": "Journal of immunology research",
+                        "issn_l": "2314-7156",
+                        "issn": [
+                            "2314-7156",
+                            "2314-8861"
+                        ],
+                        "is_oa": true,
+                        "is_in_doaj": true,
+                        "is_core": true,
+                        "host_organization": "https://openalex.org/P4310319869",
+                        "host_organization_name": "Hindawi Publishing Corporation",
+                        "host_organization_lineage": [
+                            "https://openalex.org/P4310319869"
+                        ],
+                        "host_organization_lineage_names": [
+                            "Hindawi Publishing Corporation"
+                        ],
+                        "type": "journal"
+                    },
+                    "license": "cc-by",
+                    "license_id": "https://openalex.org/licenses/cc-by",
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://europepmc.org/articles/pmc5872614",
+                    "pdf_url": "https://europepmc.org/articles/pmc5872614?pdf=render",
+                    "source": {
+                        "id": "https://openalex.org/S4306400806",
+                        "display_name": "Europe PMC (PubMed Central)",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1303153112",
+                        "host_organization_name": "European Bioinformatics Institute",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1303153112"
+                        ],
+                        "host_organization_lineage_names": [
+                            "European Bioinformatics Institute"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": "cc-by",
+                    "license_id": "https://openalex.org/licenses/cc-by",
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5872614",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S2764455111",
+                        "display_name": "PubMed Central",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://pubmed.ncbi.nlm.nih.gov/29725606",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306525036",
+                        "display_name": "PubMed",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1155/2018/9585614",
+                "pdf_url": "http://downloads.hindawi.com/journals/jir/2018/9585614.pdf",
+                "source": {
+                    "id": "https://openalex.org/S4210178340",
+                    "display_name": "Journal of immunology research",
+                    "issn_l": "2314-7156",
+                    "issn": [
+                        "2314-7156",
+                        "2314-8861"
+                    ],
+                    "is_oa": true,
+                    "is_in_doaj": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310319869",
+                    "host_organization_name": "Hindawi Publishing Corporation",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310319869"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Hindawi Publishing Corporation"
+                    ],
+                    "type": "journal"
+                },
+                "license": "cc-by",
+                "license_id": "https://openalex.org/licenses/cc-by",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "sustainable_development_goals": [
+                {
+                    "id": "https://metadata.un.org/sdg/3",
+                    "display_name": "Good health and well-being",
+                    "score": 0.82
+                }
+            ],
+            "grants": [],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 133,
+            "referenced_works": [
+                "https://openalex.org/W117902596",
+                "https://openalex.org/W1487044430",
+                "https://openalex.org/W1493141130",
+                "https://openalex.org/W1530174196",
+                "https://openalex.org/W1530695298",
+                "https://openalex.org/W1556687169",
+                "https://openalex.org/W1571009899",
+                "https://openalex.org/W1583546728",
+                "https://openalex.org/W1600577617",
+                "https://openalex.org/W1612601009",
+                "https://openalex.org/W1656760840",
+                "https://openalex.org/W1791160312",
+                "https://openalex.org/W1841392767",
+                "https://openalex.org/W1848910860",
+                "https://openalex.org/W1913780655",
+                "https://openalex.org/W1920564500",
+                "https://openalex.org/W1931627768",
+                "https://openalex.org/W1947715787",
+                "https://openalex.org/W1950572133",
+                "https://openalex.org/W1967229902",
+                "https://openalex.org/W1967884480",
+                "https://openalex.org/W1972044503",
+                "https://openalex.org/W1979083809",
+                "https://openalex.org/W1979818745",
+                "https://openalex.org/W1981480494",
+                "https://openalex.org/W1982488143",
+                "https://openalex.org/W1985408160",
+                "https://openalex.org/W1985562847",
+                "https://openalex.org/W1985579610",
+                "https://openalex.org/W1985770829",
+                "https://openalex.org/W1985981664",
+                "https://openalex.org/W1988474688",
+                "https://openalex.org/W1990602451",
+                "https://openalex.org/W1991198008",
+                "https://openalex.org/W1995621823",
+                "https://openalex.org/W1996145004",
+                "https://openalex.org/W1998971866",
+                "https://openalex.org/W1999036869",
+                "https://openalex.org/W2003723481",
+                "https://openalex.org/W2007440649",
+                "https://openalex.org/W2008271960",
+                "https://openalex.org/W2016983859",
+                "https://openalex.org/W2018426264",
+                "https://openalex.org/W2019035934",
+                "https://openalex.org/W2019057404",
+                "https://openalex.org/W2020727013",
+                "https://openalex.org/W2036921278",
+                "https://openalex.org/W2041672829",
+                "https://openalex.org/W2042797183",
+                "https://openalex.org/W2043256358",
+                "https://openalex.org/W2043993101",
+                "https://openalex.org/W2048812811",
+                "https://openalex.org/W2060897854",
+                "https://openalex.org/W2061772840",
+                "https://openalex.org/W2066671159",
+                "https://openalex.org/W2070631889",
+                "https://openalex.org/W2071572077",
+                "https://openalex.org/W2075158341",
+                "https://openalex.org/W2085890670",
+                "https://openalex.org/W2094337993",
+                "https://openalex.org/W2096844786",
+                "https://openalex.org/W2097335253",
+                "https://openalex.org/W2097995306",
+                "https://openalex.org/W2100626956",
+                "https://openalex.org/W2101477183",
+                "https://openalex.org/W2102031533",
+                "https://openalex.org/W2103930728",
+                "https://openalex.org/W2104966044",
+                "https://openalex.org/W2105400883",
+                "https://openalex.org/W2107752337",
+                "https://openalex.org/W2108585358",
+                "https://openalex.org/W2108885062",
+                "https://openalex.org/W2109485845",
+                "https://openalex.org/W2111742915",
+                "https://openalex.org/W2111842868",
+                "https://openalex.org/W2115241901",
+                "https://openalex.org/W2119064369",
+                "https://openalex.org/W2119896120",
+                "https://openalex.org/W2120291761",
+                "https://openalex.org/W2123914905",
+                "https://openalex.org/W2124446900",
+                "https://openalex.org/W2125616358",
+                "https://openalex.org/W2128758225",
+                "https://openalex.org/W2130011407",
+                "https://openalex.org/W2134442967",
+                "https://openalex.org/W2135707184",
+                "https://openalex.org/W2136390065",
+                "https://openalex.org/W2140875987",
+                "https://openalex.org/W2143045300",
+                "https://openalex.org/W2143163879",
+                "https://openalex.org/W2146116171",
+                "https://openalex.org/W2147132132",
+                "https://openalex.org/W2148523692",
+                "https://openalex.org/W2149121521",
+                "https://openalex.org/W2149209349",
+                "https://openalex.org/W2151382894",
+                "https://openalex.org/W2157466346",
+                "https://openalex.org/W2160713239",
+                "https://openalex.org/W2160834915",
+                "https://openalex.org/W2162540156",
+                "https://openalex.org/W2165119413",
+                "https://openalex.org/W2166508929",
+                "https://openalex.org/W2170403104",
+                "https://openalex.org/W2190879132",
+                "https://openalex.org/W2228349767",
+                "https://openalex.org/W2257916459",
+                "https://openalex.org/W2265134611",
+                "https://openalex.org/W2287918349",
+                "https://openalex.org/W2293178613",
+                "https://openalex.org/W2314347289",
+                "https://openalex.org/W2338515566",
+                "https://openalex.org/W2347136342",
+                "https://openalex.org/W2463490825",
+                "https://openalex.org/W2470407422",
+                "https://openalex.org/W2485026310",
+                "https://openalex.org/W2514374718",
+                "https://openalex.org/W2526607882",
+                "https://openalex.org/W2530716940",
+                "https://openalex.org/W2536600071",
+                "https://openalex.org/W2554479252",
+                "https://openalex.org/W2559914820",
+                "https://openalex.org/W2559953355",
+                "https://openalex.org/W2560301905",
+                "https://openalex.org/W2560367415",
+                "https://openalex.org/W2567023701",
+                "https://openalex.org/W2567691834",
+                "https://openalex.org/W2572174216",
+                "https://openalex.org/W2578392218",
+                "https://openalex.org/W2580985962",
+                "https://openalex.org/W2755069665",
+                "https://openalex.org/W2767574526",
+                "https://openalex.org/W4230821365",
+                "https://openalex.org/W4255758041"
+            ],
+            "related_works": [
+                "https://openalex.org/W4313343001",
+                "https://openalex.org/W4223914026",
+                "https://openalex.org/W3185708072",
+                "https://openalex.org/W3111580887",
+                "https://openalex.org/W3049036915",
+                "https://openalex.org/W2999675030",
+                "https://openalex.org/W2893846263",
+                "https://openalex.org/W2806333505",
+                "https://openalex.org/W2761992239",
+                "https://openalex.org/W2400599632"
+            ],
+            "ngrams_url": "https://api.openalex.org/works/W2790067792/ngrams",
+            "abstract_inverted_index": {
+                "3": [
+                    87
+                ],
+                "Cancer": [
+                    0
+                ],
+                "is": [
+                    1
+                ],
+                "a": [
+                    2,
+                    100
+                ],
+                "condition": [
+                    3
+                ],
+                "that": [
+                    4
+                ],
+                "has": [
+                    5,
+                    60
+                ],
+                "plagued": [
+                    6
+                ],
+                "humanity": [
+                    7
+                ],
+                "for": [
+                    8,
+                    98
+                ],
+                "thousands": [
+                    9
+                ],
+                "of": [
+                    10,
+                    102
+                ],
+                "years,": [
+                    11
+                ],
+                "with": [
+                    12
+                ],
+                "the": [
+                    13,
+                    82
+                ],
+                "first": [
+                    14
+                ],
+                "depictions": [
+                    15
+                ],
+                "dating": [
+                    16
+                ],
+                "back": [
+                    17
+                ],
+                "to": [
+                    18,
+                    35,
+                    62,
+                    69
+                ],
+                "ancient": [
+                    19
+                ],
+                "Egyptian": [
+                    20
+                ],
+                "times.": [
+                    21
+                ],
+                "However,": [
+                    22
+                ],
+                "not": [
+                    23
+                ],
+                "until": [
+                    24
+                ],
+                "recent": [
+                    25,
+                    48
+                ],
+                "decades": [
+                    26
+                ],
+                "have": [
+                    27,
+                    44
+                ],
+                "biological": [
+                    28
+                ],
+                "therapeutics": [
+                    29
+                ],
+                "been": [
+                    30
+                ],
+                "developed": [
+                    31,
+                    97
+                ],
+                "and": [
+                    32,
+                    37,
+                    56,
+                    73
+                ],
+                "refined": [
+                    33
+                ],
+                "enough": [
+                    34
+                ],
+                "safely": [
+                    36
+                ],
+                "effectively": [
+                    38
+                ],
+                "combat": [
+                    39
+                ],
+                "cancer.": [
+                    40
+                ],
+                "Three": [
+                    41
+                ],
+                "unique": [
+                    42
+                ],
+                "immunotherapies": [
+                    43,
+                    88
+                ],
+                "gained": [
+                    45
+                ],
+                "traction": [
+                    46
+                ],
+                "in": [
+                    47,
+                    71
+                ],
+                "decades:": [
+                    49
+                ],
+                "adoptive": [
+                    50
+                ],
+                "T": [
+                    51
+                ],
+                "cell": [
+                    52
+                ],
+                "transfer,": [
+                    53
+                ],
+                "checkpoint": [
+                    54
+                ],
+                "inhibitors,": [
+                    55
+                ],
+                "bivalent": [
+                    57
+                ],
+                "antibodies.": [
+                    58
+                ],
+                "Each": [
+                    59
+                ],
+                "led": [
+                    61
+                ],
+                "clinically": [
+                    63
+                ],
+                "approved": [
+                    64
+                ],
+                "therapies,": [
+                    65
+                ],
+                "as": [
+                    66,
+                    68,
+                    90,
+                    92
+                ],
+                "well": [
+                    67,
+                    91
+                ],
+                "therapies": [
+                    70
+                ],
+                "preclinical": [
+                    72
+                ],
+                "ongoing": [
+                    74
+                ],
+                "clinical": [
+                    75
+                ],
+                "trials.": [
+                    76
+                ],
+                "In": [
+                    77
+                ],
+                "this": [
+                    78
+                ],
+                "review,": [
+                    79
+                ],
+                "we": [
+                    80
+                ],
+                "outline": [
+                    81
+                ],
+                "method": [
+                    83
+                ],
+                "by": [
+                    84
+                ],
+                "which": [
+                    85
+                ],
+                "these": [
+                    86
+                ],
+                "function": [
+                    89
+                ],
+                "any": [
+                    93
+                ],
+                "major": [
+                    94
+                ],
+                "immunotherapeutic": [
+                    95
+                ],
+                "drugs": [
+                    96
+                ],
+                "treating": [
+                    99
+                ],
+                "variety": [
+                    101
+                ],
+                "cancers.": [
+                    103
+                ]
+            },
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W2790067792",
+            "counts_by_year": [
+                {
+                    "year": 2024,
+                    "cited_by_count": 13
+                },
+                {
+                    "year": 2023,
+                    "cited_by_count": 17
+                },
+                {
+                    "year": 2022,
+                    "cited_by_count": 34
+                },
+                {
+                    "year": 2021,
+                    "cited_by_count": 18
+                },
+                {
+                    "year": 2020,
+                    "cited_by_count": 11
+                },
+                {
+                    "year": 2019,
+                    "cited_by_count": 9
+                },
+                {
+                    "year": 2018,
+                    "cited_by_count": 2
+                }
+            ],
+            "updated_date": "2024-07-22T13:04:47.985953",
+            "created_date": "2018-03-29"
+        },
+        {
+            "id": "https://openalex.org/W3122953533",
+            "doi": "https://doi.org/10.3390/v13020170",
+            "title": "Innate Immune Sensing of Viruses and Its Consequences for the Central Nervous System",
+            "display_name": "Innate Immune Sensing of Viruses and Its Consequences for the Central Nervous System",
+            "publication_year": 2021,
+            "publication_date": "2021-01-23",
+            "ids": {
+                "openalex": "https://openalex.org/W3122953533",
+                "doi": "https://doi.org/10.3390/v13020170",
+                "mag": "3122953533",
+                "pmid": "https://pubmed.ncbi.nlm.nih.gov/33498715",
+                "pmcid": "https://www.ncbi.nlm.nih.gov/pmc/articles/7912342"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.3390/v13020170",
+                "pdf_url": "https://www.mdpi.com/1999-4915/13/2/170/pdf?version=1611755266",
+                "source": {
+                    "id": "https://openalex.org/S55776271",
+                    "display_name": "Viruses",
+                    "issn_l": "1999-4915",
+                    "issn": [
+                        "1999-4915"
+                    ],
+                    "is_oa": true,
+                    "is_in_doaj": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310310987",
+                    "host_organization_name": "Multidisciplinary Digital Publishing Institute",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310310987"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Multidisciplinary Digital Publishing Institute"
+                    ],
+                    "type": "journal"
+                },
+                "license": "cc-by",
+                "license_id": "https://openalex.org/licenses/cc-by",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "type": "review",
+            "type_crossref": "journal-article",
+            "indexed_in": [
+                "crossref",
+                "doaj",
+                "pubmed"
+            ],
+            "open_access": {
+                "is_oa": true,
+                "oa_status": "gold",
+                "oa_url": "https://www.mdpi.com/1999-4915/13/2/170/pdf?version=1611755266",
+                "any_repository_has_fulltext": true
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5055840064",
+                        "display_name": "Hina Singh",
+                        "orcid": "https://orcid.org/0000-0001-7067-1991"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I2799424032",
+                            "display_name": "Discovery Institute",
+                            "ror": "https://ror.org/05t8s3y29",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I2799424032"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I188891513",
+                            "display_name": "Sanford Burnham Prebys Medical Discovery Institute",
+                            "ror": "https://ror.org/03m1g2s55",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I188891513"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Hina Singh",
+                    "raw_affiliation_strings": [
+                        "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, CA 92521, USA",
+                        "Infectious and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, 10901 North Torrey Pines Road, La Jolla, CA 92037, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Infectious and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, 10901 North Torrey Pines Road, La Jolla, CA 92037, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I2799424032",
+                                "https://openalex.org/I188891513"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, CA 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5081987607",
+                        "display_name": "Jeffrey Koury",
+                        "orcid": "https://orcid.org/0000-0002-7368-4891"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jeffrey Koury",
+                    "raw_affiliation_strings": [
+                        "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, CA 92521, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, CA 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "last",
+                    "author": {
+                        "id": "https://openalex.org/A5072837198",
+                        "display_name": "Marcus Kaul",
+                        "orcid": "https://orcid.org/0000-0003-3202-670X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I2799424032",
+                            "display_name": "Discovery Institute",
+                            "ror": "https://ror.org/05t8s3y29",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I2799424032"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I188891513",
+                            "display_name": "Sanford Burnham Prebys Medical Discovery Institute",
+                            "ror": "https://ror.org/03m1g2s55",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I188891513"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Marcus Kaul",
+                    "raw_affiliation_strings": [
+                        "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, CA 92521, USA",
+                        "Infectious and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, 10901 North Torrey Pines Road, La Jolla, CA 92037, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Infectious and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, 10901 North Torrey Pines Road, La Jolla, CA 92037, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I2799424032",
+                                "https://openalex.org/I188891513"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, CA 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "countries_distinct_count": 1,
+            "institutions_distinct_count": 3,
+            "corresponding_author_ids": [
+                "https://openalex.org/A5072837198"
+            ],
+            "corresponding_institution_ids": [
+                "https://openalex.org/I2799424032",
+                "https://openalex.org/I188891513",
+                "https://openalex.org/I103635307"
+            ],
+            "apc_list": {
+                "value": 2600,
+                "currency": "CHF",
+                "value_usd": 2815,
+                "provenance": "doaj"
+            },
+            "apc_paid": {
+                "value": 2600,
+                "currency": "CHF",
+                "value_usd": 2815,
+                "provenance": "doaj"
+            },
+            "fwci": 2.965,
+            "has_fulltext": true,
+            "fulltext_origin": "pdf",
+            "cited_by_count": 30,
+            "cited_by_percentile_year": {
+                "min": 96,
+                "max": 97
+            },
+            "biblio": {
+                "volume": "13",
+                "issue": "2",
+                "first_page": "170",
+                "last_page": "170"
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T11668",
+                "display_name": "Innate Immunity to Viral Infection",
+                "score": 1,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/2403",
+                    "display_name": "Immunology"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/24",
+                    "display_name": "Immunology and Microbiology"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/1",
+                    "display_name": "Life Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T11668",
+                    "display_name": "Innate Immunity to Viral Infection",
+                    "score": 1,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2403",
+                        "display_name": "Immunology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/24",
+                        "display_name": "Immunology and Microbiology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T10371",
+                    "display_name": "Innate Immune Recognition and Signaling Pathways",
+                    "score": 0.9996,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2403",
+                        "display_name": "Immunology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/24",
+                        "display_name": "Immunology and Microbiology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11078",
+                    "display_name": "Molecular Mechanisms of Inflammasome Activation and Regulation",
+                    "score": 0.999,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/1312",
+                        "display_name": "Molecular Biology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/13",
+                        "display_name": "Biochemistry, Genetics and Molecular Biology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/immune-sensing",
+                    "display_name": "Immune Sensing",
+                    "score": 0.593339
+                },
+                {
+                    "id": "https://openalex.org/keywords/innate-antiviral-responses",
+                    "display_name": "Innate Antiviral Responses",
+                    "score": 0.565299
+                },
+                {
+                    "id": "https://openalex.org/keywords/pattern-recognition-receptors",
+                    "display_name": "Pattern Recognition Receptors",
+                    "score": 0.534009
+                },
+                {
+                    "id": "https://openalex.org/keywords/innate-immunity",
+                    "display_name": "Innate Immunity",
+                    "score": 0.511817
+                },
+                {
+                    "id": "https://openalex.org/keywords/toll-like-receptors",
+                    "display_name": "Toll-like Receptors",
+                    "score": 0.50578
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C136449434",
+                    "wikidata": "https://www.wikidata.org/wiki/Q428253",
+                    "display_name": "Innate immune system",
+                    "level": 3,
+                    "score": 0.76855564
+                },
+                {
+                    "id": "https://openalex.org/C86803240",
+                    "wikidata": "https://www.wikidata.org/wiki/Q420",
+                    "display_name": "Biology",
+                    "level": 0,
+                    "score": 0.73227954
+                },
+                {
+                    "id": "https://openalex.org/C8891405",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1059",
+                    "display_name": "Immune system",
+                    "level": 2,
+                    "score": 0.6817657
+                },
+                {
+                    "id": "https://openalex.org/C111289621",
+                    "wikidata": "https://www.wikidata.org/wiki/Q418772",
+                    "display_name": "Pattern recognition receptor",
+                    "level": 4,
+                    "score": 0.66917866
+                },
+                {
+                    "id": "https://openalex.org/C203014093",
+                    "wikidata": "https://www.wikidata.org/wiki/Q101929",
+                    "display_name": "Immunology",
+                    "level": 1,
+                    "score": 0.60038537
+                },
+                {
+                    "id": "https://openalex.org/C13373296",
+                    "wikidata": "https://www.wikidata.org/wiki/Q421866",
+                    "display_name": "Chemokine",
+                    "level": 3,
+                    "score": 0.48274845
+                },
+                {
+                    "id": "https://openalex.org/C170493617",
+                    "wikidata": "https://www.wikidata.org/wiki/Q208467",
+                    "display_name": "Receptor",
+                    "level": 2,
+                    "score": 0.4766001
+                },
+                {
+                    "id": "https://openalex.org/C47742525",
+                    "wikidata": "https://www.wikidata.org/wiki/Q13418826",
+                    "display_name": "Innate lymphoid cell",
+                    "level": 4,
+                    "score": 0.4133481
+                },
+                {
+                    "id": "https://openalex.org/C95444343",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7141",
+                    "display_name": "Cell biology",
+                    "level": 1,
+                    "score": 0.32440865
+                },
+                {
+                    "id": "https://openalex.org/C54355233",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7162",
+                    "display_name": "Genetics",
+                    "level": 1,
+                    "score": 0.076690525
+                }
+            ],
+            "mesh": [
+                {
+                    "descriptor_ui": "D002490",
+                    "descriptor_name": "Central Nervous System",
+                    "qualifier_ui": "Q000276",
+                    "qualifier_name": "immunology",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D002490",
+                    "descriptor_name": "Central Nervous System",
+                    "qualifier_ui": "Q000821",
+                    "qualifier_name": "virology",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D016207",
+                    "descriptor_name": "Cytokines",
+                    "qualifier_ui": "Q000378",
+                    "qualifier_name": "metabolism",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D007113",
+                    "descriptor_name": "Immunity, Innate",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D014777",
+                    "descriptor_name": "Virus Diseases",
+                    "qualifier_ui": "Q000276",
+                    "qualifier_name": "immunology",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D000818",
+                    "descriptor_name": "Animals",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D002490",
+                    "descriptor_name": "Central Nervous System",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D016207",
+                    "descriptor_name": "Cytokines",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D006801",
+                    "descriptor_name": "Humans",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D058847",
+                    "descriptor_name": "Inflammasomes",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D007370",
+                    "descriptor_name": "Interferon Type I",
+                    "qualifier_ui": "Q000378",
+                    "qualifier_name": "metabolism",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D007370",
+                    "descriptor_name": "Interferon Type I",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D037181",
+                    "descriptor_name": "Lectins, C-Type",
+                    "qualifier_ui": "Q000378",
+                    "qualifier_name": "metabolism",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D037181",
+                    "descriptor_name": "Lectins, C-Type",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D051192",
+                    "descriptor_name": "Receptors, Pattern Recognition",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D015398",
+                    "descriptor_name": "Signal Transduction",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D051193",
+                    "descriptor_name": "Toll-Like Receptors",
+                    "qualifier_ui": "Q000378",
+                    "qualifier_name": "metabolism",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D051193",
+                    "descriptor_name": "Toll-Like Receptors",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D014777",
+                    "descriptor_name": "Virus Diseases",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                }
+            ],
+            "locations_count": 4,
+            "locations": [
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://doi.org/10.3390/v13020170",
+                    "pdf_url": "https://www.mdpi.com/1999-4915/13/2/170/pdf?version=1611755266",
+                    "source": {
+                        "id": "https://openalex.org/S55776271",
+                        "display_name": "Viruses",
+                        "issn_l": "1999-4915",
+                        "issn": [
+                            "1999-4915"
+                        ],
+                        "is_oa": true,
+                        "is_in_doaj": true,
+                        "is_core": true,
+                        "host_organization": "https://openalex.org/P4310310987",
+                        "host_organization_name": "Multidisciplinary Digital Publishing Institute",
+                        "host_organization_lineage": [
+                            "https://openalex.org/P4310310987"
+                        ],
+                        "host_organization_lineage_names": [
+                            "Multidisciplinary Digital Publishing Institute"
+                        ],
+                        "type": "journal"
+                    },
+                    "license": "cc-by",
+                    "license_id": "https://openalex.org/licenses/cc-by",
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://doaj.org/article/3221d3b7a4ad4346bc1d9fafd8b2665d",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306401280",
+                        "display_name": "DOAJ (DOAJ: Directory of Open Access Journals)",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": null,
+                        "host_organization_name": null,
+                        "host_organization_lineage": [],
+                        "host_organization_lineage_names": [],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7912342",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S2764455111",
+                        "display_name": "PubMed Central",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://pubmed.ncbi.nlm.nih.gov/33498715",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306525036",
+                        "display_name": "PubMed",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.3390/v13020170",
+                "pdf_url": "https://www.mdpi.com/1999-4915/13/2/170/pdf?version=1611755266",
+                "source": {
+                    "id": "https://openalex.org/S55776271",
+                    "display_name": "Viruses",
+                    "issn_l": "1999-4915",
+                    "issn": [
+                        "1999-4915"
+                    ],
+                    "is_oa": true,
+                    "is_in_doaj": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310310987",
+                    "host_organization_name": "Multidisciplinary Digital Publishing Institute",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310310987"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Multidisciplinary Digital Publishing Institute"
+                    ],
+                    "type": "journal"
+                },
+                "license": "cc-by",
+                "license_id": "https://openalex.org/licenses/cc-by",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "sustainable_development_goals": [
+                {
+                    "id": "https://metadata.un.org/sdg/3",
+                    "display_name": "Good health and well-being",
+                    "score": 0.52
+                }
+            ],
+            "grants": [
+                {
+                    "funder": "https://openalex.org/F4320337346",
+                    "funder_display_name": "National Institute of Mental Health",
+                    "award_id": "R01 MH105330"
+                },
+                {
+                    "funder": "https://openalex.org/F4320337346",
+                    "funder_display_name": "National Institute of Mental Health",
+                    "award_id": "R01 MH087332"
+                },
+                {
+                    "funder": "https://openalex.org/F4320337346",
+                    "funder_display_name": "National Institute of Mental Health",
+                    "award_id": "R01 MH104131"
+                },
+                {
+                    "funder": "https://openalex.org/F4320337347",
+                    "funder_display_name": "National Institute on Drug Abuse",
+                    "award_id": "R01 DA052209"
+                }
+            ],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 342,
+            "referenced_works": [
+                "https://openalex.org/W1487686438",
+                "https://openalex.org/W1499978168",
+                "https://openalex.org/W1501003333",
+                "https://openalex.org/W1506374293",
+                "https://openalex.org/W1548452743",
+                "https://openalex.org/W1559117436",
+                "https://openalex.org/W1591766297",
+                "https://openalex.org/W1592349370",
+                "https://openalex.org/W1592851115",
+                "https://openalex.org/W1603543110",
+                "https://openalex.org/W1674878436",
+                "https://openalex.org/W1766732272",
+                "https://openalex.org/W1798984988",
+                "https://openalex.org/W1805184081",
+                "https://openalex.org/W1880236061",
+                "https://openalex.org/W1902430441",
+                "https://openalex.org/W1913184799",
+                "https://openalex.org/W1932202918",
+                "https://openalex.org/W1940100272",
+                "https://openalex.org/W1959635763",
+                "https://openalex.org/W1964626485",
+                "https://openalex.org/W1965009960",
+                "https://openalex.org/W1965260730",
+                "https://openalex.org/W1965635723",
+                "https://openalex.org/W1967896668",
+                "https://openalex.org/W1969072247",
+                "https://openalex.org/W1970436087",
+                "https://openalex.org/W1971128251",
+                "https://openalex.org/W1972434452",
+                "https://openalex.org/W1972724111",
+                "https://openalex.org/W1973472843",
+                "https://openalex.org/W1973646620",
+                "https://openalex.org/W1975110303",
+                "https://openalex.org/W1975739500",
+                "https://openalex.org/W1976641138",
+                "https://openalex.org/W1977830503",
+                "https://openalex.org/W1978450902",
+                "https://openalex.org/W1979621798",
+                "https://openalex.org/W1979976650",
+                "https://openalex.org/W1980432262",
+                "https://openalex.org/W1980560678",
+                "https://openalex.org/W1980923315",
+                "https://openalex.org/W1982076909",
+                "https://openalex.org/W1982120218",
+                "https://openalex.org/W1983419107",
+                "https://openalex.org/W1983901507",
+                "https://openalex.org/W1985751460",
+                "https://openalex.org/W1986198140",
+                "https://openalex.org/W1987484835",
+                "https://openalex.org/W1989032379",
+                "https://openalex.org/W1989215732",
+                "https://openalex.org/W1989734124",
+                "https://openalex.org/W1990776313",
+                "https://openalex.org/W1991469355",
+                "https://openalex.org/W1991683925",
+                "https://openalex.org/W1993211211",
+                "https://openalex.org/W1994710883",
+                "https://openalex.org/W1995289539",
+                "https://openalex.org/W1995866508",
+                "https://openalex.org/W1996523417",
+                "https://openalex.org/W1997332676",
+                "https://openalex.org/W1998199805",
+                "https://openalex.org/W1998690587",
+                "https://openalex.org/W2000871561",
+                "https://openalex.org/W2005312649",
+                "https://openalex.org/W2005591012",
+                "https://openalex.org/W2006501593",
+                "https://openalex.org/W2007257062",
+                "https://openalex.org/W2007689966",
+                "https://openalex.org/W2008353059",
+                "https://openalex.org/W2008747535",
+                "https://openalex.org/W2008955645",
+                "https://openalex.org/W2009392385",
+                "https://openalex.org/W2009904875",
+                "https://openalex.org/W2010480258",
+                "https://openalex.org/W2010980655",
+                "https://openalex.org/W2011211995",
+                "https://openalex.org/W2011678998",
+                "https://openalex.org/W2012297234",
+                "https://openalex.org/W2013219140",
+                "https://openalex.org/W2016675332",
+                "https://openalex.org/W2020313145",
+                "https://openalex.org/W2021740276",
+                "https://openalex.org/W2022160170",
+                "https://openalex.org/W2022978872",
+                "https://openalex.org/W2024184282",
+                "https://openalex.org/W2026500006",
+                "https://openalex.org/W2026663320",
+                "https://openalex.org/W2028575270",
+                "https://openalex.org/W2029717255",
+                "https://openalex.org/W2030428409",
+                "https://openalex.org/W2032966566",
+                "https://openalex.org/W2032980461",
+                "https://openalex.org/W2033023829",
+                "https://openalex.org/W2033828724",
+                "https://openalex.org/W2034273529",
+                "https://openalex.org/W2035189746",
+                "https://openalex.org/W2035404191",
+                "https://openalex.org/W2035802156",
+                "https://openalex.org/W2038511908",
+                "https://openalex.org/W2039294169",
+                "https://openalex.org/W2040073120",
+                "https://openalex.org/W2041562506",
+                "https://openalex.org/W2042433863",
+                "https://openalex.org/W2044173905",
+                "https://openalex.org/W2044188297",
+                "https://openalex.org/W2044210137",
+                "https://openalex.org/W2046427780",
+                "https://openalex.org/W2046622062",
+                "https://openalex.org/W2047683017",
+                "https://openalex.org/W2050623855",
+                "https://openalex.org/W2050726767",
+                "https://openalex.org/W2051329301",
+                "https://openalex.org/W2051636160",
+                "https://openalex.org/W2052046406",
+                "https://openalex.org/W2053184601",
+                "https://openalex.org/W2055651218",
+                "https://openalex.org/W2055865155",
+                "https://openalex.org/W2055972388",
+                "https://openalex.org/W2058008662",
+                "https://openalex.org/W2058277625",
+                "https://openalex.org/W2058458125",
+                "https://openalex.org/W2060441844",
+                "https://openalex.org/W2060926084",
+                "https://openalex.org/W2061242286",
+                "https://openalex.org/W2063310200",
+                "https://openalex.org/W2064553744",
+                "https://openalex.org/W2064856766",
+                "https://openalex.org/W2065554630",
+                "https://openalex.org/W2066728093",
+                "https://openalex.org/W2067678108",
+                "https://openalex.org/W2067853574",
+                "https://openalex.org/W2069750821",
+                "https://openalex.org/W2070698185",
+                "https://openalex.org/W2071638524",
+                "https://openalex.org/W2071670416",
+                "https://openalex.org/W2071889908",
+                "https://openalex.org/W2073062251",
+                "https://openalex.org/W2074673603",
+                "https://openalex.org/W2074937428",
+                "https://openalex.org/W2076361525",
+                "https://openalex.org/W2077291760",
+                "https://openalex.org/W2078811876",
+                "https://openalex.org/W2078889234",
+                "https://openalex.org/W2079066079",
+                "https://openalex.org/W2081453473",
+                "https://openalex.org/W2083757764",
+                "https://openalex.org/W2084603524",
+                "https://openalex.org/W2085812961",
+                "https://openalex.org/W2086155380",
+                "https://openalex.org/W2086467940",
+                "https://openalex.org/W2087356761",
+                "https://openalex.org/W2088557329",
+                "https://openalex.org/W2089276791",
+                "https://openalex.org/W2089503694",
+                "https://openalex.org/W2089715049",
+                "https://openalex.org/W2090180518",
+                "https://openalex.org/W2090458882",
+                "https://openalex.org/W2090640877",
+                "https://openalex.org/W2090662250",
+                "https://openalex.org/W2091362446",
+                "https://openalex.org/W2091430610",
+                "https://openalex.org/W2093755635",
+                "https://openalex.org/W2095194341",
+                "https://openalex.org/W2095377201",
+                "https://openalex.org/W2097550991",
+                "https://openalex.org/W2097556922",
+                "https://openalex.org/W2099533608",
+                "https://openalex.org/W2099610218",
+                "https://openalex.org/W2100155537",
+                "https://openalex.org/W2100301723",
+                "https://openalex.org/W2100665873",
+                "https://openalex.org/W2101269668",
+                "https://openalex.org/W2103347705",
+                "https://openalex.org/W2103925603",
+                "https://openalex.org/W2104100784",
+                "https://openalex.org/W2104740550",
+                "https://openalex.org/W2106047550",
+                "https://openalex.org/W2106248075",
+                "https://openalex.org/W2109491705",
+                "https://openalex.org/W2109513727",
+                "https://openalex.org/W2110161909",
+                "https://openalex.org/W2111040181",
+                "https://openalex.org/W2111812207",
+                "https://openalex.org/W2111907482",
+                "https://openalex.org/W2111922856",
+                "https://openalex.org/W2113302824",
+                "https://openalex.org/W2114168749",
+                "https://openalex.org/W2114796458",
+                "https://openalex.org/W2116520485",
+                "https://openalex.org/W2116566546",
+                "https://openalex.org/W2116787729",
+                "https://openalex.org/W2116912645",
+                "https://openalex.org/W2117076976",
+                "https://openalex.org/W2117704855",
+                "https://openalex.org/W2118537722",
+                "https://openalex.org/W2119492463",
+                "https://openalex.org/W2120009840",
+                "https://openalex.org/W2121246862",
+                "https://openalex.org/W2121420606",
+                "https://openalex.org/W2124969332",
+                "https://openalex.org/W2125566625",
+                "https://openalex.org/W2127677699",
+                "https://openalex.org/W2127939364",
+                "https://openalex.org/W2131889332",
+                "https://openalex.org/W2133003848",
+                "https://openalex.org/W2134167421",
+                "https://openalex.org/W2134847649",
+                "https://openalex.org/W2136329789",
+                "https://openalex.org/W2136437077",
+                "https://openalex.org/W2136947275",
+                "https://openalex.org/W2137303998",
+                "https://openalex.org/W2137624902",
+                "https://openalex.org/W2138553385",
+                "https://openalex.org/W2138677670",
+                "https://openalex.org/W2138902434",
+                "https://openalex.org/W2139266436",
+                "https://openalex.org/W2139936109",
+                "https://openalex.org/W2140912924",
+                "https://openalex.org/W2144611757",
+                "https://openalex.org/W2145011494",
+                "https://openalex.org/W2146320699",
+                "https://openalex.org/W2148178789",
+                "https://openalex.org/W2148214390",
+                "https://openalex.org/W2148898943",
+                "https://openalex.org/W2149548354",
+                "https://openalex.org/W2149854843",
+                "https://openalex.org/W2150120689",
+                "https://openalex.org/W2150170466",
+                "https://openalex.org/W2150668424",
+                "https://openalex.org/W2150786853",
+                "https://openalex.org/W2153139639",
+                "https://openalex.org/W2153342952",
+                "https://openalex.org/W2153545807",
+                "https://openalex.org/W2155732880",
+                "https://openalex.org/W2156613610",
+                "https://openalex.org/W2156643487",
+                "https://openalex.org/W2156869719",
+                "https://openalex.org/W2157650174",
+                "https://openalex.org/W2161171679",
+                "https://openalex.org/W2161208630",
+                "https://openalex.org/W2164140592",
+                "https://openalex.org/W2164610956",
+                "https://openalex.org/W2165332876",
+                "https://openalex.org/W2165804863",
+                "https://openalex.org/W2166411505",
+                "https://openalex.org/W2167457380",
+                "https://openalex.org/W2169076520",
+                "https://openalex.org/W2170720109",
+                "https://openalex.org/W2172266795",
+                "https://openalex.org/W2175794645",
+                "https://openalex.org/W2195173326",
+                "https://openalex.org/W2196530082",
+                "https://openalex.org/W2259272450",
+                "https://openalex.org/W2292422784",
+                "https://openalex.org/W2295774726",
+                "https://openalex.org/W2296537795",
+                "https://openalex.org/W2298644418",
+                "https://openalex.org/W2312126919",
+                "https://openalex.org/W2319562572",
+                "https://openalex.org/W2326233293",
+                "https://openalex.org/W2342035923",
+                "https://openalex.org/W2346484133",
+                "https://openalex.org/W2346799309",
+                "https://openalex.org/W2353041718",
+                "https://openalex.org/W2382606660",
+                "https://openalex.org/W2395719560",
+                "https://openalex.org/W2398957525",
+                "https://openalex.org/W2412727661",
+                "https://openalex.org/W2431987552",
+                "https://openalex.org/W2463949285",
+                "https://openalex.org/W2534567201",
+                "https://openalex.org/W2540816954",
+                "https://openalex.org/W2547765422",
+                "https://openalex.org/W2560298068",
+                "https://openalex.org/W2563106671",
+                "https://openalex.org/W2563906112",
+                "https://openalex.org/W2564707746",
+                "https://openalex.org/W2575386532",
+                "https://openalex.org/W2581120849",
+                "https://openalex.org/W2584234181",
+                "https://openalex.org/W2588635729",
+                "https://openalex.org/W2597943218",
+                "https://openalex.org/W2603207919",
+                "https://openalex.org/W2606808316",
+                "https://openalex.org/W2612595387",
+                "https://openalex.org/W2615098385",
+                "https://openalex.org/W2625723100",
+                "https://openalex.org/W2626686215",
+                "https://openalex.org/W2735214245",
+                "https://openalex.org/W2735796242",
+                "https://openalex.org/W2755753508",
+                "https://openalex.org/W2758704676",
+                "https://openalex.org/W2780265949",
+                "https://openalex.org/W2788541983",
+                "https://openalex.org/W2790722089",
+                "https://openalex.org/W2793358660",
+                "https://openalex.org/W2793804398",
+                "https://openalex.org/W2794127862",
+                "https://openalex.org/W2796849819",
+                "https://openalex.org/W2797350331",
+                "https://openalex.org/W2800975837",
+                "https://openalex.org/W2810612816",
+                "https://openalex.org/W2883821311",
+                "https://openalex.org/W2893220563",
+                "https://openalex.org/W2895261413",
+                "https://openalex.org/W2902015405",
+                "https://openalex.org/W2921887700",
+                "https://openalex.org/W2922191603",
+                "https://openalex.org/W2922370077",
+                "https://openalex.org/W2924838219",
+                "https://openalex.org/W2941645547",
+                "https://openalex.org/W2947901838",
+                "https://openalex.org/W2948947105",
+                "https://openalex.org/W2952863642",
+                "https://openalex.org/W2953549759",
+                "https://openalex.org/W2957468385",
+                "https://openalex.org/W2967505920",
+                "https://openalex.org/W2969347678",
+                "https://openalex.org/W2972086206",
+                "https://openalex.org/W2972488142",
+                "https://openalex.org/W2973917566",
+                "https://openalex.org/W2979621346",
+                "https://openalex.org/W2981015902",
+                "https://openalex.org/W2982401067",
+                "https://openalex.org/W2998924169",
+                "https://openalex.org/W3007268848",
+                "https://openalex.org/W3007928877",
+                "https://openalex.org/W3011483298",
+                "https://openalex.org/W3014899344",
+                "https://openalex.org/W3016127017",
+                "https://openalex.org/W3021849429",
+                "https://openalex.org/W3034687815",
+                "https://openalex.org/W3035632199",
+                "https://openalex.org/W3036958184",
+                "https://openalex.org/W3037368719",
+                "https://openalex.org/W3048531412",
+                "https://openalex.org/W3084572366",
+                "https://openalex.org/W3090503868",
+                "https://openalex.org/W3115832826",
+                "https://openalex.org/W4210548604",
+                "https://openalex.org/W4211217520"
+            ],
+            "related_works": [
+                "https://openalex.org/W4249576530",
+                "https://openalex.org/W3163115035",
+                "https://openalex.org/W3156068899",
+                "https://openalex.org/W2945199441",
+                "https://openalex.org/W2754879838",
+                "https://openalex.org/W2625922832",
+                "https://openalex.org/W2395231357",
+                "https://openalex.org/W2374919600",
+                "https://openalex.org/W2049191624",
+                "https://openalex.org/W2019893919"
+            ],
+            "ngrams_url": "https://api.openalex.org/works/W3122953533/ngrams",
+            "abstract_inverted_index": {
+                "Viral": [
+                    0,
+                    38
+                ],
+                "infections": [
+                    1
+                ],
+                "remain": [
+                    2
+                ],
+                "a": [
+                    3,
+                    10,
+                    97,
+                    162
+                ],
+                "global": [
+                    4
+                ],
+                "public": [
+                    5
+                ],
+                "health": [
+                    6
+                ],
+                "concern": [
+                    7
+                ],
+                "and": [
+                    8,
+                    13,
+                    31,
+                    74,
+                    80,
+                    91,
+                    93,
+                    131,
+                    140,
+                    178,
+                    195,
+                    210
+                ],
+                "cause": [
+                    9
+                ],
+                "severe": [
+                    11
+                ],
+                "societal": [
+                    12
+                ],
+                "economic": [
+                    14
+                ],
+                "burden.": [
+                    15
+                ],
+                "At": [
+                    16
+                ],
+                "the": [
+                    17,
+                    20,
+                    27,
+                    33,
+                    105,
+                    112,
+                    141,
+                    148,
+                    159,
+                    168,
+                    176,
+                    187,
+                    200,
+                    215
+                ],
+                "organismal": [
+                    18
+                ],
+                "level,": [
+                    19
+                ],
+                "innate": [
+                    21,
+                    192,
+                    218
+                ],
+                "immune": [
+                    22,
+                    136,
+                    193,
+                    208,
+                    219
+                ],
+                "system": [
+                    23,
+                    151
+                ],
+                "is": [
+                    24
+                ],
+                "essential": [
+                    25
+                ],
+                "for": [
+                    26,
+                    214
+                ],
+                "detection": [
+                    28
+                ],
+                "of": [
+                    29,
+                    36,
+                    86,
+                    107,
+                    118,
+                    138,
+                    164,
+                    181,
+                    206,
+                    217
+                ],
+                "viruses": [
+                    30,
+                    139,
+                    154
+                ],
+                "constitutes": [
+                    32
+                ],
+                "first": [
+                    34
+                ],
+                "line": [
+                    35
+                ],
+                "defense.": [
+                    37
+                ],
+                "components": [
+                    39
+                ],
+                "are": [
+                    40,
+                    116
+                ],
+                "sensed": [
+                    41
+                ],
+                "by": [
+                    42
+                ],
+                "host": [
+                    43
+                ],
+                "pattern": [
+                    44
+                ],
+                "recognition": [
+                    45
+                ],
+                "receptors": [
+                    46,
+                    59,
+                    63,
+                    69,
+                    72
+                ],
+                "(PRRs).": [
+                    47
+                ],
+                "PRRs": [
+                    48
+                ],
+                "can": [
+                    49,
+                    126,
+                    145,
+                    155
+                ],
+                "be": [
+                    50
+                ],
+                "further": [
+                    51
+                ],
+                "classified": [
+                    52
+                ],
+                "based": [
+                    53
+                ],
+                "on": [
+                    54
+                ],
+                "their": [
+                    55
+                ],
+                "localization": [
+                    56
+                ],
+                "into": [
+                    57
+                ],
+                "Toll-like": [
+                    58
+                ],
+                "(TLRs),": [
+                    60
+                ],
+                "C-type": [
+                    61
+                ],
+                "lectin": [
+                    62
+                ],
+                "(CLR),": [
+                    64
+                ],
+                "retinoic": [
+                    65
+                ],
+                "acid-inducible": [
+                    66
+                ],
+                "gene-I": [
+                    67
+                ],
+                "(RIG-I)-like": [
+                    68
+                ],
+                "(RLRs),": [
+                    70
+                ],
+                "NOD-like": [
+                    71
+                ],
+                "(NLRs)": [
+                    73
+                ],
+                "cytosolic": [
+                    75
+                ],
+                "DNA": [
+                    76
+                ],
+                "sensors": [
+                    77
+                ],
+                "(CDS).": [
+                    78
+                ],
+                "TLR": [
+                    79
+                ],
+                "RLR": [
+                    81
+                ],
+                "signaling": [
+                    82,
+                    102
+                ],
+                "results": [
+                    83
+                ],
+                "in": [
+                    84,
+                    96,
+                    122,
+                    199
+                ],
+                "production": [
+                    85,
+                    106
+                ],
+                "type": [
+                    87
+                ],
+                "I": [
+                    88
+                ],
+                "interferons": [
+                    89
+                ],
+                "(IFNα": [
+                    90
+                ],
+                "-β)": [
+                    92
+                ],
+                "pro-inflammatory": [
+                    94
+                ],
+                "cytokines": [
+                    95
+                ],
+                "cell-specific": [
+                    98
+                ],
+                "manner,": [
+                    99
+                ],
+                "whereas": [
+                    100
+                ],
+                "NLR": [
+                    101
+                ],
+                "leads": [
+                    103
+                ],
+                "to": [
+                    104,
+                    175,
+                    221
+                ],
+                "interleukin-1": [
+                    108
+                ],
+                "family": [
+                    109
+                ],
+                "proteins.": [
+                    110
+                ],
+                "On": [
+                    111
+                ],
+                "other": [
+                    113
+                ],
+                "hand,": [
+                    114
+                ],
+                "CLRs": [
+                    115
+                ],
+                "capable": [
+                    117
+                ],
+                "sensing": [
+                    119,
+                    137,
+                    194,
+                    209
+                ],
+                "glycans": [
+                    120
+                ],
+                "present": [
+                    121
+                ],
+                "viral": [
+                    123,
+                    207
+                ],
+                "pathogens,": [
+                    124
+                ],
+                "which": [
+                    125
+                ],
+                "induce": [
+                    127
+                ],
+                "phagocytic,": [
+                    128
+                ],
+                "endocytic,": [
+                    129
+                ],
+                "antimicrobial,": [
+                    130
+                ],
+                "pro-": [
+                    132
+                ],
+                "inflammatory": [
+                    133
+                ],
+                "responses.": [
+                    134
+                ],
+                "Peripheral": [
+                    135
+                ],
+                "ensuing": [
+                    142
+                ],
+                "cytokine": [
+                    143,
+                    196
+                ],
+                "response": [
+                    144
+                ],
+                "significantly": [
+                    146
+                ],
+                "affect": [
+                    147
+                ],
+                "central": [
+                    149
+                ],
+                "nervous": [
+                    150
+                ],
+                "(CNS).": [
+                    152
+                ],
+                "But": [
+                    153
+                ],
+                "also": [
+                    156
+                ],
+                "directly": [
+                    157,
+                    198
+                ],
+                "enter": [
+                    158
+                ],
+                "CNS": [
+                    160,
+                    216
+                ],
+                "via": [
+                    161
+                ],
+                "multitude": [
+                    163
+                ],
+                "routes,": [
+                    165
+                ],
+                "such": [
+                    166
+                ],
+                "as": [
+                    167,
+                    179
+                ],
+                "nasal": [
+                    169
+                ],
+                "epithelium,": [
+                    170
+                ],
+                "along": [
+                    171
+                ],
+                "nerve": [
+                    172
+                ],
+                "fibers": [
+                    173
+                ],
+                "connecting": [
+                    174
+                ],
+                "periphery": [
+                    177
+                ],
+                "cargo": [
+                    180
+                ],
+                "infiltrating": [
+                    182
+                ],
+                "infected": [
+                    183
+                ],
+                "cells": [
+                    184
+                ],
+                "passing": [
+                    185
+                ],
+                "through": [
+                    186
+                ],
+                "blood": [
+                    188
+                ],
+                "brain": [
+                    189
+                ],
+                "barrier,": [
+                    190
+                ],
+                "triggering": [
+                    191
+                ],
+                "responses": [
+                    197,
+                    220
+                ],
+                "CNS.": [
+                    201
+                ],
+                "Here,": [
+                    202
+                ],
+                "we": [
+                    203
+                ],
+                "review": [
+                    204
+                ],
+                "mechanisms": [
+                    205
+                ],
+                "currently": [
+                    211
+                ],
+                "recognized": [
+                    212
+                ],
+                "consequences": [
+                    213
+                ],
+                "viruses.": [
+                    222
+                ]
+            },
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W3122953533",
+            "counts_by_year": [
+                {
+                    "year": 2024,
+                    "cited_by_count": 2
+                },
+                {
+                    "year": 2023,
+                    "cited_by_count": 7
+                },
+                {
+                    "year": 2022,
+                    "cited_by_count": 14
+                },
+                {
+                    "year": 2021,
+                    "cited_by_count": 6
+                }
+            ],
+            "updated_date": "2024-07-22T14:37:56.802225",
+            "created_date": "2021-02-01"
+        },
+        {
+            "id": "https://openalex.org/W3034687815",
+            "doi": "https://doi.org/10.1016/j.bbi.2020.06.016",
+            "title": "Lipocalin-2 mediates HIV-1 induced neuronal injury and behavioral deficits by overriding CCR5-dependent protection",
+            "display_name": "Lipocalin-2 mediates HIV-1 induced neuronal injury and behavioral deficits by overriding CCR5-dependent protection",
+            "publication_year": 2020,
+            "publication_date": "2020-10-01",
+            "ids": {
+                "openalex": "https://openalex.org/W3034687815",
+                "doi": "https://doi.org/10.1016/j.bbi.2020.06.016",
+                "mag": "3034687815",
+                "pmid": "https://pubmed.ncbi.nlm.nih.gov/32534984",
+                "pmcid": "https://www.ncbi.nlm.nih.gov/pmc/articles/8153086"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": false,
+                "landing_page_url": "https://doi.org/10.1016/j.bbi.2020.06.016",
+                "pdf_url": null,
+                "source": {
+                    "id": "https://openalex.org/S102243518",
+                    "display_name": "Brain, behavior, and immunity",
+                    "issn_l": "0889-1591",
+                    "issn": [
+                        "0889-1591",
+                        "1090-2139"
+                    ],
+                    "is_oa": false,
+                    "is_in_doaj": false,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310320990",
+                    "host_organization_name": "Elsevier BV",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310320990"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Elsevier BV"
+                    ],
+                    "type": "journal"
+                },
+                "license": null,
+                "license_id": null,
+                "version": null,
+                "is_accepted": false,
+                "is_published": false
+            },
+            "type": "article",
+            "type_crossref": "journal-article",
+            "indexed_in": [
+                "crossref",
+                "pubmed"
+            ],
+            "open_access": {
+                "is_oa": true,
+                "oa_status": "green",
+                "oa_url": "https://europepmc.org/articles/pmc8153086?pdf=render",
+                "any_repository_has_fulltext": true
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5054222456",
+                        "display_name": "Daniel Ojeda-Juárez",
+                        "orcid": "https://orcid.org/0000-0002-0722-2509"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I2799424032",
+                            "display_name": "Discovery Institute",
+                            "ror": "https://ror.org/05t8s3y29",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I2799424032"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I188891513",
+                            "display_name": "Sanford Burnham Prebys Medical Discovery Institute",
+                            "ror": "https://ror.org/03m1g2s55",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I188891513"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Daniel Ojeda-Juárez",
+                    "raw_affiliation_strings": [
+                        "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA 92521, USA",
+                        "Infectious and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, 10901 North Torrey Pines Road, La Jolla, CA 92037, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Infectious and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, 10901 North Torrey Pines Road, La Jolla, CA 92037, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I2799424032",
+                                "https://openalex.org/I188891513"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5066467192",
+                        "display_name": "Rohan Shah",
+                        "orcid": "https://orcid.org/0000-0003-4796-0394"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Rohan Shah",
+                    "raw_affiliation_strings": [
+                        "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA 92521, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5006615187",
+                        "display_name": "Jerel Adam Fields",
+                        "orcid": "https://orcid.org/0000-0002-8168-1412"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I36258959",
+                            "display_name": "University of California, San Diego",
+                            "ror": "https://ror.org/0168r3w48",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I36258959"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jerel Adam Fields",
+                    "raw_affiliation_strings": [
+                        "Department of Psychiatry, University of California San Diego, 9500 Gilman Drive, La Jolla, CA 92093, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Department of Psychiatry, University of California San Diego, 9500 Gilman Drive, La Jolla, CA 92093, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I36258959"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5030728569",
+                        "display_name": "Indira S. Harahap-Carrillo",
+                        "orcid": "https://orcid.org/0009-0005-1111-434X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Indira S. Harahap-Carrillo",
+                    "raw_affiliation_strings": [
+                        "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA 92521, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5081987607",
+                        "display_name": "Jeffrey Koury",
+                        "orcid": "https://orcid.org/0000-0002-7368-4891"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jeffrey Koury",
+                    "raw_affiliation_strings": [
+                        "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA 92521, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5085498045",
+                        "display_name": "Ricky Maung",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Ricky Maung",
+                    "raw_affiliation_strings": [
+                        "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA 92521, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5033197114",
+                        "display_name": "Benjamin B. Gelman",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I55302922",
+                            "display_name": "The University of Texas Medical Branch at Galveston",
+                            "ror": "https://ror.org/016tfm930",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I55302922"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Benjamin B. Gelman",
+                    "raw_affiliation_strings": [
+                        "Department of Neuroscience and Cell Biology, University of Texas Medical Branch, 301 University Blvd, 77555-0419 Galveston, TX, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Department of Neuroscience and Cell Biology, University of Texas Medical Branch, 301 University Blvd, 77555-0419 Galveston, TX, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I55302922"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5013792622",
+                        "display_name": "Bas Baaten",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I2799424032",
+                            "display_name": "Discovery Institute",
+                            "ror": "https://ror.org/05t8s3y29",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I2799424032"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I188891513",
+                            "display_name": "Sanford Burnham Prebys Medical Discovery Institute",
+                            "ror": "https://ror.org/03m1g2s55",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I188891513"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Bas J. Baaten",
+                    "raw_affiliation_strings": [
+                        "Infectious and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, 10901 North Torrey Pines Road, La Jolla, CA 92037, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Infectious and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, 10901 North Torrey Pines Road, La Jolla, CA 92037, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I2799424032",
+                                "https://openalex.org/I188891513"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5101840977",
+                        "display_name": "Amanda J. Roberts",
+                        "orcid": "https://orcid.org/0000-0002-4044-8884"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I123431417",
+                            "display_name": "Scripps Research Institute",
+                            "ror": "https://ror.org/02dxx6824",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I123431417"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Amanda J. Roberts",
+                    "raw_affiliation_strings": [
+                        "Animal Models Core, The Scripps Research Institute, 10550 N. Torrey Pines Rd, MB-P300, La Jolla, CA 92037, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Animal Models Core, The Scripps Research Institute, 10550 N. Torrey Pines Rd, MB-P300, La Jolla, CA 92037, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I123431417"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "last",
+                    "author": {
+                        "id": "https://openalex.org/A5072837198",
+                        "display_name": "Marcus Kaul",
+                        "orcid": "https://orcid.org/0000-0003-3202-670X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I2799424032",
+                            "display_name": "Discovery Institute",
+                            "ror": "https://ror.org/05t8s3y29",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I2799424032"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I188891513",
+                            "display_name": "Sanford Burnham Prebys Medical Discovery Institute",
+                            "ror": "https://ror.org/03m1g2s55",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I188891513"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Marcus Kaul",
+                    "raw_affiliation_strings": [
+                        "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA 92521, USA",
+                        "Infectious and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, 10901 North Torrey Pines Road, La Jolla, CA 92037, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Infectious and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, 10901 North Torrey Pines Road, La Jolla, CA 92037, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I2799424032",
+                                "https://openalex.org/I188891513"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "countries_distinct_count": 1,
+            "institutions_distinct_count": 6,
+            "corresponding_author_ids": [
+                "https://openalex.org/A5072837198"
+            ],
+            "corresponding_institution_ids": [
+                "https://openalex.org/I103635307",
+                "https://openalex.org/I2799424032",
+                "https://openalex.org/I188891513"
+            ],
+            "apc_list": {
+                "value": 4480,
+                "currency": "USD",
+                "value_usd": 4480,
+                "provenance": "doaj"
+            },
+            "apc_paid": null,
+            "fwci": 2.066,
+            "has_fulltext": true,
+            "fulltext_origin": "pdf",
+            "cited_by_count": 21,
+            "cited_by_percentile_year": {
+                "min": 93,
+                "max": 94
+            },
+            "biblio": {
+                "volume": "89",
+                "issue": null,
+                "first_page": "184",
+                "last_page": "199"
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T10112",
+                "display_name": "Human Immunodeficiency Virus/Acquired Immunodeficiency Syndrome",
+                "score": 0.9988,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/2406",
+                    "display_name": "Virology"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/24",
+                    "display_name": "Immunology and Microbiology"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/1",
+                    "display_name": "Life Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T10112",
+                    "display_name": "Human Immunodeficiency Virus/Acquired Immunodeficiency Syndrome",
+                    "score": 0.9988,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2406",
+                        "display_name": "Virology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/24",
+                        "display_name": "Immunology and Microbiology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11266",
+                    "display_name": "Role of Microglia in Neurological Disorders",
+                    "score": 0.9853,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2808",
+                        "display_name": "Neurology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/28",
+                        "display_name": "Neuroscience"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11987",
+                    "display_name": "Impact of COVID-19 Infection on Pregnancy Outcomes",
+                    "score": 0.9641,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2729",
+                        "display_name": "Obstetrics and Gynecology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/hiv",
+                    "display_name": "HIV",
+                    "score": 0.532
+                },
+                {
+                    "id": "https://openalex.org/keywords/neurocognitive-disorders",
+                    "display_name": "neurocognitive disorders",
+                    "score": 0.501657
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C25498285",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1981368",
+                    "display_name": "Neuroprotection",
+                    "level": 2,
+                    "score": 0.7554045
+                },
+                {
+                    "id": "https://openalex.org/C2779491297",
+                    "wikidata": "https://www.wikidata.org/wiki/Q3338704",
+                    "display_name": "Neurotoxicity",
+                    "level": 3,
+                    "score": 0.6574613
+                },
+                {
+                    "id": "https://openalex.org/C2779830541",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1622829",
+                    "display_name": "Microglia",
+                    "level": 3,
+                    "score": 0.6148094
+                },
+                {
+                    "id": "https://openalex.org/C172467417",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1670397",
+                    "display_name": "Neurocognitive",
+                    "level": 3,
+                    "score": 0.57922864
+                },
+                {
+                    "id": "https://openalex.org/C2777222312",
+                    "wikidata": "https://www.wikidata.org/wiki/Q726562",
+                    "display_name": "Neocortex",
+                    "level": 2,
+                    "score": 0.55080014
+                },
+                {
+                    "id": "https://openalex.org/C2776925932",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1755122",
+                    "display_name": "Neurodegeneration",
+                    "level": 3,
+                    "score": 0.5145256
+                },
+                {
+                    "id": "https://openalex.org/C169760540",
+                    "wikidata": "https://www.wikidata.org/wiki/Q207011",
+                    "display_name": "Neuroscience",
+                    "level": 1,
+                    "score": 0.5010867
+                },
+                {
+                    "id": "https://openalex.org/C86803240",
+                    "wikidata": "https://www.wikidata.org/wiki/Q420",
+                    "display_name": "Biology",
+                    "level": 0,
+                    "score": 0.49330345
+                },
+                {
+                    "id": "https://openalex.org/C71924100",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11190",
+                    "display_name": "Medicine",
+                    "level": 0,
+                    "score": 0.35936946
+                },
+                {
+                    "id": "https://openalex.org/C203014093",
+                    "wikidata": "https://www.wikidata.org/wiki/Q101929",
+                    "display_name": "Immunology",
+                    "level": 1,
+                    "score": 0.3159495
+                },
+                {
+                    "id": "https://openalex.org/C142724271",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7208",
+                    "display_name": "Pathology",
+                    "level": 1,
+                    "score": 0.15351307
+                },
+                {
+                    "id": "https://openalex.org/C2776914184",
+                    "wikidata": "https://www.wikidata.org/wiki/Q101991",
+                    "display_name": "Inflammation",
+                    "level": 2,
+                    "score": 0.11438817
+                },
+                {
+                    "id": "https://openalex.org/C126322002",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11180",
+                    "display_name": "Internal medicine",
+                    "level": 1,
+                    "score": 0.10066435
+                },
+                {
+                    "id": "https://openalex.org/C169900460",
+                    "wikidata": "https://www.wikidata.org/wiki/Q2200417",
+                    "display_name": "Cognition",
+                    "level": 2,
+                    "score": 0
+                },
+                {
+                    "id": "https://openalex.org/C2779134260",
+                    "wikidata": "https://www.wikidata.org/wiki/Q12136",
+                    "display_name": "Disease",
+                    "level": 2,
+                    "score": 0
+                },
+                {
+                    "id": "https://openalex.org/C29730261",
+                    "wikidata": "https://www.wikidata.org/wiki/Q274160",
+                    "display_name": "Toxicity",
+                    "level": 2,
+                    "score": 0
+                }
+            ],
+            "mesh": [
+                {
+                    "descriptor_ui": "D015658",
+                    "descriptor_name": "HIV Infections",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D015497",
+                    "descriptor_name": "HIV-1",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D000209",
+                    "descriptor_name": "Acute-Phase Proteins",
+                    "qualifier_ui": "Q000235",
+                    "qualifier_name": "genetics",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000209",
+                    "descriptor_name": "Acute-Phase Proteins",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000818",
+                    "descriptor_name": "Animals",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D015658",
+                    "descriptor_name": "HIV Infections",
+                    "qualifier_ui": "Q000150",
+                    "qualifier_name": "complications",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D015497",
+                    "descriptor_name": "HIV-1",
+                    "qualifier_ui": "Q000378",
+                    "qualifier_name": "metabolism",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D006801",
+                    "descriptor_name": "Humans",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000071068",
+                    "descriptor_name": "Lipocalin-2",
+                    "qualifier_ui": "Q000235",
+                    "qualifier_name": "genetics",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000071068",
+                    "descriptor_name": "Lipocalin-2",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D051379",
+                    "descriptor_name": "Mice",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D009474",
+                    "descriptor_name": "Neurons",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D009474",
+                    "descriptor_name": "Neurons",
+                    "qualifier_ui": "Q000378",
+                    "qualifier_name": "metabolism",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D019713",
+                    "descriptor_name": "Receptors, CCR5",
+                    "qualifier_ui": "Q000235",
+                    "qualifier_name": "genetics",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D019713",
+                    "descriptor_name": "Receptors, CCR5",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                }
+            ],
+            "locations_count": 5,
+            "locations": [
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://doi.org/10.1016/j.bbi.2020.06.016",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S102243518",
+                        "display_name": "Brain, behavior, and immunity",
+                        "issn_l": "0889-1591",
+                        "issn": [
+                            "0889-1591",
+                            "1090-2139"
+                        ],
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_core": true,
+                        "host_organization": "https://openalex.org/P4310320990",
+                        "host_organization_name": "Elsevier BV",
+                        "host_organization_lineage": [
+                            "https://openalex.org/P4310320990"
+                        ],
+                        "host_organization_lineage_names": [
+                            "Elsevier BV"
+                        ],
+                        "type": "journal"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://europepmc.org/articles/pmc8153086",
+                    "pdf_url": "https://europepmc.org/articles/pmc8153086?pdf=render",
+                    "source": {
+                        "id": "https://openalex.org/S4306400806",
+                        "display_name": "Europe PMC (PubMed Central)",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1303153112",
+                        "host_organization_name": "European Bioinformatics Institute",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1303153112"
+                        ],
+                        "host_organization_lineage_names": [
+                            "European Bioinformatics Institute"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "acceptedVersion",
+                    "is_accepted": true,
+                    "is_published": false
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8153086",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S2764455111",
+                        "display_name": "PubMed Central",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "acceptedVersion",
+                    "is_accepted": true,
+                    "is_published": false
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://escholarship.org/uc/item/1fr916fp",
+                    "pdf_url": "https://escholarship.org/content/qt1fr916fp/qt1fr916fp.pdf?t=rw034u",
+                    "source": {
+                        "id": "https://openalex.org/S4306400115",
+                        "display_name": "eScholarship (California Digital Library)",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I2801248553",
+                        "host_organization_name": "California Digital Library",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I2801248553"
+                        ],
+                        "host_organization_lineage_names": [
+                            "California Digital Library"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": "cc-by",
+                    "license_id": "https://openalex.org/licenses/cc-by",
+                    "version": "submittedVersion",
+                    "is_accepted": false,
+                    "is_published": false
+                },
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://pubmed.ncbi.nlm.nih.gov/32534984",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306525036",
+                        "display_name": "PubMed",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": {
+                "is_oa": true,
+                "landing_page_url": "https://europepmc.org/articles/pmc8153086",
+                "pdf_url": "https://europepmc.org/articles/pmc8153086?pdf=render",
+                "source": {
+                    "id": "https://openalex.org/S4306400806",
+                    "display_name": "Europe PMC (PubMed Central)",
+                    "issn_l": null,
+                    "issn": null,
+                    "is_oa": true,
+                    "is_in_doaj": false,
+                    "is_core": false,
+                    "host_organization": "https://openalex.org/I1303153112",
+                    "host_organization_name": "European Bioinformatics Institute",
+                    "host_organization_lineage": [
+                        "https://openalex.org/I1303153112"
+                    ],
+                    "host_organization_lineage_names": [
+                        "European Bioinformatics Institute"
+                    ],
+                    "type": "repository"
+                },
+                "license": null,
+                "license_id": null,
+                "version": "acceptedVersion",
+                "is_accepted": true,
+                "is_published": false
+            },
+            "sustainable_development_goals": [
+                {
+                    "id": "https://metadata.un.org/sdg/3",
+                    "display_name": "Good health and well-being",
+                    "score": 0.83
+                }
+            ],
+            "grants": [
+                {
+                    "funder": "https://openalex.org/F4320332161",
+                    "funder_display_name": "National Institutes of Health",
+                    "award_id": null
+                }
+            ],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 80,
+            "referenced_works": [
+                "https://openalex.org/W1560653098",
+                "https://openalex.org/W1801632992",
+                "https://openalex.org/W1913367972",
+                "https://openalex.org/W1916878534",
+                "https://openalex.org/W1965521903",
+                "https://openalex.org/W1976434061",
+                "https://openalex.org/W1976772869",
+                "https://openalex.org/W1981379366",
+                "https://openalex.org/W1983402821",
+                "https://openalex.org/W1983633456",
+                "https://openalex.org/W1984811742",
+                "https://openalex.org/W1987224349",
+                "https://openalex.org/W1999048558",
+                "https://openalex.org/W2001350690",
+                "https://openalex.org/W2002335756",
+                "https://openalex.org/W2005754542",
+                "https://openalex.org/W2017510842",
+                "https://openalex.org/W2018002636",
+                "https://openalex.org/W2022978872",
+                "https://openalex.org/W2023997996",
+                "https://openalex.org/W2026328614",
+                "https://openalex.org/W2032940358",
+                "https://openalex.org/W2034909046",
+                "https://openalex.org/W2039112178",
+                "https://openalex.org/W2043599256",
+                "https://openalex.org/W2050489421",
+                "https://openalex.org/W2050542278",
+                "https://openalex.org/W2051515223",
+                "https://openalex.org/W2052305221",
+                "https://openalex.org/W2058458125",
+                "https://openalex.org/W2060668038",
+                "https://openalex.org/W2061480204",
+                "https://openalex.org/W2067954157",
+                "https://openalex.org/W2069893872",
+                "https://openalex.org/W2074692187",
+                "https://openalex.org/W2077528285",
+                "https://openalex.org/W2086419987",
+                "https://openalex.org/W2087053296",
+                "https://openalex.org/W2093530590",
+                "https://openalex.org/W2099623158",
+                "https://openalex.org/W2103861118",
+                "https://openalex.org/W2105489252",
+                "https://openalex.org/W2107277218",
+                "https://openalex.org/W2115118763",
+                "https://openalex.org/W2115950573",
+                "https://openalex.org/W2128847428",
+                "https://openalex.org/W2137882516",
+                "https://openalex.org/W2138902434",
+                "https://openalex.org/W2139155915",
+                "https://openalex.org/W2141208208",
+                "https://openalex.org/W2149410369",
+                "https://openalex.org/W2160212383",
+                "https://openalex.org/W2162325038",
+                "https://openalex.org/W2162623926",
+                "https://openalex.org/W2166083796",
+                "https://openalex.org/W2167404536",
+                "https://openalex.org/W2168073523",
+                "https://openalex.org/W2168114040",
+                "https://openalex.org/W2170485551",
+                "https://openalex.org/W2170685896",
+                "https://openalex.org/W2187648708",
+                "https://openalex.org/W2192080449",
+                "https://openalex.org/W2214440891",
+                "https://openalex.org/W2295774726",
+                "https://openalex.org/W2399787808",
+                "https://openalex.org/W2521220667",
+                "https://openalex.org/W2561607968",
+                "https://openalex.org/W2570076292",
+                "https://openalex.org/W2590185148",
+                "https://openalex.org/W2598934409",
+                "https://openalex.org/W2606808316",
+                "https://openalex.org/W2613917013",
+                "https://openalex.org/W2620242306",
+                "https://openalex.org/W2765922299",
+                "https://openalex.org/W2767658959",
+                "https://openalex.org/W2903294600",
+                "https://openalex.org/W2917730612",
+                "https://openalex.org/W2939589261",
+                "https://openalex.org/W2966285432",
+                "https://openalex.org/W4322703199"
+            ],
+            "related_works": [
+                "https://openalex.org/W4310571718",
+                "https://openalex.org/W2952887780",
+                "https://openalex.org/W2891888347",
+                "https://openalex.org/W2265533101",
+                "https://openalex.org/W2169663442",
+                "https://openalex.org/W2156427445",
+                "https://openalex.org/W2021389999",
+                "https://openalex.org/W1976698932",
+                "https://openalex.org/W1973442679",
+                "https://openalex.org/W1492225438"
+            ],
+            "ngrams_url": "https://api.openalex.org/works/W3034687815/ngrams",
+            "abstract_inverted_index": {
+                "168": [
+                    168
+                ],
+                "People": [
+                    0
+                ],
+                "living": [
+                    1
+                ],
+                "with": [
+                    2,
+                    56,
+                    61,
+                    119,
+                    182
+                ],
+                "HIV": [
+                    3,
+                    229
+                ],
+                "(PLWH)": [
+                    4
+                ],
+                "continue": [
+                    5
+                ],
+                "to": [
+                    6,
+                    77
+                ],
+                "develop": [
+                    7
+                ],
+                "HIV-associated": [
+                    8,
+                    37,
+                    78,
+                    203
+                ],
+                "neurocognitive": [
+                    9,
+                    238
+                ],
+                "disorders": [
+                    10
+                ],
+                "despite": [
+                    11
+                ],
+                "combination": [
+                    12
+                ],
+                "anti-retroviral": [
+                    13
+                ],
+                "therapy.": [
+                    14
+                ],
+                "Lipocalin-2": [
+                    15
+                ],
+                "(LCN2)": [
+                    16
+                ],
+                "is": [
+                    17,
+                    29,
+                    45,
+                    81
+                ],
+                "an": [
+                    18,
+                    120
+                ],
+                "acute": [
+                    19
+                ],
+                "phase": [
+                    20
+                ],
+                "protein": [
+                    21
+                ],
+                "that": [
+                    22,
+                    43,
+                    93,
+                    132,
+                    154,
+                    174
+                ],
+                "has": [
+                    23
+                ],
+                "been": [
+                    24
+                ],
+                "implicated": [
+                    25
+                ],
+                "in": [
+                    26,
+                    31,
+                    48,
+                    64,
+                    69,
+                    98,
+                    103,
+                    117,
+                    147,
+                    171,
+                    202,
+                    228
+                ],
+                "neurodegeneration": [
+                    27
+                ],
+                "and": [
+                    28,
+                    59,
+                    66,
+                    113,
+                    139,
+                    161,
+                    177,
+                    184,
+                    210,
+                    218,
+                    225,
+                    237
+                ],
+                "upregulated": [
+                    30,
+                    47
+                ],
+                "a": [
+                    32,
+                    51,
+                    84,
+                    199,
+                    223
+                ],
+                "transgenic": [
+                    33,
+                    99
+                ],
+                "mouse": [
+                    34
+                ],
+                "model": [
+                    35
+                ],
+                "of": [
+                    36,
+                    50,
+                    53,
+                    83,
+                    96,
+                    122,
+                    145,
+                    167,
+                    233
+                ],
+                "brain": [
+                    38,
+                    57,
+                    105,
+                    204,
+                    235
+                ],
+                "injury.": [
+                    39
+                ],
+                "Here": [
+                    40
+                ],
+                "we": [
+                    41
+                ],
+                "show": [
+                    42,
+                    131
+                ],
+                "LCN2": [
+                    44,
+                    75,
+                    97,
+                    133,
+                    155,
+                    197,
+                    217
+                ],
+                "significantly": [
+                    46
+                ],
+                "neocortex": [
+                    49
+                ],
+                "subset": [
+                    52
+                ],
+                "HIV-infected": [
+                    54
+                ],
+                "individuals": [
+                    55
+                ],
+                "pathology": [
+                    58,
+                    236
+                ],
+                "correlates": [
+                    60
+                ],
+                "viral": [
+                    62
+                ],
+                "load": [
+                    63
+                ],
+                "CSF": [
+                    65
+                ],
+                "pro-viral": [
+                    67
+                ],
+                "DNA": [
+                    68
+                ],
+                "neocortex.": [
+                    70
+                ],
+                "However,": [
+                    71
+                ],
+                "the": [
+                    72,
+                    94,
+                    104,
+                    123,
+                    213
+                ],
+                "question": [
+                    73
+                ],
+                "if": [
+                    74
+                ],
+                "contributes": [
+                    76
+                ],
+                "neurotoxicity": [
+                    79,
+                    134
+                ],
+                "or": [
+                    80
+                ],
+                "part": [
+                    82
+                ],
+                "protective": [
+                    85
+                ],
+                "host": [
+                    86
+                ],
+                "response": [
+                    87
+                ],
+                "required": [
+                    88
+                ],
+                "further": [
+                    89
+                ],
+                "investigation.": [
+                    90
+                ],
+                "We": [
+                    91
+                ],
+                "found": [
+                    92
+                ],
+                "knockout": [
+                    95
+                ],
+                "mice": [
+                    100,
+                    150
+                ],
+                "expressing": [
+                    101
+                ],
+                "HIVgp120": [
+                    102
+                ],
+                "(HIVgp120tg)": [
+                    106
+                ],
+                "abrogates": [
+                    107
+                ],
+                "behavioral": [
+                    108
+                ],
+                "impairment,": [
+                    109
+                ],
+                "ameliorates": [
+                    110
+                ],
+                "neuronal": [
+                    111,
+                    175
+                ],
+                "damage,": [
+                    112
+                ],
+                "reduces": [
+                    114
+                ],
+                "microglial": [
+                    115
+                ],
+                "activation": [
+                    116
+                ],
+                "association": [
+                    118
+                ],
+                "increase": [
+                    121
+                ],
+                "neuroprotective": [
+                    124
+                ],
+                "CCR5": [
+                    125,
+                    146,
+                    160,
+                    219
+                ],
+                "ligand": [
+                    126
+                ],
+                "CCL4.": [
+                    127
+                ],
+                "In": [
+                    128,
+                    192
+                ],
+                "vitro": [
+                    129
+                ],
+                "experiments": [
+                    130
+                ],
+                "also": [
+                    135
+                ],
+                "depends": [
+                    136
+                ],
+                "on": [
+                    137
+                ],
+                "microglia": [
+                    138
+                ],
+                "p38": [
+                    140,
+                    208
+                ],
+                "MAPK": [
+                    141,
+                    209
+                ],
+                "activity.": [
+                    142
+                ],
+                "Genetic": [
+                    143
+                ],
+                "ablation": [
+                    144
+                ],
+                "LCN2-deficient": [
+                    148
+                ],
+                "HIVgp120tg": [
+                    149
+                ],
+                "restores": [
+                    151
+                ],
+                "neuropathology,": [
+                    152
+                ],
+                "suggesting": [
+                    153
+                ],
+                "overrides": [
+                    156
+                ],
+                "neuroprotection": [
+                    157
+                ],
+                "mediated": [
+                    158
+                ],
+                "by": [
+                    159
+                ],
+                "its": [
+                    162
+                ],
+                "chemokine": [
+                    163
+                ],
+                "ligands.": [
+                    164
+                ],
+                "RNA": [
+                    165
+                ],
+                "expression": [
+                    166
+                ],
+                "genes": [
+                    169
+                ],
+                "involved": [
+                    170
+                ],
+                "neurotransmission": [
+                    172
+                ],
+                "reveals": [
+                    173
+                ],
+                "injury": [
+                    176,
+                    205
+                ],
+                "protection": [
+                    178
+                ],
+                "are": [
+                    179
+                ],
+                "each": [
+                    180
+                ],
+                "associated": [
+                    181
+                ],
+                "genotype-": [
+                    183
+                ],
+                "sex-specific": [
+                    185
+                ],
+                "patterns": [
+                    186
+                ],
+                "affecting": [
+                    187
+                ],
+                "common": [
+                    188
+                ],
+                "neural": [
+                    189
+                ],
+                "gene": [
+                    190
+                ],
+                "networks.": [
+                    191
+                ],
+                "conclusion,": [
+                    193
+                ],
+                "our": [
+                    194
+                ],
+                "study": [
+                    195
+                ],
+                "identifies": [
+                    196
+                ],
+                "as": [
+                    198,
+                    222
+                ],
+                "novel": [
+                    200
+                ],
+                "factor": [
+                    201
+                ],
+                "involving": [
+                    206
+                ],
+                "CCR5,": [
+                    207
+                ],
+                "microglia.": [
+                    211
+                ],
+                "Furthermore,": [
+                    212
+                ],
+                "mechanistic": [
+                    214
+                ],
+                "interaction": [
+                    215
+                ],
+                "between": [
+                    216
+                ],
+                "may": [
+                    220
+                ],
+                "serve": [
+                    221
+                ],
+                "diagnostic": [
+                    224
+                ],
+                "therapeutic": [
+                    226
+                ],
+                "target": [
+                    227
+                ],
+                "patients": [
+                    230
+                ],
+                "at": [
+                    231
+                ],
+                "risk": [
+                    232
+                ],
+                "developing": [
+                    234
+                ],
+                "impairment.": [
+                    239
+                ]
+            },
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W3034687815",
+            "counts_by_year": [
+                {
+                    "year": 2024,
+                    "cited_by_count": 4
+                },
+                {
+                    "year": 2023,
+                    "cited_by_count": 3
+                },
+                {
+                    "year": 2022,
+                    "cited_by_count": 5
+                },
+                {
+                    "year": 2021,
+                    "cited_by_count": 7
+                },
+                {
+                    "year": 2020,
+                    "cited_by_count": 2
+                }
+            ],
+            "updated_date": "2024-07-14T09:39:20.619263",
+            "created_date": "2020-06-19"
+        },
+        {
+            "id": "https://openalex.org/W4377292675",
+            "doi": "https://doi.org/10.1038/s41598-023-34943-w",
+            "title": "ACCT is a fast and accessible automatic cell counting tool using machine learning for 2D image segmentation",
+            "display_name": "ACCT is a fast and accessible automatic cell counting tool using machine learning for 2D image segmentation",
+            "publication_year": 2023,
+            "publication_date": "2023-05-22",
+            "ids": {
+                "openalex": "https://openalex.org/W4377292675",
+                "doi": "https://doi.org/10.1038/s41598-023-34943-w",
+                "pmid": "https://pubmed.ncbi.nlm.nih.gov/37217558"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1038/s41598-023-34943-w",
+                "pdf_url": "https://www.nature.com/articles/s41598-023-34943-w.pdf",
+                "source": {
+                    "id": "https://openalex.org/S196734849",
+                    "display_name": "Scientific reports",
+                    "issn_l": "2045-2322",
+                    "issn": [
+                        "2045-2322"
+                    ],
+                    "is_oa": true,
+                    "is_in_doaj": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310319908",
+                    "host_organization_name": "Nature Portfolio",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310319908",
+                        "https://openalex.org/P4310319965"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Nature Portfolio",
+                        "Springer Nature"
+                    ],
+                    "type": "journal"
+                },
+                "license": "cc-by",
+                "license_id": "https://openalex.org/licenses/cc-by",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "type": "article",
+            "type_crossref": "journal-article",
+            "indexed_in": [
+                "crossref",
+                "pubmed"
+            ],
+            "open_access": {
+                "is_oa": true,
+                "oa_status": "gold",
+                "oa_url": "https://www.nature.com/articles/s41598-023-34943-w.pdf",
+                "any_repository_has_fulltext": true
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5046297003",
+                        "display_name": "Theodore J. Kataras",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Theodore J. Kataras",
+                    "raw_affiliation_strings": [
+                        "Graduate Program of Genetics, Genomics and Bioinformatics, University of California, Riverside, Riverside, CA, 92521, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate Program of Genetics, Genomics and Bioinformatics, University of California, Riverside, Riverside, CA, 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5035557559",
+                        "display_name": "Tyler Jang",
+                        "orcid": "https://orcid.org/0000-0001-9815-4478"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Tyler J. Jang",
+                    "raw_affiliation_strings": [
+                        "Graduate Program of Genetics, Genomics and Bioinformatics, University of California, Riverside, Riverside, CA, 92521, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate Program of Genetics, Genomics and Bioinformatics, University of California, Riverside, Riverside, CA, 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5081987607",
+                        "display_name": "Jeffrey Koury",
+                        "orcid": "https://orcid.org/0000-0002-7368-4891"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jeffrey Koury",
+                    "raw_affiliation_strings": [
+                        "School of Medicine, Division of Biomedical Sciences, University of California, Riverside, Riverside, CA, 92521, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "School of Medicine, Division of Biomedical Sciences, University of California, Riverside, Riverside, CA, 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5055840064",
+                        "display_name": "Hina Singh",
+                        "orcid": "https://orcid.org/0000-0001-7067-1991"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Hina Singh",
+                    "raw_affiliation_strings": [
+                        "School of Medicine, Division of Biomedical Sciences, University of California, Riverside, Riverside, CA, 92521, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "School of Medicine, Division of Biomedical Sciences, University of California, Riverside, Riverside, CA, 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5076166722",
+                        "display_name": "Daniel Fok",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Dominic Fok",
+                    "raw_affiliation_strings": [
+                        "School of Medicine, Division of Biomedical Sciences, University of California, Riverside, Riverside, CA, 92521, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "School of Medicine, Division of Biomedical Sciences, University of California, Riverside, Riverside, CA, 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "last",
+                    "author": {
+                        "id": "https://openalex.org/A5072837198",
+                        "display_name": "Marcus Kaul",
+                        "orcid": "https://orcid.org/0000-0003-3202-670X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Marcus Kaul",
+                    "raw_affiliation_strings": [
+                        "Graduate Program of Genetics, Genomics and Bioinformatics, University of California, Riverside, Riverside, CA, 92521, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate Program of Genetics, Genomics and Bioinformatics, University of California, Riverside, Riverside, CA, 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "countries_distinct_count": 1,
+            "institutions_distinct_count": 1,
+            "corresponding_author_ids": [],
+            "corresponding_institution_ids": [],
+            "apc_list": {
+                "value": 1890,
+                "currency": "EUR",
+                "value_usd": 2190,
+                "provenance": "doaj"
+            },
+            "apc_paid": {
+                "value": 1890,
+                "currency": "EUR",
+                "value_usd": 2190,
+                "provenance": "doaj"
+            },
+            "fwci": 1.284,
+            "has_fulltext": true,
+            "fulltext_origin": "pdf",
+            "cited_by_count": 4,
+            "cited_by_percentile_year": {
+                "min": 92,
+                "max": 94
+            },
+            "biblio": {
+                "volume": "13",
+                "issue": "1",
+                "first_page": null,
+                "last_page": null
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T11266",
+                "display_name": "Role of Microglia in Neurological Disorders",
+                "score": 0.9998,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/2808",
+                    "display_name": "Neurology"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/28",
+                    "display_name": "Neuroscience"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/1",
+                    "display_name": "Life Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T11266",
+                    "display_name": "Role of Microglia in Neurological Disorders",
+                    "score": 0.9998,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2808",
+                        "display_name": "Neurology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/28",
+                        "display_name": "Neuroscience"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T12859",
+                    "display_name": "Advanced Techniques in Bioimage Analysis and Microscopy",
+                    "score": 0.9983,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/1304",
+                        "display_name": "Biophysics"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/13",
+                        "display_name": "Biochemistry, Genetics and Molecular Biology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11289",
+                    "display_name": "Comprehensive Integration of Single-Cell Transcriptomic Data",
+                    "score": 0.9944,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/1312",
+                        "display_name": "Molecular Biology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/13",
+                        "display_name": "Biochemistry, Genetics and Molecular Biology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/cellular-imaging",
+                    "display_name": "Cellular Imaging",
+                    "score": 0.528211
+                },
+                {
+                    "id": "https://openalex.org/keywords/cell-heterogeneity",
+                    "display_name": "Cell Heterogeneity",
+                    "score": 0.504354
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C41008148",
+                    "wikidata": "https://www.wikidata.org/wiki/Q21198",
+                    "display_name": "Computer science",
+                    "level": 0,
+                    "score": 0.8368157
+                },
+                {
+                    "id": "https://openalex.org/C89600930",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1423946",
+                    "display_name": "Segmentation",
+                    "level": 2,
+                    "score": 0.712376
+                },
+                {
+                    "id": "https://openalex.org/C154945302",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11660",
+                    "display_name": "Artificial intelligence",
+                    "level": 1,
+                    "score": 0.6371975
+                },
+                {
+                    "id": "https://openalex.org/C98045186",
+                    "wikidata": "https://www.wikidata.org/wiki/Q205663",
+                    "display_name": "Process (computing)",
+                    "level": 2,
+                    "score": 0.60270137
+                },
+                {
+                    "id": "https://openalex.org/C153180895",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7148389",
+                    "display_name": "Pattern recognition (psychology)",
+                    "level": 2,
+                    "score": 0.4819824
+                },
+                {
+                    "id": "https://openalex.org/C115961682",
+                    "wikidata": "https://www.wikidata.org/wiki/Q860623",
+                    "display_name": "Image (mathematics)",
+                    "level": 2,
+                    "score": 0.45364735
+                },
+                {
+                    "id": "https://openalex.org/C2781238097",
+                    "wikidata": "https://www.wikidata.org/wiki/Q175026",
+                    "display_name": "Object (grammar)",
+                    "level": 2,
+                    "score": 0.44972917
+                },
+                {
+                    "id": "https://openalex.org/C124504099",
+                    "wikidata": "https://www.wikidata.org/wiki/Q56933",
+                    "display_name": "Image segmentation",
+                    "level": 3,
+                    "score": 0.4415686
+                },
+                {
+                    "id": "https://openalex.org/C31972630",
+                    "wikidata": "https://www.wikidata.org/wiki/Q844240",
+                    "display_name": "Computer vision",
+                    "level": 1,
+                    "score": 0.43622023
+                },
+                {
+                    "id": "https://openalex.org/C108583219",
+                    "wikidata": "https://www.wikidata.org/wiki/Q197536",
+                    "display_name": "Deep learning",
+                    "level": 2,
+                    "score": 0.41353267
+                },
+                {
+                    "id": "https://openalex.org/C2583947",
+                    "wikidata": "https://www.wikidata.org/wiki/Q5058179",
+                    "display_name": "Cell counting",
+                    "level": 4,
+                    "score": 0.4111305
+                },
+                {
+                    "id": "https://openalex.org/C1491633281",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7868",
+                    "display_name": "Cell",
+                    "level": 2,
+                    "score": 0.079316914
+                },
+                {
+                    "id": "https://openalex.org/C54355233",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7162",
+                    "display_name": "Genetics",
+                    "level": 1,
+                    "score": 0
+                },
+                {
+                    "id": "https://openalex.org/C86803240",
+                    "wikidata": "https://www.wikidata.org/wiki/Q420",
+                    "display_name": "Biology",
+                    "level": 0,
+                    "score": 0
+                },
+                {
+                    "id": "https://openalex.org/C29537977",
+                    "wikidata": "https://www.wikidata.org/wiki/Q188941",
+                    "display_name": "Cell cycle",
+                    "level": 3,
+                    "score": 0
+                },
+                {
+                    "id": "https://openalex.org/C111919701",
+                    "wikidata": "https://www.wikidata.org/wiki/Q9135",
+                    "display_name": "Operating system",
+                    "level": 1,
+                    "score": 0
+                }
+            ],
+            "mesh": [
+                {
+                    "descriptor_ui": "D002452",
+                    "descriptor_name": "Cell Count",
+                    "qualifier_ui": "Q000379",
+                    "qualifier_name": "methods",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D007091",
+                    "descriptor_name": "Image Processing, Computer-Assisted",
+                    "qualifier_ui": "Q000379",
+                    "qualifier_name": "methods",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000069550",
+                    "descriptor_name": "Machine Learning",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D009474",
+                    "descriptor_name": "Neurons",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D053001",
+                    "descriptor_name": "Tool Use Behavior",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                }
+            ],
+            "locations_count": 4,
+            "locations": [
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://doi.org/10.1038/s41598-023-34943-w",
+                    "pdf_url": "https://www.nature.com/articles/s41598-023-34943-w.pdf",
+                    "source": {
+                        "id": "https://openalex.org/S196734849",
+                        "display_name": "Scientific reports",
+                        "issn_l": "2045-2322",
+                        "issn": [
+                            "2045-2322"
+                        ],
+                        "is_oa": true,
+                        "is_in_doaj": true,
+                        "is_core": true,
+                        "host_organization": "https://openalex.org/P4310319908",
+                        "host_organization_name": "Nature Portfolio",
+                        "host_organization_lineage": [
+                            "https://openalex.org/P4310319908",
+                            "https://openalex.org/P4310319965"
+                        ],
+                        "host_organization_lineage_names": [
+                            "Nature Portfolio",
+                            "Springer Nature"
+                        ],
+                        "type": "journal"
+                    },
+                    "license": "cc-by",
+                    "license_id": "https://openalex.org/licenses/cc-by",
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10202925",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S2764455111",
+                        "display_name": "PubMed Central",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://doi.org/10.21203/rs.3.rs-1743231/v1",
+                    "pdf_url": "https://www.researchsquare.com/article/rs-1743231/latest.pdf",
+                    "source": null,
+                    "license": "cc-by",
+                    "license_id": "https://openalex.org/licenses/cc-by",
+                    "version": "submittedVersion",
+                    "is_accepted": false,
+                    "is_published": false
+                },
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://pubmed.ncbi.nlm.nih.gov/37217558",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306525036",
+                        "display_name": "PubMed",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1038/s41598-023-34943-w",
+                "pdf_url": "https://www.nature.com/articles/s41598-023-34943-w.pdf",
+                "source": {
+                    "id": "https://openalex.org/S196734849",
+                    "display_name": "Scientific reports",
+                    "issn_l": "2045-2322",
+                    "issn": [
+                        "2045-2322"
+                    ],
+                    "is_oa": true,
+                    "is_in_doaj": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310319908",
+                    "host_organization_name": "Nature Portfolio",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310319908",
+                        "https://openalex.org/P4310319965"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Nature Portfolio",
+                        "Springer Nature"
+                    ],
+                    "type": "journal"
+                },
+                "license": "cc-by",
+                "license_id": "https://openalex.org/licenses/cc-by",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "sustainable_development_goals": [],
+            "grants": [
+                {
+                    "funder": "https://openalex.org/F4320332161",
+                    "funder_display_name": "National Institutes of Health",
+                    "award_id": "R01 MH104131"
+                }
+            ],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 27,
+            "referenced_works": [
+                "https://openalex.org/W1535485604",
+                "https://openalex.org/W1817561967",
+                "https://openalex.org/W1901129140",
+                "https://openalex.org/W1988785687",
+                "https://openalex.org/W2011301426",
+                "https://openalex.org/W2036091553",
+                "https://openalex.org/W2093530590",
+                "https://openalex.org/W2099540110",
+                "https://openalex.org/W2124260943",
+                "https://openalex.org/W2136482257",
+                "https://openalex.org/W2139815913",
+                "https://openalex.org/W2167279371",
+                "https://openalex.org/W2342249984",
+                "https://openalex.org/W2404695164",
+                "https://openalex.org/W2467414813",
+                "https://openalex.org/W2601810315",
+                "https://openalex.org/W2911964244",
+                "https://openalex.org/W2975634117",
+                "https://openalex.org/W2997591727",
+                "https://openalex.org/W3003257820",
+                "https://openalex.org/W3007268491",
+                "https://openalex.org/W3045852227",
+                "https://openalex.org/W3099878876",
+                "https://openalex.org/W3103145119",
+                "https://openalex.org/W3196897371",
+                "https://openalex.org/W3216149514",
+                "https://openalex.org/W4226215591"
+            ],
+            "related_works": [
+                "https://openalex.org/W4383066092",
+                "https://openalex.org/W4375867731",
+                "https://openalex.org/W4304166257",
+                "https://openalex.org/W4294635752",
+                "https://openalex.org/W4230611425",
+                "https://openalex.org/W3215138031",
+                "https://openalex.org/W2731899572",
+                "https://openalex.org/W2611989081",
+                "https://openalex.org/W2097035005",
+                "https://openalex.org/W1522196789"
+            ],
+            "ngrams_url": "https://api.openalex.org/works/W4377292675/ngrams",
+            "abstract_inverted_index": {
+                "Abstract": [
+                    0
+                ],
+                "Counting": [
+                    1,
+                    69
+                ],
+                "cells": [
+                    2,
+                    26,
+                    47,
+                    128
+                ],
+                "is": [
+                    3,
+                    18,
+                    31,
+                    88
+                ],
+                "a": [
+                    4,
+                    63,
+                    91,
+                    130
+                ],
+                "cornerstone": [
+                    5
+                ],
+                "of": [
+                    6,
+                    54,
+                    94,
+                    98,
+                    104,
+                    119
+                ],
+                "tracking": [
+                    7
+                ],
+                "disease": [
+                    8
+                ],
+                "progression": [
+                    9
+                ],
+                "in": [
+                    10,
+                    48,
+                    129
+                ],
+                "neuroscience.": [
+                    11
+                ],
+                "A": [
+                    12
+                ],
+                "common": [
+                    13
+                ],
+                "approach": [
+                    14
+                ],
+                "for": [
+                    15,
+                    76,
+                    136
+                ],
+                "this": [
+                    16
+                ],
+                "process": [
+                    17
+                ],
+                "having": [
+                    19
+                ],
+                "trained": [
+                    20
+                ],
+                "researchers": [
+                    21
+                ],
+                "individually": [
+                    22
+                ],
+                "select": [
+                    23
+                ],
+                "and": [
+                    24,
+                    52,
+                    100
+                ],
+                "count": [
+                    25,
+                    46
+                ],
+                "within": [
+                    27
+                ],
+                "an": [
+                    28,
+                    101,
+                    122
+                ],
+                "image,": [
+                    29
+                ],
+                "which": [
+                    30,
+                    74
+                ],
+                "not": [
+                    32
+                ],
+                "only": [
+                    33
+                ],
+                "difficult": [
+                    34
+                ],
+                "to": [
+                    35,
+                    44,
+                    115,
+                    125
+                ],
+                "standardize": [
+                    36
+                ],
+                "but": [
+                    37
+                ],
+                "also": [
+                    38
+                ],
+                "very": [
+                    39
+                ],
+                "time-consuming.": [
+                    40
+                ],
+                "While": [
+                    41
+                ],
+                "tools": [
+                    42,
+                    56
+                ],
+                "exist": [
+                    43
+                ],
+                "automatically": [
+                    45,
+                    126
+                ],
+                "images,": [
+                    49
+                ],
+                "the": [
+                    50,
+                    117,
+                    134
+                ],
+                "accuracy": [
+                    51
+                ],
+                "accessibility": [
+                    53
+                ],
+                "such": [
+                    55
+                ],
+                "can": [
+                    57
+                ],
+                "be": [
+                    58
+                ],
+                "improved.": [
+                    59
+                ],
+                "Thus,": [
+                    60
+                ],
+                "we": [
+                    61
+                ],
+                "introduce": [
+                    62
+                ],
+                "novel": [
+                    64
+                ],
+                "tool": [
+                    65
+                ],
+                "ACCT:": [
+                    66
+                ],
+                "Automatic": [
+                    67
+                ],
+                "Cell": [
+                    68
+                ],
+                "with": [
+                    70,
+                    90
+                ],
+                "Trainable": [
+                    71
+                ],
+                "Weka": [
+                    72
+                ],
+                "Segmentation": [
+                    73
+                ],
+                "allows": [
+                    75
+                ],
+                "flexible": [
+                    77
+                ],
+                "automatic": [
+                    78
+                ],
+                "cell": [
+                    79
+                ],
+                "counting": [
+                    80
+                ],
+                "via": [
+                    81
+                ],
+                "object": [
+                    82
+                ],
+                "segmentation": [
+                    83
+                ],
+                "after": [
+                    84
+                ],
+                "user-driven": [
+                    85
+                ],
+                "training.": [
+                    86
+                ],
+                "ACCT": [
+                    87,
+                    120
+                ],
+                "demonstrated": [
+                    89
+                ],
+                "comparative": [
+                    92
+                ],
+                "analysis": [
+                    93
+                ],
+                "publicly": [
+                    95
+                ],
+                "available": [
+                    96
+                ],
+                "images": [
+                    97
+                ],
+                "neurons": [
+                    99
+                ],
+                "in-house": [
+                    102
+                ],
+                "dataset": [
+                    103
+                ],
+                "immunofluorescence-stained": [
+                    105
+                ],
+                "microglia": [
+                    106
+                ],
+                "cells.": [
+                    107
+                ],
+                "For": [
+                    108
+                ],
+                "comparison,": [
+                    109
+                ],
+                "both": [
+                    110
+                ],
+                "datasets": [
+                    111
+                ],
+                "were": [
+                    112
+                ],
+                "manually": [
+                    113
+                ],
+                "counted": [
+                    114
+                ],
+                "demonstrate": [
+                    116
+                ],
+                "applicability": [
+                    118
+                ],
+                "as": [
+                    121
+                ],
+                "accessible": [
+                    123
+                ],
+                "means": [
+                    124
+                ],
+                "quantify": [
+                    127
+                ],
+                "precise": [
+                    131
+                ],
+                "manner": [
+                    132
+                ],
+                "without": [
+                    133
+                ],
+                "need": [
+                    135
+                ],
+                "computing": [
+                    137
+                ],
+                "clusters": [
+                    138
+                ],
+                "or": [
+                    139
+                ],
+                "advanced": [
+                    140
+                ],
+                "data": [
+                    141
+                ],
+                "preparation.": [
+                    142
+                ]
+            },
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W4377292675",
+            "counts_by_year": [
+                {
+                    "year": 2024,
+                    "cited_by_count": 3
+                },
+                {
+                    "year": 2023,
+                    "cited_by_count": 1
+                }
+            ],
+            "updated_date": "2024-07-19T04:16:11.636605",
+            "created_date": "2023-05-23"
+        },
+        {
+            "id": "https://openalex.org/W2949138467",
+            "doi": "https://doi.org/10.1371/journal.pone.0218670",
+            "title": "Phosphodiesterase 4D, miR-203 and selected cytokines in the peripheral blood are associated with canine atopic dermatitis",
+            "display_name": "Phosphodiesterase 4D, miR-203 and selected cytokines in the peripheral blood are associated with canine atopic dermatitis",
+            "publication_year": 2019,
+            "publication_date": "2019-06-21",
+            "ids": {
+                "openalex": "https://openalex.org/W2949138467",
+                "doi": "https://doi.org/10.1371/journal.pone.0218670",
+                "mag": "2949138467",
+                "pmid": "https://pubmed.ncbi.nlm.nih.gov/31226136",
+                "pmcid": "https://www.ncbi.nlm.nih.gov/pmc/articles/6588236"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1371/journal.pone.0218670",
+                "pdf_url": null,
+                "source": {
+                    "id": "https://openalex.org/S202381698",
+                    "display_name": "PloS one",
+                    "issn_l": "1932-6203",
+                    "issn": [
+                        "1932-6203"
+                    ],
+                    "is_oa": true,
+                    "is_in_doaj": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310315706",
+                    "host_organization_name": "Public Library of Science",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310315706"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Public Library of Science"
+                    ],
+                    "type": "journal"
+                },
+                "license": "cc-by",
+                "license_id": "https://openalex.org/licenses/cc-by",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "type": "article",
+            "type_crossref": "journal-article",
+            "indexed_in": [
+                "crossref",
+                "doaj",
+                "pubmed"
+            ],
+            "open_access": {
+                "is_oa": true,
+                "oa_status": "gold",
+                "oa_url": "https://doi.org/10.1371/journal.pone.0218670",
+                "any_repository_has_fulltext": true
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5081987607",
+                        "display_name": "Jeffrey Koury",
+                        "orcid": "https://orcid.org/0000-0002-7368-4891"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Jeffrey Koury",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, California, United States of America"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, California, United States of America",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5014030056",
+                        "display_name": "Ana M. Ramírez",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I98947143",
+                            "display_name": "California State Polytechnic University",
+                            "ror": "https://ror.org/05by5hm18",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I98947143"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Ana Ramirez",
+                    "raw_affiliation_strings": [
+                        "College of Science, California State Polytechnic University, Pomona, California, United States of America"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "College of Science, California State Polytechnic University, Pomona, California, United States of America",
+                            "institution_ids": [
+                                "https://openalex.org/I98947143"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5059224542",
+                        "display_name": "Chen Xie",
+                        "orcid": "https://orcid.org/0000-0002-0912-9543"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Chen Xie",
+                    "raw_affiliation_strings": [
+                        "College of Veterinary Medicine, Western University of Health Sciences, Pomona, California, United States of America"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "College of Veterinary Medicine, Western University of Health Sciences, Pomona, California, United States of America",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5027956121",
+                        "display_name": "Jerry Harb",
+                        "orcid": "https://orcid.org/0000-0001-5457-6564"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Jerry Harb",
+                    "raw_affiliation_strings": [
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, California, United States of America"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, California, United States of America",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5084329497",
+                        "display_name": "Charli Dong",
+                        "orcid": null
+                    },
+                    "institutions": [],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Charli Dong",
+                    "raw_affiliation_strings": [
+                        "Animal Dermatology Clinic, Pasadena, California, United States of America"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Animal Dermatology Clinic, Pasadena, California, United States of America",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5038461927",
+                        "display_name": "Chad B. Maki",
+                        "orcid": null
+                    },
+                    "institutions": [],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Chad Maki",
+                    "raw_affiliation_strings": [
+                        "VetCell Therapeutics, Santa Ana, California, United States of America"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "VetCell Therapeutics, Santa Ana, California, United States of America",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5061933968",
+                        "display_name": "Tom Ramos",
+                        "orcid": null
+                    },
+                    "institutions": [],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Tom Ramos",
+                    "raw_affiliation_strings": [
+                        "VetCell Therapeutics, Santa Ana, California, United States of America"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "VetCell Therapeutics, Santa Ana, California, United States of America",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5090786513",
+                        "display_name": "Fari Izadyar",
+                        "orcid": null
+                    },
+                    "institutions": [],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Fari Izadyar",
+                    "raw_affiliation_strings": [
+                        "VetCell Therapeutics, Santa Ana, California, United States of America"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "VetCell Therapeutics, Santa Ana, California, United States of America",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5103693666",
+                        "display_name": "David L. Clark",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "David Clark",
+                    "raw_affiliation_strings": [
+                        "College of Veterinary Medicine, Western University of Health Sciences, Pomona, California, United States of America"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "College of Veterinary Medicine, Western University of Health Sciences, Pomona, California, United States of America",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5089451869",
+                        "display_name": "Yvonne Drechsler",
+                        "orcid": "https://orcid.org/0000-0001-6923-8509"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Yvonne Drechsler",
+                    "raw_affiliation_strings": [
+                        "College of Veterinary Medicine, Western University of Health Sciences, Pomona, California, United States of America"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "College of Veterinary Medicine, Western University of Health Sciences, Pomona, California, United States of America",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5088210385",
+                        "display_name": "Gagandeep Kaur",
+                        "orcid": "https://orcid.org/0000-0002-6651-5547"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Gagandeep Kaur",
+                    "raw_affiliation_strings": [
+                        "College of Veterinary Medicine, Western University of Health Sciences, Pomona, California, United States of America"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "College of Veterinary Medicine, Western University of Health Sciences, Pomona, California, United States of America",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "last",
+                    "author": {
+                        "id": "https://openalex.org/A5046138088",
+                        "display_name": "Jijun Hao",
+                        "orcid": "https://orcid.org/0000-0002-6769-9069"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I93393672",
+                            "display_name": "Western University of Health Sciences",
+                            "ror": "https://ror.org/05167c961",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Jijun Hao",
+                    "raw_affiliation_strings": [
+                        "College of Veterinary Medicine, Western University of Health Sciences, Pomona, California, United States of America",
+                        "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, California, United States of America"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "College of Veterinary Medicine, Western University of Health Sciences, Pomona, California, United States of America",
+                            "institution_ids": [
+                                "https://openalex.org/I93393672"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Graduate College of Biomedical Sciences, Western University of Health Sciences, Pomona, California, United States of America",
+                            "institution_ids": []
+                        }
+                    ]
+                }
+            ],
+            "countries_distinct_count": 1,
+            "institutions_distinct_count": 2,
+            "corresponding_author_ids": [
+                "https://openalex.org/A5081987607",
+                "https://openalex.org/A5014030056",
+                "https://openalex.org/A5059224542",
+                "https://openalex.org/A5027956121",
+                "https://openalex.org/A5084329497",
+                "https://openalex.org/A5038461927",
+                "https://openalex.org/A5061933968",
+                "https://openalex.org/A5090786513",
+                "https://openalex.org/A5103693666",
+                "https://openalex.org/A5089451869",
+                "https://openalex.org/A5088210385",
+                "https://openalex.org/A5046138088"
+            ],
+            "corresponding_institution_ids": [
+                "https://openalex.org/I93393672",
+                "https://openalex.org/I98947143",
+                "https://openalex.org/I93393672",
+                "https://openalex.org/I93393672",
+                "https://openalex.org/I93393672",
+                "https://openalex.org/I93393672",
+                "https://openalex.org/I93393672",
+                "https://openalex.org/I93393672"
+            ],
+            "apc_list": {
+                "value": 1805,
+                "currency": "USD",
+                "value_usd": 1805,
+                "provenance": "doaj"
+            },
+            "apc_paid": {
+                "value": 1805,
+                "currency": "USD",
+                "value_usd": 1805,
+                "provenance": "doaj"
+            },
+            "fwci": 2.374,
+            "has_fulltext": true,
+            "fulltext_origin": "ngrams",
+            "cited_by_count": 18,
+            "cited_by_percentile_year": {
+                "min": 91,
+                "max": 92
+            },
+            "biblio": {
+                "volume": "14",
+                "issue": "6",
+                "first_page": "e0218670",
+                "last_page": "e0218670"
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T10837",
+                "display_name": "Atopic Dermatitis and Skin Microbiome",
+                "score": 0.9983,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/2708",
+                    "display_name": "Dermatology"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/27",
+                    "display_name": "Medicine"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/4",
+                    "display_name": "Health Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T10837",
+                    "display_name": "Atopic Dermatitis and Skin Microbiome",
+                    "score": 0.9983,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2708",
+                        "display_name": "Dermatology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11346",
+                    "display_name": "Role of Mast Cells in Immunoregulation and Disease",
+                    "score": 0.9976,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2403",
+                        "display_name": "Immunology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/24",
+                        "display_name": "Immunology and Microbiology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T10051",
+                    "display_name": "Asthma",
+                    "score": 0.9935,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2737",
+                        "display_name": "Physiology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/allergic-diseases",
+                    "display_name": "Allergic Diseases",
+                    "score": 0.440055
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C2778329239",
+                    "wikidata": "https://www.wikidata.org/wiki/Q268667",
+                    "display_name": "Atopic dermatitis",
+                    "level": 2,
+                    "score": 0.7718816
+                },
+                {
+                    "id": "https://openalex.org/C71924100",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11190",
+                    "display_name": "Medicine",
+                    "level": 0,
+                    "score": 0.7675422
+                },
+                {
+                    "id": "https://openalex.org/C137061746",
+                    "wikidata": "https://www.wikidata.org/wiki/Q736033",
+                    "display_name": "Peripheral blood mononuclear cell",
+                    "level": 3,
+                    "score": 0.6776698
+                },
+                {
+                    "id": "https://openalex.org/C203014093",
+                    "wikidata": "https://www.wikidata.org/wiki/Q101929",
+                    "display_name": "Immunology",
+                    "level": 1,
+                    "score": 0.6019823
+                },
+                {
+                    "id": "https://openalex.org/C207480886",
+                    "wikidata": "https://www.wikidata.org/wiki/Q42982",
+                    "display_name": "Allergy",
+                    "level": 2,
+                    "score": 0.5262334
+                },
+                {
+                    "id": "https://openalex.org/C67636389",
+                    "wikidata": "https://www.wikidata.org/wiki/Q784237",
+                    "display_name": "Genetic predisposition",
+                    "level": 3,
+                    "score": 0.45692065
+                },
+                {
+                    "id": "https://openalex.org/C8891405",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1059",
+                    "display_name": "Immune system",
+                    "level": 2,
+                    "score": 0.45270205
+                },
+                {
+                    "id": "https://openalex.org/C167672396",
+                    "wikidata": "https://www.wikidata.org/wiki/Q417800",
+                    "display_name": "CD8",
+                    "level": 3,
+                    "score": 0.419749
+                },
+                {
+                    "id": "https://openalex.org/C2776217527",
+                    "wikidata": "https://www.wikidata.org/wiki/Q944828",
+                    "display_name": "Sensitization",
+                    "level": 2,
+                    "score": 0.4132089
+                },
+                {
+                    "id": "https://openalex.org/C2779134260",
+                    "wikidata": "https://www.wikidata.org/wiki/Q12136",
+                    "display_name": "Disease",
+                    "level": 2,
+                    "score": 0.33825684
+                },
+                {
+                    "id": "https://openalex.org/C126322002",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11180",
+                    "display_name": "Internal medicine",
+                    "level": 1,
+                    "score": 0.30549335
+                },
+                {
+                    "id": "https://openalex.org/C86803240",
+                    "wikidata": "https://www.wikidata.org/wiki/Q420",
+                    "display_name": "Biology",
+                    "level": 0,
+                    "score": 0.10755387
+                },
+                {
+                    "id": "https://openalex.org/C55493867",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7094",
+                    "display_name": "Biochemistry",
+                    "level": 1,
+                    "score": 0
+                },
+                {
+                    "id": "https://openalex.org/C202751555",
+                    "wikidata": "https://www.wikidata.org/wiki/Q221681",
+                    "display_name": "In vitro",
+                    "level": 2,
+                    "score": 0
+                }
+            ],
+            "mesh": [
+                {
+                    "descriptor_ui": "D015415",
+                    "descriptor_name": "Biomarkers",
+                    "qualifier_ui": "Q000097",
+                    "qualifier_name": "blood",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D054703",
+                    "descriptor_name": "Cyclic Nucleotide Phosphodiesterases, Type 4",
+                    "qualifier_ui": "Q000097",
+                    "qualifier_name": "blood",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D016207",
+                    "descriptor_name": "Cytokines",
+                    "qualifier_ui": "Q000097",
+                    "qualifier_name": "blood",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D003876",
+                    "descriptor_name": "Dermatitis, Atopic",
+                    "qualifier_ui": "Q000097",
+                    "qualifier_name": "blood",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D004283",
+                    "descriptor_name": "Dog Diseases",
+                    "qualifier_ui": "Q000097",
+                    "qualifier_name": "blood",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D035683",
+                    "descriptor_name": "MicroRNAs",
+                    "qualifier_ui": "Q000097",
+                    "qualifier_name": "blood",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D000818",
+                    "descriptor_name": "Animals",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D015415",
+                    "descriptor_name": "Biomarkers",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D016022",
+                    "descriptor_name": "Case-Control Studies",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D054703",
+                    "descriptor_name": "Cyclic Nucleotide Phosphodiesterases, Type 4",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D016207",
+                    "descriptor_name": "Cytokines",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D003876",
+                    "descriptor_name": "Dermatitis, Atopic",
+                    "qualifier_ui": "Q000235",
+                    "qualifier_name": "genetics",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D003876",
+                    "descriptor_name": "Dermatitis, Atopic",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D004283",
+                    "descriptor_name": "Dog Diseases",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D004283",
+                    "descriptor_name": "Dog Diseases",
+                    "qualifier_ui": "Q000235",
+                    "qualifier_name": "genetics",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D004285",
+                    "descriptor_name": "Dogs",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D005260",
+                    "descriptor_name": "Female",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D020869",
+                    "descriptor_name": "Gene Expression Profiling",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D007963",
+                    "descriptor_name": "Leukocytes, Mononuclear",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D007963",
+                    "descriptor_name": "Leukocytes, Mononuclear",
+                    "qualifier_ui": "Q000378",
+                    "qualifier_name": "metabolism",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D007963",
+                    "descriptor_name": "Leukocytes, Mononuclear",
+                    "qualifier_ui": "Q000737",
+                    "qualifier_name": "chemistry",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D008297",
+                    "descriptor_name": "Male",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D035683",
+                    "descriptor_name": "MicroRNAs",
+                    "qualifier_ui": "Q000235",
+                    "qualifier_name": "genetics",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D035683",
+                    "descriptor_name": "MicroRNAs",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                }
+            ],
+            "locations_count": 5,
+            "locations": [
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://doi.org/10.1371/journal.pone.0218670",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S202381698",
+                        "display_name": "PloS one",
+                        "issn_l": "1932-6203",
+                        "issn": [
+                            "1932-6203"
+                        ],
+                        "is_oa": true,
+                        "is_in_doaj": true,
+                        "is_core": true,
+                        "host_organization": "https://openalex.org/P4310315706",
+                        "host_organization_name": "Public Library of Science",
+                        "host_organization_lineage": [
+                            "https://openalex.org/P4310315706"
+                        ],
+                        "host_organization_lineage_names": [
+                            "Public Library of Science"
+                        ],
+                        "type": "journal"
+                    },
+                    "license": "cc-by",
+                    "license_id": "https://openalex.org/licenses/cc-by",
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://doaj.org/article/da98824e7a1a463887dcc9724af81406",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306401280",
+                        "display_name": "DOAJ (DOAJ: Directory of Open Access Journals)",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": null,
+                        "host_organization_name": null,
+                        "host_organization_lineage": [],
+                        "host_organization_lineage_names": [],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://europepmc.org/articles/pmc6588236",
+                    "pdf_url": "https://europepmc.org/articles/pmc6588236?pdf=render",
+                    "source": {
+                        "id": "https://openalex.org/S4306400806",
+                        "display_name": "Europe PMC (PubMed Central)",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1303153112",
+                        "host_organization_name": "European Bioinformatics Institute",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1303153112"
+                        ],
+                        "host_organization_lineage_names": [
+                            "European Bioinformatics Institute"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": "cc-by",
+                    "license_id": "https://openalex.org/licenses/cc-by",
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6588236",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S2764455111",
+                        "display_name": "PubMed Central",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://pubmed.ncbi.nlm.nih.gov/31226136",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306525036",
+                        "display_name": "PubMed",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1371/journal.pone.0218670",
+                "pdf_url": null,
+                "source": {
+                    "id": "https://openalex.org/S202381698",
+                    "display_name": "PloS one",
+                    "issn_l": "1932-6203",
+                    "issn": [
+                        "1932-6203"
+                    ],
+                    "is_oa": true,
+                    "is_in_doaj": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310315706",
+                    "host_organization_name": "Public Library of Science",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310315706"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Public Library of Science"
+                    ],
+                    "type": "journal"
+                },
+                "license": "cc-by",
+                "license_id": "https://openalex.org/licenses/cc-by",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "sustainable_development_goals": [
+                {
+                    "id": "https://metadata.un.org/sdg/3",
+                    "display_name": "Good health and well-being",
+                    "score": 0.52
+                }
+            ],
+            "grants": [],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 52,
+            "referenced_works": [
+                "https://openalex.org/W1504621077",
+                "https://openalex.org/W1914347682",
+                "https://openalex.org/W1941136997",
+                "https://openalex.org/W1946930161",
+                "https://openalex.org/W1972029787",
+                "https://openalex.org/W1982292637",
+                "https://openalex.org/W1983822796",
+                "https://openalex.org/W1988863516",
+                "https://openalex.org/W1991320836",
+                "https://openalex.org/W1994226794",
+                "https://openalex.org/W1996670699",
+                "https://openalex.org/W1997277329",
+                "https://openalex.org/W1998439798",
+                "https://openalex.org/W2000934648",
+                "https://openalex.org/W2006777790",
+                "https://openalex.org/W2007571390",
+                "https://openalex.org/W2009138937",
+                "https://openalex.org/W2009645092",
+                "https://openalex.org/W2010207650",
+                "https://openalex.org/W2012158702",
+                "https://openalex.org/W2015866581",
+                "https://openalex.org/W2016943253",
+                "https://openalex.org/W2029299795",
+                "https://openalex.org/W2046593555",
+                "https://openalex.org/W2056551327",
+                "https://openalex.org/W2069443154",
+                "https://openalex.org/W2082851150",
+                "https://openalex.org/W2084711279",
+                "https://openalex.org/W2087384773",
+                "https://openalex.org/W2089432886",
+                "https://openalex.org/W2092018614",
+                "https://openalex.org/W2100467573",
+                "https://openalex.org/W2117410237",
+                "https://openalex.org/W2117983771",
+                "https://openalex.org/W2120922998",
+                "https://openalex.org/W2123846748",
+                "https://openalex.org/W2139133242",
+                "https://openalex.org/W2193571202",
+                "https://openalex.org/W2203837633",
+                "https://openalex.org/W2278078807",
+                "https://openalex.org/W2397614262",
+                "https://openalex.org/W2409262956",
+                "https://openalex.org/W2415052762",
+                "https://openalex.org/W2471976905",
+                "https://openalex.org/W2473541542",
+                "https://openalex.org/W2510623842",
+                "https://openalex.org/W2724375169",
+                "https://openalex.org/W2738844374",
+                "https://openalex.org/W2763871174",
+                "https://openalex.org/W2790421467",
+                "https://openalex.org/W2794174069",
+                "https://openalex.org/W4211026773"
+            ],
+            "related_works": [
+                "https://openalex.org/W4321018639",
+                "https://openalex.org/W4220817159",
+                "https://openalex.org/W3167826726",
+                "https://openalex.org/W2980804201",
+                "https://openalex.org/W2620852772",
+                "https://openalex.org/W257745813",
+                "https://openalex.org/W229479006",
+                "https://openalex.org/W2137605400",
+                "https://openalex.org/W2094668679",
+                "https://openalex.org/W2009436399"
+            ],
+            "ngrams_url": "https://api.openalex.org/works/W2949138467/ngrams",
+            "abstract_inverted_index": {
+                "Canine": [
+                    0
+                ],
+                "Atopic": [
+                    1
+                ],
+                "Dermatitis": [
+                    2
+                ],
+                "(AD)": [
+                    3
+                ],
+                "is": [
+                    4
+                ],
+                "a": [
+                    5,
+                    32,
+                    129,
+                    137,
+                    151,
+                    192
+                ],
+                "common": [
+                    6
+                ],
+                "complex": [
+                    7
+                ],
+                "and": [
+                    8,
+                    21,
+                    41,
+                    76,
+                    86,
+                    114,
+                    146,
+                    178
+                ],
+                "multifactorial": [
+                    9
+                ],
+                "disease": [
+                    10
+                ],
+                "involving": [
+                    11
+                ],
+                "immune": [
+                    12
+                ],
+                "dysregulation,": [
+                    13
+                ],
+                "genetic": [
+                    14
+                ],
+                "predisposition,": [
+                    15
+                ],
+                "skin": [
+                    16
+                ],
+                "barrier": [
+                    17
+                ],
+                "defects,": [
+                    18
+                ],
+                "environmental": [
+                    19
+                ],
+                "factors": [
+                    20
+                ],
+                "allergic": [
+                    22
+                ],
+                "sensitization.": [
+                    23
+                ],
+                "To": [
+                    24
+                ],
+                "date,": [
+                    25
+                ],
+                "diagnosis": [
+                    26
+                ],
+                "of": [
+                    27,
+                    34,
+                    63,
+                    73,
+                    103,
+                    133,
+                    140,
+                    153,
+                    156,
+                    175,
+                    185
+                ],
+                "canine": [
+                    28,
+                    176,
+                    189
+                ],
+                "AD": [
+                    29,
+                    53,
+                    74,
+                    119,
+                    159,
+                    190
+                ],
+                "relies": [
+                    30
+                ],
+                "on": [
+                    31
+                ],
+                "combination": [
+                    33
+                ],
+                "patient": [
+                    35
+                ],
+                "history,": [
+                    36
+                ],
+                "clinical": [
+                    37,
+                    59
+                ],
+                "examination,": [
+                    38
+                ],
+                "allergy": [
+                    39
+                ],
+                "testing": [
+                    40
+                ],
+                "response": [
+                    42
+                ],
+                "to": [
+                    43,
+                    51,
+                    65,
+                    122,
+                    163,
+                    181
+                ],
+                "diet": [
+                    44
+                ],
+                "trials/therapies": [
+                    45
+                ],
+                "with": [
+                    46,
+                    57,
+                    82
+                ],
+                "no": [
+                    47
+                ],
+                "reliable": [
+                    48
+                ],
+                "biomarkers": [
+                    49,
+                    68
+                ],
+                "available": [
+                    50
+                ],
+                "distinguish": [
+                    52
+                ],
+                "from": [
+                    54,
+                    118
+                ],
+                "other": [
+                    55
+                ],
+                "diseases": [
+                    56
+                ],
+                "similar": [
+                    58
+                ],
+                "presentations.": [
+                    60
+                ],
+                "A": [
+                    61
+                ],
+                "handful": [
+                    62
+                ],
+                "studies": [
+                    64,
+                    180
+                ],
+                "identify": [
+                    66
+                ],
+                "potential": [
+                    67
+                ],
+                "in": [
+                    69,
+                    101,
+                    108,
+                    116,
+                    158,
+                    161
+                ],
+                "the": [
+                    70,
+                    94,
+                    134,
+                    164,
+                    173,
+                    183
+                ],
+                "peripheral": [
+                    71,
+                    109
+                ],
+                "blood": [
+                    72,
+                    110
+                ],
+                "dogs": [
+                    75,
+                    120,
+                    160
+                ],
+                "healthy": [
+                    77,
+                    123,
+                    165
+                ],
+                "controls": [
+                    78
+                ],
+                "have": [
+                    79
+                ],
+                "been": [
+                    80
+                ],
+                "performed": [
+                    81
+                ],
+                "some": [
+                    83
+                ],
+                "showing": [
+                    84
+                ],
+                "inconsistent": [
+                    85
+                ],
+                "contradictory": [
+                    87
+                ],
+                "results.": [
+                    88
+                ],
+                "In": [
+                    89,
+                    125
+                ],
+                "this": [
+                    90
+                ],
+                "study,": [
+                    91
+                ],
+                "we,": [
+                    92
+                ],
+                "for": [
+                    93,
+                    188
+                ],
+                "first": [
+                    95
+                ],
+                "time,": [
+                    96
+                ],
+                "report": [
+                    97,
+                    128
+                ],
+                "statistically": [
+                    98,
+                    130
+                ],
+                "significant": [
+                    99
+                ],
+                "increases": [
+                    100
+                ],
+                "expression": [
+                    102,
+                    155
+                ],
+                "phosphodiesterase": [
+                    104
+                ],
+                "4D": [
+                    105
+                ],
+                "(PDE4D)": [
+                    106
+                ],
+                "gene": [
+                    107,
+                    142
+                ],
+                "mononuclear": [
+                    111
+                ],
+                "cells": [
+                    112
+                ],
+                "(PBMCs)": [
+                    113
+                ],
+                "miR-203": [
+                    115
+                ],
+                "plasma": [
+                    117
+                ],
+                "compared": [
+                    121
+                ],
+                "controls.": [
+                    124,
+                    166
+                ],
+                "addition,": [
+                    126
+                ],
+                "we": [
+                    127
+                ],
+                "non-significant": [
+                    131
+                ],
+                "change": [
+                    132
+                ],
+                "CD4+/CD8+": [
+                    135
+                ],
+                "ratio,": [
+                    136
+                ],
+                "dramatic": [
+                    138
+                ],
+                "decrease": [
+                    139
+                ],
+                "three": [
+                    141
+                ],
+                "markers": [
+                    143
+                ],
+                "(PIAS1,": [
+                    144
+                ],
+                "RORA": [
+                    145
+                ],
+                "SH2B1)": [
+                    147
+                ],
+                "as": [
+                    148,
+                    150
+                ],
+                "well": [
+                    149
+                ],
+                "panel": [
+                    152
+                ],
+                "differential": [
+                    154
+                ],
+                "cytokines": [
+                    157
+                ],
+                "comparison": [
+                    162
+                ],
+                "Our": [
+                    167
+                ],
+                "study": [
+                    168
+                ],
+                "provides": [
+                    169
+                ],
+                "important": [
+                    170
+                ],
+                "insight": [
+                    171
+                ],
+                "into": [
+                    172
+                ],
+                "complexities": [
+                    174
+                ],
+                "AD,": [
+                    177
+                ],
+                "further": [
+                    179
+                ],
+                "verify": [
+                    182
+                ],
+                "specificity": [
+                    184
+                ],
+                "these": [
+                    186
+                ],
+                "findings": [
+                    187
+                ],
+                "at": [
+                    191
+                ],
+                "larger-scale": [
+                    193
+                ],
+                "are": [
+                    194
+                ],
+                "warranted.": [
+                    195
+                ]
+            },
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W2949138467",
+            "counts_by_year": [
+                {
+                    "year": 2024,
+                    "cited_by_count": 2
+                },
+                {
+                    "year": 2023,
+                    "cited_by_count": 5
+                },
+                {
+                    "year": 2022,
+                    "cited_by_count": 5
+                },
+                {
+                    "year": 2021,
+                    "cited_by_count": 5
+                },
+                {
+                    "year": 2020,
+                    "cited_by_count": 1
+                }
+            ],
+            "updated_date": "2024-07-22T13:42:50.825170",
+            "created_date": "2019-06-27"
+        },
+        {
+            "id": "https://openalex.org/W4391775041",
+            "doi": "https://doi.org/10.1016/j.bbi.2024.02.014",
+            "title": "Interferon-β deficiency alters brain response to chronic HIV-1 envelope protein exposure in a transgenic model of NeuroHIV",
+            "display_name": "Interferon-β deficiency alters brain response to chronic HIV-1 envelope protein exposure in a transgenic model of NeuroHIV",
+            "publication_year": 2024,
+            "publication_date": "2024-02-01",
+            "ids": {
+                "openalex": "https://openalex.org/W4391775041",
+                "doi": "https://doi.org/10.1016/j.bbi.2024.02.014",
+                "pmid": "https://pubmed.ncbi.nlm.nih.gov/38360376"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1016/j.bbi.2024.02.014",
+                "pdf_url": null,
+                "source": {
+                    "id": "https://openalex.org/S102243518",
+                    "display_name": "Brain Behavior and Immunity",
+                    "issn_l": "0889-1591",
+                    "issn": [
+                        "0889-1591",
+                        "1090-2139"
+                    ],
+                    "is_oa": false,
+                    "is_in_doaj": false,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310320990",
+                    "host_organization_name": "Elsevier BV",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310320990"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Elsevier BV"
+                    ],
+                    "type": "journal"
+                },
+                "license": "cc-by",
+                "license_id": "https://openalex.org/licenses/cc-by",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "type": "article",
+            "type_crossref": "journal-article",
+            "indexed_in": [
+                "crossref",
+                "pubmed"
+            ],
+            "open_access": {
+                "is_oa": true,
+                "oa_status": "hybrid",
+                "oa_url": "https://doi.org/10.1016/j.bbi.2024.02.014",
+                "any_repository_has_fulltext": true
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5055840064",
+                        "display_name": "Hina Singh",
+                        "orcid": "https://orcid.org/0000-0001-7067-1991"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I2799424032",
+                            "display_name": "Discovery Institute",
+                            "ror": "https://ror.org/05t8s3y29",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I2799424032"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I188891513",
+                            "display_name": "Sanford Burnham Prebys Medical Discovery Institute",
+                            "ror": "https://ror.org/03m1g2s55",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I188891513"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Hina Singh",
+                    "raw_affiliation_strings": [
+                        "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA, 92521, USA",
+                        "Infection and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, La Jolla, CA 92037, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Infection and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, La Jolla, CA 92037, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I2799424032",
+                                "https://openalex.org/I188891513"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA, 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5081987607",
+                        "display_name": "Jeffrey Koury",
+                        "orcid": "https://orcid.org/0000-0002-7368-4891"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jeffrey Koury",
+                    "raw_affiliation_strings": [
+                        "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA, 92521, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA, 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5085498045",
+                        "display_name": "Ricky Maung",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I2799424032",
+                            "display_name": "Discovery Institute",
+                            "ror": "https://ror.org/05t8s3y29",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I2799424032"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I188891513",
+                            "display_name": "Sanford Burnham Prebys Medical Discovery Institute",
+                            "ror": "https://ror.org/03m1g2s55",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I188891513"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Ricky Maung",
+                    "raw_affiliation_strings": [
+                        "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA, 92521, USA",
+                        "Infection and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, La Jolla, CA 92037, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA, 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Infection and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, La Jolla, CA 92037, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I2799424032",
+                                "https://openalex.org/I188891513"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5101840977",
+                        "display_name": "Amanda J. Roberts",
+                        "orcid": "https://orcid.org/0000-0002-4044-8884"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I123431417",
+                            "display_name": "Scripps Research Institute",
+                            "ror": "https://ror.org/02dxx6824",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I123431417"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Amanda J. Roberts",
+                    "raw_affiliation_strings": [
+                        "Animal Models Core, The Scripps Research Institute, 10550 North Torrey Pines Road, MB6, La Jolla, CA 92037, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Animal Models Core, The Scripps Research Institute, 10550 North Torrey Pines Road, MB6, La Jolla, CA 92037, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I123431417"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "last",
+                    "author": {
+                        "id": "https://openalex.org/A5072837198",
+                        "display_name": "Marcus Kaul",
+                        "orcid": "https://orcid.org/0000-0003-3202-670X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I2799424032",
+                            "display_name": "Discovery Institute",
+                            "ror": "https://ror.org/05t8s3y29",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I2799424032"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I188891513",
+                            "display_name": "Sanford Burnham Prebys Medical Discovery Institute",
+                            "ror": "https://ror.org/03m1g2s55",
+                            "country_code": "US",
+                            "type": "nonprofit",
+                            "lineage": [
+                                "https://openalex.org/I188891513"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Marcus Kaul",
+                    "raw_affiliation_strings": [
+                        "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA, 92521, USA",
+                        "Infection and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, La Jolla, CA 92037, USA"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Infection and Inflammatory Disease Center, Sanford Burnham Prebys Medical Discovery Institute, La Jolla, CA 92037, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I2799424032",
+                                "https://openalex.org/I188891513"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Division of Biomedical Sciences, School of Medicine, University of California, Riverside, 900 University Ave, Riverside, CA, 92521, USA",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "countries_distinct_count": 1,
+            "institutions_distinct_count": 4,
+            "corresponding_author_ids": [
+                "https://openalex.org/A5072837198"
+            ],
+            "corresponding_institution_ids": [
+                "https://openalex.org/I2799424032",
+                "https://openalex.org/I188891513",
+                "https://openalex.org/I103635307"
+            ],
+            "apc_list": {
+                "value": 4480,
+                "currency": "USD",
+                "value_usd": 4480,
+                "provenance": "doaj"
+            },
+            "apc_paid": {
+                "value": 4480,
+                "currency": "USD",
+                "value_usd": 4480,
+                "provenance": "doaj"
+            },
+            "fwci": 0,
+            "has_fulltext": true,
+            "fulltext_origin": "pdf",
+            "cited_by_count": 0,
+            "cited_by_percentile_year": {
+                "min": 0,
+                "max": 88
+            },
+            "biblio": {
+                "volume": null,
+                "issue": null,
+                "first_page": null,
+                "last_page": null
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T10112",
+                "display_name": "Human Immunodeficiency Virus/Acquired Immunodeficiency Syndrome",
+                "score": 0.9998,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/2406",
+                    "display_name": "Virology"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/24",
+                    "display_name": "Immunology and Microbiology"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/1",
+                    "display_name": "Life Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T10112",
+                    "display_name": "Human Immunodeficiency Virus/Acquired Immunodeficiency Syndrome",
+                    "score": 0.9998,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2406",
+                        "display_name": "Virology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/24",
+                        "display_name": "Immunology and Microbiology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11266",
+                    "display_name": "Role of Microglia in Neurological Disorders",
+                    "score": 0.9876,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2808",
+                        "display_name": "Neurology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/28",
+                        "display_name": "Neuroscience"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11668",
+                    "display_name": "Innate Immunity to Viral Infection",
+                    "score": 0.9846,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2403",
+                        "display_name": "Immunology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/24",
+                        "display_name": "Immunology and Microbiology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/hiv",
+                    "display_name": "HIV",
+                    "score": 0.556057
+                },
+                {
+                    "id": "https://openalex.org/keywords/neuroinflammation",
+                    "display_name": "Neuroinflammation",
+                    "score": 0.510172
+                },
+                {
+                    "id": "https://openalex.org/keywords/immune-responses",
+                    "display_name": "Immune Responses",
+                    "score": 0.508731
+                },
+                {
+                    "id": "https://openalex.org/keywords/interferon-signaling",
+                    "display_name": "Interferon Signaling",
+                    "score": 0.504786
+                },
+                {
+                    "id": "https://openalex.org/keywords/immune-activation",
+                    "display_name": "Immune Activation",
+                    "score": 0.503155
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C86803240",
+                    "wikidata": "https://www.wikidata.org/wiki/Q420",
+                    "display_name": "Biology",
+                    "level": 0,
+                    "score": 0.58531016
+                },
+                {
+                    "id": "https://openalex.org/C2781161787",
+                    "wikidata": "https://www.wikidata.org/wiki/Q48360",
+                    "display_name": "Hippocampus",
+                    "level": 2,
+                    "score": 0.53690696
+                },
+                {
+                    "id": "https://openalex.org/C2779830541",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1622829",
+                    "display_name": "Microglia",
+                    "level": 3,
+                    "score": 0.5183864
+                },
+                {
+                    "id": "https://openalex.org/C8891405",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1059",
+                    "display_name": "Immune system",
+                    "level": 2,
+                    "score": 0.50176287
+                },
+                {
+                    "id": "https://openalex.org/C203014093",
+                    "wikidata": "https://www.wikidata.org/wiki/Q101929",
+                    "display_name": "Immunology",
+                    "level": 1,
+                    "score": 0.4963134
+                },
+                {
+                    "id": "https://openalex.org/C169760540",
+                    "wikidata": "https://www.wikidata.org/wiki/Q207011",
+                    "display_name": "Neuroscience",
+                    "level": 1,
+                    "score": 0.48909718
+                },
+                {
+                    "id": "https://openalex.org/C2776178377",
+                    "wikidata": "https://www.wikidata.org/wiki/Q188269",
+                    "display_name": "Interferon",
+                    "level": 2,
+                    "score": 0.4524348
+                },
+                {
+                    "id": "https://openalex.org/C87753298",
+                    "wikidata": "https://www.wikidata.org/wiki/Q17157137",
+                    "display_name": "Neuroinflammation",
+                    "level": 3,
+                    "score": 0.42607927
+                },
+                {
+                    "id": "https://openalex.org/C148762608",
+                    "wikidata": "https://www.wikidata.org/wiki/Q3748185",
+                    "display_name": "Hippocampal formation",
+                    "level": 2,
+                    "score": 0.4223043
+                },
+                {
+                    "id": "https://openalex.org/C136449434",
+                    "wikidata": "https://www.wikidata.org/wiki/Q428253",
+                    "display_name": "Innate immune system",
+                    "level": 3,
+                    "score": 0.41917655
+                },
+                {
+                    "id": "https://openalex.org/C529278444",
+                    "wikidata": "https://www.wikidata.org/wiki/Q47273",
+                    "display_name": "Central nervous system",
+                    "level": 2,
+                    "score": 0.41497478
+                },
+                {
+                    "id": "https://openalex.org/C2776914184",
+                    "wikidata": "https://www.wikidata.org/wiki/Q101991",
+                    "display_name": "Inflammation",
+                    "level": 2,
+                    "score": 0.21024865
+                }
+            ],
+            "mesh": [
+                {
+                    "descriptor_ui": "D000818",
+                    "descriptor_name": "Animals",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D001921",
+                    "descriptor_name": "Brain",
+                    "qualifier_ui": "Q000378",
+                    "qualifier_name": "metabolism",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D005260",
+                    "descriptor_name": "Female",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D015658",
+                    "descriptor_name": "HIV Infections",
+                    "qualifier_ui": "Q000378",
+                    "qualifier_name": "metabolism",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D015497",
+                    "descriptor_name": "HIV-1",
+                    "qualifier_ui": "Q000378",
+                    "qualifier_name": "metabolism",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D016899",
+                    "descriptor_name": "Interferon-beta",
+                    "qualifier_ui": "Q000378",
+                    "qualifier_name": "metabolism",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D008297",
+                    "descriptor_name": "Male",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D051379",
+                    "descriptor_name": "Mice",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D008822",
+                    "descriptor_name": "Mice, Transgenic",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                }
+            ],
+            "locations_count": 3,
+            "locations": [
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://doi.org/10.1016/j.bbi.2024.02.014",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S102243518",
+                        "display_name": "Brain Behavior and Immunity",
+                        "issn_l": "0889-1591",
+                        "issn": [
+                            "0889-1591",
+                            "1090-2139"
+                        ],
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_core": true,
+                        "host_organization": "https://openalex.org/P4310320990",
+                        "host_organization_name": "Elsevier BV",
+                        "host_organization_lineage": [
+                            "https://openalex.org/P4310320990"
+                        ],
+                        "host_organization_lineage_names": [
+                            "Elsevier BV"
+                        ],
+                        "type": "journal"
+                    },
+                    "license": "cc-by",
+                    "license_id": "https://openalex.org/licenses/cc-by",
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11173373",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S2764455111",
+                        "display_name": "PubMed Central",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "acceptedVersion",
+                    "is_accepted": true,
+                    "is_published": false
+                },
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://pubmed.ncbi.nlm.nih.gov/38360376",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306525036",
+                        "display_name": "PubMed",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1016/j.bbi.2024.02.014",
+                "pdf_url": null,
+                "source": {
+                    "id": "https://openalex.org/S102243518",
+                    "display_name": "Brain Behavior and Immunity",
+                    "issn_l": "0889-1591",
+                    "issn": [
+                        "0889-1591",
+                        "1090-2139"
+                    ],
+                    "is_oa": false,
+                    "is_in_doaj": false,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310320990",
+                    "host_organization_name": "Elsevier BV",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310320990"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Elsevier BV"
+                    ],
+                    "type": "journal"
+                },
+                "license": "cc-by",
+                "license_id": "https://openalex.org/licenses/cc-by",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "sustainable_development_goals": [
+                {
+                    "id": "https://metadata.un.org/sdg/3",
+                    "display_name": "Good health and well-being",
+                    "score": 0.68
+                }
+            ],
+            "grants": [
+                {
+                    "funder": "https://openalex.org/F4320332161",
+                    "funder_display_name": "National Institutes of Health",
+                    "award_id": null
+                }
+            ],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 44,
+            "referenced_works": [
+                "https://openalex.org/W1891164717",
+                "https://openalex.org/W1964184380",
+                "https://openalex.org/W1966060871",
+                "https://openalex.org/W1981379366",
+                "https://openalex.org/W1984811742",
+                "https://openalex.org/W1995440985",
+                "https://openalex.org/W2000684605",
+                "https://openalex.org/W2002335756",
+                "https://openalex.org/W2006527508",
+                "https://openalex.org/W2010571480",
+                "https://openalex.org/W2030739472",
+                "https://openalex.org/W2032940358",
+                "https://openalex.org/W2039112178",
+                "https://openalex.org/W2045301606",
+                "https://openalex.org/W2052305221",
+                "https://openalex.org/W2058458125",
+                "https://openalex.org/W2063358396",
+                "https://openalex.org/W2078646756",
+                "https://openalex.org/W2086419987",
+                "https://openalex.org/W2093530590",
+                "https://openalex.org/W2107277218",
+                "https://openalex.org/W2121501941",
+                "https://openalex.org/W2131327798",
+                "https://openalex.org/W2133801172",
+                "https://openalex.org/W2139155915",
+                "https://openalex.org/W2149410369",
+                "https://openalex.org/W2160212383",
+                "https://openalex.org/W2168030096",
+                "https://openalex.org/W2168778458",
+                "https://openalex.org/W2169304317",
+                "https://openalex.org/W2170685896",
+                "https://openalex.org/W2295774726",
+                "https://openalex.org/W2328570866",
+                "https://openalex.org/W2442608682",
+                "https://openalex.org/W2606808316",
+                "https://openalex.org/W2753366322",
+                "https://openalex.org/W2889216614",
+                "https://openalex.org/W2893220563",
+                "https://openalex.org/W2921025827",
+                "https://openalex.org/W2952011251",
+                "https://openalex.org/W3034687815",
+                "https://openalex.org/W3045852227",
+                "https://openalex.org/W3122953533",
+                "https://openalex.org/W3158396191"
+            ],
+            "related_works": [
+                "https://openalex.org/W4390463473",
+                "https://openalex.org/W4281290245",
+                "https://openalex.org/W4221075899",
+                "https://openalex.org/W3107395714",
+                "https://openalex.org/W2995828647",
+                "https://openalex.org/W2965172925",
+                "https://openalex.org/W2807379694",
+                "https://openalex.org/W2804482952",
+                "https://openalex.org/W2803817550",
+                "https://openalex.org/W163337889"
+            ],
+            "ngrams_url": "https://api.openalex.org/works/W4391775041/ngrams",
+            "abstract_inverted_index": {
+                "1": [
+                    42
+                ],
+                "Human": [
+                    0
+                ],
+                "immunodeficiency": [
+                    1
+                ],
+                "virus-1": [
+                    2
+                ],
+                "(HIV-1)": [
+                    3
+                ],
+                "infects": [
+                    4
+                ],
+                "the": [
+                    5,
+                    20,
+                    24,
+                    33,
+                    38,
+                    57,
+                    76,
+                    119,
+                    152,
+                    220,
+                    257,
+                    280,
+                    289
+                ],
+                "central": [
+                    6
+                ],
+                "nervous": [
+                    7
+                ],
+                "system": [
+                    8
+                ],
+                "(CNS)": [
+                    9
+                ],
+                "and": [
+                    10,
+                    46,
+                    62,
+                    67,
+                    92,
+                    98,
+                    159,
+                    188,
+                    190,
+                    206,
+                    226,
+                    297,
+                    327
+                ],
+                "causes": [
+                    11
+                ],
+                "HIV-associated": [
+                    12
+                ],
+                "neurocognitive": [
+                    13
+                ],
+                "disorders": [
+                    14
+                ],
+                "(HAND)": [
+                    15
+                ],
+                "in": [
+                    16,
+                    56,
+                    90,
+                    124,
+                    129,
+                    139,
+                    146,
+                    151,
+                    163,
+                    186,
+                    193,
+                    211,
+                    228,
+                    252,
+                    279,
+                    300,
+                    323
+                ],
+                "about": [
+                    17
+                ],
+                "half": [
+                    18
+                ],
+                "of": [
+                    19,
+                    40,
+                    78,
+                    112,
+                    121,
+                    132,
+                    156,
+                    167,
+                    174,
+                    222,
+                    231,
+                    236,
+                    243,
+                    259,
+                    266,
+                    271,
+                    276,
+                    291,
+                    310
+                ],
+                "population": [
+                    21
+                ],
+                "living": [
+                    22
+                ],
+                "with": [
+                    23,
+                    72,
+                    248,
+                    268
+                ],
+                "virus": [
+                    25
+                ],
+                "despite": [
+                    26
+                ],
+                "combination": [
+                    27
+                ],
+                "anti-retroviral": [
+                    28
+                ],
+                "therapy": [
+                    29
+                ],
+                "(cART).": [
+                    30
+                ],
+                "HIV-1": [
+                    31,
+                    51
+                ],
+                "activates": [
+                    32
+                ],
+                "innate": [
+                    34
+                ],
+                "immune": [
+                    35,
+                    204
+                ],
+                "system,": [
+                    36
+                ],
+                "including": [
+                    37,
+                    75
+                ],
+                "production": [
+                    39
+                ],
+                "type": [
+                    41
+                ],
+                "interferons": [
+                    43
+                ],
+                "(IFNs)": [
+                    44
+                ],
+                "α": [
+                    45
+                ],
+                "β.": [
+                    47
+                ],
+                "Transgenic": [
+                    48
+                ],
+                "mice": [
+                    49,
+                    95,
+                    162,
+                    181
+                ],
+                "expressing": [
+                    50
+                ],
+                "envelope": [
+                    52
+                ],
+                "glycoprotein": [
+                    53
+                ],
+                "gp120": [
+                    54
+                ],
+                "(HIVgp120tg)": [
+                    55
+                ],
+                "CNS": [
+                    58,
+                    69
+                ],
+                "develop": [
+                    59
+                ],
+                "memory": [
+                    60,
+                    294,
+                    328
+                ],
+                "impairment": [
+                    61
+                ],
+                "share": [
+                    63
+                ],
+                "key": [
+                    64
+                ],
+                "neuropathological": [
+                    65
+                ],
+                "features": [
+                    66
+                ],
+                "differential": [
+                    68
+                ],
+                "gene": [
+                    70
+                ],
+                "expression": [
+                    71,
+                    201
+                ],
+                "HIV": [
+                    73
+                ],
+                "patients,": [
+                    74
+                ],
+                "induction": [
+                    77,
+                    221
+                ],
+                "IFN-stimulated": [
+                    79
+                ],
+                "genes": [
+                    80,
+                    205,
+                    239
+                ],
+                "(ISG).": [
+                    81
+                ],
+                "Here": [
+                    82
+                ],
+                "we": [
+                    83
+                ],
+                "show": [
+                    84,
+                    287
+                ],
+                "that": [
+                    85,
+                    288,
+                    304,
+                    316
+                ],
+                "knocking": [
+                    86
+                ],
+                "out": [
+                    87
+                ],
+                "IFNβ": [
+                    88,
+                    122,
+                    244,
+                    292,
+                    318
+                ],
+                "(IFNβKO)": [
+                    89
+                ],
+                "HIVgp120tg": [
+                    91,
+                    113,
+                    161,
+                    180,
+                    229,
+                    281,
+                    301
+                ],
+                "non-tg": [
+                    93
+                ],
+                "control": [
+                    94
+                ],
+                "impairs": [
+                    96,
+                    293
+                ],
+                "recognition": [
+                    97
+                ],
+                "spatial": [
+                    99
+                ],
+                "memory,": [
+                    100
+                ],
+                "but": [
+                    101,
+                    123,
+                    171,
+                    274
+                ],
+                "does": [
+                    102
+                ],
+                "not": [
+                    103
+                ],
+                "affect": [
+                    104
+                ],
+                "anxiety-like": [
+                    105
+                ],
+                "behavior,": [
+                    106
+                ],
+                "locomotion,": [
+                    107
+                ],
+                "or": [
+                    108,
+                    218
+                ],
+                "vision.": [
+                    109
+                ],
+                "The": [
+                    110,
+                    148,
+                    215
+                ],
+                "neuropathology": [
+                    111,
+                    299
+                ],
+                "is": [
+                    114,
+                    208
+                ],
+                "only": [
+                    115
+                ],
+                "moderately": [
+                    116
+                ],
+                "affected": [
+                    117,
+                    210
+                ],
+                "by": [
+                    118
+                ],
+                "KO": [
+                    120
+                ],
+                "a": [
+                    125,
+                    212,
+                    320
+                ],
+                "sex-dependent": [
+                    126,
+                    213
+                ],
+                "fashion.": [
+                    127
+                ],
+                "Notably,": [
+                    128
+                ],
+                "cerebral": [
+                    130
+                ],
+                "cortex": [
+                    131,
+                    187
+                ],
+                "IFNβKO": [
+                    133,
+                    149,
+                    216,
+                    253,
+                    260
+                ],
+                "animals": [
+                    134
+                ],
+                "presynaptic": [
+                    135,
+                    169
+                ],
+                "terminals": [
+                    136,
+                    170
+                ],
+                "are": [
+                    137,
+                    144,
+                    264
+                ],
+                "reduced": [
+                    138,
+                    145
+                ],
+                "males": [
+                    140
+                ],
+                "while": [
+                    141
+                ],
+                "neuronal": [
+                    142,
+                    168,
+                    175,
+                    325
+                ],
+                "dendrites": [
+                    143
+                ],
+                "females.": [
+                    147,
+                    254
+                ],
+                "results": [
+                    150
+                ],
+                "hippocampal": [
+                    153
+                ],
+                "CA1": [
+                    154
+                ],
+                "region": [
+                    155
+                ],
+                "both": [
+                    157,
+                    232
+                ],
+                "male": [
+                    158
+                ],
+                "female": [
+                    160,
+                    178
+                ],
+                "an": [
+                    164,
+                    241
+                ],
+                "ameliorated": [
+                    165
+                ],
+                "loss": [
+                    166
+                ],
+                "no": [
+                    172
+                ],
+                "protection": [
+                    173
+                ],
+                "dendrites.": [
+                    176
+                ],
+                "Only": [
+                    177
+                ],
+                "IFNβ-deficient": [
+                    179
+                ],
+                "display": [
+                    182
+                ],
+                "diminished": [
+                    183
+                ],
+                "microglial": [
+                    184
+                ],
+                "activation": [
+                    185
+                ],
+                "hippocampus": [
+                    189,
+                    194
+                ],
+                "increased": [
+                    191
+                ],
+                "astrocytosis": [
+                    192
+                ],
+                "compared": [
+                    195
+                ],
+                "to": [
+                    196
+                ],
+                "their": [
+                    197
+                ],
+                "IFNβ-expressing": [
+                    198
+                ],
+                "counterparts.": [
+                    199
+                ],
+                "RNA": [
+                    200
+                ],
+                "for": [
+                    202
+                ],
+                "some": [
+                    203
+                ],
+                "ISGs": [
+                    207
+                ],
+                "also": [
+                    209,
+                    275
+                ],
+                "way.": [
+                    214
+                ],
+                "abrogates": [
+                    217
+                ],
+                "diminishes": [
+                    219
+                ],
+                "MX1,": [
+                    223
+                ],
+                "DDX58,": [
+                    224
+                ],
+                "IRF7": [
+                    225
+                ],
+                "IRF9": [
+                    227
+                ],
+                "brains": [
+                    230
+                ],
+                "sexes.": [
+                    233
+                ],
+                "Expression": [
+                    234
+                ],
+                "analysis": [
+                    235
+                ],
+                "neurotransmission": [
+                    237
+                ],
+                "related": [
+                    238
+                ],
+                "reveals": [
+                    240
+                ],
+                "influence": [
+                    242
+                ],
+                "on": [
+                    245,
+                    261
+                ],
+                "multiple": [
+                    246
+                ],
+                "components": [
+                    247
+                ],
+                "more": [
+                    249
+                ],
+                "pronounced": [
+                    250,
+                    269
+                ],
+                "changes": [
+                    251
+                ],
+                "In": [
+                    255,
+                    283
+                ],
+                "contrast,": [
+                    256
+                ],
+                "effects": [
+                    258
+                ],
+                "MAPK": [
+                    262
+                ],
+                "activities": [
+                    263
+                ],
+                "independent": [
+                    265
+                ],
+                "sex": [
+                    267
+                ],
+                "reduction": [
+                    270
+                ],
+                "active": [
+                    272,
+                    277
+                ],
+                "ERK1/2": [
+                    273
+                ],
+                "p38": [
+                    278
+                ],
+                "brain.": [
+                    282
+                ],
+                "summary,": [
+                    284
+                ],
+                "our": [
+                    285,
+                    313
+                ],
+                "findings": [
+                    286
+                ],
+                "absence": [
+                    290,
+                    306
+                ],
+                "dependent": [
+                    295
+                ],
+                "behavior": [
+                    296
+                ],
+                "modulates": [
+                    298
+                ],
+                "brains,": [
+                    302
+                ],
+                "indicating": [
+                    303
+                ],
+                "its": [
+                    305
+                ],
+                "may": [
+                    307
+                ],
+                "facilitate": [
+                    308
+                ],
+                "development": [
+                    309
+                ],
+                "HAND.": [
+                    311
+                ],
+                "Moreover,": [
+                    312
+                ],
+                "data": [
+                    314
+                ],
+                "suggests": [
+                    315
+                ],
+                "endogenous": [
+                    317
+                ],
+                "plays": [
+                    319
+                ],
+                "vital": [
+                    321
+                ],
+                "role": [
+                    322
+                ],
+                "maintaining": [
+                    324
+                ],
+                "homeostasis": [
+                    326
+                ],
+                "function.": [
+                    329
+                ]
+            },
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W4391775041",
+            "counts_by_year": [],
+            "updated_date": "2024-07-27T02:28:15.908316",
+            "created_date": "2024-02-14"
+        },
+        {
+            "id": "https://openalex.org/W4318592244",
+            "doi": "https://doi.org/10.55277/researchhub.aydefpsl",
+            "title": "Huberman Lab Podcast #93 Summary and Commentary",
+            "display_name": "Huberman Lab Podcast #93 Summary and Commentary",
+            "publication_year": 2023,
+            "publication_date": "2023-01-31",
+            "ids": {
+                "openalex": "https://openalex.org/W4318592244",
+                "doi": "https://doi.org/10.55277/researchhub.aydefpsl"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": false,
+                "landing_page_url": "https://doi.org/10.55277/researchhub.aydefpsl",
+                "pdf_url": null,
+                "source": null,
+                "license": null,
+                "license_id": null,
+                "version": null,
+                "is_accepted": false,
+                "is_published": false
+            },
+            "type": "report",
+            "type_crossref": "report",
+            "indexed_in": [
+                "crossref"
+            ],
+            "open_access": {
+                "is_oa": false,
+                "oa_status": "closed",
+                "oa_url": null,
+                "any_repository_has_fulltext": false
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5081987607",
+                        "display_name": "Jeffrey Koury",
+                        "orcid": "https://orcid.org/0000-0002-7368-4891"
+                    },
+                    "institutions": [],
+                    "countries": [],
+                    "is_corresponding": true,
+                    "raw_author_name": "Jeffrey Koury",
+                    "raw_affiliation_strings": [],
+                    "affiliations": []
+                }
+            ],
+            "countries_distinct_count": 0,
+            "institutions_distinct_count": 0,
+            "corresponding_author_ids": [
+                "https://openalex.org/A5081987607"
+            ],
+            "corresponding_institution_ids": [],
+            "apc_list": null,
+            "apc_paid": null,
+            "fwci": null,
+            "has_fulltext": false,
+            "cited_by_count": 0,
+            "cited_by_percentile_year": {
+                "min": 0,
+                "max": 74
+            },
+            "biblio": {
+                "volume": null,
+                "issue": null,
+                "first_page": null,
+                "last_page": null
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T12553",
+                "display_name": "Therapeutic Potential of Psychedelic Therapy",
+                "score": 0.9988,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/3203",
+                    "display_name": "Clinical Psychology"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/32",
+                    "display_name": "Psychology"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/2",
+                    "display_name": "Social Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T12553",
+                    "display_name": "Therapeutic Potential of Psychedelic Therapy",
+                    "score": 0.9988,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/3203",
+                        "display_name": "Clinical Psychology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/32",
+                        "display_name": "Psychology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/2",
+                        "display_name": "Social Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T10056",
+                    "display_name": "Neurobiological Mechanisms of Drug Addiction and Depression",
+                    "score": 0.9013,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2804",
+                        "display_name": "Cellular and Molecular Neuroscience"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/28",
+                        "display_name": "Neuroscience"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/depression",
+                    "display_name": "Depression",
+                    "score": 0.49149
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C2776502132",
+                    "wikidata": "https://www.wikidata.org/wiki/Q208118",
+                    "display_name": "Psilocybin",
+                    "level": 3,
+                    "score": 0.8497926
+                },
+                {
+                    "id": "https://openalex.org/C2780733359",
+                    "wikidata": "https://www.wikidata.org/wiki/Q331769",
+                    "display_name": "Mood",
+                    "level": 2,
+                    "score": 0.5491413
+                },
+                {
+                    "id": "https://openalex.org/C15744967",
+                    "wikidata": "https://www.wikidata.org/wiki/Q9418",
+                    "display_name": "Psychology",
+                    "level": 0,
+                    "score": 0.5355017
+                },
+                {
+                    "id": "https://openalex.org/C542102704",
+                    "wikidata": "https://www.wikidata.org/wiki/Q183257",
+                    "display_name": "Psychotherapist",
+                    "level": 1,
+                    "score": 0.4475341
+                },
+                {
+                    "id": "https://openalex.org/C2776867660",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1814941",
+                    "display_name": "Depression (economics)",
+                    "level": 2,
+                    "score": 0.4411919
+                },
+                {
+                    "id": "https://openalex.org/C2777134132",
+                    "wikidata": "https://www.wikidata.org/wiki/Q188638",
+                    "display_name": "Mood disorders",
+                    "level": 3,
+                    "score": 0.4303068
+                },
+                {
+                    "id": "https://openalex.org/C118552586",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7867",
+                    "display_name": "Psychiatry",
+                    "level": 1,
+                    "score": 0.4222166
+                },
+                {
+                    "id": "https://openalex.org/C558461103",
+                    "wikidata": "https://www.wikidata.org/wiki/Q154430",
+                    "display_name": "Anxiety",
+                    "level": 2,
+                    "score": 0.22555423
+                },
+                {
+                    "id": "https://openalex.org/C124315065",
+                    "wikidata": "https://www.wikidata.org/wiki/Q194270",
+                    "display_name": "Hallucinogen",
+                    "level": 2,
+                    "score": 0.14978918
+                },
+                {
+                    "id": "https://openalex.org/C162324750",
+                    "wikidata": "https://www.wikidata.org/wiki/Q8134",
+                    "display_name": "Economics",
+                    "level": 0,
+                    "score": 0
+                },
+                {
+                    "id": "https://openalex.org/C139719470",
+                    "wikidata": "https://www.wikidata.org/wiki/Q39680",
+                    "display_name": "Macroeconomics",
+                    "level": 1,
+                    "score": 0
+                }
+            ],
+            "mesh": [],
+            "locations_count": 1,
+            "locations": [
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://doi.org/10.55277/researchhub.aydefpsl",
+                    "pdf_url": null,
+                    "source": null,
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": null,
+            "sustainable_development_goals": [
+                {
+                    "id": "https://metadata.un.org/sdg/3",
+                    "display_name": "Good health and well-being",
+                    "score": 0.69
+                }
+            ],
+            "grants": [],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 0,
+            "referenced_works": [],
+            "related_works": [
+                "https://openalex.org/W4384835068",
+                "https://openalex.org/W4312534256",
+                "https://openalex.org/W4306177051",
+                "https://openalex.org/W4285605468",
+                "https://openalex.org/W4283204986",
+                "https://openalex.org/W3161556967",
+                "https://openalex.org/W2810710828",
+                "https://openalex.org/W2154105276",
+                "https://openalex.org/W2072670605",
+                "https://openalex.org/W108080335"
+            ],
+            "ngrams_url": "https://api.openalex.org/works/W4318592244/ngrams",
+            "abstract_inverted_index": {
+                "1": [
+                    1002,
+                    2534,
+                    3397
+                ],
+                "2": [
+                    3399,
+                    4047
+                ],
+                "3": [
+                    463,
+                    3537,
+                    3601,
+                    4055
+                ],
+                "4": [
+                    486,
+                    2736
+                ],
+                "8": [
+                    1006
+                ],
+                "9": [
+                    577
+                ],
+                "23": [
+                    601,
+                    4029
+                ],
+                "70": [
+                    4060
+                ],
+                "2014": [
+                    2074
+                ],
+                "2016": [
+                    1105
+                ],
+                "2020": [
+                    4078
+                ],
+                "2022": [
+                    3520
+                ],
+                "Podcast": [
+                    0
+                ],
+                "Host:": [
+                    1
+                ],
+                "Dr.": [
+                    2,
+                    25,
+                    50,
+                    146,
+                    163,
+                    166,
+                    322,
+                    725,
+                    746,
+                    1711,
+                    1979,
+                    2010,
+                    2519,
+                    2790
+                ],
+                "Andrew": [
+                    3,
+                    2263
+                ],
+                "Huberman": [
+                    4,
+                    167,
+                    856,
+                    2264
+                ],
+                "(Stanford": [
+                    5,
+                    28
+                ],
+                "Associate": [
+                    6
+                ],
+                "Professor": [
+                    7,
+                    30
+                ],
+                "-": [
+                    8,
+                    19,
+                    21,
+                    31,
+                    45,
+                    285,
+                    332,
+                    375,
+                    461,
+                    483,
+                    574,
+                    598,
+                    644,
+                    724,
+                    745,
+                    752,
+                    936,
+                    1281,
+                    1434,
+                    1762,
+                    2141,
+                    2192,
+                    2256,
+                    2487,
+                    2522
+                ],
+                "brain": [
+                    9,
+                    11,
+                    127,
+                    562,
+                    696,
+                    791,
+                    811,
+                    929,
+                    959,
+                    1078,
+                    1532,
+                    1955,
+                    2080,
+                    3051,
+                    3116,
+                    3139,
+                    3171,
+                    3247,
+                    3285,
+                    4009,
+                    4065,
+                    4157
+                ],
+                "development,": [
+                    10
+                ],
+                "plasticity,": [
+                    12
+                ],
+                "and": [
+                    13,
+                    16,
+                    36,
+                    42,
+                    87,
+                    99,
+                    124,
+                    143,
+                    161,
+                    165,
+                    174,
+                    241,
+                    269,
+                    287,
+                    327,
+                    350,
+                    458,
+                    511,
+                    657,
+                    663,
+                    737,
+                    795,
+                    843,
+                    857,
+                    910,
+                    968,
+                    974,
+                    1128,
+                    1188,
+                    1214,
+                    1262,
+                    1299,
+                    1303,
+                    1322,
+                    1344,
+                    1355,
+                    1372,
+                    1463,
+                    1519,
+                    1533,
+                    1536,
+                    1550,
+                    1629,
+                    1654,
+                    1673,
+                    1715,
+                    1744,
+                    1793,
+                    1796,
+                    1812,
+                    1848,
+                    1862,
+                    1906,
+                    1912,
+                    1943,
+                    1970,
+                    2047,
+                    2072,
+                    2088,
+                    2125,
+                    2145,
+                    2184,
+                    2269,
+                    2275,
+                    2287,
+                    2297,
+                    2338,
+                    2357,
+                    2369,
+                    2393,
+                    2437,
+                    2452,
+                    2602,
+                    2688,
+                    2796,
+                    2812,
+                    2892,
+                    2896,
+                    2961,
+                    2987,
+                    3010,
+                    3017,
+                    3047,
+                    3147,
+                    3210,
+                    3329,
+                    3337,
+                    3341,
+                    3402,
+                    3554,
+                    3676,
+                    3723,
+                    3764,
+                    3776,
+                    3885,
+                    3891,
+                    3939,
+                    3948,
+                    3952,
+                    4069,
+                    4088,
+                    4111,
+                    4140,
+                    4158,
+                    4168
+                ],
+                "neural": [
+                    14,
+                    512,
+                    522,
+                    541,
+                    2874
+                ],
+                "regeneration": [
+                    15
+                ],
+                "repair": [
+                    17
+                ],
+                "fields)": [
+                    18
+                ],
+                "Youtube": [
+                    20
+                ],
+                "Lab": [
+                    22,
+                    46
+                ],
+                "WebsitePodcast": [
+                    23
+                ],
+                "Guest:": [
+                    24
+                ],
+                "Nolan": [
+                    26,
+                    726,
+                    747,
+                    1712
+                ],
+                "Williams": [
+                    27,
+                    147,
+                    164,
+                    800,
+                    858,
+                    1713,
+                    1980,
+                    2011,
+                    2520,
+                    2791,
+                    2906,
+                    3213
+                ],
+                "Assistant": [
+                    29
+                ],
+                "synergistic": [
+                    32
+                ],
+                "treatments": [
+                    33,
+                    155,
+                    410,
+                    774,
+                    2127,
+                    2417
+                ],
+                "with": [
+                    34,
+                    107,
+                    150,
+                    496,
+                    793,
+                    808,
+                    882,
+                    908,
+                    1368,
+                    1374,
+                    1390,
+                    1474,
+                    1786,
+                    1838,
+                    1978,
+                    2221,
+                    2319,
+                    2494,
+                    2667,
+                    2699,
+                    2718,
+                    2933,
+                    3050,
+                    3420,
+                    3744,
+                    3853,
+                    3969,
+                    4028,
+                    4101
+                ],
+                "TMS": [
+                    35,
+                    149,
+                    685,
+                    840,
+                    1559,
+                    1716,
+                    1923,
+                    2002,
+                    2119,
+                    2676,
+                    2698,
+                    4128
+                ],
+                "psychedelics": [
+                    37,
+                    3365
+                ],
+                "for": [
+                    38,
+                    49,
+                    68,
+                    79,
+                    83,
+                    281,
+                    369,
+                    401,
+                    425,
+                    457,
+                    479,
+                    583,
+                    610,
+                    618,
+                    674,
+                    906,
+                    1001,
+                    1005,
+                    1050,
+                    1055,
+                    1284,
+                    1301,
+                    1320,
+                    1332,
+                    1455,
+                    1585,
+                    1671,
+                    1691,
+                    1722,
+                    1836,
+                    1858,
+                    2123,
+                    2170,
+                    2281,
+                    2302,
+                    2325,
+                    2418,
+                    2633,
+                    3014,
+                    3032,
+                    3173,
+                    3220,
+                    3265,
+                    3454,
+                    3513,
+                    3581,
+                    3593,
+                    3612,
+                    3714,
+                    3718,
+                    3839,
+                    3972,
+                    4179
+                ],
+                "treatment": [
+                    39,
+                    84,
+                    202,
+                    736,
+                    1331,
+                    2339,
+                    3483,
+                    3580,
+                    4129,
+                    4181
+                ],
+                "of": [
+                    40,
+                    85,
+                    96,
+                    110,
+                    122,
+                    176,
+                    199,
+                    210,
+                    217,
+                    226,
+                    238,
+                    296,
+                    339,
+                    358,
+                    385,
+                    431,
+                    436,
+                    468,
+                    508,
+                    539,
+                    558,
+                    571,
+                    588,
+                    653,
+                    760,
+                    773,
+                    789,
+                    819,
+                    876,
+                    888,
+                    898,
+                    917,
+                    920,
+                    940,
+                    984,
+                    988,
+                    994,
+                    1017,
+                    1027,
+                    1098,
+                    1108,
+                    1186,
+                    1218,
+                    1226,
+                    1235,
+                    1246,
+                    1314,
+                    1349,
+                    1352,
+                    1366,
+                    1399,
+                    1446,
+                    1450,
+                    1478,
+                    1502,
+                    1545,
+                    1588,
+                    1683,
+                    1694,
+                    1725,
+                    1736,
+                    1758,
+                    1772,
+                    1779,
+                    1875,
+                    1894,
+                    1903,
+                    1937,
+                    1953,
+                    1968,
+                    1989,
+                    2136,
+                    2152,
+                    2163,
+                    2227,
+                    2240,
+                    2340,
+                    2353,
+                    2383,
+                    2446,
+                    2454,
+                    2460,
+                    2483,
+                    2490,
+                    2528,
+                    2536,
+                    2550,
+                    2563,
+                    2629,
+                    2639,
+                    2653,
+                    2677,
+                    2697,
+                    2716,
+                    2771,
+                    2889,
+                    2911,
+                    2914,
+                    2998,
+                    3004,
+                    3035,
+                    3075,
+                    3170,
+                    3176,
+                    3243,
+                    3255,
+                    3269,
+                    3346,
+                    3357,
+                    3364,
+                    3411,
+                    3423,
+                    3436,
+                    3452,
+                    3476,
+                    3482,
+                    3496,
+                    3498,
+                    3525,
+                    3536,
+                    3548,
+                    3616,
+                    3622,
+                    3662,
+                    3692,
+                    3701,
+                    3770,
+                    3778,
+                    3815,
+                    3863,
+                    3911,
+                    4043,
+                    4074,
+                    4106,
+                    4118,
+                    4147,
+                    4155,
+                    4182
+                ],
+                "depression": [
+                    41,
+                    86,
+                    142,
+                    707,
+                    709,
+                    728,
+                    1081,
+                    1258,
+                    1277,
+                    1285,
+                    1373,
+                    1695,
+                    1726,
+                    1861,
+                    2228,
+                    2356,
+                    2419,
+                    2556,
+                    2962,
+                    3471,
+                    3516,
+                    3531
+                ],
+                "mood": [
+                    43,
+                    89,
+                    144,
+                    820,
+                    837,
+                    1131,
+                    2712
+                ],
+                "disorders)": [
+                    44
+                ],
+                "Website*Subject": [
+                    47
+                ],
+                "Recruitment": [
+                    48
+                ],
+                "William's": [
+                    51
+                ],
+                "Lab's": [
+                    52
+                ],
+                "Clinical": [
+                    53,
+                    1189
+                ],
+                "Trial:": [
+                    54
+                ],
+                "A": [
+                    55,
+                    1364,
+                    1842,
+                    1887,
+                    3958,
+                    4185,
+                    4215
+                ],
+                "bounty": [
+                    56,
+                    116
+                ],
+                "on": [
+                    57,
+                    92,
+                    777,
+                    802,
+                    860,
+                    1076,
+                    1645,
+                    1809,
+                    2108,
+                    2201,
+                    2568,
+                    2574,
+                    2589,
+                    2757,
+                    3136,
+                    3287,
+                    3479,
+                    3650,
+                    3882,
+                    3895,
+                    3996,
+                    4177
+                ],
+                "ResearchHub,": [
+                    58
+                ],
+                "paid": [
+                    59
+                ],
+                "in": [
+                    60,
+                    266,
+                    311,
+                    319,
+                    346,
+                    379,
+                    391,
+                    403,
+                    417,
+                    536,
+                    647,
+                    699,
+                    749,
+                    754,
+                    763,
+                    836,
+                    850,
+                    1012,
+                    1030,
+                    1144,
+                    1151,
+                    1172,
+                    1275,
+                    1425,
+                    1438,
+                    1490,
+                    1531,
+                    1567,
+                    1590,
+                    1612,
+                    1710,
+                    1740,
+                    1745,
+                    1756,
+                    1763,
+                    1770,
+                    1799,
+                    1815,
+                    1872,
+                    2015,
+                    2021,
+                    2038,
+                    2044,
+                    2058,
+                    2195,
+                    2206,
+                    2251,
+                    2355,
+                    2555,
+                    2557,
+                    2607,
+                    2642,
+                    2660,
+                    2711,
+                    2759,
+                    2864,
+                    2959,
+                    2966,
+                    3025,
+                    3066,
+                    3093,
+                    3115,
+                    3304,
+                    3311,
+                    3317,
+                    3360,
+                    3372,
+                    3418,
+                    3443,
+                    3449,
+                    3472,
+                    3518,
+                    3521,
+                    3546,
+                    3569,
+                    3647,
+                    3704,
+                    3732,
+                    3742,
+                    3820,
+                    3828,
+                    3837,
+                    3856,
+                    3865,
+                    3870,
+                    3876,
+                    3926,
+                    4007,
+                    4021,
+                    4097,
+                    4132,
+                    4149,
+                    4200
+                ],
+                "ResearchCoin,": [
+                    61
+                ],
+                "will": [
+                    62,
+                    250,
+                    271,
+                    1974,
+                    3766
+                ],
+                "be": [
+                    63,
+                    76,
+                    490,
+                    525,
+                    532,
+                    545,
+                    1022,
+                    1328,
+                    1513,
+                    1784,
+                    2158,
+                    2618,
+                    2743,
+                    2776,
+                    2829,
+                    2976,
+                    2991,
+                    3065,
+                    3238,
+                    3263,
+                    3645,
+                    3671,
+                    3736
+                ],
+                "attached": [
+                    64
+                ],
+                "to": [
+                    65,
+                    75,
+                    117,
+                    131,
+                    140,
+                    194,
+                    264,
+                    293,
+                    355,
+                    524,
+                    528,
+                    593,
+                    625,
+                    688,
+                    693,
+                    832,
+                    839,
+                    863,
+                    873,
+                    893,
+                    923,
+                    951,
+                    1085,
+                    1089,
+                    1124,
+                    1179,
+                    1256,
+                    1267,
+                    1305,
+                    1324,
+                    1327,
+                    1392,
+                    1429,
+                    1515,
+                    1578,
+                    1619,
+                    1627,
+                    1640,
+                    1689,
+                    1720,
+                    1783,
+                    1806,
+                    1998,
+                    2008,
+                    2019,
+                    2067,
+                    2095,
+                    2100,
+                    2133,
+                    2157,
+                    2187,
+                    2260,
+                    2321,
+                    2441,
+                    2458,
+                    2481,
+                    2502,
+                    2559,
+                    2647,
+                    2692,
+                    2738,
+                    2780,
+                    2823,
+                    2831,
+                    2841,
+                    2853,
+                    2857,
+                    2869,
+                    2880,
+                    2885,
+                    2975,
+                    3006,
+                    3023,
+                    3183,
+                    3190,
+                    3273,
+                    3288,
+                    3309,
+                    3370,
+                    3416,
+                    3474,
+                    3670,
+                    3673,
+                    3710,
+                    3735,
+                    3754,
+                    3851,
+                    3859,
+                    4016,
+                    4063,
+                    4126
+                ],
+                "incentivize": [
+                    66
+                ],
+                "recruitment": [
+                    67
+                ],
+                "this": [
+                    69,
+                    244,
+                    267,
+                    353,
+                    364,
+                    420,
+                    476,
+                    831,
+                    886,
+                    947,
+                    1411,
+                    1630,
+                    2188,
+                    2578,
+                    3261,
+                    3321,
+                    3351,
+                    3421,
+                    3799,
+                    3848,
+                    4159
+                ],
+                "clinical": [
+                    70,
+                    81,
+                    3821,
+                    4175
+                ],
+                "trial.": [
+                    71
+                ],
+                "If": [
+                    72,
+                    254,
+                    2609,
+                    2625,
+                    3750
+                ],
+                "you": [
+                    73,
+                    102,
+                    255,
+                    1287,
+                    1458,
+                    1960,
+                    2806
+                ],
+                "apply": [
+                    74
+                ],
+                "a": [
+                    77,
+                    105,
+                    108,
+                    137,
+                    227,
+                    246,
+                    344,
+                    347,
+                    398,
+                    426,
+                    432,
+                    454,
+                    505,
+                    716,
+                    721,
+                    740,
+                    743,
+                    816,
+                    870,
+                    896,
+                    938,
+                    997,
+                    1013,
+                    1329,
+                    1337,
+                    1380,
+                    1400,
+                    1407,
+                    1412,
+                    1416,
+                    1443,
+                    1486,
+                    1572,
+                    1600,
+                    1617,
+                    1642,
+                    1705,
+                    1826,
+                    1864,
+                    1966,
+                    1982,
+                    1987,
+                    2106,
+                    2130,
+                    2159,
+                    2175,
+                    2207,
+                    2247,
+                    2258,
+                    2305,
+                    2424,
+                    2464,
+                    2472,
+                    2504,
+                    2709,
+                    2714,
+                    2800,
+                    2898,
+                    3073,
+                    3078,
+                    3240,
+                    3358,
+                    3439,
+                    3508,
+                    3534,
+                    3596,
+                    3613,
+                    3648,
+                    3654,
+                    3689,
+                    3702,
+                    3802,
+                    3808,
+                    3834,
+                    3840,
+                    3854,
+                    3904,
+                    3912,
+                    3992,
+                    4022,
+                    4098,
+                    4121
+                ],
+                "participant": [
+                    78
+                ],
+                "the": [
+                    80,
+                    93,
+                    97,
+                    115,
+                    132,
+                    171,
+                    192,
+                    196,
+                    200,
+                    205,
+                    215,
+                    224,
+                    236,
+                    273,
+                    294,
+                    297,
+                    356,
+                    429,
+                    446,
+                    469,
+                    472,
+                    537,
+                    540,
+                    559,
+                    569,
+                    581,
+                    608,
+                    623,
+                    669,
+                    681,
+                    690,
+                    695,
+                    758,
+                    767,
+                    771,
+                    790,
+                    796,
+                    861,
+                    874,
+                    918,
+                    928,
+                    945,
+                    958,
+                    971,
+                    976,
+                    981,
+                    985,
+                    1018,
+                    1031,
+                    1077,
+                    1087,
+                    1090,
+                    1125,
+                    1134,
+                    1137,
+                    1141,
+                    1147,
+                    1210,
+                    1237,
+                    1247,
+                    1253,
+                    1260,
+                    1318,
+                    1426,
+                    1430,
+                    1447,
+                    1451,
+                    1460,
+                    1467,
+                    1476,
+                    1503,
+                    1508,
+                    1586,
+                    1613,
+                    1623,
+                    1635,
+                    1666,
+                    1675,
+                    1730,
+                    1737,
+                    1741,
+                    1746,
+                    1751,
+                    1759,
+                    1766,
+                    1773,
+                    1787,
+                    1821,
+                    1931,
+                    1935,
+                    1948,
+                    1951,
+                    1954,
+                    1971,
+                    2001,
+                    2022,
+                    2039,
+                    2045,
+                    2048,
+                    2051,
+                    2059,
+                    2068,
+                    2089,
+                    2109,
+                    2134,
+                    2142,
+                    2147,
+                    2153,
+                    2196,
+                    2202,
+                    2213,
+                    2276,
+                    2336,
+                    2407,
+                    2442,
+                    2484,
+                    2495,
+                    2547,
+                    2565,
+                    2569,
+                    2575,
+                    2590,
+                    2599,
+                    2603,
+                    2613,
+                    2622,
+                    2626,
+                    2634,
+                    2683,
+                    2694,
+                    2704,
+                    2731,
+                    2740,
+                    2760,
+                    2765,
+                    2768,
+                    2772,
+                    2793,
+                    2797,
+                    2809,
+                    2815,
+                    2825,
+                    2833,
+                    2844,
+                    2855,
+                    2859,
+                    2870,
+                    2882,
+                    2887,
+                    2967,
+                    2995,
+                    3026,
+                    3033,
+                    3067,
+                    3100,
+                    3128,
+                    3137,
+                    3168,
+                    3174,
+                    3186,
+                    3192,
+                    3199,
+                    3258,
+                    3267,
+                    3270,
+                    3275,
+                    3284,
+                    3318,
+                    3361,
+                    3368,
+                    3412,
+                    3429,
+                    3450,
+                    3556,
+                    3659,
+                    3674,
+                    3685,
+                    3712,
+                    3715,
+                    3719,
+                    3756,
+                    3768,
+                    3860,
+                    3896,
+                    3956,
+                    3997,
+                    4008,
+                    4092,
+                    4107,
+                    4127,
+                    4133,
+                    4136,
+                    4141,
+                    4150,
+                    4156,
+                    4174,
+                    4180
+                ],
+                "trial": [
+                    82,
+                    2762
+                ],
+                "other": [
+                    88,
+                    151,
+                    1233,
+                    1676,
+                    2548,
+                    3829
+                ],
+                "disorders": [
+                    90
+                ],
+                "(here": [
+                    91
+                ],
+                "right": [
+                    94,
+                    1126,
+                    1129,
+                    1142,
+                    1148,
+                    1160
+                ],
+                "side": [
+                    95
+                ],
+                "page)": [
+                    98
+                ],
+                "if": [
+                    100,
+                    2212
+                ],
+                "approved": [
+                    101
+                ],
+                "can": [
+                    103,
+                    306,
+                    645,
+                    1021,
+                    1961,
+                    2427,
+                    2807
+                ],
+                "post": [
+                    104
+                ],
+                "comment": [
+                    106,
+                    265,
+                    3762
+                ],
+                "screenshot": [
+                    109
+                ],
+                "an": [
+                    111,
+                    586,
+                    1309,
+                    2013,
+                    2097,
+                    2224,
+                    2234,
+                    2664,
+                    2700,
+                    2782,
+                    3091,
+                    3301,
+                    3407,
+                    3880,
+                    3889,
+                    3975
+                ],
+                "approval": [
+                    112
+                ],
+                "email": [
+                    113
+                ],
+                "under": [
+                    114,
+                    556,
+                    703
+                ],
+                "receive": [
+                    118
+                ],
+                "payment.": [
+                    119
+                ],
+                "-Current": [
+                    120
+                ],
+                "price": [
+                    121
+                ],
+                "ResearchCoinOverview": [
+                    123
+                ],
+                "SummaryTranscranial": [
+                    125
+                ],
+                "magnetic": [
+                    126,
+                    810
+                ],
+                "stimulation": [
+                    128,
+                    812
+                ],
+                "(TMS),": [
+                    129
+                ],
+                "namely": [
+                    130
+                ],
+                "dorsolateral": [
+                    133,
+                    989,
+                    1092,
+                    1180
+                ],
+                "pre-frontal": [
+                    134,
+                    913,
+                    990,
+                    1093
+                ],
+                "cortex": [
+                    135,
+                    914,
+                    991,
+                    1094,
+                    2113,
+                    2274
+                ],
+                "is": [
+                    136,
+                    191,
+                    245,
+                    335,
+                    442,
+                    449,
+                    471,
+                    580,
+                    666,
+                    686,
+                    701,
+                    710,
+                    729,
+                    824,
+                    841,
+                    895,
+                    949,
+                    980,
+                    1308,
+                    1388,
+                    1442,
+                    1485,
+                    1570,
+                    1631,
+                    1733,
+                    1754,
+                    1769,
+                    1797,
+                    1824,
+                    1934,
+                    2036,
+                    2129,
+                    2223,
+                    2233,
+                    2246,
+                    2265,
+                    2423,
+                    2492,
+                    2611,
+                    2803,
+                    2819,
+                    2839,
+                    2847,
+                    2852,
+                    2867,
+                    2878,
+                    2981,
+                    3055,
+                    3152,
+                    3159,
+                    3179,
+                    3181,
+                    3428,
+                    3668,
+                    3752,
+                    3795,
+                    3812,
+                    3818,
+                    3833,
+                    3888,
+                    3901,
+                    3955,
+                    4004,
+                    4131,
+                    4173
+                ],
+                "viable": [
+                    138
+                ],
+                "option": [
+                    139
+                ],
+                "treat": [
+                    141,
+                    594,
+                    2101,
+                    2739,
+                    2814
+                ],
+                "disorders.": [
+                    145
+                ],
+                "combines": [
+                    148
+                ],
+                "more": [
+                    152,
+                    2143,
+                    2754,
+                    3910
+                ],
+                "novel": [
+                    153,
+                    3352
+                ],
+                "psychedelic": [
+                    154,
+                    177,
+                    341,
+                    619,
+                    2773,
+                    2810,
+                    2826,
+                    2845,
+                    3259
+                ],
+                "including": [
+                    156,
+                    650,
+                    2082,
+                    2598,
+                    3551
+                ],
+                "ibogaine,": [
+                    157
+                ],
+                "psilocybin,": [
+                    158
+                ],
+                "cannabis,": [
+                    159
+                ],
+                "ketamine": [
+                    160,
+                    2421,
+                    2541,
+                    2572,
+                    2630,
+                    2668,
+                    2761,
+                    3148
+                ],
+                "DMT.": [
+                    162
+                ],
+                "discuss": [
+                    168
+                ],
+                "studies": [
+                    169,
+                    186,
+                    1351,
+                    3663
+                ],
+                "surrounding": [
+                    170
+                ],
+                "efficacy,": [
+                    172
+                ],
+                "safety,": [
+                    173
+                ],
+                "future": [
+                    175
+                ],
+                "research,": [
+                    178
+                ],
+                "as": [
+                    179,
+                    181,
+                    275,
+                    277,
+                    316,
+                    397,
+                    668,
+                    678,
+                    712,
+                    714,
+                    730,
+                    732,
+                    766,
+                    834,
+                    869,
+                    1594,
+                    2077,
+                    2118,
+                    2189,
+                    2645,
+                    2686,
+                    2747,
+                    2749,
+                    3325,
+                    3485,
+                    3495,
+                    3699
+                ],
+                "well": [
+                    180,
+                    276,
+                    466,
+                    1280,
+                    2748,
+                    3083
+                ],
+                "what": [
+                    182,
+                    393,
+                    2561,
+                    3954
+                ],
+                "some": [
+                    183,
+                    279,
+                    1216,
+                    1292,
+                    2820,
+                    3455
+                ],
+                "early": [
+                    184
+                ],
+                "mouse": [
+                    185
+                ],
+                "are": [
+                    187,
+                    222,
+                    290,
+                    367,
+                    382,
+                    415,
+                    423,
+                    553,
+                    798,
+                    1120,
+                    1156,
+                    1472,
+                    1991,
+                    2120,
+                    2180,
+                    2631,
+                    2727,
+                    2956,
+                    3011,
+                    3041,
+                    3048,
+                    3205
+                ],
+                "pointing": [
+                    188
+                ],
+                "towards": [
+                    189
+                ],
+                "which": [
+                    190,
+                    249,
+                    414,
+                    1495,
+                    1575,
+                    2103,
+                    2422,
+                    2763,
+                    2858,
+                    3030,
+                    3156,
+                    3550,
+                    3791,
+                    3811,
+                    3878,
+                    4130
+                ],
+                "ability": [
+                    193,
+                    862,
+                    3268,
+                    3415
+                ],
+                "remove": [
+                    195,
+                    2808
+                ],
+                "psychological": [
+                    197,
+                    2509,
+                    2769,
+                    3970
+                ],
+                "effects": [
+                    198,
+                    2620,
+                    2696,
+                    3894,
+                    4117
+                ],
+                "drug": [
+                    201,
+                    2465,
+                    2473,
+                    3914,
+                    3994
+                ],
+                "but": [
+                    203,
+                    1357,
+                    1379,
+                    1598,
+                    1986,
+                    1996,
+                    2499,
+                    2849,
+                    2963,
+                    3060,
+                    3087,
+                    3185,
+                    3823,
+                    3899,
+                    4084
+                ],
+                "maintain": [
+                    204,
+                    2832
+                ],
+                "mental": [
+                    206,
+                    437
+                ],
+                "illness": [
+                    207
+                ],
+                "treating": [
+                    208,
+                    2744
+                ],
+                "aspect": [
+                    209
+                ],
+                "it.": [
+                    211
+                ],
+                "Additional": [
+                    212
+                ],
+                "discussions": [
+                    213
+                ],
+                "include,": [
+                    214
+                ],
+                "topic": [
+                    216
+                ],
+                "whether": [
+                    218,
+                    2805
+                ],
+                "or": [
+                    219,
+                    259,
+                    388,
+                    407,
+                    547,
+                    934,
+                    1139,
+                    1403,
+                    1415,
+                    1658,
+                    2230,
+                    2236,
+                    2242,
+                    2414,
+                    2533,
+                    2539,
+                    2873,
+                    2949,
+                    3077,
+                    3202,
+                    3398,
+                    3434,
+                    3564,
+                    3566,
+                    3906,
+                    4040
+                ],
+                "not": [
+                    220,
+                    383,
+                    1375,
+                    1435,
+                    2500,
+                    2840,
+                    2965,
+                    3064,
+                    3072,
+                    3166,
+                    3460,
+                    3490,
+                    3677,
+                    3682,
+                    3697,
+                    3782,
+                    3796,
+                    3825
+                ],
+                "SSRI's": [
+                    221,
+                    584,
+                    2999,
+                    3020
+                ],
+                "efficacious,": [
+                    223
+                ],
+                "misconception": [
+                    225
+                ],
+                "chemical": [
+                    228,
+                    3079
+                ],
+                "imbalance,": [
+                    229
+                ],
+                "ketamine,": [
+                    230
+                ],
+                "cannabis": [
+                    231
+                ],
+                "(THC/CBD": [
+                    232
+                ],
+                "balances),": [
+                    233
+                ],
+                "Note:": [
+                    234
+                ],
+                "In": [
+                    235,
+                    440,
+                    944,
+                    3257
+                ],
+                "ethos": [
+                    237
+                ],
+                "Open": [
+                    239
+                ],
+                "Science": [
+                    240
+                ],
+                "transparent": [
+                    242
+                ],
+                "publication,": [
+                    243
+                ],
+                "living": [
+                    247
+                ],
+                "document": [
+                    248,
+                    274
+                ],
+                "undergo": [
+                    251
+                ],
+                "continuous": [
+                    252
+                ],
+                "improvement.": [
+                    253
+                ],
+                "have": [
+                    256,
+                    1082,
+                    1163,
+                    1421,
+                    1464,
+                    1599,
+                    1686,
+                    2514,
+                    2580,
+                    2708,
+                    2729,
+                    2799,
+                    3107,
+                    3191,
+                    3406,
+                    3801,
+                    3850,
+                    4120
+                ],
+                "suggestions,": [
+                    257
+                ],
+                "expansions,": [
+                    258
+                ],
+                "corrections": [
+                    260
+                ],
+                "please": [
+                    261,
+                    3761
+                ],
+                "feel": [
+                    262,
+                    1965,
+                    2428,
+                    3208
+                ],
+                "free": [
+                    263
+                ],
+                "thread": [
+                    268
+                ],
+                "we": [
+                    270,
+                    366,
+                    422,
+                    891,
+                    1395,
+                    1928,
+                    1939,
+                    3069
+                ],
+                "adjust": [
+                    272,
+                    3767
+                ],
+                "award": [
+                    278
+                ],
+                "RSC": [
+                    280
+                ],
+                "your": [
+                    282,
+                    865,
+                    3246
+                ],
+                "help.Key": [
+                    283
+                ],
+                "Bounties": [
+                    284
+                ],
+                "Discussion": [
+                    286
+                ],
+                "Direction:The": [
+                    288
+                ],
+                "following": [
+                    289,
+                    853,
+                    2024
+                ],
+                "bounties": [
+                    291
+                ],
+                "related": [
+                    292,
+                    872,
+                    3102,
+                    3342
+                ],
+                "topics": [
+                    295,
+                    628
+                ],
+                "podcast": [
+                    298
+                ],
+                "Bounty:": [
+                    299,
+                    464,
+                    487,
+                    578,
+                    602
+                ],
+                "Is": [
+                    300,
+                    475,
+                    1410,
+                    3627
+                ],
+                "there": [
+                    301,
+                    443,
+                    823,
+                    1484,
+                    2616,
+                    2980,
+                    3541
+                ],
+                "any": [
+                    302
+                ],
+                "evidence": [
+                    303,
+                    444,
+                    567,
+                    1359,
+                    2280,
+                    4176
+                ],
+                "that": [
+                    304,
+                    445,
+                    491,
+                    517,
+                    520,
+                    531,
+                    552,
+                    829,
+                    1079,
+                    1117,
+                    1272,
+                    1383,
+                    1510,
+                    1604,
+                    1810,
+                    1930,
+                    1950,
+                    2249,
+                    2439,
+                    2466,
+                    2474,
+                    2726,
+                    2767,
+                    2843,
+                    2978,
+                    2993,
+                    3056,
+                    3104,
+                    3113,
+                    3122,
+                    3131,
+                    3145,
+                    3279,
+                    3290,
+                    3305,
+                    3349,
+                    3527,
+                    3561,
+                    3639,
+                    3642,
+                    3656,
+                    3658,
+                    3684,
+                    3772,
+                    3780,
+                    3793,
+                    4080
+                ],
+                "“self-talk”": [
+                    305,
+                    349
+                ],
+                "modulate": [
+                    307
+                ],
+                "heart": [
+                    308,
+                    380,
+                    498,
+                    691,
+                    697,
+                    717,
+                    722,
+                    797,
+                    804,
+                    851,
+                    979,
+                    1211,
+                    1227,
+                    1238,
+                    1340,
+                    1369,
+                    1385,
+                    2182,
+                    2450
+                ],
+                "rate,": [
+                    309,
+                    2451
+                ],
+                "particularly": [
+                    310
+                ],
+                "rapid": [
+                    312
+                ],
+                "recovery": [
+                    313,
+                    387
+                ],
+                "situations": [
+                    314
+                ],
+                "such": [
+                    315,
+                    1593,
+                    2117
+                ],
+                "those": [
+                    317
+                ],
+                "detailed": [
+                    318
+                ],
+                "work": [
+                    320,
+                    1278,
+                    1367,
+                    1690,
+                    3009,
+                    3059
+                ],
+                "by": [
+                    321,
+                    680,
+                    1634,
+                    1993,
+                    2583,
+                    2916,
+                    3043
+                ],
+                "David": [
+                    323
+                ],
+                "Burns": [
+                    324
+                ],
+                "(see": [
+                    325
+                ],
+                "publications": [
+                    326
+                ],
+                "podcasts,": [
+                    328
+                ],
+                "available": [
+                    329
+                ],
+                "at": [
+                    330,
+                    4054
+                ],
+                "https://feelinggood.com)?": [
+                    331
+                ],
+                "JCMBounty:": [
+                    333,
+                    376
+                ],
+                "What": [
+                    334,
+                    2042,
+                    2989,
+                    4003
+                ],
+                "our": [
+                    336
+                ],
+                "current": [
+                    337,
+                    926,
+                    954,
+                    1350
+                ],
+                "understanding": [
+                    338
+                ],
+                "how": [
+                    340,
+                    351,
+                    705,
+                    803,
+                    1656,
+                    1938
+                ],
+                "trips": [
+                    342
+                ],
+                "induce": [
+                    343,
+                    924,
+                    3090
+                ],
+                "change": [
+                    345,
+                    835,
+                    2510,
+                    3274,
+                    3442,
+                    4124
+                ],
+                "person's": [
+                    348
+                ],
+                "does": [
+                    352,
+                    1206,
+                    2787
+                ],
+                "relate": [
+                    354
+                ],
+                "“lack": [
+                    357,
+                    875
+                ],
+                "control": [
+                    359,
+                    550,
+                    877,
+                    1290,
+                    1969
+                ],
+                "over": [
+                    360,
+                    630,
+                    658,
+                    878,
+                    1291,
+                    2595,
+                    3037,
+                    3084,
+                    3533,
+                    4010,
+                    4046
+                ],
+                "inner": [
+                    361,
+                    879
+                ],
+                "states?\"": [
+                    362
+                ],
+                "For": [
+                    363,
+                    419
+                ],
+                "bounty,": [
+                    365,
+                    421
+                ],
+                "looking": [
+                    368,
+                    424
+                ],
+                "anecdotal": [
+                    370,
+                    566,
+                    1358
+                ],
+                "and/or": [
+                    371
+                ],
+                "peer-reviewed": [
+                    372
+                ],
+                "research": [
+                    373
+                ],
+                "statements.": [
+                    374
+                ],
+                "As": [
+                    377
+                ],
+                "changes": [
+                    378,
+                    390,
+                    3121,
+                    3447,
+                    3459,
+                    4094
+                ],
+                "rate": [
+                    381,
+                    499,
+                    692,
+                    805,
+                    852,
+                    1212,
+                    1239,
+                    1341,
+                    1370,
+                    1386,
+                    2183
+                ],
+                "indicative": [
+                    384
+                ],
+                "long-term": [
+                    386,
+                    3458
+                ],
+                "chronic": [
+                    389,
+                    3044
+                ],
+                "mood,": [
+                    392
+                ],
+                "might": [
+                    394,
+                    3063
+                ],
+                "clinicians": [
+                    395
+                ],
+                "use": [
+                    396,
+                    411,
+                    1981,
+                    3293
+                ],
+                "physiological": [
+                    399,
+                    1941
+                ],
+                "marker": [
+                    400,
+                    435
+                ],
+                "reduction": [
+                    402,
+                    849
+                ],
+                "baseline": [
+                    404,
+                    4089
+                ],
+                "anxiety,": [
+                    405
+                ],
+                "panic,": [
+                    406
+                ],
+                "depression?": [
+                    408,
+                    1219
+                ],
+                "Current": [
+                    409
+                ],
+                "self-assessment": [
+                    412
+                ],
+                "strategies": [
+                    413
+                ],
+                "qualitative": [
+                    416
+                ],
+                "nature.": [
+                    418
+                ],
+                "discussion": [
+                    427
+                ],
+                "around": [
+                    428,
+                    2734
+                ],
+                "design": [
+                    430
+                ],
+                "quantitative,": [
+                    433
+                ],
+                "non-invasive": [
+                    434,
+                    2124
+                ],
+                "health": [
+                    438
+                ],
+                "rehabilitation.": [
+                    439
+                ],
+                "addition,": [
+                    441
+                ],
+                "proposed": [
+                    447
+                ],
+                "metric": [
+                    448
+                ],
+                "hypothetically": [
+                    450
+                ],
+                "sound?": [
+                    451
+                ],
+                "Please": [
+                    452
+                ],
+                "provide": [
+                    453,
+                    3123
+                ],
+                "short": [
+                    455
+                ],
+                "description": [
+                    456
+                ],
+                "against": [
+                    459,
+                    3099
+                ],
+                "this.": [
+                    460
+                ],
+                "JCMSegment": [
+                    462
+                ],
+                "How": [
+                    465,
+                    2462
+                ],
+                "representative": [
+                    467
+                ],
+                "population": [
+                    470
+                ],
+                "human": [
+                    473
+                ],
+                "connectome?": [
+                    474
+                ],
+                "only": [
+                    477,
+                    814,
+                    2587,
+                    3465,
+                    3773
+                ],
+                "valid": [
+                    478
+                ],
+                "healthy": [
+                    480,
+                    845,
+                    1963,
+                    4030,
+                    4034
+                ],
+                "adult": [
+                    481
+                ],
+                "males?": [
+                    482
+                ],
+                "Tyler": [
+                    484,
+                    575,
+                    599
+                ],
+                "DiorioSegment": [
+                    485,
+                    576,
+                    600
+                ],
+                "Could": [
+                    488
+                ],
+                "it": [
+                    489,
+                    1297,
+                    1361,
+                    1814,
+                    1946,
+                    2851,
+                    3061,
+                    3088,
+                    3158,
+                    3178,
+                    3680,
+                    3806
+                ],
+                "depressive": [
+                    492,
+                    1401,
+                    1788
+                ],
+                "symptoms": [
+                    493,
+                    1217,
+                    3331
+                ],
+                "line": [
+                    494
+                ],
+                "up": [
+                    495
+                ],
+                "decreased": [
+                    497
+                ],
+                "variability": [
+                    500,
+                    1371,
+                    1387
+                ],
+                "because": [
+                    501,
+                    2003,
+                    2585,
+                    3196
+                ],
+                "depressed": [
+                    502,
+                    561,
+                    572,
+                    1728,
+                    2728,
+                    3271
+                ],
+                "individuals": [
+                    503,
+                    1639,
+                    1667,
+                    1729,
+                    1990,
+                    3272,
+                    3419,
+                    3771,
+                    3779
+                ],
+                "employ": [
+                    504
+                ],
+                "coping": [
+                    506
+                ],
+                "mechanism": [
+                    507
+                ],
+                "downplaying": [
+                    509
+                ],
+                "emotions": [
+                    510,
+                    2432
+                ],
+                "queues": [
+                    513
+                ],
+                "so": [
+                    514,
+                    516,
+                    2006,
+                    3826
+                ],
+                "much": [
+                    515,
+                    1436,
+                    3827,
+                    3903,
+                    3909
+                ],
+                "they": [
+                    518,
+                    1609,
+                    1660,
+                    2513,
+                    2553,
+                    2689,
+                    3197,
+                    3306,
+                    3394
+                ],
+                "train": [
+                    519,
+                    993
+                ],
+                "specific": [
+                    521,
+                    3757,
+                    4122
+                ],
+                "pathways": [
+                    523,
+                    542
+                ],
+                "less": [
+                    526,
+                    2237,
+                    2515
+                ],
+                "reactive": [
+                    527
+                ],
+                "signaling.": [
+                    529
+                ],
+                "Whether": [
+                    530
+                ],
+                "through": [
+                    533,
+                    548,
+                    568,
+                    927,
+                    1252,
+                    1498
+                ],
+                "physical": [
+                    534,
+                    2750
+                ],
+                "increases": [
+                    535,
+                    753,
+                    3875
+                ],
+                "resistance": [
+                    538,
+                    3484
+                ],
+                "(which": [
+                    543,
+                    563,
+                    3667
+                ],
+                "would": [
+                    544,
+                    564,
+                    2579,
+                    3283
+                ],
+                "measurable)": [
+                    546
+                ],
+                "underlying": [
+                    549,
+                    2794,
+                    2871
+                ],
+                "mechanisms": [
+                    551
+                ],
+                "being": [
+                    554,
+                    1817,
+                    2017,
+                    2121,
+                    3759,
+                    3991
+                ],
+                "trained": [
+                    555
+                ],
+                "supervision": [
+                    557
+                ],
+                "conscious,": [
+                    560
+                ],
+                "require": [
+                    565
+                ],
+                "experiences": [
+                    570,
+                    614,
+                    3164
+                ],
+                "individuals)": [
+                    573
+                ],
+                "Why": [
+                    579,
+                    1205
+                ],
+                "dose": [
+                    582,
+                    2551,
+                    2733,
+                    3431,
+                    3571
+                ],
+                "almost": [
+                    585
+                ],
+                "order": [
+                    587,
+                    2558
+                ],
+                "magnitude": [
+                    589
+                ],
+                "higher": [
+                    590
+                ],
+                "when": [
+                    591,
+                    2656,
+                    3502
+                ],
+                "attempting": [
+                    592
+                ],
+                "OCD": [
+                    595,
+                    2076,
+                    2960
+                ],
+                "vs": [
+                    596
+                ],
+                "Depression?": [
+                    597
+                ],
+                "Does": [
+                    603
+                ],
+                "Space": [
+                    604
+                ],
+                "Learning": [
+                    605
+                ],
+                "Theory": [
+                    606
+                ],
+                "support": [
+                    607,
+                    3971
+                ],
+                "need": [
+                    609
+                ],
+                "long": [
+                    611,
+                    2860
+                ],
+                "time": [
+                    612,
+                    1488,
+                    1602,
+                    1822,
+                    3497,
+                    4056
+                ],
+                "frame": [
+                    613
+                ],
+                "(>": [
+                    615
+                ],
+                "2-3": [
+                    616
+                ],
+                "hours)": [
+                    617
+                ],
+                "compounds,": [
+                    620
+                ],
+                "potentially": [
+                    621,
+                    1825,
+                    2964
+                ],
+                "allowing": [
+                    622
+                ],
+                "individual": [
+                    624
+                ],
+                "approach": [
+                    626
+                ],
+                "similar": [
+                    627,
+                    848,
+                    4125
+                ],
+                "spaced": [
+                    629
+                ],
+                "1-1.5": [
+                    631
+                ],
+                "hour": [
+                    632
+                ],
+                "rest": [
+                    633,
+                    1952,
+                    3175,
+                    3371
+                ],
+                "periods?": [
+                    634
+                ],
+                "Segment": [
+                    635,
+                    779,
+                    1062,
+                    1192,
+                    1554,
+                    1918,
+                    2026,
+                    2404,
+                    2940,
+                    3226,
+                    3375,
+                    3625,
+                    3982
+                ],
+                "1:": [
+                    636
+                ],
+                "Depression,": [
+                    637,
+                    1197
+                ],
+                "Risk": [
+                    638
+                ],
+                "Factors,": [
+                    639
+                ],
+                "Emergency": [
+                    640
+                ],
+                "Psychiatric": [
+                    641
+                ],
+                "Treatments": [
+                    642
+                ],
+                "(00:09:16)Depression": [
+                    643
+                ],
+                "manifest": [
+                    646
+                ],
+                "various": [
+                    648
+                ],
+                "forms": [
+                    649
+                ],
+                "1.": [
+                    651
+                ],
+                "loss": [
+                    652,
+                    1967,
+                    2638
+                ],
+                "interest": [
+                    654
+                ],
+                "2.": [
+                    655
+                ],
+                "anxious": [
+                    656
+                ],
+                "active": [
+                    659
+                ],
+                "3.": [
+                    660
+                ],
+                "no": [
+                    661,
+                    2581,
+                    2619,
+                    2982,
+                    3787
+                ],
+                "motivation": [
+                    662
+                ],
+                "inactive.": [
+                    664
+                ],
+                "Depression": [
+                    665,
+                    1535,
+                    1847,
+                    1925,
+                    3386,
+                    3988
+                ],
+                "listed": [
+                    667,
+                    679
+                ],
+                "4th": [
+                    670
+                ],
+                "major": [
+                    671,
+                    3515
+                ],
+                "risk": [
+                    672
+                ],
+                "factor": [
+                    673
+                ],
+                "coronary": [
+                    675
+                ],
+                "artery": [
+                    676
+                ],
+                "disease": [
+                    677,
+                    768,
+                    2816,
+                    2865
+                ],
+                "American": [
+                    682,
+                    1892
+                ],
+                "Heart": [
+                    683,
+                    1194
+                ],
+                "Association.": [
+                    684
+                ],
+                "able": [
+                    687,
+                    1805,
+                    2018,
+                    2691,
+                    3753
+                ],
+                "decelerate": [
+                    689
+                ],
+                "probe": [
+                    694
+                ],
+                "connection": [
+                    698,
+                    1020,
+                    1437,
+                    4134
+                ],
+                "depression.It": [
+                    700
+                ],
+                "very": [
+                    702,
+                    3902
+                ],
+                "appreciated": [
+                    704
+                ],
+                "disabling": [
+                    706,
+                    713,
+                    731
+                ],
+                "is:“Moderate": [
+                    708
+                ],
+                "about": [
+                    711,
+                    1622,
+                    3339
+                ],
+                "having": [
+                    715,
+                    720,
+                    733
+                ],
+                "attack,": [
+                    718
+                ],
+                "acutely": [
+                    719
+                ],
+                "attack.”": [
+                    723
+                ],
+                "Williams“Severe": [
+                    727
+                ],
+                "cancer": [
+                    734,
+                    741
+                ],
+                "without": [
+                    735,
+                    742
+                ],
+                "dying": [
+                    738
+                ],
+                "from": [
+                    739,
+                    1039,
+                    1101,
+                    1115,
+                    1259,
+                    1524,
+                    1816,
+                    2430,
+                    3300,
+                    3470,
+                    3487,
+                    3491,
+                    3504,
+                    3746
+                ],
+                "treatment”": [
+                    744
+                ],
+                "WilliamsGenerally": [
+                    748
+                ],
+                "emergency": [
+                    750
+                ],
+                "medicine": [
+                    751
+                ],
+                "symptom": [
+                    755,
+                    1402
+                ],
+                "severity": [
+                    756,
+                    769
+                ],
+                "increase": [
+                    757,
+                    2014,
+                    4017
+                ],
+                "amount": [
+                    759
+                ],
+                "treatments/procedures": [
+                    761
+                ],
+                "attempted;": [
+                    762
+                ],
+                "psychiatric": [
+                    764,
+                    2303,
+                    4183
+                ],
+                "disease,": [
+                    765
+                ],
+                "increases,": [
+                    770
+                ],
+                "number": [
+                    772
+                ],
+                "go": [
+                    775,
+                    1975
+                ],
+                "down": [
+                    776,
+                    957,
+                    1011,
+                    1213,
+                    1225,
+                    1240,
+                    1808
+                ],
+                "average!": [
+                    778
+                ],
+                "2:": [
+                    780
+                ],
+                "The": [
+                    781,
+                    978,
+                    1184,
+                    1662,
+                    1790,
+                    1801,
+                    2488,
+                    2784,
+                    3053,
+                    3694,
+                    3726,
+                    4072
+                ],
+                "Brain-Heart": [
+                    782
+                ],
+                "Connection,": [
+                    783
+                ],
+                "Vagus": [
+                    784
+                ],
+                "Nerve,": [
+                    785
+                ],
+                "Prefrontal": [
+                    786,
+                    1181,
+                    1921
+                ],
+                "Cortex": [
+                    787,
+                    1182,
+                    2029
+                ],
+                "(00:15:11)Regions": [
+                    788
+                ],
+                "associated": [
+                    792,
+                    807,
+                    881,
+                    1389,
+                    2318,
+                    2493,
+                    3049
+                ],
+                "emotion": [
+                    794
+                ],
+                "connected.Dr.": [
+                    799
+                ],
+                "comments": [
+                    801
+                ],
+                "modulation": [
+                    806,
+                    2866
+                ],
+                "transcranial": [
+                    809
+                ],
+                "(TMS)": [
+                    813,
+                    1203
+                ],
+                "explains": [
+                    815,
+                    2994
+                ],
+                "small": [
+                    817
+                ],
+                "percentage": [
+                    818
+                ],
+                "shifts.": [
+                    821
+                ],
+                "Rather,": [
+                    822
+                ],
+                "likely": [
+                    825,
+                    3847
+                ],
+                "“some": [
+                    826
+                ],
+                "parasympathetic": [
+                    827
+                ],
+                "process”": [
+                    828
+                ],
+                "causes": [
+                    830,
+                    937,
+                    996
+                ],
+                "happen": [
+                    833
+                ],
+                "due": [
+                    838,
+                    950
+                ],
+                "acute": [
+                    842,
+                    3462
+                ],
+                "otherwise": [
+                    844
+                ],
+                "persons": [
+                    846,
+                    907
+                ],
+                "experience": [
+                    847,
+                    2770
+                ],
+                "TMS.": [
+                    854
+                ],
+                "Drs.": [
+                    855
+                ],
+                "speak": [
+                    859
+                ],
+                "‘control’": [
+                    864
+                ],
+                "autonomic": [
+                    866,
+                    2185
+                ],
+                "nervous": [
+                    867
+                ],
+                "system": [
+                    868,
+                    1449,
+                    2601,
+                    3898
+                ],
+                "‘hinge'": [
+                    871
+                ],
+                "states\"": [
+                    880
+                ],
+                "depression.": [
+                    883,
+                    1334,
+                    1800,
+                    2461,
+                    2988
+                ],
+                "Of": [
+                    884
+                ],
+                "note,": [
+                    885
+                ],
+                "sense": [
+                    887,
+                    2453
+                ],
+                "‘how": [
+                    889
+                ],
+                "do": [
+                    890,
+                    1466,
+                    1641,
+                    1701,
+                    2096,
+                    3165,
+                    3389,
+                    3852
+                ],
+                "talk": [
+                    892,
+                    1396,
+                    1404
+                ],
+                "ourselves’": [
+                    894
+                ],
+                "keystone": [
+                    897
+                ],
+                "cognitive": [
+                    899,
+                    1834
+                ],
+                "behavioral": [
+                    900,
+                    1648,
+                    1856
+                ],
+                "therapy": [
+                    901,
+                    1649,
+                    1684,
+                    1703,
+                    1835,
+                    1857,
+                    3592
+                ],
+                "(CBT)--a": [
+                    902
+                ],
+                "profoundly": [
+                    903
+                ],
+                "powerful": [
+                    904
+                ],
+                "tool": [
+                    905
+                ],
+                "compulsive": [
+                    909
+                ],
+                "debilitating": [
+                    911
+                ],
+                "depressions.Dorsolateral": [
+                    912
+                ],
+                "(DLPFC):": [
+                    915
+                ],
+                "governor": [
+                    916,
+                    1936
+                ],
+                "brainUse": [
+                    919
+                ],
+                "magnet": [
+                    921
+                ],
+                "pulse": [
+                    922
+                ],
+                "electric": [
+                    925
+                ],
+                "tissue": [
+                    930
+                ],
+                "(not": [
+                    931
+                ],
+                "skull,": [
+                    932
+                ],
+                "scalp": [
+                    933
+                ],
+                "hair)": [
+                    935
+                ],
+                "depolarization": [
+                    939,
+                    948
+                ],
+                "cortical": [
+                    941
+                ],
+                "(surface)": [
+                    942
+                ],
+                "neurons.": [
+                    943
+                ],
+                "scanner,": [
+                    946
+                ],
+                "induced": [
+                    952
+                ],
+                "electrical": [
+                    953
+                ],
+                "physically": [
+                    955
+                ],
+                "traveling": [
+                    956
+                ],
+                "anterior": [
+                    960,
+                    1432,
+                    1731,
+                    1760,
+                    1774,
+                    2040,
+                    2060,
+                    2069,
+                    2085,
+                    2098,
+                    2111,
+                    2154,
+                    2323,
+                    4138
+                ],
+                "cingulate,": [
+                    961
+                ],
+                "insula,": [
+                    962
+                ],
+                "amygdala,": [
+                    963
+                ],
+                "…,": [
+                    964
+                ],
+                "nucleus": [
+                    965
+                ],
+                "tractus": [
+                    966
+                ],
+                "soltarius,": [
+                    967
+                ],
+                "ultimately": [
+                    969,
+                    2545
+                ],
+                "into": [
+                    970,
+                    1406,
+                    1678
+                ],
+                "vagus": [
+                    972,
+                    1248
+                ],
+                "nerve": [
+                    973,
+                    1243,
+                    1249
+                ],
+                "thus": [
+                    975,
+                    3892
+                ],
+                "heart.": [
+                    977
+                ],
+                "end": [
+                    982
+                ],
+                "organ": [
+                    983
+                ],
+                "DLPFC": [
+                    986,
+                    1149,
+                    1208,
+                    1265,
+                    1354,
+                    1428,
+                    1453,
+                    1462,
+                    1494,
+                    1624,
+                    1739,
+                    1753,
+                    1768,
+                    1803,
+                    1933,
+                    1973,
+                    2679
+                ],
+                "[2-1].Stimulation": [
+                    987
+                ],
+                "(2-second": [
+                    992
+                ],
+                "stimulation)": [
+                    995
+                ],
+                "repeatable": [
+                    998
+                ],
+                "10-bpm": [
+                    999
+                ],
+                "deceleration": [
+                    1000
+                ],
+                "second,": [
+                    1003
+                ],
+                "breaks": [
+                    1004
+                ],
+                "seconds,": [
+                    1007
+                ],
+                "then": [
+                    1008,
+                    1664,
+                    2217,
+                    2637,
+                    4050
+                ],
+                "goes": [
+                    1009
+                ],
+                "back": [
+                    1010,
+                    3098
+                ],
+                "sinusoidal": [
+                    1014
+                ],
+                "fashion.": [
+                    1015
+                ],
+                "Schematic": [
+                    1016
+                ],
+                "brain-heart": [
+                    1019,
+                    1035
+                ],
+                "found": [
+                    1023
+                ],
+                "belowFigure": [
+                    1024
+                ],
+                "2-1:": [
+                    1025
+                ],
+                "Map": [
+                    1026,
+                    1097
+                ],
+                "spatial": [
+                    1028,
+                    2131,
+                    4102
+                ],
+                "connections": [
+                    1029,
+                    1424
+                ],
+                "frontal-vegal": [
+                    1032
+                ],
+                "pathway,": [
+                    1033
+                ],
+                "demonstrating": [
+                    1034
+                ],
+                "connection.": [
+                    1036
+                ],
+                "Image": [
+                    1037,
+                    1113,
+                    1522
+                ],
+                "obtained": [
+                    1038,
+                    1114,
+                    1523
+                ],
+                "[2-1].": [
+                    1040
+                ],
+                "References[2-1]": [
+                    1041
+                ],
+                "Iseger": [
+                    1042
+                ],
+                "et": [
+                    1043,
+                    1103,
+                    1167,
+                    1540,
+                    1830,
+                    1852,
+                    1880,
+                    1898,
+                    2313,
+                    2332,
+                    2348,
+                    2377,
+                    2907,
+                    2926,
+                    3214,
+                    3575,
+                    3588,
+                    3607,
+                    3738,
+                    3917,
+                    3932,
+                    3965,
+                    4076,
+                    4193,
+                    4208
+                ],
+                "al.": [
+                    1044,
+                    1104,
+                    1168,
+                    1541,
+                    1831,
+                    1853,
+                    1881,
+                    1899,
+                    2314,
+                    2333,
+                    2349,
+                    2378,
+                    2908,
+                    2927,
+                    3215,
+                    3576,
+                    3589,
+                    3608,
+                    3739,
+                    3918,
+                    3933,
+                    3966,
+                    4077,
+                    4194,
+                    4209
+                ],
+                "2020.": [
+                    1045,
+                    2334,
+                    2928,
+                    4195
+                ],
+                "“A": [
+                    1046,
+                    2929
+                ],
+                "frontal-vagal": [
+                    1047
+                ],
+                "network": [
+                    1048,
+                    4144
+                ],
+                "theory": [
+                    1049
+                ],
+                "Major": [
+                    1051,
+                    3617
+                ],
+                "Depressive": [
+                    1052
+                ],
+                "Disorder:": [
+                    1053
+                ],
+                "Implications": [
+                    1054
+                ],
+                "optimizing": [
+                    1056
+                ],
+                "neuromodulation": [
+                    1057
+                ],
+                "techniques”.": [
+                    1058
+                ],
+                "Brain": [
+                    1059,
+                    1067,
+                    3223,
+                    3985
+                ],
+                "Stimulation.": [
+                    1060,
+                    3224
+                ],
+                "https://www.sciencedirect.com/science/article/pii/S1935861X19304139": [
+                    1061
+                ],
+                "3:": [
+                    1063
+                ],
+                "Right": [
+                    1064
+                ],
+                "vs.": [
+                    1065
+                ],
+                "Left": [
+                    1066,
+                    1174
+                ],
+                "Hemispheres": [
+                    1068
+                ],
+                "&": [
+                    1069,
+                    1196,
+                    1560,
+                    1924,
+                    2030,
+                    2033,
+                    2410,
+                    2944,
+                    3229,
+                    3233,
+                    3378,
+                    3385,
+                    3987
+                ],
+                "Mood": [
+                    1070
+                ],
+                "Balance,": [
+                    1071
+                ],
+                "Connectome": [
+                    1072
+                ],
+                "(00:17:51)Left": [
+                    1073
+                ],
+                "DLPFC:": [
+                    1074
+                ],
+                "Strokes": [
+                    1075
+                ],
+                "cause": [
+                    1080,
+                    1118,
+                    3021,
+                    3118,
+                    3873
+                ],
+                "been": [
+                    1083,
+                    1687,
+                    1718,
+                    2005,
+                    4014
+                ],
+                "shown": [
+                    1084,
+                    1566,
+                    1688,
+                    1719,
+                    4015
+                ],
+                "interrupt": [
+                    1086
+                ],
+                "wiring": [
+                    1088
+                ],
+                "left": [
+                    1091,
+                    1138,
+                    1207,
+                    1264,
+                    1353,
+                    1427,
+                    1452,
+                    1461,
+                    1493,
+                    1738,
+                    1752,
+                    1767,
+                    1802,
+                    1932,
+                    1972,
+                    2678
+                ],
+                "[3-1].Figure": [
+                    1095
+                ],
+                "3-1:": [
+                    1096
+                ],
+                "overlaid": [
+                    1099
+                ],
+                "lesions": [
+                    1100
+                ],
+                "Grajny": [
+                    1102,
+                    1166
+                ],
+                "showing": [
+                    1106,
+                    1507,
+                    3457,
+                    3729
+                ],
+                "locations": [
+                    1107
+                ],
+                "most": [
+                    1109
+                ],
+                "frequent": [
+                    1110
+                ],
+                "lesion": [
+                    1111,
+                    2107
+                ],
+                "distribution.": [
+                    1112
+                ],
+                "[3-1].Lesions": [
+                    1116
+                ],
+                "mania": [
+                    1119
+                ],
+                "all": [
+                    1121,
+                    1376,
+                    1820,
+                    2777,
+                    3570
+                ],
+                "commonly": [
+                    1122
+                ],
+                "connected": [
+                    1123
+                ],
+                "DLPFC.Left": [
+                    1127
+                ],
+                "balance": [
+                    1130
+                ],
+                "spatially": [
+                    1132
+                ],
+                "across": [
+                    1133
+                ],
+                "brain.Either": [
+                    1135
+                ],
+                "exciting": [
+                    1136
+                ],
+                "inhibit": [
+                    1140
+                ],
+                "result": [
+                    1143,
+                    2226
+                ],
+                "anti-depressant": [
+                    1145,
+                    4116
+                ],
+                "outcomesExciting": [
+                    1146
+                ],
+                "results": [
+                    1150,
+                    1378,
+                    3494,
+                    4073
+                ],
+                "anti-manic": [
+                    1152
+                ],
+                "outcomesHandedness?25%": [
+                    1153
+                ],
+                "Left-handed": [
+                    1154
+                ],
+                "people": [
+                    1155,
+                    1162,
+                    1420,
+                    1465,
+                    1471,
+                    1480,
+                    1582,
+                    1700,
+                    1964,
+                    2205,
+                    2218,
+                    2254,
+                    2661,
+                    2717,
+                    2725,
+                    3106,
+                    3437
+                ],
+                "usually": [
+                    1157
+                ],
+                "right-brain": [
+                    1158,
+                    1164
+                ],
+                "dominant1%": [
+                    1159
+                ],
+                "handed": [
+                    1161
+                ],
+                "dominantReferences[3-1]": [
+                    1165
+                ],
+                "2016.": [
+                    1169,
+                    2371,
+                    3967
+                ],
+                "“Depression": [
+                    1170
+                ],
+                "Symptoms": [
+                    1171
+                ],
+                "Chronic": [
+                    1173
+                ],
+                "Hemisphere": [
+                    1175
+                ],
+                "Stroke": [
+                    1176
+                ],
+                "Are": [
+                    1177,
+                    3393
+                ],
+                "Related": [
+                    1178
+                ],
+                "Damage”.": [
+                    1183
+                ],
+                "Journal": [
+                    1185,
+                    1874,
+                    1893,
+                    3524,
+                    3621
+                ],
+                "Neuropsychiatry": [
+                    1187
+                ],
+                "Neurosciences.": [
+                    1190
+                ],
+                "https://neuro.psychiatryonline.org/doi/10.1176/appi.neuropsych.16010004": [
+                    1191
+                ],
+                "4:": [
+                    1193
+                ],
+                "Rate": [
+                    1195
+                ],
+                "Behavioral": [
+                    1198,
+                    1876
+                ],
+                "Interventions,": [
+                    1199
+                ],
+                "Transcranial": [
+                    1200
+                ],
+                "Magnetic": [
+                    1201
+                ],
+                "Stimulation": [
+                    1202,
+                    1245
+                ],
+                "(00:22:34)": [
+                    1204
+                ],
+                "slow": [
+                    1209
+                ],
+                "alleviate": [
+                    1215,
+                    1241,
+                    1257
+                ],
+                "Brachycardia": [
+                    1220
+                ],
+                "occurs": [
+                    1221,
+                    2250,
+                    4162
+                ],
+                "during": [
+                    1222,
+                    4067
+                ],
+                "fear": [
+                    1223
+                ],
+                "(slowing": [
+                    1224
+                ],
+                "rate)": [
+                    1228
+                ],
+                "rather": [
+                    1229,
+                    2850,
+                    3126
+                ],
+                "than": [
+                    1230,
+                    1342,
+                    3127
+                ],
+                "speeding": [
+                    1231
+                ],
+                "upDo": [
+                    1232
+                ],
+                "ways": [
+                    1234
+                ],
+                "slowing": [
+                    1236
+                ],
+                "depression?Vagus": [
+                    1242
+                ],
+                "stimulation:": [
+                    1244
+                ],
+                "pervade": [
+                    1250
+                ],
+                "upward": [
+                    1251
+                ],
+                "same": [
+                    1254,
+                    2485,
+                    2684,
+                    2834,
+                    3138,
+                    4160
+                ],
+                "track": [
+                    1255
+                ],
+                "neck!Mindfulness": [
+                    1261
+                ],
+                "Meditation:": [
+                    1263
+                ],
+                "linked": [
+                    1266
+                ],
+                "meditation": [
+                    1268,
+                    1302,
+                    1321
+                ],
+                "mindfulness,": [
+                    1269
+                ],
+                "etc..": [
+                    1270
+                ],
+                "suggesting": [
+                    1271
+                ],
+                "behavior": [
+                    1273,
+                    3565
+                ],
+                "interventions": [
+                    1274
+                ],
+                "mild": [
+                    1276,
+                    1333,
+                    1692
+                ],
+                "quite": [
+                    1279,
+                    1704
+                ],
+                "volitional": [
+                    1282
+                ],
+                "threshold": [
+                    1283,
+                    1295,
+                    1319
+                ],
+                "where": [
+                    1286,
+                    1959,
+                    3245
+                ],
+                "start": [
+                    1288
+                ],
+                "losing": [
+                    1289
+                ],
+                "thoughts.": [
+                    1293
+                ],
+                "This": [
+                    1294,
+                    2838,
+                    3096,
+                    3151
+                ],
+                "makes": [
+                    1296
+                ],
+                "harder": [
+                    1298,
+                    1300
+                ],
+                "mindfulness": [
+                    1304,
+                    1323
+                ],
+                "work.": [
+                    1306
+                ],
+                "Catatonia": [
+                    1307,
+                    2034
+                ],
+                "extremely": [
+                    1310
+                ],
+                "far": [
+                    1311,
+                    1316
+                ],
+                "gone": [
+                    1312
+                ],
+                "categorization": [
+                    1313
+                ],
+                "depression,": [
+                    1315,
+                    3015
+                ],
+                "above": [
+                    1317,
+                    2174
+                ],
+                "work.Exercise:": [
+                    1325
+                ],
+                "seems": [
+                    1326,
+                    1782,
+                    2156,
+                    2974,
+                    3734
+                ],
+                "great": [
+                    1330
+                ],
+                "Athletes": [
+                    1335
+                ],
+                "hold": [
+                    1336,
+                    3286,
+                    3296
+                ],
+                "lower": [
+                    1338,
+                    1384
+                ],
+                "resting": [
+                    1339
+                ],
+                "non-athletes": [
+                    1343
+                ],
+                "non-active": [
+                    1345
+                ],
+                "athletes.": [
+                    1346
+                ],
+                "Not": [
+                    1347
+                ],
+                "aware": [
+                    1348
+                ],
+                "exercise": [
+                    1356
+                ],
+                "suggests": [
+                    1360
+                ],
+                "could": [
+                    1362,
+                    2463,
+                    2479,
+                    2742,
+                    2990,
+                    3237,
+                    3262,
+                    3366,
+                    3849
+                ],
+                "correlate.": [
+                    1363
+                ],
+                "lot": [
+                    1365,
+                    1381,
+                    1988
+                ],
+                "positive": [
+                    1377
+                ],
+                "say": [
+                    1382,
+                    1929,
+                    2842
+                ],
+                "moderate": [
+                    1391,
+                    1723
+                ],
+                "severe": [
+                    1393,
+                    3594
+                ],
+                "depression.Can": [
+                    1394
+                ],
+                "ourselves": [
+                    1397,
+                    1405
+                ],
+                "out": [
+                    1398
+                ],
+                "manic": [
+                    1408
+                ],
+                "situation?": [
+                    1409
+                ],
+                "structural": [
+                    1413
+                ],
+                "thing": [
+                    1414
+                ],
+                "thought-pattern": [
+                    1417
+                ],
+                "thing?Highly": [
+                    1418
+                ],
+                "hypnotizable": [
+                    1419,
+                    1440,
+                    2253
+                ],
+                "highly": [
+                    1422,
+                    2252,
+                    2447,
+                    3153,
+                    3160
+                ],
+                "functionally": [
+                    1423
+                ],
+                "dorsal": [
+                    1431,
+                    2110,
+                    2150,
+                    2322
+                ],
+                "cingulate": [
+                    1433,
+                    1732,
+                    1761,
+                    1775,
+                    1791,
+                    1811,
+                    2052,
+                    2061,
+                    2086,
+                    2112,
+                    2155,
+                    2203,
+                    2214,
+                    2273,
+                    4139
+                ],
+                "low": [
+                    1439
+                ],
+                "[4-1]This": [
+                    1441
+                ],
+                "smaller": [
+                    1444
+                ],
+                "subcategorization": [
+                    1445
+                ],
+                "larger": [
+                    1448
+                ],
+                "important": [
+                    1454,
+                    2879,
+                    3264
+                ],
+                "regulating": [
+                    1456
+                ],
+                "moodIf": [
+                    1457
+                ],
+                "knockout": [
+                    1459
+                ],
+                "Stroop": [
+                    1468,
+                    1505,
+                    1564,
+                    1636,
+                    1643,
+                    2054,
+                    2277,
+                    3241
+                ],
+                "test": [
+                    1469,
+                    2169,
+                    3242,
+                    4048
+                ],
+                "(where": [
+                    1470
+                ],
+                "tasked": [
+                    1473
+                ],
+                "naming": [
+                    1475
+                ],
+                "color": [
+                    1477
+                ],
+                "words),": [
+                    1479
+                ],
+                "perform": [
+                    1481,
+                    3310
+                ],
+                "poorly.": [
+                    1482
+                ],
+                "Specifically,": [
+                    1483
+                ],
+                "greater": [
+                    1487
+                ],
+                "delay": [
+                    1489
+                ],
+                "poorly": [
+                    1491
+                ],
+                "functioning": [
+                    1492
+                ],
+                "was": [
+                    1496,
+                    2658,
+                    3507,
+                    3681,
+                    3708,
+                    3786
+                ],
+                "improved": [
+                    1497,
+                    1992
+                ],
+                "stimulationFigure": [
+                    1499
+                ],
+                "4-1:": [
+                    1500
+                ],
+                "Example": [
+                    1501
+                ],
+                "original": [
+                    1504
+                ],
+                "Test": [
+                    1506,
+                    1644,
+                    2055
+                ],
+                "prompts": [
+                    1509
+                ],
+                "participants": [
+                    1511,
+                    1577,
+                    4031,
+                    4035
+                ],
+                "may": [
+                    1512,
+                    2707,
+                    2775,
+                    2828,
+                    3644
+                ],
+                "given": [
+                    1514,
+                    2659,
+                    3000,
+                    4037
+                ],
+                "analyze": [
+                    1516
+                ],
+                "language": [
+                    1517
+                ],
+                "processing": [
+                    1518
+                ],
+                "‘rule": [
+                    1520
+                ],
+                "switching’.": [
+                    1521
+                ],
+                "[4-2].References[4-1]": [
+                    1525
+                ],
+                "D.": [
+                    1526
+                ],
+                "Spiegel.": [
+                    1527
+                ],
+                "2013.": [
+                    1528,
+                    3934
+                ],
+                "“Tranceformations:": [
+                    1529
+                ],
+                "hypnosis": [
+                    1530
+                ],
+                "body”.": [
+                    1534
+                ],
+                "Anxiety.": [
+                    1537,
+                    1849
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/23423952/[4-2]": [
+                    1538
+                ],
+                "Baghdadi": [
+                    1539
+                ],
+                "2021.": [
+                    1542,
+                    3216,
+                    3577,
+                    3590,
+                    4171,
+                    4210
+                ],
+                "“Neurocognitive": [
+                    1543
+                ],
+                "Mechanisms": [
+                    1544
+                ],
+                "Attention”.": [
+                    1546
+                ],
+                "Computational": [
+                    1547
+                ],
+                "Models,": [
+                    1548
+                ],
+                "Physiology,": [
+                    1549
+                ],
+                "Disease": [
+                    1551
+                ],
+                "States.": [
+                    1552
+                ],
+                "https://www.sciencedirect.com/topics/neuroscience/stroop-effect": [
+                    1553
+                ],
+                "5:": [
+                    1555
+                ],
+                "Belief/Identity": [
+                    1556
+                ],
+                "“Rules”,": [
+                    1557
+                ],
+                "Re-scripting,": [
+                    1558
+                ],
+                "Talk": [
+                    1561
+                ],
+                "Therapy": [
+                    1562,
+                    1885,
+                    3219,
+                    4213
+                ],
+                "(00:39:00)The": [
+                    1563
+                ],
+                "Task,": [
+                    1565
+                ],
+                "Figure": [
+                    1568
+                ],
+                "4-1,": [
+                    1569
+                ],
+                "like": [
+                    1571,
+                    1616,
+                    2257,
+                    3239
+                ],
+                "rule-switching": [
+                    1573
+                ],
+                "game": [
+                    1574
+                ],
+                "forces": [
+                    1576
+                ],
+                "suppress": [
+                    1579
+                ],
+                "responses.": [
+                    1580
+                ],
+                "Depressed": [
+                    1581
+                ],
+                "set": [
+                    1583,
+                    3661
+                ],
+                "‘rules’": [
+                    1584
+                ],
+                "context": [
+                    1587
+                ],
+                "positivity": [
+                    1589
+                ],
+                "their": [
+                    1591,
+                    1646,
+                    1679,
+                    1702,
+                    2431,
+                    3001,
+                    3281,
+                    3347,
+                    3444,
+                    3480
+                ],
+                "lives": [
+                    1592
+                ],
+                "‘I": [
+                    1595
+                ],
+                "dress": [
+                    1596
+                ],
+                "poorly’": [
+                    1597
+                ],
+                "hard": [
+                    1601
+                ],
+                "contradicting": [
+                    1603
+                ],
+                "rule": [
+                    1605,
+                    3353
+                ],
+                "(i.e.": [
+                    1606,
+                    3332
+                ],
+                "telling": [
+                    1607
+                ],
+                "themselves": [
+                    1608
+                ],
+                "look": [
+                    1610
+                ],
+                "good": [
+                    1611
+                ],
+                "mirror": [
+                    1614
+                ],
+                "feels": [
+                    1615
+                ],
+                "lie": [
+                    1618
+                ],
+                "them).": [
+                    1620
+                ],
+                "Something": [
+                    1621
+                ],
+                "gives": [
+                    1625
+                ],
+                "flexibility": [
+                    1626
+                ],
+                "rules": [
+                    1628,
+                    3289
+                ],
+                "measured": [
+                    1632
+                ],
+                "indirectly": [
+                    1633
+                ],
+                "Task.Journaling": [
+                    1637
+                ],
+                "allows": [
+                    1638,
+                    3031
+                ],
+                "emotionsCognitive": [
+                    1647
+                ],
+                "sessions": [
+                    1650,
+                    1685,
+                    1709,
+                    3405
+                ],
+                "identify": [
+                    1651,
+                    2854
+                ],
+                "these": [
+                    1652,
+                    3057,
+                    3298,
+                    3390
+                ],
+                "beliefs": [
+                    1653
+                ],
+                "determine": [
+                    1655
+                ],
+                "fixed": [
+                    1657,
+                    1983
+                ],
+                "flexible": [
+                    1659
+                ],
+                "are.": [
+                    1661
+                ],
+                "therapists": [
+                    1663
+                ],
+                "help": [
+                    1665,
+                    3367
+                ],
+                "find": [
+                    1668,
+                    3711,
+                    3755
+                ],
+                "another": [
+                    1669
+                ],
+                "explanation": [
+                    1670,
+                    1677
+                ],
+                "them": [
+                    1672,
+                    3763
+                ],
+                "reintegrate": [
+                    1674
+                ],
+                "memory.": [
+                    1680
+                ],
+                "These": [
+                    1681,
+                    2955,
+                    3446,
+                    4033
+                ],
+                "types": [
+                    1682
+                ],
+                "degrees": [
+                    1693,
+                    1724
+                ],
+                "[5-1,": [
+                    1696
+                ],
+                "5-2].TMS": [
+                    1697
+                ],
+                "really": [
+                    1698,
+                    1781,
+                    3082
+                ],
+                "helps": [
+                    1699
+                ],
+                "bit": [
+                    1706
+                ],
+                "better": [
+                    1707
+                ],
+                "(5": [
+                    1708
+                ],
+                "studies)": [
+                    1714
+                ],
+                "has": [
+                    1717,
+                    3879,
+                    3893,
+                    4013
+                ],
+                "works": [
+                    1721,
+                    2573,
+                    2588,
+                    2594,
+                    3081
+                ],
+                "[5-3].In": [
+                    1727
+                ],
+                "temporally": [
+                    1734,
+                    1755
+                ],
+                "ahead": [
+                    1735
+                ],
+                "signaling": [
+                    1742
+                ],
+                "cascade,": [
+                    1743
+                ],
+                "normal": [
+                    1747
+                ],
+                "controls": [
+                    1748
+                ],
+                "(no": [
+                    1749
+                ],
+                "depression)": [
+                    1750
+                ],
+                "front": [
+                    1757,
+                    1771
+                ],
+                "effective": [
+                    1764,
+                    2958,
+                    3395
+                ],
+                "treatment,": [
+                    1765
+                ],
+                "[5-4].The": [
+                    1776
+                ],
+                "temporal": [
+                    1777
+                ],
+                "ordering": [
+                    1778
+                ],
+                "firing": [
+                    1780
+                ],
+                "coordinated": [
+                    1785
+                ],
+                "symptoms.": [
+                    1789
+                ],
+                "finds": [
+                    1792
+                ],
+                "identifies": [
+                    1794
+                ],
+                "conflict": [
+                    1795,
+                    2137
+                ],
+                "overactive": [
+                    1798
+                ],
+                "isn't": [
+                    1804
+                ],
+                "clamp": [
+                    1807
+                ],
+                "reign": [
+                    1813
+                ],
+                "too": [
+                    1818
+                ],
+                "dramatic": [
+                    1819
+                ],
+                "(this": [
+                    1823
+                ],
+                "bad": [
+                    1827
+                ],
+                "analogy).References[5-1]": [
+                    1828
+                ],
+                "Cladder-Micus": [
+                    1829
+                ],
+                "2018.": [
+                    1832,
+                    1900,
+                    2909
+                ],
+                "“Mindfulness-based": [
+                    1833
+                ],
+                "patients": [
+                    1837,
+                    2016,
+                    3187,
+                    3549
+                ],
+                "chronic,": [
+                    1839
+                ],
+                "treatment-resistant": [
+                    1840,
+                    3514,
+                    3973
+                ],
+                "depression:": [
+                    1841,
+                    2897,
+                    3974
+                ],
+                "pragmatic": [
+                    1843
+                ],
+                "randomized": [
+                    1844
+                ],
+                "controlled": [
+                    1845
+                ],
+                "trial”.": [
+                    1846
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/30088834/[5-2]": [
+                    1850
+                ],
+                "Zhang": [
+                    1851
+                ],
+                "2019.": [
+                    1854,
+                    2894
+                ],
+                "\"Cognitive": [
+                    1855
+                ],
+                "primary": [
+                    1859
+                ],
+                "care": [
+                    1860
+                ],
+                "anxiety:": [
+                    1863
+                ],
+                "secondary": [
+                    1865
+                ],
+                "meta-analytic": [
+                    1866
+                ],
+                "review": [
+                    1867,
+                    3959
+                ],
+                "using": [
+                    1868,
+                    3252,
+                    3844
+                ],
+                "robust": [
+                    1869
+                ],
+                "variance": [
+                    1870
+                ],
+                "estimation": [
+                    1871
+                ],
+                "meta-regression\".": [
+                    1873
+                ],
+                "Medicine.": [
+                    1877,
+                    3623
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/31004323/[5-3]": [
+                    1878
+                ],
+                "Cole": [
+                    1879,
+                    4207
+                ],
+                "2022.": [
+                    1882,
+                    2350,
+                    3609
+                ],
+                "“Stanford": [
+                    1883,
+                    4211
+                ],
+                "Neuromodulation": [
+                    1884,
+                    3218,
+                    4212
+                ],
+                "(SNT):": [
+                    1886,
+                    4214
+                ],
+                "Double-Blind": [
+                    1888
+                ],
+                "Randomized": [
+                    1889
+                ],
+                "Controlled": [
+                    1890
+                ],
+                "Trial”.": [
+                    1891
+                ],
+                "Psychiatry.": [
+                    1895,
+                    2329,
+                    2402,
+                    3980,
+                    4205
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/34711062/[5-4]": [
+                    1896
+                ],
+                "Bartoli": [
+                    1897
+                ],
+                "“Temporal": [
+                    1901
+                ],
+                "Dynamics": [
+                    1902
+                ],
+                "Human": [
+                    1904
+                ],
+                "Frontal": [
+                    1905
+                ],
+                "Cingulate": [
+                    1907,
+                    2028
+                ],
+                "Neural": [
+                    1908
+                ],
+                "Activity": [
+                    1909
+                ],
+                "During": [
+                    1910
+                ],
+                "Conflict": [
+                    1911
+                ],
+                "Cognitive": [
+                    1913
+                ],
+                "Control”.": [
+                    1914
+                ],
+                "Cerebral": [
+                    1915
+                ],
+                "Cortex.": [
+                    1916
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/29028974/": [
+                    1917
+                ],
+                "6:": [
+                    1919
+                ],
+                "Dorsolateral": [
+                    1920
+                ],
+                "Cortex,": [
+                    1922
+                ],
+                "Treatment": [
+                    1926,
+                    3387,
+                    3989
+                ],
+                "(00:45:49)Can": [
+                    1927
+                ],
+                "interpret": [
+                    1940
+                ],
+                "signals": [
+                    1942
+                ],
+                "spontaneous": [
+                    1944
+                ],
+                "thoughts?Yes": [
+                    1945
+                ],
+                "places": [
+                    1947
+                ],
+                "lens": [
+                    1949
+                ],
+                "sees": [
+                    1956
+                ],
+                "things": [
+                    1957,
+                    2043
+                ],
+                "through.Experiments": [
+                    1958
+                ],
+                "make": [
+                    1962,
+                    2050,
+                    3698
+                ],
+                "offline.TMS": [
+                    1976
+                ],
+                "trials": [
+                    1977,
+                    3391
+                ],
+                "5-day": [
+                    1984
+                ],
+                "schedule": [
+                    1985
+                ],
+                "day": [
+                    1994,
+                    2735
+                ],
+                "3-4": [
+                    1995
+                ],
+                "request": [
+                    1997
+                ],
+                "continue": [
+                    1999
+                ],
+                "doing": [
+                    2000,
+                    4006
+                ],
+                "it's": [
+                    2004
+                ],
+                "beneficial": [
+                    2007,
+                    3013
+                ],
+                "them.Anecdotally,": [
+                    2009
+                ],
+                "notes": [
+                    2012
+                ],
+                "“be": [
+                    2020
+                ],
+                "present\"": [
+                    2023
+                ],
+                "TMSReferences": [
+                    2025
+                ],
+                "7:": [
+                    2027
+                ],
+                "Emotion,": [
+                    2031
+                ],
+                "Dissociation": [
+                    2032,
+                    2395
+                ],
+                "(00:48:36)What": [
+                    2035
+                ],
+                "mapped": [
+                    2037
+                ],
+                "cingulate?": [
+                    2041
+                ],
+                "body": [
+                    2046
+                ],
+                "mind": [
+                    2049
+                ],
+                "fire?The": [
+                    2053
+                ],
+                "elicits": [
+                    2056
+                ],
+                "activity": [
+                    2057
+                ],
+                "[7-1].For": [
+                    2062
+                ],
+                "OCD,": [
+                    2063,
+                    2102,
+                    3016
+                ],
+                "certain": [
+                    2064
+                ],
+                "triggers": [
+                    2065
+                ],
+                "point": [
+                    2066
+                ],
+                "cingulate;": [
+                    2070
+                ],
+                "Bokor": [
+                    2071,
+                    2286
+                ],
+                "Anderson": [
+                    2073,
+                    2288
+                ],
+                "described": [
+                    2075
+                ],
+                "involving": [
+                    2078
+                ],
+                "several": [
+                    2079
+                ],
+                "regions": [
+                    2081,
+                    3117,
+                    3140
+                ],
+                "orbitofrontal": [
+                    2083
+                ],
+                "cortex,": [
+                    2084
+                ],
+                "gyrus,": [
+                    2087
+                ],
+                "basal": [
+                    2090
+                ],
+                "ganglia": [
+                    2091
+                ],
+                "[7-2].": [
+                    2092
+                ],
+                "They": [
+                    2093,
+                    3207
+                ],
+                "used": [
+                    2094,
+                    2122
+                ],
+                "cingulotomy": [
+                    2099,
+                    2324
+                ],
+                "involved": [
+                    2104
+                ],
+                "inducing": [
+                    2105
+                ],
+                "[7-3].": [
+                    2114
+                ],
+                "Modern": [
+                    2115
+                ],
+                "therapies": [
+                    2116
+                ],
+                "effect": [
+                    2126,
+                    2506,
+                    2562,
+                    2582,
+                    2615,
+                    2636,
+                    2641,
+                    2655,
+                    2666,
+                    2756,
+                    2774,
+                    2811,
+                    2827,
+                    2846,
+                    2888,
+                    3409,
+                    3691,
+                    3881
+                ],
+                "[7-4].There": [
+                    2128
+                ],
+                "orientation": [
+                    2132
+                ],
+                "degree": [
+                    2135,
+                    2856
+                ],
+                "tasks'": [
+                    2138
+                ],
+                "emotional": [
+                    2139,
+                    2745,
+                    3937
+                ],
+                "component": [
+                    2140,
+                    2151
+                ],
+                "ventral": [
+                    2144
+                ],
+                "sub-genual": [
+                    2146,
+                    2178
+                ],
+                "activation": [
+                    2148
+                ],
+                "is.The": [
+                    2149
+                ],
+                "pure": [
+                    2160
+                ],
+                "cognitive,": [
+                    2161
+                ],
+                "OCD-type": [
+                    2162
+                ],
+                "disorder.Mood": [
+                    2164
+                ],
+                "disorders,": [
+                    2165
+                ],
+                "facial": [
+                    2166
+                ],
+                "expression": [
+                    2167,
+                    4104
+                ],
+                "conflictsStroop": [
+                    2168
+                ],
+                "happy": [
+                    2171
+                ],
+                "face": [
+                    2172
+                ],
+                "written": [
+                    2173
+                ],
+                "sad": [
+                    2176
+                ],
+                "facePeri-genual,": [
+                    2177
+                ],
+                "areasThere": [
+                    2179
+                ],
+                "also": [
+                    2181,
+                    3558,
+                    3872
+                ],
+                "components": [
+                    2186
+                ],
+                "wellAkinetic": [
+                    2190
+                ],
+                "mutism": [
+                    2191
+                ],
+                "glioma": [
+                    2193
+                ],
+                "sitting": [
+                    2194
+                ],
+                "interhemispheric": [
+                    2197
+                ],
+                "fissure": [
+                    2198
+                ],
+                "putting": [
+                    2199
+                ],
+                "pressure": [
+                    2200
+                ],
+                "puts": [
+                    2204
+                ],
+                "catatonic": [
+                    2208
+                ],
+                "space": [
+                    2209
+                ],
+                "[7-5].": [
+                    2210
+                ],
+                "Basically": [
+                    2211
+                ],
+                "can't": [
+                    2215,
+                    2219
+                ],
+                "function,": [
+                    2216
+                ],
+                "connect": [
+                    2220
+                ],
+                "reality.Catatonia": [
+                    2222
+                ],
+                "extreme": [
+                    2225,
+                    2235,
+                    2238
+                ],
+                "[7-6]": [
+                    2229
+                ],
+                "schizophrenia": [
+                    2231
+                ],
+                "[7-7]Dissociation": [
+                    2232
+                ],
+                "outcome": [
+                    2239
+                ],
+                "PTSD": [
+                    2241,
+                    3330,
+                    3424
+                ],
+                "trauma": [
+                    2243,
+                    3204
+                ],
+                "[7-8].": [
+                    2244
+                ],
+                "It": [
+                    2245,
+                    2802,
+                    2877
+                ],
+                "phenomenon": [
+                    2248
+                ],
+                "sometimes": [
+                    2255
+                ],
+                "capacity": [
+                    2259
+                ],
+                "dissociate.Fun": [
+                    2261
+                ],
+                "fact:": [
+                    2262
+                ],
+                "super": [
+                    2266
+                ],
+                "hypnotizableReferences[7-1]": [
+                    2267
+                ],
+                "Swick": [
+                    2268
+                ],
+                "Jovanovic": [
+                    2270
+                ],
+                "2002.": [
+                    2271
+                ],
+                "“Anterior": [
+                    2272
+                ],
+                "task:": [
+                    2278
+                ],
+                "neuropsychological": [
+                    2279
+                ],
+                "topographic": [
+                    2282
+                ],
+                "specificity”.": [
+                    2283
+                ],
+                "Neuropsychologia.": [
+                    2284
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/11931927/[7-2]": [
+                    2285
+                ],
+                "2014.": [
+                    2289
+                ],
+                "“Obsessive-compulsive": [
+                    2290
+                ],
+                "disorder”.": [
+                    2291,
+                    2327
+                ],
+                "J.": [
+                    2292,
+                    4190
+                ],
+                "Pharm": [
+                    2293
+                ],
+                "Pract.": [
+                    2294
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/24576790/[7-3]": [
+                    2295
+                ],
+                "Diering": [
+                    2296
+                ],
+                "Bell": [
+                    2298
+                ],
+                "1991.": [
+                    2299
+                ],
+                "“Functional": [
+                    2300
+                ],
+                "neurosurgery": [
+                    2301
+                ],
+                "disorders:": [
+                    2304
+                ],
+                "historical": [
+                    2306
+                ],
+                "perspective”.": [
+                    2307
+                ],
+                "Stereotact": [
+                    2308
+                ],
+                "Funct": [
+                    2309
+                ],
+                "Neurosurg.": [
+                    2310
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/1842976/[7-4]": [
+                    2311
+                ],
+                "Banks": [
+                    2312
+                ],
+                "2015.": [
+                    2315
+                ],
+                "“Neuroanatomical": [
+                    2316
+                ],
+                "characteristics": [
+                    2317
+                ],
+                "response": [
+                    2320
+                ],
+                "obsessive-compulsive": [
+                    2326
+                ],
+                "JAMA": [
+                    2328
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/25536384/[7-5]": [
+                    2330
+                ],
+                "Arnts": [
+                    2331
+                ],
+                "“On": [
+                    2335
+                ],
+                "pathophysiology": [
+                    2337
+                ],
+                "akinetic": [
+                    2341
+                ],
+                "mutism”.": [
+                    2342
+                ],
+                "Neurosci": [
+                    2343
+                ],
+                "Biobehav": [
+                    2344
+                ],
+                "Rev.": [
+                    2345
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/32044373/[7-6]": [
+                    2346
+                ],
+                "Bolgov": [
+                    2347
+                ],
+                "\"The": [
+                    2351
+                ],
+                "structure": [
+                    2352
+                ],
+                "catatonia": [
+                    2354
+                ],
+                "depressive-delusional": [
+                    2358
+                ],
+                "conditions\".": [
+                    2359
+                ],
+                "Zh": [
+                    2360
+                ],
+                "Nevrol": [
+                    2361
+                ],
+                "Psikhiatr": [
+                    2362
+                ],
+                "Im": [
+                    2363
+                ],
+                "S": [
+                    2364,
+                    2365
+                ],
+                "Korsakova.": [
+                    2366
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/35797200/[7-7]": [
+                    2367
+                ],
+                "Walther": [
+                    2368
+                ],
+                "Strik": [
+                    2370
+                ],
+                "“Catatonia”.": [
+                    2372
+                ],
+                "CNS": [
+                    2373
+                ],
+                "Spectr.": [
+                    2374
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/27255726/[7-8]": [
+                    2375
+                ],
+                "Choi": [
+                    2376
+                ],
+                "2017.": [
+                    2379
+                ],
+                "“The": [
+                    2380
+                ],
+                "Dissociative": [
+                    2381
+                ],
+                "Subtype": [
+                    2382
+                ],
+                "Posttraumatic": [
+                    2384
+                ],
+                "Stress": [
+                    2385,
+                    3380
+                ],
+                "Disorder": [
+                    2386,
+                    3381
+                ],
+                "(PTSD)": [
+                    2387,
+                    3382
+                ],
+                "Among": [
+                    2388
+                ],
+                "Adolescents:": [
+                    2389
+                ],
+                "Co-Occurring": [
+                    2390
+                ],
+                "PTSD,": [
+                    2391
+                ],
+                "Depersonalization/Derealization,": [
+                    2392
+                ],
+                "Other": [
+                    2394
+                ],
+                "Symptoms”.": [
+                    2396
+                ],
+                "J": [
+                    2397,
+                    2921,
+                    3961
+                ],
+                "Am": [
+                    2398,
+                    2920
+                ],
+                "Acad": [
+                    2399
+                ],
+                "Child": [
+                    2400
+                ],
+                "Adolesc": [
+                    2401
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/29173740/": [
+                    2403
+                ],
+                "8:": [
+                    2405
+                ],
+                "Ketamine,": [
+                    2406
+                ],
+                "Opioid": [
+                    2408,
+                    2917
+                ],
+                "System": [
+                    2409
+                ],
+                "Depression;": [
+                    2411,
+                    2945
+                ],
+                "Psychedelic": [
+                    2412
+                ],
+                "Experience": [
+                    2413
+                ],
+                "Biology?": [
+                    2415
+                ],
+                "(00:54:27)Popular": [
+                    2416
+                ],
+                "include": [
+                    2420,
+                    2435
+                ],
+                "dissociative": [
+                    2425,
+                    2468
+                ],
+                "anesthetic.People": [
+                    2426
+                ],
+                "distant": [
+                    2429
+                ],
+                "(third-person": [
+                    2433
+                ],
+                "themselves)Others": [
+                    2434
+                ],
+                "psilocybin": [
+                    2436,
+                    3146,
+                    3340,
+                    3511,
+                    3900,
+                    4005,
+                    4044,
+                    4081,
+                    4119,
+                    4164,
+                    4178
+                ],
+                "MDMA": [
+                    2438,
+                    2604,
+                    3377,
+                    3579,
+                    3628,
+                    3643,
+                    3720,
+                    3730,
+                    3775,
+                    3794,
+                    3804,
+                    3816,
+                    3866
+                ],
+                "lead": [
+                    2440,
+                    2480
+                ],
+                "exact": [
+                    2443
+                ],
+                "opposite": [
+                    2444
+                ],
+                "state": [
+                    2445,
+                    2798,
+                    3363
+                ],
+                "engaged": [
+                    2448
+                ],
+                "emotionality,": [
+                    2449
+                ],
+                "self": [
+                    2455
+                ],
+                "→": [
+                    2456
+                ],
+                "leading": [
+                    2457
+                ],
+                "alleviation": [
+                    2459
+                ],
+                "induces": [
+                    2467,
+                    2475
+                ],
+                "states": [
+                    2469,
+                    2477
+                ],
+                "(ketamine)": [
+                    2470
+                ],
+                "AND": [
+                    2471
+                ],
+                "hyper-associative": [
+                    2476
+                ],
+                "(MDMA)": [
+                    2478
+                ],
+                "relief": [
+                    2482
+                ],
+                "system?Ketamine": [
+                    2486
+                ],
+                "level": [
+                    2489,
+                    3120,
+                    3422,
+                    3481
+                ],
+                "dissociation": [
+                    2491,
+                    2758
+                ],
+                "therapeutic": [
+                    2496,
+                    2505,
+                    2542,
+                    2835,
+                    2862,
+                    2934,
+                    2996,
+                    3124
+                ],
+                "effect.": [
+                    2497,
+                    2650,
+                    2783,
+                    2836
+                ],
+                "Necessary": [
+                    2498
+                ],
+                "sufficient": [
+                    2501
+                ],
+                "produce": [
+                    2503,
+                    2781
+                ],
+                "[8-1].": [
+                    2507
+                ],
+                "No": [
+                    2508
+                ],
+                "typically": [
+                    2511
+                ],
+                "means": [
+                    2512,
+                    3157
+                ],
+                "potent": [
+                    2516
+                ],
+                "anti--depressant": [
+                    2517
+                ],
+                "benefits.Study": [
+                    2518
+                ],
+                "conducted": [
+                    2521
+                ],
+                "naltrexone": [
+                    2523,
+                    2532,
+                    2584,
+                    2586,
+                    2644,
+                    2657
+                ],
+                "(opiate": [
+                    2524
+                ],
+                "antagonist)": [
+                    2525
+                ],
+                "[8-2]1": [
+                    2526
+                ],
+                "pill": [
+                    2527,
+                    2535
+                ],
+                "50mg": [
+                    2529
+                ],
+                "(high": [
+                    2530
+                ],
+                "dose)": [
+                    2531
+                ],
+                "placebo": [
+                    2537,
+                    2649,
+                    2670,
+                    4039
+                ],
+                "(blinded)": [
+                    2538
+                ],
+                "typical": [
+                    2540
+                ],
+                "dose.": [
+                    2543
+                ],
+                "Participants": [
+                    2544
+                ],
+                "received": [
+                    2546
+                ],
+                "type": [
+                    2549
+                ],
+                "after": [
+                    2552,
+                    3396,
+                    3843,
+                    4163
+                ],
+                "relapsed": [
+                    2554
+                ],
+                "evaluate": [
+                    2560,
+                    2886
+                ],
+                "blocking": [
+                    2564
+                ],
+                "opioid": [
+                    2566,
+                    2627,
+                    2732
+                ],
+                "receptor": [
+                    2567,
+                    2605,
+                    2706
+                ],
+                "antidepressant": [
+                    2570
+                ],
+                "effect.If": [
+                    2571
+                ],
+                "glutamate": [
+                    2576,
+                    2610
+                ],
+                "system,": [
+                    2577
+                ],
+                "opiate": [
+                    2591,
+                    2600,
+                    2701,
+                    2705
+                ],
+                "system.": [
+                    2592
+                ],
+                "Ketamine": [
+                    2593,
+                    2915
+                ],
+                "multiple": [
+                    2596
+                ],
+                "areas": [
+                    2597,
+                    3254
+                ],
+                "antagonism": [
+                    2606
+                ],
+                "glutamate.": [
+                    2608
+                ],
+                "driving": [
+                    2612
+                ],
+                "anti-depressive": [
+                    2614,
+                    2635,
+                    2640,
+                    2654,
+                    2665,
+                    3045
+                ],
+                "should": [
+                    2617
+                ],
+                "between": [
+                    2621,
+                    2984,
+                    3028,
+                    4135
+                ],
+                "two": [
+                    2623
+                ],
+                "regions.": [
+                    2624
+                ],
+                "properties": [
+                    2628
+                ],
+                "necessary": [
+                    2632,
+                    2779
+                ],
+                "+": [
+                    2643,
+                    2648,
+                    2669,
+                    2673,
+                    2680
+                ],
+                "opposed": [
+                    2646
+                ],
+                "Dramatic": [
+                    2651
+                ],
+                "block": [
+                    2652,
+                    2693
+                ],
+                "who": [
+                    2662
+                ],
+                "had": [
+                    2663,
+                    3438
+                ],
+                "alone.TMS": [
+                    2671
+                ],
+                "study": [
+                    2672,
+                    2715,
+                    3512,
+                    3637,
+                    3649,
+                    3687,
+                    3722,
+                    3728,
+                    3810,
+                    4027
+                ],
+                "pain": [
+                    2674,
+                    2746
+                ],
+                "-→": [
+                    2675
+                ],
+                "naloxone": [
+                    2681
+                ],
+                "(basically": [
+                    2682
+                ],
+                "function": [
+                    2685
+                ],
+                "naltrexone)": [
+                    2687
+                ],
+                "were": [
+                    2690,
+                    3542,
+                    4036,
+                    4095
+                ],
+                "anti-pain": [
+                    2695
+                ],
+                "blocker.": [
+                    2702
+                ],
+                "Therefore": [
+                    2703
+                ],
+                "role": [
+                    2710
+                ],
+                "regulation.In": [
+                    2713
+                ],
+                "total": [
+                    2719
+                ],
+                "knee": [
+                    2720
+                ],
+                "replacement": [
+                    2721
+                ],
+                "(super": [
+                    2722
+                ],
+                "painful": [
+                    2723
+                ],
+                "surgery),": [
+                    2724
+                ],
+                "triple": [
+                    2730
+                ],
+                "required": [
+                    2737
+                ],
+                "pain.It": [
+                    2741
+                ],
+                "pain,": [
+                    2751
+                ],
+                "hence": [
+                    2752
+                ],
+                "requiring": [
+                    2753
+                ],
+                "dosage.No": [
+                    2755
+                ],
+                "challenges": [
+                    2764
+                ],
+                "idea": [
+                    2766,
+                    3054
+                ],
+                "that's": [
+                    2778
+                ],
+                "pharmacology": [
+                    2785,
+                    2795
+                ],
+                "probably": [
+                    2786
+                ],
+                "matter": [
+                    2788
+                ],
+                "since": [
+                    2789
+                ],
+                "shows": [
+                    2792
+                ],
+                "role.": [
+                    2801
+                ],
+                "unclear": [
+                    2804
+                ],
+                "still": [
+                    2813
+                ],
+                "state.": [
+                    2817
+                ],
+                "There": [
+                    2818,
+                    2973,
+                    3506,
+                    3785,
+                    3832
+                ],
+                "animal": [
+                    2821
+                ],
+                "data": [
+                    2822,
+                    2977
+                ],
+                "suggest": [
+                    2824,
+                    2979
+                ],
+                "removable": [
+                    2830
+                ],
+                "[8-3].": [
+                    2837
+                ],
+                "useless,": [
+                    2848
+                ],
+                "term": [
+                    2861
+                ],
+                "shift": [
+                    2863
+                ],
+                "attributable": [
+                    2868
+                ],
+                "pharmacological": [
+                    2872
+                ],
+                "circuitry": [
+                    2875,
+                    3172
+                ],
+                "changes.": [
+                    2876
+                ],
+                "separate": [
+                    2881
+                ],
+                "variables": [
+                    2883
+                ],
+                "individually": [
+                    2884
+                ],
+                "all.References[8-1]": [
+                    2890
+                ],
+                "Corriger": [
+                    2891
+                ],
+                "Pickering": [
+                    2893
+                ],
+                "“Ketamine": [
+                    2895
+                ],
+                "narrative": [
+                    2899
+                ],
+                "review”": [
+                    2900
+                ],
+                "Drug": [
+                    2901,
+                    3630
+                ],
+                "Des": [
+                    2902
+                ],
+                "Devel": [
+                    2903
+                ],
+                "Ther.": [
+                    2904
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/31695324/[8-2]": [
+                    2905
+                ],
+                "\"Attenuation": [
+                    2910
+                ],
+                "Antidepressant": [
+                    2912
+                ],
+                "Effects": [
+                    2913
+                ],
+                "Receptor": [
+                    2918
+                ],
+                "Antagonism.": [
+                    2919
+                ],
+                "Psychiatry": [
+                    2922,
+                    3110
+                ],
+                "175:12.": [
+                    2923
+                ],
+                "https://ajp.psychiatryonline.org/doi/pdf/10.1176/appi.ajp.2018.18020138[8-3]": [
+                    2924
+                ],
+                "Cameron": [
+                    2925
+                ],
+                "non-hallucinogenic": [
+                    2930
+                ],
+                "psychadelic": [
+                    2931
+                ],
+                "analogue": [
+                    2932
+                ],
+                "potential”.": [
+                    2935
+                ],
+                "Nature": [
+                    2936,
+                    3603
+                ],
+                "589,": [
+                    2937
+                ],
+                "474-479.": [
+                    2938
+                ],
+                "https://www.nature.com/articles/s41586-020-3008-z": [
+                    2939
+                ],
+                "9:": [
+                    2941
+                ],
+                "SSRIs,": [
+                    2942
+                ],
+                "Serotonin": [
+                    2943
+                ],
+                "Childhood,": [
+                    2946
+                ],
+                "Chemical": [
+                    2947
+                ],
+                "Imbalance": [
+                    2948
+                ],
+                "Circuit?": [
+                    2950
+                ],
+                "(01:03:42)Selective": [
+                    2951
+                ],
+                "serotonin": [
+                    2952,
+                    2985,
+                    3022,
+                    3036,
+                    3076,
+                    3094,
+                    3101,
+                    3999
+                ],
+                "re-uptake": [
+                    2953
+                ],
+                "inhibitors.": [
+                    2954
+                ],
+                "powerfully": [
+                    2957
+                ],
+                "way": [
+                    2968,
+                    3068
+                ],
+                "we're": [
+                    2969
+                ],
+                "thinking": [
+                    2970
+                ],
+                "they're": [
+                    2971
+                ],
+                "working.": [
+                    2972
+                ],
+                "correlation": [
+                    2983,
+                    3005
+                ],
+                "levels": [
+                    2986
+                ],
+                "happening": [
+                    2992
+                ],
+                "benefit": [
+                    2997
+                ],
+                "potential": [
+                    3002
+                ],
+                "lack": [
+                    3003
+                ],
+                "serotonin?SSRI's": [
+                    3007
+                ],
+                "clearly": [
+                    3008
+                ],
+                "greatly": [
+                    3012
+                ],
+                "generalized": [
+                    3018
+                ],
+                "anxiety/panic.": [
+                    3019
+                ],
+                "remain": [
+                    3024
+                ],
+                "cleft": [
+                    3027
+                ],
+                "neurons": [
+                    3029,
+                    3925
+                ],
+                "accumulation": [
+                    3034
+                ],
+                "time.Brain-derived": [
+                    3038
+                ],
+                "neurotrophic": [
+                    3039
+                ],
+                "factors": [
+                    3040
+                ],
+                "upregulated": [
+                    3042
+                ],
+                "usage": [
+                    3046
+                ],
+                "plasticity.": [
+                    3052
+                ],
+                "drugs": [
+                    3058
+                ],
+                "just": [
+                    3062,
+                    3461
+                ],
+                "think.": [
+                    3070
+                ],
+                "It's": [
+                    3071
+                ],
+                "deficit": [
+                    3074
+                ],
+                "imbalance.TMS": [
+                    3080
+                ],
+                "1-5": [
+                    3085
+                ],
+                "days": [
+                    3086,
+                    3842,
+                    4049
+                ],
+                "doesn't": [
+                    3089,
+                    3322
+                ],
+                "upregulation": [
+                    3092
+                ],
+                "[9-1].": [
+                    3095
+                ],
+                "pushes": [
+                    3097
+                ],
+                "hypothesis": [
+                    3103
+                ],
+                "posits": [
+                    3105,
+                    3112
+                ],
+                "“chemical": [
+                    3108
+                ],
+                "imbalances”.": [
+                    3109
+                ],
+                "3.0": [
+                    3111
+                ],
+                "perturbations": [
+                    3114
+                ],
+                "circuit": [
+                    3119
+                ],
+                "effect,": [
+                    3125
+                ],
+                "‘chemical": [
+                    3129,
+                    3200
+                ],
+                "imbalances’": [
+                    3130
+                ],
+                "psychiatry": [
+                    3132
+                ],
+                "2.0": [
+                    3133
+                ],
+                "thought.TMS": [
+                    3134
+                ],
+                "act": [
+                    3135,
+                    3149
+                ],
+                "(subgenual": [
+                    3141
+                ],
+                "default": [
+                    3142,
+                    4142
+                ],
+                "mode": [
+                    3143,
+                    4143
+                ],
+                "network)": [
+                    3144
+                ],
+                "on.": [
+                    3150
+                ],
+                "correctable": [
+                    3154
+                ],
+                "electrophysiology": [
+                    3155
+                ],
+                "treatable.": [
+                    3161,
+                    3206
+                ],
+                "Early": [
+                    3162
+                ],
+                "life": [
+                    3163
+                ],
+                "dictate": [
+                    3167
+                ],
+                "cascade": [
+                    3169
+                ],
+                "life,": [
+                    3177
+                ],
+                "correctable.It": [
+                    3180
+                ],
+                "possible": [
+                    3182
+                ],
+                "relapse": [
+                    3184
+                ],
+                "never": [
+                    3188
+                ],
+                "seem": [
+                    3189
+                ],
+                "terminal": [
+                    3193
+                ],
+                "life-ending": [
+                    3194
+                ],
+                "thoughts": [
+                    3195
+                ],
+                "realize": [
+                    3198
+                ],
+                "imbalance’": [
+                    3201
+                ],
+                "childhood": [
+                    3203
+                ],
+                "in-control": [
+                    3209
+                ],
+                "optimistic": [
+                    3211
+                ],
+                "still.References[9-1]": [
+                    3212
+                ],
+                "\"Accelerated": [
+                    3217
+                ],
+                "Obsessive-Compulsive": [
+                    3221
+                ],
+                "Disorder.": [
+                    3222
+                ],
+                "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8114181/": [
+                    3225
+                ],
+                "10:": [
+                    3227
+                ],
+                "Memories": [
+                    3228
+                ],
+                "“Rule”": [
+                    3230,
+                    3234,
+                    3276
+                ],
+                "Creation;": [
+                    3231
+                ],
+                "Psilocybin": [
+                    3232,
+                    3384,
+                    3401,
+                    3611,
+                    4012
+                ],
+                "Resolution": [
+                    3235
+                ],
+                "(01:13:58)Synesthesia": [
+                    3236
+                ],
+                "sorts": [
+                    3244
+                ],
+                "interprets": [
+                    3248
+                ],
+                "colors,": [
+                    3249
+                ],
+                "sounds,": [
+                    3250
+                ],
+                "sights,": [
+                    3251
+                ],
+                "alternate": [
+                    3253
+                ],
+                "perception.": [
+                    3256
+                ],
+                "experience,": [
+                    3260
+                ],
+                "affecting": [
+                    3266
+                ],
+                "creation": [
+                    3277
+                ],
+                "laws": [
+                    3278
+                ],
+                "govern": [
+                    3280
+                ],
+                "thought.Why": [
+                    3282
+                ],
+                "don't": [
+                    3291
+                ],
+                "serve": [
+                    3292,
+                    3323
+                ],
+                "well?": [
+                    3294
+                ],
+                "We": [
+                    3295
+                ],
+                "onto": [
+                    3297
+                ],
+                "memories": [
+                    3299
+                ],
+                "evolutionary": [
+                    3302
+                ],
+                "perspective": [
+                    3303
+                ],
+                "allow": [
+                    3307,
+                    3350
+                ],
+                "us": [
+                    3308,
+                    3324
+                ],
+                "similarly": [
+                    3312
+                ],
+                "negatively": [
+                    3313,
+                    4151
+                ],
+                "valanced": [
+                    3314
+                ],
+                "situations.": [
+                    3315
+                ],
+                "But": [
+                    3316
+                ],
+                "modern": [
+                    3319
+                ],
+                "world,": [
+                    3320
+                ],
+                "well.For": [
+                    3326
+                ],
+                "example:": [
+                    3327
+                ],
+                "Veterans": [
+                    3328
+                ],
+                "Loud": [
+                    3333
+                ],
+                "noise": [
+                    3334
+                ],
+                "triggering": [
+                    3335
+                ],
+                "hiding": [
+                    3336
+                ],
+                "running).What": [
+                    3338
+                ],
+                "molecules": [
+                    3343
+                ],
+                "(in": [
+                    3344
+                ],
+                "terms": [
+                    3345
+                ],
+                "neurochemistry)": [
+                    3348
+                ],
+                "consideration": [
+                    3354
+                ],
+                "phenomenon?": [
+                    3355
+                ],
+                "Reconsolidation": [
+                    3356
+                ],
+                "memory": [
+                    3359,
+                    3369
+                ],
+                "neuroplastic": [
+                    3362
+                ],
+                "one's": [
+                    3373
+                ],
+                "mind.References": [
+                    3374
+                ],
+                "11:": [
+                    3376
+                ],
+                "Post-Traumatic": [
+                    3379
+                ],
+                "Treatment,": [
+                    3383
+                ],
+                "(01:21:00)What": [
+                    3388
+                ],
+                "show?": [
+                    3392
+                ],
+                "sessions?": [
+                    3400
+                ],
+                "MDMAMDMA:": [
+                    3403
+                ],
+                "1-2": [
+                    3404
+                ],
+                "anti-PTSD": [
+                    3408
+                ],
+                "outside": [
+                    3410
+                ],
+                "standard": [
+                    3413,
+                    3430
+                ],
+                "assumed": [
+                    3414
+                ],
+                "recover": [
+                    3417
+                ],
+                "[11-1,": [
+                    3425
+                ],
+                "11-2].": [
+                    3426
+                ],
+                "150-175mg": [
+                    3427
+                ],
+                "repeated": [
+                    3432
+                ],
+                "once": [
+                    3433
+                ],
+                "twice.⅔": [
+                    3435
+                ],
+                "clinically": [
+                    3440
+                ],
+                "significant": [
+                    3441
+                ],
+                "PTSD.": [
+                    3445
+                ],
+                "lasted": [
+                    3448
+                ],
+                "range": [
+                    3451
+                ],
+                "years": [
+                    3453
+                ],
+                "people,": [
+                    3456,
+                    3477
+                ],
+                "alleviations.Ketamine": [
+                    3463
+                ],
+                "comparatively": [
+                    3464
+                ],
+                "lasts": [
+                    3466
+                ],
+                "1.5": [
+                    3467
+                ],
+                "weeks.Psilocybin:": [
+                    3468
+                ],
+                "Relief": [
+                    3469
+                ],
+                "½": [
+                    3473
+                ],
+                "⅔": [
+                    3475
+                ],
+                "depending": [
+                    3478
+                ],
+                "demonstrated": [
+                    3486
+                ],
+                "press": [
+                    3488
+                ],
+                "releases,": [
+                    3489
+                ],
+                "fully": [
+                    3492
+                ],
+                "published": [
+                    3493,
+                    3517,
+                    3653,
+                    3741
+                ],
+                "video.": [
+                    3499
+                ],
+                "Very": [
+                    3500,
+                    3846
+                ],
+                "promising": [
+                    3501
+                ],
+                "separated": [
+                    3503
+                ],
+                "placebo.": [
+                    3505
+                ],
+                "single-dose": [
+                    3509
+                ],
+                "(25mg)": [
+                    3510
+                ],
+                "Nov.": [
+                    3519
+                ],
+                "New": [
+                    3522,
+                    3619
+                ],
+                "England": [
+                    3523,
+                    3620
+                ],
+                "Medicine": [
+                    3526
+                ],
+                "showed": [
+                    3528,
+                    3688,
+                    3807,
+                    4079
+                ],
+                "significantly": [
+                    3529
+                ],
+                "reduced": [
+                    3530,
+                    4082
+                ],
+                "scores": [
+                    3532
+                ],
+                "period": [
+                    3535
+                ],
+                "weeks": [
+                    3538
+                ],
+                "[11-3].": [
+                    3539
+                ],
+                "Notably,": [
+                    3540
+                ],
+                "adverse": [
+                    3543
+                ],
+                "events": [
+                    3544
+                ],
+                "reported": [
+                    3545,
+                    3835
+                ],
+                "77%": [
+                    3547
+                ],
+                "headache,": [
+                    3552
+                ],
+                "nausea,": [
+                    3553
+                ],
+                "dizziness;": [
+                    3555
+                ],
+                "authors": [
+                    3557,
+                    3745
+                ],
+                "note": [
+                    3559
+                ],
+                "explicitly": [
+                    3560
+                ],
+                "\"suicidal": [
+                    3562
+                ],
+                "ideation": [
+                    3563
+                ],
+                "self-injury": [
+                    3567
+                ],
+                "occurred": [
+                    3568
+                ],
+                "groups\"": [
+                    3572
+                ],
+                "[11-3].References[11-1]": [
+                    3573
+                ],
+                "Krystal": [
+                    3574
+                ],
+                "\"Psychotherapy-supported": [
+                    3578
+                ],
+                "PTSD”.": [
+                    3582
+                ],
+                "Cell": [
+                    3583
+                ],
+                "Rep": [
+                    3584
+                ],
+                "Med.": [
+                    3585,
+                    3604
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/34467253/[11-2]": [
+                    3586
+                ],
+                "Mitchell": [
+                    3587
+                ],
+                "“MDMA-assisted": [
+                    3591
+                ],
+                "PTSD:": [
+                    3595
+                ],
+                "randomized,": [
+                    3597,
+                    4024
+                ],
+                "double-blind,": [
+                    3598,
+                    4023
+                ],
+                "placebo-controlled": [
+                    3599
+                ],
+                "phase": [
+                    3600
+                ],
+                "study”.": [
+                    3602,
+                    3978
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/33972795/[11-3]": [
+                    3605
+                ],
+                "Goodwin": [
+                    3606
+                ],
+                "“Single-Dose": [
+                    3610
+                ],
+                "Treatment-Resistant": [
+                    3614
+                ],
+                "Episode": [
+                    3615
+                ],
+                "Depression”.": [
+                    3618
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/36322843/": [
+                    3624
+                ],
+                "12:": [
+                    3626
+                ],
+                "Neurotoxic?,": [
+                    3629
+                ],
+                "Purity,": [
+                    3631
+                ],
+                "Dopamine": [
+                    3632
+                ],
+                "Surges,": [
+                    3633
+                ],
+                "Post-MDMA": [
+                    3634
+                ],
+                "Prolactin": [
+                    3635
+                ],
+                "(01:24:12)The": [
+                    3636
+                ],
+                "group": [
+                    3638,
+                    3777
+                ],
+                "first": [
+                    3640,
+                    3660,
+                    3727
+                ],
+                "identified": [
+                    3641
+                ],
+                "neurotoxic": [
+                    3646,
+                    3690
+                ],
+                "monkeys": [
+                    3651,
+                    3675
+                ],
+                "later": [
+                    3652
+                ],
+                "follow-up": [
+                    3655,
+                    3724
+                ],
+                "determined": [
+                    3657
+                ],
+                "actually": [
+                    3664
+                ],
+                "utilized": [
+                    3665
+                ],
+                "methamphetamine": [
+                    3666
+                ],
+                "known": [
+                    3669
+                ],
+                "neurotoxic)": [
+                    3672
+                ],
+                "MDMA.": [
+                    3678,
+                    3693,
+                    3784,
+                    3845
+                ],
+                "Therefore,": [
+                    3679
+                ],
+                "true": [
+                    3683
+                ],
+                "initial": [
+                    3686
+                ],
+                "correction": [
+                    3695
+                ],
+                "did": [
+                    3696,
+                    3781
+                ],
+                "big": [
+                    3700,
+                    3861
+                ],
+                "splash": [
+                    3703
+                ],
+                "popular": [
+                    3705
+                ],
+                "press.Attention:": [
+                    3706
+                ],
+                "I": [
+                    3707,
+                    3765
+                ],
+                "unable": [
+                    3709
+                ],
+                "reference": [
+                    3713
+                ],
+                "groups": [
+                    3716
+                ],
+                "mentioned": [
+                    3717
+                ],
+                "neurotoxicity": [
+                    3721,
+                    3731
+                ],
+                "publication.": [
+                    3725
+                ],
+                "primates": [
+                    3733
+                ],
+                "Ricuarte": [
+                    3737,
+                    3916
+                ],
+                "1988,": [
+                    3740
+                ],
+                "JAMA,": [
+                    3743
+                ],
+                "Johns": [
+                    3747
+                ],
+                "Hopkins": [
+                    3748
+                ],
+                "[12-1].": [
+                    3749
+                ],
+                "anyone": [
+                    3751
+                ],
+                "references": [
+                    3758
+                ],
+                "mentioned,": [
+                    3760
+                ],
+                "document.Group": [
+                    3769
+                ],
+                "took": [
+                    3774
+                ],
+                "take": [
+                    3783
+                ],
+                "neurocognitive": [
+                    3788
+                ],
+                "profile": [
+                    3789
+                ],
+                "differences": [
+                    3790
+                ],
+                "proved": [
+                    3792
+                ],
+                "damaging.": [
+                    3797
+                ],
+                "Although": [
+                    3798
+                ],
+                "didn't": [
+                    3800
+                ],
+                "pre-post": [
+                    3803
+                ],
+                "exposure,": [
+                    3805
+                ],
+                "comparative": [
+                    3809
+                ],
+                "pretty": [
+                    3813
+                ],
+                "good.Purity": [
+                    3814
+                ],
+                "substances": [
+                    3817
+                ],
+                "guaranteed": [
+                    3819
+                ],
+                "studies,": [
+                    3822
+                ],
+                "maybe": [
+                    3824
+                ],
+                "settings": [
+                    3830
+                ],
+                "(raves).": [
+                    3831
+                ],
+                "drop": [
+                    3836
+                ],
+                "energy": [
+                    3838
+                ],
+                "few": [
+                    3841
+                ],
+                "surge": [
+                    3855,
+                    3862
+                ],
+                "prolactin": [
+                    3857,
+                    3877
+                ],
+                "subsequent": [
+                    3858
+                ],
+                "dopamine": [
+                    3864,
+                    3871
+                ],
+                "[12-2].": [
+                    3867
+                ],
+                "Huge": [
+                    3868
+                ],
+                "lifts": [
+                    3869
+                ],
+                "huge": [
+                    3874
+                ],
+                "libido,": [
+                    3883
+                ],
+                "energy,": [
+                    3884
+                ],
+                "fatigue": [
+                    3886
+                ],
+                "[12-3].MDMA": [
+                    3887
+                ],
+                "amphetamine": [
+                    3890
+                ],
+                "dopaminergic": [
+                    3897
+                ],
+                "neutral": [
+                    3905
+                ],
+                "lightly": [
+                    3907
+                ],
+                "dopamine,": [
+                    3908
+                ],
+                "serotonergic": [
+                    3913,
+                    3924,
+                    3993
+                ],
+                "[12-4].References[12-1]": [
+                    3915
+                ],
+                "1988.": [
+                    3919
+                ],
+                "“(+/-)3,4-Methylenedioxymethamphetamine": [
+                    3920
+                ],
+                "selectively": [
+                    3921
+                ],
+                "damages": [
+                    3922
+                ],
+                "central": [
+                    3923
+                ],
+                "nonhuman": [
+                    3927
+                ],
+                "primates”.": [
+                    3928
+                ],
+                "JAMA.": [
+                    3929
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/2454332/[12-2]": [
+                    3930
+                ],
+                "Hysek": [
+                    3931
+                ],
+                "“MDMA": [
+                    3935
+                ],
+                "enhances": [
+                    3936
+                ],
+                "empathy": [
+                    3938
+                ],
+                "prosocial": [
+                    3940
+                ],
+                "behavior”.": [
+                    3941
+                ],
+                "Soc": [
+                    3942
+                ],
+                "Cogn": [
+                    3943
+                ],
+                "Affect": [
+                    3944
+                ],
+                "Neurosci.": [
+                    3945
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/24097374/[12-3]": [
+                    3946
+                ],
+                "Fitzgerald": [
+                    3947
+                ],
+                "Dinan": [
+                    3949
+                ],
+                "2008.": [
+                    3950
+                ],
+                "“Prolactin": [
+                    3951
+                ],
+                "dopamine:": [
+                    3953
+                ],
+                "connection?": [
+                    3957
+                ],
+                "article”.": [
+                    3960
+                ],
+                "Psychopharmacol.": [
+                    3962
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/18477617/[12-4]": [
+                    3963
+                ],
+                "Carhart-Harris": [
+                    3964
+                ],
+                "“Psilocybin": [
+                    3968,
+                    4196
+                ],
+                "open-label": [
+                    3976
+                ],
+                "feasibility": [
+                    3977
+                ],
+                "Lancet": [
+                    3979
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/27210031/": [
+                    3981
+                ],
+                "13:": [
+                    3983
+                ],
+                "Psilocybin,": [
+                    3984
+                ],
+                "Connectivity": [
+                    3986
+                ],
+                "(01:30:38)Psilocybin": [
+                    3990
+                ],
+                "operates": [
+                    3995
+                ],
+                "5HT": [
+                    3998
+                ],
+                "2A": [
+                    4000
+                ],
+                "receptors": [
+                    4001
+                ],
+                "[13-1].": [
+                    4002
+                ],
+                "time?": [
+                    4011
+                ],
+                "global": [
+                    4018
+                ],
+                "functional": [
+                    4019
+                ],
+                "connectivity": [
+                    4020,
+                    4066,
+                    4123,
+                    4148
+                ],
+                "counter-balanced,": [
+                    4025
+                ],
+                "crossover": [
+                    4026
+                ],
+                "[13-2].": [
+                    4032
+                ],
+                "either": [
+                    4038
+                ],
+                "0.2": [
+                    4041
+                ],
+                "mg/kg": [
+                    4042
+                ],
+                "(orally)": [
+                    4045
+                ],
+                "underwent": [
+                    4051
+                ],
+                "MRI": [
+                    4052
+                ],
+                "scans": [
+                    4053
+                ],
+                "points": [
+                    4057
+                ],
+                "(20,": [
+                    4058
+                ],
+                "40,": [
+                    4059
+                ],
+                "min": [
+                    4061
+                ],
+                "post-administration)": [
+                    4062
+                ],
+                "view": [
+                    4064
+                ],
+                "peak": [
+                    4068
+                ],
+                "non-peak": [
+                    4070
+                ],
+                "effects.": [
+                    4071
+                ],
+                "Preller": [
+                    4075,
+                    4192
+                ],
+                "associative": [
+                    4083
+                ],
+                "increased": [
+                    4085
+                ],
+                "sensory,": [
+                    4086
+                ],
+                "brain-wide,": [
+                    4087
+                ],
+                "connectivity.": [
+                    4090
+                ],
+                "Additionally,": [
+                    4091
+                ],
+                "psilocybin-associated": [
+                    4093
+                ],
+                "“correlated": [
+                    4096
+                ],
+                "time-dependent": [
+                    4099
+                ],
+                "manner": [
+                    4100
+                ],
+                "gene": [
+                    4103
+                ],
+                "patterns": [
+                    4105
+                ],
+                "5-HT2A": [
+                    4108
+                ],
+                "(5-hydroxytryptamine": [
+                    4109,
+                    4113
+                ],
+                "2A)": [
+                    4110
+                ],
+                "5-HT1A": [
+                    4112
+                ],
+                "1A)": [
+                    4114
+                ],
+                "receptors”.The": [
+                    4115
+                ],
+                "subgenual": [
+                    4137
+                ],
+                "[13-3].": [
+                    4145
+                ],
+                "Downregulation": [
+                    4146
+                ],
+                "valenced,": [
+                    4152
+                ],
+                "self-representation": [
+                    4153
+                ],
+                "part": [
+                    4154
+                ],
+                "downregulation": [
+                    4161
+                ],
+                "dose.References[13-1]": [
+                    4165
+                ],
+                "Castro": [
+                    4166
+                ],
+                "Santos": [
+                    4167
+                ],
+                "Gama": [
+                    4169
+                ],
+                "Marques": [
+                    4170
+                ],
+                "“What": [
+                    4172
+                ],
+                "disorders?": [
+                    4184
+                ],
+                "systematic": [
+                    4186
+                ],
+                "review”.": [
+                    4187
+                ],
+                "Porto": [
+                    4188
+                ],
+                "Biomed": [
+                    4189
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/33884324/[13-2]": [
+                    4191
+                ],
+                "Induces": [
+                    4197
+                ],
+                "Time-Dependent": [
+                    4198
+                ],
+                "Changes": [
+                    4199
+                ],
+                "Global": [
+                    4201
+                ],
+                "Functional": [
+                    4202
+                ],
+                "Connectivity”.": [
+                    4203
+                ],
+                "Biol": [
+                    4204
+                ],
+                "https://pubmed.ncbi.nlm.nih.gov/32111343/[13-3]": [
+                    4206
+                ],
+                "Double-Blin": [
+                    4216
+                ]
+            },
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W4318592244",
+            "counts_by_year": [],
+            "updated_date": "2024-07-26T14:53:04.731727",
+            "created_date": "2023-01-31"
+        },
+        {
+            "id": "https://openalex.org/W2766868798",
+            "doi": "https://doi.org/10.4049/jimmunol.196.supp.209.29",
+            "title": "MojoSort™ kit isolated cells maintain physical function in magnetic cell separator and column",
+            "display_name": "MojoSort™ kit isolated cells maintain physical function in magnetic cell separator and column",
+            "publication_year": 2016,
+            "publication_date": "2016-05-01",
+            "ids": {
+                "openalex": "https://openalex.org/W2766868798",
+                "doi": "https://doi.org/10.4049/jimmunol.196.supp.209.29",
+                "mag": "2766868798"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": false,
+                "landing_page_url": "https://doi.org/10.4049/jimmunol.196.supp.209.29",
+                "pdf_url": null,
+                "source": {
+                    "id": "https://openalex.org/S38008053",
+                    "display_name": "The Journal of Immunology",
+                    "issn_l": "0022-1767",
+                    "issn": [
+                        "0022-1767",
+                        "1550-6606"
+                    ],
+                    "is_oa": false,
+                    "is_in_doaj": false,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4320800377",
+                    "host_organization_name": "American Association of Immunologists",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4320800377"
+                    ],
+                    "host_organization_lineage_names": [
+                        "American Association of Immunologists"
+                    ],
+                    "type": "journal"
+                },
+                "license": null,
+                "license_id": null,
+                "version": null,
+                "is_accepted": false,
+                "is_published": false
+            },
+            "type": "article",
+            "type_crossref": "journal-article",
+            "indexed_in": [
+                "crossref"
+            ],
+            "open_access": {
+                "is_oa": false,
+                "oa_status": "closed",
+                "oa_url": null,
+                "any_repository_has_fulltext": false
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5100430282",
+                        "display_name": "Hong Zhang",
+                        "orcid": "https://orcid.org/0000-0002-3342-5377"
+                    },
+                    "institutions": [],
+                    "countries": [],
+                    "is_corresponding": false,
+                    "raw_author_name": "Hong Zhang",
+                    "raw_affiliation_strings": [
+                        "1BioLegend, Inc."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1BioLegend, Inc.",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5057425882",
+                        "display_name": "Miguel A. Tam",
+                        "orcid": "https://orcid.org/0000-0001-8094-7090"
+                    },
+                    "institutions": [],
+                    "countries": [],
+                    "is_corresponding": false,
+                    "raw_author_name": "Miguel Tam",
+                    "raw_affiliation_strings": [
+                        "1BioLegend, Inc."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1BioLegend, Inc.",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5048116067",
+                        "display_name": "Dhanesh Gohel",
+                        "orcid": null
+                    },
+                    "institutions": [],
+                    "countries": [],
+                    "is_corresponding": false,
+                    "raw_author_name": "Dhanesh Gohel",
+                    "raw_affiliation_strings": [
+                        "1BioLegend, Inc."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1BioLegend, Inc.",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5081987607",
+                        "display_name": "Jeffrey Koury",
+                        "orcid": "https://orcid.org/0000-0002-7368-4891"
+                    },
+                    "institutions": [],
+                    "countries": [],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jeffrey Koury",
+                    "raw_affiliation_strings": [
+                        "1BioLegend, Inc."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1BioLegend, Inc.",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5064202199",
+                        "display_name": "Crystal Shen",
+                        "orcid": null
+                    },
+                    "institutions": [],
+                    "countries": [],
+                    "is_corresponding": false,
+                    "raw_author_name": "Crystal Shen",
+                    "raw_affiliation_strings": [
+                        "1BioLegend, Inc."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1BioLegend, Inc.",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100675680",
+                        "display_name": "David Chen",
+                        "orcid": "https://orcid.org/0000-0003-1858-7201"
+                    },
+                    "institutions": [],
+                    "countries": [],
+                    "is_corresponding": false,
+                    "raw_author_name": "David Chen",
+                    "raw_affiliation_strings": [
+                        "1BioLegend, Inc."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1BioLegend, Inc.",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5055384331",
+                        "display_name": "Xifeng Yang",
+                        "orcid": "https://orcid.org/0000-0003-2892-6545"
+                    },
+                    "institutions": [],
+                    "countries": [],
+                    "is_corresponding": false,
+                    "raw_author_name": "Xifeng Yang",
+                    "raw_affiliation_strings": [
+                        "1BioLegend, Inc."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1BioLegend, Inc.",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "last",
+                    "author": {
+                        "id": "https://openalex.org/A5035888442",
+                        "display_name": "Gene Lay",
+                        "orcid": null
+                    },
+                    "institutions": [],
+                    "countries": [],
+                    "is_corresponding": false,
+                    "raw_author_name": "Gene Lay",
+                    "raw_affiliation_strings": [
+                        "1BioLegend, Inc."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1BioLegend, Inc.",
+                            "institution_ids": []
+                        }
+                    ]
+                }
+            ],
+            "countries_distinct_count": 0,
+            "institutions_distinct_count": 0,
+            "corresponding_author_ids": [],
+            "corresponding_institution_ids": [],
+            "apc_list": null,
+            "apc_paid": null,
+            "fwci": 0,
+            "has_fulltext": false,
+            "cited_by_count": 0,
+            "cited_by_percentile_year": {
+                "min": 0,
+                "max": 69
+            },
+            "biblio": {
+                "volume": "196",
+                "issue": "1_Supplement",
+                "first_page": "209.29",
+                "last_page": "209.29"
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T11255",
+                "display_name": "Microfluidic Techniques for Particle Manipulation and Separation",
+                "score": 0.9908,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/2204",
+                    "display_name": "Biomedical Engineering"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/22",
+                    "display_name": "Engineering"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/3",
+                    "display_name": "Physical Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T11255",
+                    "display_name": "Microfluidic Techniques for Particle Manipulation and Separation",
+                    "score": 0.9908,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2204",
+                        "display_name": "Biomedical Engineering"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/22",
+                        "display_name": "Engineering"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/3",
+                        "display_name": "Physical Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11190",
+                    "display_name": "3D Bioprinting Technology",
+                    "score": 0.9881,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2204",
+                        "display_name": "Biomedical Engineering"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/22",
+                        "display_name": "Engineering"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/3",
+                        "display_name": "Physical Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11407",
+                    "display_name": "Droplet Microfluidics Technology",
+                    "score": 0.963,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2204",
+                        "display_name": "Biomedical Engineering"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/22",
+                        "display_name": "Engineering"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/3",
+                        "display_name": "Physical Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/cell-sorting",
+                    "display_name": "Cell Sorting",
+                    "score": 0.559919
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C2779833257",
+                    "wikidata": "https://www.wikidata.org/wiki/Q2663154",
+                    "display_name": "Magnetic separation",
+                    "level": 2,
+                    "score": 0.6437312
+                },
+                {
+                    "id": "https://openalex.org/C1491633281",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7868",
+                    "display_name": "Cell",
+                    "level": 2,
+                    "score": 0.5396929
+                },
+                {
+                    "id": "https://openalex.org/C185004128",
+                    "wikidata": "https://www.wikidata.org/wiki/Q3011536",
+                    "display_name": "Separator (oil production)",
+                    "level": 2,
+                    "score": 0.5354915
+                },
+                {
+                    "id": "https://openalex.org/C2778630268",
+                    "wikidata": "https://www.wikidata.org/wiki/Q17113277",
+                    "display_name": "Cell sorting",
+                    "level": 3,
+                    "score": 0.49521723
+                },
+                {
+                    "id": "https://openalex.org/C87023908",
+                    "wikidata": "https://www.wikidata.org/wiki/Q3870166",
+                    "display_name": "Magnetic nanoparticles",
+                    "level": 3,
+                    "score": 0.46101227
+                },
+                {
+                    "id": "https://openalex.org/C2993110782",
+                    "wikidata": "https://www.wikidata.org/wiki/Q3870166",
+                    "display_name": "Magnetic bead",
+                    "level": 2,
+                    "score": 0.44153684
+                },
+                {
+                    "id": "https://openalex.org/C192562407",
+                    "wikidata": "https://www.wikidata.org/wiki/Q228736",
+                    "display_name": "Materials science",
+                    "level": 0,
+                    "score": 0.3680088
+                },
+                {
+                    "id": "https://openalex.org/C43617362",
+                    "wikidata": "https://www.wikidata.org/wiki/Q170050",
+                    "display_name": "Chromatography",
+                    "level": 1,
+                    "score": 0.3345266
+                },
+                {
+                    "id": "https://openalex.org/C185592680",
+                    "wikidata": "https://www.wikidata.org/wiki/Q2329",
+                    "display_name": "Chemistry",
+                    "level": 0,
+                    "score": 0.30686468
+                },
+                {
+                    "id": "https://openalex.org/C171250308",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11468",
+                    "display_name": "Nanotechnology",
+                    "level": 1,
+                    "score": 0.18715051
+                },
+                {
+                    "id": "https://openalex.org/C55493867",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7094",
+                    "display_name": "Biochemistry",
+                    "level": 1,
+                    "score": 0.1148313
+                },
+                {
+                    "id": "https://openalex.org/C121332964",
+                    "wikidata": "https://www.wikidata.org/wiki/Q413",
+                    "display_name": "Physics",
+                    "level": 0,
+                    "score": 0.08503926
+                },
+                {
+                    "id": "https://openalex.org/C155672457",
+                    "wikidata": "https://www.wikidata.org/wiki/Q61231",
+                    "display_name": "Nanoparticle",
+                    "level": 2,
+                    "score": 0.08469215
+                },
+                {
+                    "id": "https://openalex.org/C191897082",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11467",
+                    "display_name": "Metallurgy",
+                    "level": 1,
+                    "score": 0
+                },
+                {
+                    "id": "https://openalex.org/C97355855",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11473",
+                    "display_name": "Thermodynamics",
+                    "level": 1,
+                    "score": 0
+                }
+            ],
+            "mesh": [],
+            "locations_count": 1,
+            "locations": [
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://doi.org/10.4049/jimmunol.196.supp.209.29",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S38008053",
+                        "display_name": "The Journal of Immunology",
+                        "issn_l": "0022-1767",
+                        "issn": [
+                            "0022-1767",
+                            "1550-6606"
+                        ],
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_core": true,
+                        "host_organization": "https://openalex.org/P4320800377",
+                        "host_organization_name": "American Association of Immunologists",
+                        "host_organization_lineage": [
+                            "https://openalex.org/P4320800377"
+                        ],
+                        "host_organization_lineage_names": [
+                            "American Association of Immunologists"
+                        ],
+                        "type": "journal"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": null,
+            "sustainable_development_goals": [],
+            "grants": [],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 0,
+            "referenced_works": [],
+            "related_works": [
+                "https://openalex.org/W3039983714",
+                "https://openalex.org/W3010397653",
+                "https://openalex.org/W2766868798",
+                "https://openalex.org/W2382428761",
+                "https://openalex.org/W2105955939",
+                "https://openalex.org/W2040744703",
+                "https://openalex.org/W2013811683",
+                "https://openalex.org/W1789853956",
+                "https://openalex.org/W163702335",
+                "https://openalex.org/W1594298200"
+            ],
+            "ngrams_url": "https://api.openalex.org/works/W2766868798/ngrams",
+            "abstract_inverted_index": {
+                "Abstract": [
+                    0
+                ],
+                "Magnetic": [
+                    1
+                ],
+                "cell": [
+                    2,
+                    11,
+                    33,
+                    62,
+                    103,
+                    125,
+                    176,
+                    199
+                ],
+                "sorting": [
+                    3
+                ],
+                "has": [
+                    4,
+                    38
+                ],
+                "been": [
+                    5,
+                    39
+                ],
+                "widely": [
+                    6
+                ],
+                "used": [
+                    7
+                ],
+                "to": [
+                    8,
+                    21,
+                    31,
+                    203
+                ],
+                "isolate": [
+                    9
+                ],
+                "different": [
+                    10,
+                    42
+                ],
+                "types": [
+                    12
+                ],
+                "as": [
+                    13,
+                    134,
+                    201
+                ],
+                "it": [
+                    14
+                ],
+                "is": [
+                    15
+                ],
+                "a": [
+                    16,
+                    192
+                ],
+                "fast": [
+                    17
+                ],
+                "and": [
+                    18,
+                    28,
+                    65,
+                    91,
+                    102,
+                    139,
+                    228
+                ],
+                "reliable": [
+                    19
+                ],
+                "method": [
+                    20
+                ],
+                "obtain": [
+                    22
+                ],
+                "discrete": [
+                    23
+                ],
+                "populations": [
+                    24
+                ],
+                "with": [
+                    25,
+                    35,
+                    51,
+                    68,
+                    88,
+                    114,
+                    152,
+                    187,
+                    223
+                ],
+                "high": [
+                    26
+                ],
+                "purity": [
+                    27
+                ],
+                "yield.": [
+                    29
+                ],
+                "However,": [
+                    30
+                ],
+                "maintain": [
+                    32,
+                    213
+                ],
+                "functionality": [
+                    34,
+                    94
+                ],
+                "this": [
+                    36
+                ],
+                "approach": [
+                    37
+                ],
+                "concerned": [
+                    40
+                ],
+                "for": [
+                    41
+                ],
+                "studies.": [
+                    43
+                ],
+                "To": [
+                    44
+                ],
+                "address": [
+                    45
+                ],
+                "this,": [
+                    46
+                ],
+                "the": [
+                    47,
+                    78,
+                    92,
+                    140,
+                    175,
+                    198,
+                    210,
+                    232
+                ],
+                "cells": [
+                    48,
+                    84,
+                    113,
+                    142,
+                    151,
+                    167,
+                    183,
+                    204,
+                    211,
+                    221
+                ],
+                "were": [
+                    49,
+                    85
+                ],
+                "isolated": [
+                    50,
+                    83,
+                    112,
+                    141,
+                    150,
+                    166,
+                    205,
+                    222
+                ],
+                "our": [
+                    52,
+                    217
+                ],
+                "recently": [
+                    53
+                ],
+                "developed": [
+                    54
+                ],
+                "MojoSort™": [
+                    55,
+                    110,
+                    115,
+                    154,
+                    165,
+                    185,
+                    188,
+                    224
+                ],
+                "isolation": [
+                    56
+                ],
+                "kit": [
+                    57,
+                    155,
+                    161,
+                    186
+                ],
+                "using": [
+                    58,
+                    184,
+                    206
+                ],
+                "commercially": [
+                    59
+                ],
+                "available": [
+                    60
+                ],
+                "magnetic": [
+                    61,
+                    71,
+                    79,
+                    118,
+                    157,
+                    233
+                ],
+                "separation": [
+                    63,
+                    158,
+                    207
+                ],
+                "column,": [
+                    64
+                ],
+                "compared": [
+                    66,
+                    202
+                ],
+                "that": [
+                    67,
+                    109,
+                    220
+                ],
+                "other": [
+                    69
+                ],
+                "commercial": [
+                    70
+                ],
+                "column": [
+                    72,
+                    119,
+                    159
+                ],
+                "related": [
+                    73,
+                    160
+                ],
+                "products.": [
+                    74
+                ],
+                "The": [
+                    75
+                ],
+                "stickiness": [
+                    76
+                ],
+                "of": [
+                    77,
+                    81,
+                    99,
+                    128,
+                    171,
+                    195,
+                    231
+                ],
+                "particles": [
+                    80,
+                    172
+                ],
+                "those": [
+                    82
+                ],
+                "then": [
+                    86
+                ],
+                "imaged": [
+                    87
+                ],
+                "electron": [
+                    89
+                ],
+                "microscope,": [
+                    90
+                ],
+                "cellular": [
+                    93
+                ],
+                "was": [
+                    95
+                ],
+                "tested": [
+                    96
+                ],
+                "by": [
+                    97,
+                    136
+                ],
+                "activation": [
+                    98
+                ],
+                "MAPK/ERK": [
+                    100
+                ],
+                "pathway": [
+                    101
+                ],
+                "proliferation": [
+                    104
+                ],
+                "assay.": [
+                    105
+                ],
+                "Our": [
+                    106
+                ],
+                "data": [
+                    107,
+                    218
+                ],
+                "show": [
+                    108
+                ],
+                "negative": [
+                    111
+                ],
+                "separator": [
+                    116,
+                    234
+                ],
+                "or": [
+                    117,
+                    156,
+                    238
+                ],
+                "do": [
+                    120
+                ],
+                "not": [
+                    121,
+                    132
+                ],
+                "display": [
+                    122
+                ],
+                "beads": [
+                    123,
+                    196
+                ],
+                "on": [
+                    124,
+                    174,
+                    197
+                ],
+                "surface,": [
+                    126
+                ],
+                "phosphorylation": [
+                    127
+                ],
+                "ERK1/2": [
+                    129
+                ],
+                "level": [
+                    130
+                ],
+                "did": [
+                    131
+                ],
+                "increase": [
+                    133
+                ],
+                "detected": [
+                    135
+                ],
+                "western": [
+                    137
+                ],
+                "blot,": [
+                    138
+                ],
+                "showed": [
+                    143
+                ],
+                "fully": [
+                    144
+                ],
+                "functional.": [
+                    145
+                ],
+                "In": [
+                    146
+                ],
+                "addition,": [
+                    147
+                ],
+                "both": [
+                    148
+                ],
+                "positively": [
+                    149,
+                    181
+                ],
+                "either": [
+                    153,
+                    236
+                ],
+                "preserved": [
+                    162
+                ],
+                "functionality.": [
+                    163,
+                    215
+                ],
+                "Furthermore,": [
+                    164
+                ],
+                "only": [
+                    168
+                ],
+                "have": [
+                    169
+                ],
+                "&amp;lt;10%": [
+                    170
+                ],
+                "covered": [
+                    173
+                ],
+                "surface.": [
+                    177
+                ],
+                "Finally,": [
+                    178
+                ],
+                "when": [
+                    179
+                ],
+                "analyzing": [
+                    180
+                ],
+                "selected": [
+                    182
+                ],
+                "magnet,": [
+                    189
+                ],
+                "we": [
+                    190
+                ],
+                "observed": [
+                    191
+                ],
+                "higher": [
+                    193
+                ],
+                "number": [
+                    194
+                ],
+                "surface": [
+                    200
+                ],
+                "columns,": [
+                    208
+                ],
+                "but": [
+                    209
+                ],
+                "still": [
+                    212
+                ],
+                "their": [
+                    214
+                ],
+                "Thus,": [
+                    216
+                ],
+                "demonstrates": [
+                    219
+                ],
+                "reagents": [
+                    225
+                ],
+                "are": [
+                    226
+                ],
+                "viable": [
+                    227
+                ],
+                "functional,": [
+                    229
+                ],
+                "independently": [
+                    230
+                ],
+                "used,": [
+                    235
+                ],
+                "column-based": [
+                    237
+                ],
+                "handheld": [
+                    239
+                ],
+                "magnet.": [
+                    240
+                ]
+            },
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W2766868798",
+            "counts_by_year": [],
+            "updated_date": "2024-07-26T16:12:25.407982",
+            "created_date": "2017-11-10"
+        },
+        {
+            "id": "https://openalex.org/W4285796306",
+            "doi": "https://doi.org/10.55277/researchhub.g1hc22hv",
+            "title": "Towards a More Equitable Publishing Framework: Fractionalized Non-Transferable Publications",
+            "display_name": "Towards a More Equitable Publishing Framework: Fractionalized Non-Transferable Publications",
+            "publication_year": 2022,
+            "publication_date": "2022-07-19",
+            "ids": {
+                "openalex": "https://openalex.org/W4285796306",
+                "doi": "https://doi.org/10.55277/researchhub.g1hc22hv"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": false,
+                "landing_page_url": "https://doi.org/10.55277/researchhub.g1hc22hv",
+                "pdf_url": null,
+                "source": null,
+                "license": null,
+                "license_id": null,
+                "version": null,
+                "is_accepted": false,
+                "is_published": false
+            },
+            "type": "report",
+            "type_crossref": "report",
+            "indexed_in": [
+                "crossref"
+            ],
+            "open_access": {
+                "is_oa": false,
+                "oa_status": "closed",
+                "oa_url": null,
+                "any_repository_has_fulltext": false
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5081987607",
+                        "display_name": "Jeffrey Koury",
+                        "orcid": "https://orcid.org/0000-0002-7368-4891"
+                    },
+                    "institutions": [],
+                    "countries": [],
+                    "is_corresponding": true,
+                    "raw_author_name": "Jeffrey Koury",
+                    "raw_affiliation_strings": [],
+                    "affiliations": []
+                }
+            ],
+            "countries_distinct_count": 0,
+            "institutions_distinct_count": 0,
+            "corresponding_author_ids": [
+                "https://openalex.org/A5081987607"
+            ],
+            "corresponding_institution_ids": [],
+            "apc_list": null,
+            "apc_paid": null,
+            "fwci": null,
+            "has_fulltext": false,
+            "cited_by_count": 0,
+            "cited_by_percentile_year": {
+                "min": 0,
+                "max": 64
+            },
+            "biblio": {
+                "volume": null,
+                "issue": null,
+                "first_page": null,
+                "last_page": null
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T13516",
+                "display_name": "Evolution and Impact of Scholarly Publishing Practices",
+                "score": 0.8376,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/1207",
+                    "display_name": "History and Philosophy of Science"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/12",
+                    "display_name": "Arts and Humanities"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/2",
+                    "display_name": "Social Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T13516",
+                    "display_name": "Evolution and Impact of Scholarly Publishing Practices",
+                    "score": 0.8376,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/1207",
+                        "display_name": "History and Philosophy of Science"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/12",
+                        "display_name": "Arts and Humanities"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/2",
+                        "display_name": "Social Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11813",
+                    "display_name": "Usage and Impact of E-Books in Academic Settings",
+                    "score": 0.7717,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/1710",
+                        "display_name": "Information Systems"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/17",
+                        "display_name": "Computer Science"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/3",
+                        "display_name": "Physical Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/publication-ethics",
+                    "display_name": "Publication Ethics",
+                    "score": 0.583425
+                },
+                {
+                    "id": "https://openalex.org/keywords/scholarly-publishing",
+                    "display_name": "Scholarly Publishing",
+                    "score": 0.567549
+                },
+                {
+                    "id": "https://openalex.org/keywords/book-publishing",
+                    "display_name": "Book Publishing",
+                    "score": 0.554729
+                },
+                {
+                    "id": "https://openalex.org/keywords/research-dissemination",
+                    "display_name": "Research Dissemination",
+                    "score": 0.549481
+                },
+                {
+                    "id": "https://openalex.org/keywords/print-vs.-digital",
+                    "display_name": "Print vs. Digital",
+                    "score": 0.515537
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C151719136",
+                    "wikidata": "https://www.wikidata.org/wiki/Q3972943",
+                    "display_name": "Publishing",
+                    "level": 2,
+                    "score": 0.62811315
+                },
+                {
+                    "id": "https://openalex.org/C41008148",
+                    "wikidata": "https://www.wikidata.org/wiki/Q21198",
+                    "display_name": "Computer science",
+                    "level": 0,
+                    "score": 0.4541473
+                },
+                {
+                    "id": "https://openalex.org/C17744445",
+                    "wikidata": "https://www.wikidata.org/wiki/Q36442",
+                    "display_name": "Political science",
+                    "level": 0,
+                    "score": 0.3025633
+                },
+                {
+                    "id": "https://openalex.org/C199539241",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7748",
+                    "display_name": "Law",
+                    "level": 1,
+                    "score": 0.11973071
+                }
+            ],
+            "mesh": [],
+            "locations_count": 1,
+            "locations": [
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://doi.org/10.55277/researchhub.g1hc22hv",
+                    "pdf_url": null,
+                    "source": null,
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": null,
+            "sustainable_development_goals": [],
+            "grants": [],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 0,
+            "referenced_works": [],
+            "related_works": [
+                "https://openalex.org/W2899084033",
+                "https://openalex.org/W2756635080",
+                "https://openalex.org/W2748952813",
+                "https://openalex.org/W2698935035",
+                "https://openalex.org/W249766449",
+                "https://openalex.org/W2390279801",
+                "https://openalex.org/W2376932109",
+                "https://openalex.org/W2358668433",
+                "https://openalex.org/W2294677930",
+                "https://openalex.org/W2028846973"
+            ],
+            "ngrams_url": "https://api.openalex.org/works/W4285796306/ngrams",
+            "abstract_inverted_index": null,
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W4285796306",
+            "counts_by_year": [],
+            "updated_date": "2024-07-18T01:37:01.790525",
+            "created_date": "2022-07-19"
+        },
+        {
+            "id": "https://openalex.org/W4308399185",
+            "doi": "https://doi.org/10.55277/researchhub.l8vj1ujl",
+            "title": "Elucidating the role of ephrin-B1 in IFNB mediated neuroprotection in HIV associated neurocognitive disorder (HAND)",
+            "display_name": "Elucidating the role of ephrin-B1 in IFNB mediated neuroprotection in HIV associated neurocognitive disorder (HAND)",
+            "publication_year": 2022,
+            "publication_date": "2022-11-08",
+            "ids": {
+                "openalex": "https://openalex.org/W4308399185",
+                "doi": "https://doi.org/10.55277/researchhub.l8vj1ujl"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": false,
+                "landing_page_url": "https://doi.org/10.55277/researchhub.l8vj1ujl",
+                "pdf_url": null,
+                "source": null,
+                "license": null,
+                "license_id": null,
+                "version": null,
+                "is_accepted": false,
+                "is_published": false
+            },
+            "type": "report",
+            "type_crossref": "report",
+            "indexed_in": [
+                "crossref"
+            ],
+            "open_access": {
+                "is_oa": false,
+                "oa_status": "closed",
+                "oa_url": null,
+                "any_repository_has_fulltext": false
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5081987607",
+                        "display_name": "Jeffrey Koury",
+                        "orcid": "https://orcid.org/0000-0002-7368-4891"
+                    },
+                    "institutions": [],
+                    "countries": [],
+                    "is_corresponding": true,
+                    "raw_author_name": "Jeffrey Koury",
+                    "raw_affiliation_strings": [],
+                    "affiliations": []
+                }
+            ],
+            "countries_distinct_count": 0,
+            "institutions_distinct_count": 0,
+            "corresponding_author_ids": [
+                "https://openalex.org/A5081987607"
+            ],
+            "corresponding_institution_ids": [],
+            "apc_list": null,
+            "apc_paid": null,
+            "fwci": null,
+            "has_fulltext": false,
+            "cited_by_count": 0,
+            "cited_by_percentile_year": {
+                "min": 0,
+                "max": 64
+            },
+            "biblio": {
+                "volume": null,
+                "issue": null,
+                "first_page": null,
+                "last_page": null
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T12061",
+                "display_name": "Molecular Mechanisms of Axon Guidance",
+                "score": 0.9632,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/2804",
+                    "display_name": "Cellular and Molecular Neuroscience"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/28",
+                    "display_name": "Neuroscience"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/1",
+                    "display_name": "Life Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T12061",
+                    "display_name": "Molecular Mechanisms of Axon Guidance",
+                    "score": 0.9632,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2804",
+                        "display_name": "Cellular and Molecular Neuroscience"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/28",
+                        "display_name": "Neuroscience"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11266",
+                    "display_name": "Role of Microglia in Neurological Disorders",
+                    "score": 0.9616,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2808",
+                        "display_name": "Neurology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/28",
+                        "display_name": "Neuroscience"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/neuroinflammation",
+                    "display_name": "Neuroinflammation",
+                    "score": 0.502299
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C172467417",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1670397",
+                    "display_name": "Neurocognitive",
+                    "level": 3,
+                    "score": 0.9260244
+                },
+                {
+                    "id": "https://openalex.org/C25498285",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1981368",
+                    "display_name": "Neuroprotection",
+                    "level": 2,
+                    "score": 0.81744474
+                },
+                {
+                    "id": "https://openalex.org/C3013748606",
+                    "wikidata": "https://www.wikidata.org/wiki/Q15787",
+                    "display_name": "Human immunodeficiency virus (HIV)",
+                    "level": 2,
+                    "score": 0.6336609
+                },
+                {
+                    "id": "https://openalex.org/C15744967",
+                    "wikidata": "https://www.wikidata.org/wiki/Q9418",
+                    "display_name": "Psychology",
+                    "level": 0,
+                    "score": 0.47170353
+                },
+                {
+                    "id": "https://openalex.org/C169760540",
+                    "wikidata": "https://www.wikidata.org/wiki/Q207011",
+                    "display_name": "Neuroscience",
+                    "level": 1,
+                    "score": 0.46518415
+                },
+                {
+                    "id": "https://openalex.org/C71924100",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11190",
+                    "display_name": "Medicine",
+                    "level": 0,
+                    "score": 0.38217276
+                },
+                {
+                    "id": "https://openalex.org/C70410870",
+                    "wikidata": "https://www.wikidata.org/wiki/Q199906",
+                    "display_name": "Clinical psychology",
+                    "level": 1,
+                    "score": 0.3651206
+                },
+                {
+                    "id": "https://openalex.org/C169900460",
+                    "wikidata": "https://www.wikidata.org/wiki/Q2200417",
+                    "display_name": "Cognition",
+                    "level": 2,
+                    "score": 0.27817672
+                },
+                {
+                    "id": "https://openalex.org/C159047783",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7215",
+                    "display_name": "Virology",
+                    "level": 1,
+                    "score": 0.11279383
+                }
+            ],
+            "mesh": [],
+            "locations_count": 1,
+            "locations": [
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://doi.org/10.55277/researchhub.l8vj1ujl",
+                    "pdf_url": null,
+                    "source": null,
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": null,
+            "sustainable_development_goals": [
+                {
+                    "id": "https://metadata.un.org/sdg/3",
+                    "display_name": "Good health and well-being",
+                    "score": 0.55
+                }
+            ],
+            "grants": [],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 0,
+            "referenced_works": [],
+            "related_works": [
+                "https://openalex.org/W3175973148",
+                "https://openalex.org/W2899084033",
+                "https://openalex.org/W2748952813",
+                "https://openalex.org/W2747715884",
+                "https://openalex.org/W2531432350",
+                "https://openalex.org/W2077302930",
+                "https://openalex.org/W2050697792",
+                "https://openalex.org/W2031595470",
+                "https://openalex.org/W2010778623",
+                "https://openalex.org/W1479886833"
+            ],
+            "ngrams_url": "https://api.openalex.org/works/W4308399185/ngrams",
+            "abstract_inverted_index": null,
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W4308399185",
+            "counts_by_year": [],
+            "updated_date": "2024-07-17T07:48:18.745969",
+            "created_date": "2022-11-11"
+        },
+        {
+            "id": "https://openalex.org/W4319432251",
+            "doi": "https://doi.org/10.4049/jimmunol.206.supp.27.23",
+            "title": "An Accessible Automatic Cell Counting Methodology Using Trainable Weka Segmentation in ImageJ Validated on Murine Microglia",
+            "display_name": "An Accessible Automatic Cell Counting Methodology Using Trainable Weka Segmentation in ImageJ Validated on Murine Microglia",
+            "publication_year": 2021,
+            "publication_date": "2021-05-01",
+            "ids": {
+                "openalex": "https://openalex.org/W4319432251",
+                "doi": "https://doi.org/10.4049/jimmunol.206.supp.27.23"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": false,
+                "landing_page_url": "https://doi.org/10.4049/jimmunol.206.supp.27.23",
+                "pdf_url": null,
+                "source": {
+                    "id": "https://openalex.org/S38008053",
+                    "display_name": "The journal of immunology/The Journal of immunology",
+                    "issn_l": "0022-1767",
+                    "issn": [
+                        "0022-1767",
+                        "1550-6606"
+                    ],
+                    "is_oa": false,
+                    "is_in_doaj": false,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4320800377",
+                    "host_organization_name": "American Association of Immunologists",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4320800377"
+                    ],
+                    "host_organization_lineage_names": [
+                        "American Association of Immunologists"
+                    ],
+                    "type": "journal"
+                },
+                "license": null,
+                "license_id": null,
+                "version": null,
+                "is_accepted": false,
+                "is_published": false
+            },
+            "type": "article",
+            "type_crossref": "journal-article",
+            "indexed_in": [
+                "crossref"
+            ],
+            "open_access": {
+                "is_oa": false,
+                "oa_status": "closed",
+                "oa_url": null,
+                "any_repository_has_fulltext": false
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5068103348",
+                        "display_name": "Theo J Kataras",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Theo J Kataras",
+                    "raw_affiliation_strings": [
+                        "1University of California Riverside"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1University of California Riverside",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5081987607",
+                        "display_name": "Jeffrey Koury",
+                        "orcid": "https://orcid.org/0000-0002-7368-4891"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jeffrey Koury",
+                    "raw_affiliation_strings": [
+                        "1University of California Riverside"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1University of California Riverside",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5055840064",
+                        "display_name": "Hina Singh",
+                        "orcid": "https://orcid.org/0000-0001-7067-1991"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Hina Singh",
+                    "raw_affiliation_strings": [
+                        "1University of California Riverside"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1University of California Riverside",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "last",
+                    "author": {
+                        "id": "https://openalex.org/A5072837198",
+                        "display_name": "Marcus Kaul",
+                        "orcid": "https://orcid.org/0000-0003-3202-670X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Marcus Kaul",
+                    "raw_affiliation_strings": [
+                        "1University of California Riverside"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1University of California Riverside",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "countries_distinct_count": 1,
+            "institutions_distinct_count": 1,
+            "corresponding_author_ids": [],
+            "corresponding_institution_ids": [],
+            "apc_list": null,
+            "apc_paid": null,
+            "fwci": 0,
+            "has_fulltext": false,
+            "cited_by_count": 0,
+            "cited_by_percentile_year": {
+                "min": 0,
+                "max": 61
+            },
+            "biblio": {
+                "volume": "206",
+                "issue": "1_Supplement",
+                "first_page": "27.23",
+                "last_page": "27.23"
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T11266",
+                "display_name": "Role of Microglia in Neurological Disorders",
+                "score": 0.9999,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/2808",
+                    "display_name": "Neurology"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/28",
+                    "display_name": "Neuroscience"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/1",
+                    "display_name": "Life Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T11266",
+                    "display_name": "Role of Microglia in Neurological Disorders",
+                    "score": 0.9999,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2808",
+                        "display_name": "Neurology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/28",
+                        "display_name": "Neuroscience"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11313",
+                    "display_name": "Macrophage Activation and Polarization",
+                    "score": 0.9951,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2403",
+                        "display_name": "Immunology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/24",
+                        "display_name": "Immunology and Microbiology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11289",
+                    "display_name": "Comprehensive Integration of Single-Cell Transcriptomic Data",
+                    "score": 0.9865,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/1312",
+                        "display_name": "Molecular Biology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/13",
+                        "display_name": "Biochemistry, Genetics and Molecular Biology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/cell-heterogeneity",
+                    "display_name": "Cell Heterogeneity",
+                    "score": 0.488761
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C2779830541",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1622829",
+                    "display_name": "Microglia",
+                    "level": 3,
+                    "score": 0.74243736
+                },
+                {
+                    "id": "https://openalex.org/C89600930",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1423946",
+                    "display_name": "Segmentation",
+                    "level": 2,
+                    "score": 0.57619387
+                },
+                {
+                    "id": "https://openalex.org/C154945302",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11660",
+                    "display_name": "Artificial intelligence",
+                    "level": 1,
+                    "score": 0.534501
+                },
+                {
+                    "id": "https://openalex.org/C4924752",
+                    "wikidata": "https://www.wikidata.org/wiki/Q184148",
+                    "display_name": "Plug-in",
+                    "level": 2,
+                    "score": 0.51719105
+                },
+                {
+                    "id": "https://openalex.org/C41008148",
+                    "wikidata": "https://www.wikidata.org/wiki/Q21198",
+                    "display_name": "Computer science",
+                    "level": 0,
+                    "score": 0.48896658
+                },
+                {
+                    "id": "https://openalex.org/C153180895",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7148389",
+                    "display_name": "Pattern recognition (psychology)",
+                    "level": 2,
+                    "score": 0.35444096
+                },
+                {
+                    "id": "https://openalex.org/C86803240",
+                    "wikidata": "https://www.wikidata.org/wiki/Q420",
+                    "display_name": "Biology",
+                    "level": 0,
+                    "score": 0.22123367
+                },
+                {
+                    "id": "https://openalex.org/C2776914184",
+                    "wikidata": "https://www.wikidata.org/wiki/Q101991",
+                    "display_name": "Inflammation",
+                    "level": 2,
+                    "score": 0.17824492
+                },
+                {
+                    "id": "https://openalex.org/C203014093",
+                    "wikidata": "https://www.wikidata.org/wiki/Q101929",
+                    "display_name": "Immunology",
+                    "level": 1,
+                    "score": 0.17297515
+                },
+                {
+                    "id": "https://openalex.org/C111919701",
+                    "wikidata": "https://www.wikidata.org/wiki/Q9135",
+                    "display_name": "Operating system",
+                    "level": 1,
+                    "score": 0.11990672
+                }
+            ],
+            "mesh": [],
+            "locations_count": 1,
+            "locations": [
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://doi.org/10.4049/jimmunol.206.supp.27.23",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S38008053",
+                        "display_name": "The journal of immunology/The Journal of immunology",
+                        "issn_l": "0022-1767",
+                        "issn": [
+                            "0022-1767",
+                            "1550-6606"
+                        ],
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_core": true,
+                        "host_organization": "https://openalex.org/P4320800377",
+                        "host_organization_name": "American Association of Immunologists",
+                        "host_organization_lineage": [
+                            "https://openalex.org/P4320800377"
+                        ],
+                        "host_organization_lineage_names": [
+                            "American Association of Immunologists"
+                        ],
+                        "type": "journal"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": null,
+            "sustainable_development_goals": [
+                {
+                    "id": "https://metadata.un.org/sdg/3",
+                    "display_name": "Good health and well-being",
+                    "score": 0.82
+                }
+            ],
+            "grants": [],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 0,
+            "referenced_works": [],
+            "related_works": [
+                "https://openalex.org/W47352601",
+                "https://openalex.org/W4287448745",
+                "https://openalex.org/W4287378204",
+                "https://openalex.org/W4240705470",
+                "https://openalex.org/W2981957539",
+                "https://openalex.org/W2885325217",
+                "https://openalex.org/W2546440307",
+                "https://openalex.org/W2545422590",
+                "https://openalex.org/W2042327336",
+                "https://openalex.org/W2033914206"
+            ],
+            "ngrams_url": "https://api.openalex.org/works/W4319432251/ngrams",
+            "abstract_inverted_index": {
+                "Abstract": [
+                    0
+                ],
+                "Counting": [
+                    1
+                ],
+                "cells": [
+                    2,
+                    26
+                ],
+                "is": [
+                    3,
+                    18,
+                    31
+                ],
+                "a": [
+                    4,
+                    113,
+                    133,
+                    138,
+                    238
+                ],
+                "cornerstone": [
+                    5
+                ],
+                "of": [
+                    6,
+                    61,
+                    94,
+                    105,
+                    118,
+                    173,
+                    240,
+                    253,
+                    256
+                ],
+                "tracking": [
+                    7
+                ],
+                "disease": [
+                    8
+                ],
+                "progression": [
+                    9
+                ],
+                "in": [
+                    10,
+                    57,
+                    154,
+                    166,
+                    191,
+                    195,
+                    216
+                ],
+                "neuroscience.": [
+                    11
+                ],
+                "A": [
+                    12
+                ],
+                "common": [
+                    13
+                ],
+                "approach": [
+                    14
+                ],
+                "for": [
+                    15,
+                    74,
+                    142,
+                    179,
+                    243,
+                    249
+                ],
+                "this": [
+                    16,
+                    102,
+                    129
+                ],
+                "process": [
+                    17
+                ],
+                "having": [
+                    19
+                ],
+                "trained": [
+                    20
+                ],
+                "researchers": [
+                    21
+                ],
+                "individually": [
+                    22
+                ],
+                "select": [
+                    23
+                ],
+                "and": [
+                    24,
+                    137,
+                    152
+                ],
+                "count": [
+                    25,
+                    208
+                ],
+                "within": [
+                    27,
+                    99
+                ],
+                "an": [
+                    28,
+                    43,
+                    78
+                ],
+                "image,": [
+                    29
+                ],
+                "which": [
+                    30,
+                    48,
+                    96
+                ],
+                "not": [
+                    32
+                ],
+                "only": [
+                    33
+                ],
+                "difficult": [
+                    34
+                ],
+                "to": [
+                    35,
+                    70,
+                    84,
+                    112
+                ],
+                "standardize": [
+                    36
+                ],
+                "but": [
+                    37
+                ],
+                "also": [
+                    38,
+                    209
+                ],
+                "very": [
+                    39
+                ],
+                "time-consuming.": [
+                    40
+                ],
+                "We": [
+                    41,
+                    107
+                ],
+                "present": [
+                    42
+                ],
+                "automatic": [
+                    44,
+                    110
+                ],
+                "cell": [
+                    45
+                ],
+                "counting": [
+                    46,
+                    184,
+                    233
+                ],
+                "methodology": [
+                    47
+                ],
+                "leverages": [
+                    49
+                ],
+                "the": [
+                    50,
+                    58,
+                    92,
+                    159,
+                    167,
+                    189,
+                    198,
+                    213,
+                    241,
+                    244,
+                    250
+                ],
+                "Trainable": [
+                    51
+                ],
+                "WEKA": [
+                    52
+                ],
+                "Segmentation": [
+                    53
+                ],
+                "(TWS)": [
+                    54
+                ],
+                "plugin": [
+                    55
+                ],
+                "available": [
+                    56
+                ],
+                "FIJI": [
+                    59
+                ],
+                "distribution": [
+                    60
+                ],
+                "ImageJ": [
+                    62,
+                    100
+                ],
+                "(Schindelin": [
+                    63
+                ],
+                "2012,": [
+                    64
+                ],
+                "Schneider": [
+                    65
+                ],
+                "2012).": [
+                    66
+                ],
+                "TWS": [
+                    67,
+                    187
+                ],
+                "provides": [
+                    68
+                ],
+                "access": [
+                    69
+                ],
+                "machine": [
+                    71
+                ],
+                "learning": [
+                    72
+                ],
+                "tools": [
+                    73
+                ],
+                "object": [
+                    75
+                ],
+                "segmentation": [
+                    76
+                ],
+                "with": [
+                    77,
+                    186,
+                    212
+                ],
+                "accessible": [
+                    79
+                ],
+                "graphical": [
+                    80
+                ],
+                "user": [
+                    81
+                ],
+                "interface.": [
+                    82
+                ],
+                "However,": [
+                    83
+                ],
+                "analyze": [
+                    85
+                ],
+                "whole": [
+                    86
+                ],
+                "datasets": [
+                    87
+                ],
+                "requires": [
+                    88
+                ],
+                "further": [
+                    89
+                ],
+                "automation": [
+                    90
+                ],
+                "through": [
+                    91
+                ],
+                "use": [
+                    93
+                ],
+                "macros": [
+                    95
+                ],
+                "we": [
+                    97,
+                    131
+                ],
+                "constructed": [
+                    98
+                ],
+                "maintain": [
+                    101
+                ],
+                "high": [
+                    103
+                ],
+                "level": [
+                    104
+                ],
+                "accessibility.": [
+                    106
+                ],
+                "compared": [
+                    108
+                ],
+                "our": [
+                    109
+                ],
+                "counts": [
+                    111,
+                    215
+                ],
+                "published,": [
+                    114
+                ],
+                "hand": [
+                    115
+                ],
+                "counted": [
+                    116
+                ],
+                "dataset": [
+                    117
+                ],
+                "Immunofluorescence": [
+                    119
+                ],
+                "stained": [
+                    120
+                ],
+                "mouse": [
+                    121,
+                    140
+                ],
+                "cortex": [
+                    122
+                ],
+                "microglia": [
+                    123,
+                    155
+                ],
+                "(Singh": [
+                    124
+                ],
+                "et": [
+                    125
+                ],
+                "al.": [
+                    126
+                ],
+                "2020).": [
+                    127
+                ],
+                "For": [
+                    128
+                ],
+                "analysis": [
+                    130
+                ],
+                "used": [
+                    132
+                ],
+                "wild-type": [
+                    134
+                ],
+                "(WT)": [
+                    135
+                ],
+                "control": [
+                    136
+                ],
+                "transgenic": [
+                    139
+                ],
+                "model": [
+                    141
+                ],
+                "HIV-induced": [
+                    143
+                ],
+                "brain": [
+                    144,
+                    171
+                ],
+                "injury": [
+                    145
+                ],
+                "(HIVgp120).": [
+                    146
+                ],
+                "HIVgp120": [
+                    147,
+                    199,
+                    226
+                ],
+                "mice": [
+                    148,
+                    178,
+                    200
+                ],
+                "showed": [
+                    149
+                ],
+                "behavioral": [
+                    150
+                ],
+                "deficits,": [
+                    151
+                ],
+                "increase": [
+                    153,
+                    190
+                ],
+                "numbers": [
+                    156
+                ],
+                "presumably": [
+                    157
+                ],
+                "caused": [
+                    158
+                ],
+                "gp120": [
+                    160
+                ],
+                "protein.": [
+                    161
+                ],
+                "10X": [
+                    162
+                ],
+                "images": [
+                    163,
+                    196
+                ],
+                "were": [
+                    164
+                ],
+                "collected": [
+                    165
+                ],
+                "sagittal": [
+                    168
+                ],
+                "plane": [
+                    169
+                ],
+                "from": [
+                    170,
+                    197
+                ],
+                "slices": [
+                    172
+                ],
+                "three": [
+                    174
+                ],
+                "11–14": [
+                    175
+                ],
+                "month-old": [
+                    176
+                ],
+                "male": [
+                    177
+                ],
+                "each": [
+                    180
+                ],
+                "genotype.": [
+                    181
+                ],
+                "The": [
+                    182,
+                    206,
+                    231
+                ],
+                "auto": [
+                    183,
+                    207,
+                    232
+                ],
+                "strategy": [
+                    185,
+                    234
+                ],
+                "replicated": [
+                    188
+                ],
+                "mean": [
+                    192
+                ],
+                "microglial": [
+                    193
+                ],
+                "density": [
+                    194
+                ],
+                "(Manual": [
+                    201
+                ],
+                "p": [
+                    202
+                ],
+                "=0.0001;": [
+                    203
+                ],
+                "Auto": [
+                    204
+                ],
+                "p=0.0002).": [
+                    205
+                ],
+                "correlates": [
+                    210
+                ],
+                "significantly": [
+                    211
+                ],
+                "manual": [
+                    214,
+                    246
+                ],
+                "both": [
+                    217
+                ],
+                "genotypes": [
+                    218
+                ],
+                "(WT": [
+                    219
+                ],
+                "p=": [
+                    220
+                ],
+                "2.297": [
+                    221
+                ],
+                "e−07,": [
+                    222
+                ],
+                "adj.": [
+                    223,
+                    229
+                ],
+                "R2=": [
+                    224
+                ],
+                "0.65;": [
+                    225
+                ],
+                "p=2.591": [
+                    227
+                ],
+                "e−04": [
+                    228
+                ],
+                "R2=0.423).": [
+                    230
+                ],
+                "took": [
+                    235
+                ],
+                "less": [
+                    236
+                ],
+                "than": [
+                    237
+                ],
+                "fifth": [
+                    239
+                ],
+                "time": [
+                    242
+                ],
+                "expert": [
+                    245
+                ],
+                "count,": [
+                    247
+                ],
+                "allowing": [
+                    248
+                ],
+                "efficient": [
+                    251
+                ],
+                "exploration": [
+                    252
+                ],
+                "large": [
+                    254
+                ],
+                "sets": [
+                    255
+                ],
+                "image": [
+                    257
+                ],
+                "data.": [
+                    258
+                ]
+            },
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W4319432251",
+            "counts_by_year": [],
+            "updated_date": "2024-07-21T03:37:43.014094",
+            "created_date": "2023-02-09"
+        },
+        {
+            "id": "https://openalex.org/W4319433402",
+            "doi": "https://doi.org/10.4049/jimmunol.206.supp.112.14",
+            "title": "Elucidating the mechanism of Interferon Beta (IFNβ) mediated neuroprotection in HIV associated neurocognitive disorder (HAND)",
+            "display_name": "Elucidating the mechanism of Interferon Beta (IFNβ) mediated neuroprotection in HIV associated neurocognitive disorder (HAND)",
+            "publication_year": 2021,
+            "publication_date": "2021-05-01",
+            "ids": {
+                "openalex": "https://openalex.org/W4319433402",
+                "doi": "https://doi.org/10.4049/jimmunol.206.supp.112.14"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": false,
+                "landing_page_url": "https://doi.org/10.4049/jimmunol.206.supp.112.14",
+                "pdf_url": null,
+                "source": {
+                    "id": "https://openalex.org/S38008053",
+                    "display_name": "The journal of immunology/The Journal of immunology",
+                    "issn_l": "0022-1767",
+                    "issn": [
+                        "0022-1767",
+                        "1550-6606"
+                    ],
+                    "is_oa": false,
+                    "is_in_doaj": false,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4320800377",
+                    "host_organization_name": "American Association of Immunologists",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4320800377"
+                    ],
+                    "host_organization_lineage_names": [
+                        "American Association of Immunologists"
+                    ],
+                    "type": "journal"
+                },
+                "license": null,
+                "license_id": null,
+                "version": null,
+                "is_accepted": false,
+                "is_published": false
+            },
+            "type": "article",
+            "type_crossref": "journal-article",
+            "indexed_in": [
+                "crossref"
+            ],
+            "open_access": {
+                "is_oa": false,
+                "oa_status": "closed",
+                "oa_url": null,
+                "any_repository_has_fulltext": false
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5081987607",
+                        "display_name": "Jeffrey Koury",
+                        "orcid": "https://orcid.org/0000-0002-7368-4891"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jeffrey Koury",
+                    "raw_affiliation_strings": [
+                        "1University of California Riverside"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1University of California Riverside",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5055840064",
+                        "display_name": "Hina Singh",
+                        "orcid": "https://orcid.org/0000-0001-7067-1991"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Hina Singh",
+                    "raw_affiliation_strings": [
+                        "1University of California Riverside"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1University of California Riverside",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "last",
+                    "author": {
+                        "id": "https://openalex.org/A5072837198",
+                        "display_name": "Marcus Kaul",
+                        "orcid": "https://orcid.org/0000-0003-3202-670X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I103635307",
+                            "display_name": "University of California, Riverside",
+                            "ror": "https://ror.org/03nawhv43",
+                            "country_code": "US",
+                            "type": "education",
+                            "lineage": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "US"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Marcus Kaul",
+                    "raw_affiliation_strings": [
+                        "1University of California Riverside"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "1University of California Riverside",
+                            "institution_ids": [
+                                "https://openalex.org/I103635307"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "countries_distinct_count": 1,
+            "institutions_distinct_count": 1,
+            "corresponding_author_ids": [],
+            "corresponding_institution_ids": [],
+            "apc_list": null,
+            "apc_paid": null,
+            "fwci": 0,
+            "has_fulltext": false,
+            "cited_by_count": 0,
+            "cited_by_percentile_year": {
+                "min": 0,
+                "max": 61
+            },
+            "biblio": {
+                "volume": "206",
+                "issue": "1_Supplement",
+                "first_page": "112.14",
+                "last_page": "112.14"
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T10112",
+                "display_name": "Human Immunodeficiency Virus/Acquired Immunodeficiency Syndrome",
+                "score": 0.9984,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/2406",
+                    "display_name": "Virology"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/24",
+                    "display_name": "Immunology and Microbiology"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/1",
+                    "display_name": "Life Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T10112",
+                    "display_name": "Human Immunodeficiency Virus/Acquired Immunodeficiency Syndrome",
+                    "score": 0.9984,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2406",
+                        "display_name": "Virology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/24",
+                        "display_name": "Immunology and Microbiology"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11266",
+                    "display_name": "Role of Microglia in Neurological Disorders",
+                    "score": 0.9975,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2808",
+                        "display_name": "Neurology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/28",
+                        "display_name": "Neuroscience"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11337",
+                    "display_name": "Neuroimmune Interaction in Psychiatric Disorders",
+                    "score": 0.9209,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2803",
+                        "display_name": "Biological Psychiatry"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/28",
+                        "display_name": "Neuroscience"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/1",
+                        "display_name": "Life Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/hiv",
+                    "display_name": "HIV",
+                    "score": 0.551025
+                },
+                {
+                    "id": "https://openalex.org/keywords/neuroinflammation",
+                    "display_name": "Neuroinflammation",
+                    "score": 0.539437
+                },
+                {
+                    "id": "https://openalex.org/keywords/immune-responses",
+                    "display_name": "Immune Responses",
+                    "score": 0.50364
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C25498285",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1981368",
+                    "display_name": "Neuroprotection",
+                    "level": 2,
+                    "score": 0.9310126
+                },
+                {
+                    "id": "https://openalex.org/C2779830541",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1622829",
+                    "display_name": "Microglia",
+                    "level": 3,
+                    "score": 0.65076923
+                },
+                {
+                    "id": "https://openalex.org/C2776966659",
+                    "wikidata": "https://www.wikidata.org/wiki/Q18028003",
+                    "display_name": "IRF7",
+                    "level": 4,
+                    "score": 0.64536875
+                },
+                {
+                    "id": "https://openalex.org/C13373296",
+                    "wikidata": "https://www.wikidata.org/wiki/Q421866",
+                    "display_name": "Chemokine",
+                    "level": 3,
+                    "score": 0.60513955
+                },
+                {
+                    "id": "https://openalex.org/C86803240",
+                    "wikidata": "https://www.wikidata.org/wiki/Q420",
+                    "display_name": "Biology",
+                    "level": 0,
+                    "score": 0.55490273
+                },
+                {
+                    "id": "https://openalex.org/C203014093",
+                    "wikidata": "https://www.wikidata.org/wiki/Q101929",
+                    "display_name": "Immunology",
+                    "level": 1,
+                    "score": 0.5519745
+                },
+                {
+                    "id": "https://openalex.org/C2776178377",
+                    "wikidata": "https://www.wikidata.org/wiki/Q188269",
+                    "display_name": "Interferon",
+                    "level": 2,
+                    "score": 0.5269633
+                },
+                {
+                    "id": "https://openalex.org/C87753298",
+                    "wikidata": "https://www.wikidata.org/wiki/Q17157137",
+                    "display_name": "Neuroinflammation",
+                    "level": 3,
+                    "score": 0.5140122
+                },
+                {
+                    "id": "https://openalex.org/C159047783",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7215",
+                    "display_name": "Virology",
+                    "level": 1,
+                    "score": 0.45235
+                },
+                {
+                    "id": "https://openalex.org/C136449434",
+                    "wikidata": "https://www.wikidata.org/wiki/Q428253",
+                    "display_name": "Innate immune system",
+                    "level": 3,
+                    "score": 0.43544245
+                },
+                {
+                    "id": "https://openalex.org/C169760540",
+                    "wikidata": "https://www.wikidata.org/wiki/Q207011",
+                    "display_name": "Neuroscience",
+                    "level": 1,
+                    "score": 0.35219133
+                },
+                {
+                    "id": "https://openalex.org/C8891405",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1059",
+                    "display_name": "Immune system",
+                    "level": 2,
+                    "score": 0.33258277
+                },
+                {
+                    "id": "https://openalex.org/C2776914184",
+                    "wikidata": "https://www.wikidata.org/wiki/Q101991",
+                    "display_name": "Inflammation",
+                    "level": 2,
+                    "score": 0.3083143
+                }
+            ],
+            "mesh": [],
+            "locations_count": 1,
+            "locations": [
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://doi.org/10.4049/jimmunol.206.supp.112.14",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S38008053",
+                        "display_name": "The journal of immunology/The Journal of immunology",
+                        "issn_l": "0022-1767",
+                        "issn": [
+                            "0022-1767",
+                            "1550-6606"
+                        ],
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_core": true,
+                        "host_organization": "https://openalex.org/P4320800377",
+                        "host_organization_name": "American Association of Immunologists",
+                        "host_organization_lineage": [
+                            "https://openalex.org/P4320800377"
+                        ],
+                        "host_organization_lineage_names": [
+                            "American Association of Immunologists"
+                        ],
+                        "type": "journal"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": null,
+            "sustainable_development_goals": [
+                {
+                    "id": "https://metadata.un.org/sdg/3",
+                    "display_name": "Good health and well-being",
+                    "score": 0.82
+                }
+            ],
+            "grants": [],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 0,
+            "referenced_works": [],
+            "related_works": [
+                "https://openalex.org/W4310076785",
+                "https://openalex.org/W4281290245",
+                "https://openalex.org/W3107395714",
+                "https://openalex.org/W2965172925",
+                "https://openalex.org/W2946961190",
+                "https://openalex.org/W2804482952",
+                "https://openalex.org/W2803817550",
+                "https://openalex.org/W2674947112",
+                "https://openalex.org/W2098128683",
+                "https://openalex.org/W1642077366"
+            ],
+            "ngrams_url": "https://api.openalex.org/works/W4319433402/ngrams",
+            "abstract_inverted_index": {
+                "1": [
+                    43
+                ],
+                "37": [
+                    1
+                ],
+                "Abstract": [
+                    0
+                ],
+                "million": [
+                    2
+                ],
+                "people": [
+                    3
+                ],
+                "worldwide": [
+                    4
+                ],
+                "are": [
+                    5,
+                    189
+                ],
+                "diagnosed": [
+                    6
+                ],
+                "with": [
+                    7
+                ],
+                "Human": [
+                    8
+                ],
+                "Immunodeficiency": [
+                    9,
+                    58
+                ],
+                "Virus": [
+                    10,
+                    59
+                ],
+                "(HIV).": [
+                    11
+                ],
+                "An": [
+                    12
+                ],
+                "estimated": [
+                    13
+                ],
+                "15–55%": [
+                    14
+                ],
+                "of": [
+                    15,
+                    34,
+                    132,
+                    150,
+                    192,
+                    219
+                ],
+                "these": [
+                    16
+                ],
+                "individuals": [
+                    17
+                ],
+                "develop": [
+                    18
+                ],
+                "HIV-associated": [
+                    19
+                ],
+                "neurocognitive": [
+                    20
+                ],
+                "disorder": [
+                    21
+                ],
+                "(HAND).": [
+                    22
+                ],
+                "Previous": [
+                    23
+                ],
+                "studies,": [
+                    24
+                ],
+                "including": [
+                    25,
+                    176
+                ],
+                "work": [
+                    26
+                ],
+                "in": [
+                    27,
+                    51,
+                    68,
+                    87,
+                    118,
+                    147,
+                    171
+                ],
+                "our": [
+                    28
+                ],
+                "lab": [
+                    29
+                ],
+                "identifies": [
+                    30
+                ],
+                "a": [
+                    31,
+                    63,
+                    166
+                ],
+                "transient": [
+                    32
+                ],
+                "increase": [
+                    33,
+                    170
+                ],
+                "interferon": [
+                    35,
+                    139
+                ],
+                "beta": [
+                    36,
+                    195,
+                    224
+                ],
+                "(IFNβ),": [
+                    37
+                ],
+                "an": [
+                    38
+                ],
+                "anti-inflammatory": [
+                    39
+                ],
+                "and": [
+                    40,
+                    56,
+                    143,
+                    180,
+                    201,
+                    222,
+                    228
+                ],
+                "anti-viral": [
+                    41,
+                    174,
+                    184,
+                    220
+                ],
+                "type": [
+                    42
+                ],
+                "interferon,": [
+                    44
+                ],
+                "preceding": [
+                    45
+                ],
+                "any": [
+                    46
+                ],
+                "behavioral": [
+                    47
+                ],
+                "or": [
+                    48
+                ],
+                "neuropathological": [
+                    49
+                ],
+                "signs": [
+                    50
+                ],
+                "the": [
+                    52,
+                    92,
+                    106,
+                    119,
+                    148,
+                    158,
+                    193
+                ],
+                "HIVgp120": [
+                    53,
+                    88
+                ],
+                "transgenic": [
+                    54,
+                    89
+                ],
+                "mouse": [
+                    55
+                ],
+                "Simian": [
+                    57
+                ],
+                "(SIV)": [
+                    60
+                ],
+                "models,": [
+                    61
+                ],
+                "suggesting": [
+                    62
+                ],
+                "neuroprotective": [
+                    64,
+                    194,
+                    223
+                ],
+                "role": [
+                    65
+                ],
+                "for": [
+                    66
+                ],
+                "IFNβ": [
+                    67,
+                    79,
+                    96,
+                    110,
+                    128,
+                    151,
+                    186,
+                    210
+                ],
+                "early": [
+                    69
+                ],
+                "HIV": [
+                    70,
+                    114
+                ],
+                "infection.": [
+                    71
+                ],
+                "We": [
+                    72
+                ],
+                "have": [
+                    73
+                ],
+                "previously": [
+                    74
+                ],
+                "shown": [
+                    75
+                ],
+                "that": [
+                    76,
+                    126,
+                    209
+                ],
+                "exogenous": [
+                    77
+                ],
+                "intranasal": [
+                    78
+                ],
+                "treatment": [
+                    80
+                ],
+                "is": [
+                    81
+                ],
+                "sufficient": [
+                    82
+                ],
+                "to": [
+                    83,
+                    109
+                ],
+                "confer": [
+                    84
+                ],
+                "neuronal": [
+                    85
+                ],
+                "protection": [
+                    86
+                ],
+                "mice.": [
+                    90,
+                    154
+                ],
+                "However,": [
+                    91
+                ],
+                "mechanism": [
+                    93
+                ],
+                "by": [
+                    94
+                ],
+                "which": [
+                    95
+                ],
+                "mediates": [
+                    97
+                ],
+                "neuroprotection": [
+                    98,
+                    214
+                ],
+                "remains": [
+                    99
+                ],
+                "unclear.": [
+                    100
+                ],
+                "Here": [
+                    101
+                ],
+                "we": [
+                    102,
+                    124,
+                    164
+                ],
+                "focus": [
+                    103
+                ],
+                "primarily": [
+                    104
+                ],
+                "on": [
+                    105
+                ],
+                "microglial": [
+                    107,
+                    161,
+                    216
+                ],
+                "contribution": [
+                    108
+                ],
+                "mediated": [
+                    111
+                ],
+                "neuroprotection,": [
+                    112
+                ],
+                "as": [
+                    113,
+                    136,
+                    138
+                ],
+                "productively": [
+                    115
+                ],
+                "infects": [
+                    116
+                ],
+                "macrophage/microglia": [
+                    117
+                ],
+                "CNS.": [
+                    120
+                ],
+                "In": [
+                    121,
+                    155
+                ],
+                "this": [
+                    122,
+                    206
+                ],
+                "study,": [
+                    123
+                ],
+                "show": [
+                    125,
+                    165
+                ],
+                "abrogating": [
+                    127
+                ],
+                "down": [
+                    129
+                ],
+                "regulates": [
+                    130
+                ],
+                "expression": [
+                    131
+                ],
+                "viral": [
+                    133
+                ],
+                "sensor,": [
+                    134
+                ],
+                "RIG-I,": [
+                    135
+                ],
+                "well": [
+                    137
+                ],
+                "regulatory": [
+                    140
+                ],
+                "factors,": [
+                    141
+                ],
+                "IRF9,": [
+                    142
+                ],
+                "most": [
+                    144
+                ],
+                "robustly": [
+                    145
+                ],
+                "IRF7": [
+                    146
+                ],
+                "cortex": [
+                    149
+                ],
+                "KO": [
+                    152
+                ],
+                "HIVgp120tg": [
+                    153
+                ],
+                "addition,": [
+                    156
+                ],
+                "using": [
+                    157
+                ],
+                "HMC3": [
+                    159
+                ],
+                "human": [
+                    160
+                ],
+                "cell": [
+                    162
+                ],
+                "line": [
+                    163
+                ],
+                "robust": [
+                    167
+                ],
+                "dose": [
+                    168
+                ],
+                "dependent": [
+                    169
+                ],
+                "innate": [
+                    172
+                ],
+                "immune": [
+                    173
+                ],
+                "genes": [
+                    175,
+                    221
+                ],
+                "IRF7,": [
+                    177
+                ],
+                "IFIT1,": [
+                    178
+                ],
+                "GBP1": [
+                    179
+                ],
+                "GBP4.": [
+                    181
+                ],
+                "Beyond": [
+                    182
+                ],
+                "its": [
+                    183
+                ],
+                "effects,": [
+                    185
+                ],
+                "treated": [
+                    187
+                ],
+                "microglia": [
+                    188
+                ],
+                "potent": [
+                    190
+                ],
+                "inducers": [
+                    191
+                ],
+                "chemokines": [
+                    196,
+                    225
+                ],
+                "MIP-1a": [
+                    197
+                ],
+                "(CCL3),": [
+                    198
+                ],
+                "MIP-1b": [
+                    199
+                ],
+                "(CCL4)": [
+                    200
+                ],
+                "RANTES": [
+                    202
+                ],
+                "(CCL5).": [
+                    203
+                ],
+                "Taken": [
+                    204
+                ],
+                "together,": [
+                    205
+                ],
+                "data": [
+                    207
+                ],
+                "suggests": [
+                    208
+                ],
+                "may": [
+                    211
+                ],
+                "be": [
+                    212
+                ],
+                "conferring": [
+                    213
+                ],
+                "through": [
+                    215
+                ],
+                "specific": [
+                    217
+                ],
+                "induction": [
+                    218
+                ],
+                "CCL3,": [
+                    226
+                ],
+                "-4": [
+                    227
+                ],
+                "-5.": [
+                    229
+                ]
+            },
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W4319433402",
+            "counts_by_year": [],
+            "updated_date": "2024-07-21T03:37:43.073984",
+            "created_date": "2023-02-09"
+        }
+    ],
+    "group_by": []
+}

--- a/src/utils/tests/test_openalex.py
+++ b/src/utils/tests/test_openalex.py
@@ -23,9 +23,8 @@ class OpenAlexTests(TestCase):
     @responses.activate
     def test_get_data_from_doi(self):
         response = responses.Response(
-            method=self.method,
-            url=self.works_url,
-            json=self.works_json)
+            method=self.method, url=self.works_url, json=self.works_json
+        )
         responses.add(response)
 
         result = OpenAlex().get_data_from_doi(self.doi)
@@ -52,19 +51,14 @@ class OpenAlexTests(TestCase):
     @responses.activate
     def test_get_data_from_doi_with_retry(self):
         response_429 = responses.Response(
-            method=self.method,
-            url=self.works_url,
-            status=429
+            method=self.method, url=self.works_url, status=429
         )
         response_500 = responses.Response(
-            method=self.method,
-            url=self.works_url,
-            status=500
+            method=self.method, url=self.works_url, status=500
         )
         response_ok = responses.Response(
-            method=self.method,
-            url=self.works_url,
-            json=self.works_json)
+            method=self.method, url=self.works_url, json=self.works_json
+        )
         responses.add(response_429)
         responses.add(response_500)
         responses.add(response_ok)

--- a/src/utils/tests/test_openalex.py
+++ b/src/utils/tests/test_openalex.py
@@ -2,8 +2,8 @@ import json
 import re
 
 import responses
-
 from django.test import TestCase
+
 from utils.openalex import OpenAlex
 
 


### PR DESCRIPTION
Filter out works published on ResearchHub when fetching works from OpenAlex. Works published on ResearchHub have
a `researchhub` namespaced DOI, e.g. `10.55277/researchhub.aydefpsl`.