### PR TITLE
Allow works where DOI field has a `null` value

### DIFF
--- a/src/utils/openalex.py
+++ b/src/utils/openalex.py
@@ -386,7 +386,8 @@ class OpenAlex:
         # have a `researchhub` namespace in the DOI.
         filtered_works = list(
             filter(
-                lambda w: "/researchhub." not in w.get("doi", "").lower(),
+                lambda w: w.get("doi") is None
+                or "/researchhub." not in w.get("doi", "").lower(),
                 works,
             )
         )

--- a/src/utils/tests/openalex_with_researchhub_works.json
+++ b/src/utils/tests/openalex_with_researchhub_works.json
@@ -18115,7 +18115,7 @@
         },
         {
             "id": "https://openalex.org/W2766868798",
-            "doi": "https://doi.org/10.4049/jimmunol.196.supp.209.29",
+            "doi": null,
             "title": "MojoSort™ kit isolated cells maintain physical function in magnetic cell separator and column",
             "display_name": "MojoSort™ kit isolated cells maintain physical function in magnetic cell separator and column",
             "publication_year": 2016,

--- a/src/utils/tests/test_openalex.py
+++ b/src/utils/tests/test_openalex.py
@@ -46,7 +46,12 @@ class OpenAlexTests(TestCase):
 
         # Assert
         self.assertEqual(len(works), 10)
-        self.assertFalse(any("/researchhub." in work.get("doi", "") for work in works))
+        self.assertFalse(
+            any(
+                work.get("doi") is not None and "/researchhub." in work.get("doi", "")
+                for work in works
+            )
+        )
 
     @responses.activate
     def test_get_data_from_doi_with_retry(self):


### PR DESCRIPTION
Works returned by OpenAlex sometimes have the `doi` field set to `null`:

```
{
    "id": "https://openalex.org/W2766868798",
    "doi": null,
    [...]
```

The code for filtering out `researchhub`-namespaced DOIs must be able to handle those.

Replaces #1746 