### PR TITLE
Add `user` to author profile

### DIFF
--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -1140,9 +1140,15 @@ class DynamicAuthorProfileSerializer(DynamicModelFieldSerializer):
         if user is None:
             return None
 
+        is_verified = False
+        user_verification = UserVerification.objects.filter(user=user).first()
+        if user_verification:
+            is_verified = user_verification.is_verified
+
         return {
             "id": user.id,
             "created_date": user.created_date,
+            "is_verified": is_verified,
         }
 
     def get_achievements(self, author):

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -1096,6 +1096,7 @@ class DynamicAuthorProfileSerializer(DynamicModelFieldSerializer):
     open_access_pct = SerializerMethodField()
     achievements = SerializerMethodField()
     headline = SerializerMethodField()
+    user = SerializerMethodField()
 
     class Meta:
         model = Author
@@ -1133,6 +1134,17 @@ class DynamicAuthorProfileSerializer(DynamicModelFieldSerializer):
             }
         except Exception:
             return None
+
+    def get_user(self, author):
+        user = author.user
+
+        if user is None:
+            return None
+
+        return {
+            "id": user.id,
+            "created_date": user.created_date,
+        }
 
     def get_achievements(self, author):
         summary_stats = self.get_summary_stats(author)

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -170,8 +170,7 @@ class AuthorSerializer(ModelSerializer):
 
         try:
             return WalletSerializer(obj.wallet).data
-        except Exception as error:
-            # sentry.log_error(error)
+        except Exception:
             pass
 
     def get_sift_link(self, author):

--- a/src/user/tests/test_views.py
+++ b/src/user/tests/test_views.py
@@ -207,6 +207,9 @@ class UserViewsTests(TestCase):
     def test_get_author_profile_user(self):
         # Arrange
         user = create_random_default_user("user1")
+        UserVerification.objects.create(
+            user=user, status=UserVerification.Status.APPROVED
+        )
 
         # Act
         url = f"/api/author/{user.author_profile.id}/profile/"
@@ -219,6 +222,7 @@ class UserViewsTests(TestCase):
             {
                 "id": user.id,
                 "created_date": user.created_date,
+                "is_verified": True,
             },
         )
 

--- a/src/user/tests/test_views.py
+++ b/src/user/tests/test_views.py
@@ -9,7 +9,12 @@ from paper.related_models.authorship_model import Authorship
 from paper.related_models.paper_model import Paper
 from reputation.models import Score
 from user.models import UserVerification
-from user.tests.helpers import create_random_authenticated_user, create_user
+from user.related_models.author_model import Author
+from user.tests.helpers import (
+    create_random_authenticated_user,
+    create_random_default_user,
+    create_user,
+)
 from utils.openalex import OpenAlex
 from utils.test_helpers import (
     get_authenticated_get_response,
@@ -198,6 +203,36 @@ class UserViewsTests(TestCase):
 
         user.refresh_from_db()
         self.assertTrue(user.has_seen_first_coin_modal)
+
+    def test_get_author_profile_user(self):
+        # Arrange
+        user = create_random_default_user("user1")
+
+        # Act
+        url = f"/api/author/{user.author_profile.id}/profile/"
+        response = self.client.get(url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data["user"],
+            {
+                "id": user.id,
+                "created_date": user.created_date,
+            },
+        )
+
+    def test_get_author_profile_user_without_user(self):
+        # Arrange
+        author = Author.objects.create(first_name="firstName1", last_name="lastName1")
+
+        # Act
+        url = f"/api/author/{author.id}/profile/"
+        response = self.client.get(url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["user"], None)
 
     @patch.object(OpenAlex, "get_authors")
     def test_get_author_profile_reputation(self, mock_get_authors):

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -176,6 +176,7 @@ class AuthorViewSet(viewsets.ModelViewSet):
                 "open_access_pct",
                 "achievements",
                 "education",
+                "user",
             ),
         )
         return Response(serializer.data, status=200)


### PR DESCRIPTION
Add a `user` element to the author profile (`/api/author/<ID>/profile`) with the following elements:
- `id`: The ID of the user
- `created_date`: The creation date of the user.
- `is_verified`: Whether the user's identity has been verified.
