### PR TITLE
Separate profile endpoint into 3 endpoints: profile, achievements, su…

### DIFF
--- a/src/user/related_models/author_model.py
+++ b/src/user/related_models/author_model.py
@@ -166,7 +166,7 @@ class Author(models.Model):
             )
         )
 
-        return paper_citations_res.get("citation_count", 0)
+        return paper_citations_res.get("citation_count") or 0
 
     @property
     def paper_count(self):
@@ -180,7 +180,7 @@ class Author(models.Model):
             )
         )
 
-        return paper_count_res.get("paper_count", 0)
+        return paper_count_res.get("paper_count") or 0
 
     @property
     def person_types_indexing(self):

--- a/src/user/related_models/author_model.py
+++ b/src/user/related_models/author_model.py
@@ -143,7 +143,6 @@ class Author(models.Model):
         authorships = Authorship.objects.filter(author=self)
         authored_papers = Paper.objects.filter(
             id__in=authorships.values_list("paper_id", flat=True),
-            work_type__in=["preprint", "article"],
         )
 
         total_paper_count = authored_papers.count()
@@ -152,8 +151,7 @@ class Author(models.Model):
             return 0
         else:
             return (
-                self.authored_papers.filter(is_open_access=True).count()
-                / total_paper_count
+                authored_papers.filter(is_open_access=True).count() / total_paper_count
             )
 
     @property
@@ -240,7 +238,6 @@ class Author(models.Model):
 
         return achievements
 
-    @property
     def is_claimed(self):
         return (
             self.user is not None

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -1112,6 +1112,9 @@ class DynamicAuthorProfileSerializer(DynamicModelFieldSerializer):
         model = Author
         fields = "__all__"
 
+    def get_achievements(self, author):
+        return author.achievements
+
     def get_headline(self, author):
         from collections import Counter
 
@@ -1162,83 +1165,18 @@ class DynamicAuthorProfileSerializer(DynamicModelFieldSerializer):
             "is_verified": is_verified,
         }
 
-    def get_achievements(self, author):
-        summary_stats = self.get_summary_stats(author)
-        open_access_pct = self.get_open_access_pct(author)
-
-        achievements = []
-        if summary_stats["citation_count"] >= 1:
-            achievements.append("CITED_AUTHOR")
-        if open_access_pct >= 0.5:
-            achievements.append("OPEN_ACCESS")
-        if summary_stats["upvote_count"] >= 10:
-            achievements.append("HIGHLY_UPVOTED_1")
-        if summary_stats["upvote_count"] >= 25:
-            achievements.append("HIGHLY_UPVOTED_2")
-        if summary_stats["upvote_count"] >= 100:
-            achievements.append("HIGHLY_UPVOTED_3")
-        if summary_stats["upvote_count"] >= 500:
-            achievements.append("HIGHLY_UPVOTED_4")
-        if summary_stats["upvote_count"] >= 1000:
-            achievements.append("HIGHLY_UPVOTED_5")
-        if summary_stats["peer_review_count"] >= 1:
-            achievements.append("EXPERT_PEER_REVIEWER_1")
-        if summary_stats["peer_review_count"] >= 5:
-            achievements.append("EXPERT_PEER_REVIEWER_2")
-        if summary_stats["peer_review_count"] >= 25:
-            achievements.append("EXPERT_PEER_REVIEWER_3")
-        if summary_stats["peer_review_count"] >= 100:
-            achievements.append("EXPERT_PEER_REVIEWER_4")
-        if summary_stats["peer_review_count"] >= 250:
-            achievements.append("EXPERT_PEER_REVIEWER_5")
-        if summary_stats["amount_funded"] > 1:
-            achievements.append("OPEN_SCIENCE_SUPPORTER")
-
-        return achievements
-
     def get_summary_stats(self, author):
-        from django.db.models import Count, Sum
-
-        citation_count, paper_count = (
-            Authorship.objects.filter(author=author)
-            .select_related("paper")
-            .aggregate(
-                citation_count=Sum("paper__citations"),
-                paper_count=Count("paper"),
-            )
-            .values()
-        )
-
-        upvote_count = (
-            Distribution.objects.filter(
-                recipient=author.user,
-                proof_item_content_type=ContentType.objects.get_for_model(GrmVote),
-                reputation_amount=1,
-            ).aggregate(count=Count("id"))["count"]
-            or 0
-        )
-
-        amount_funded = (
-            Bounty.objects.filter(
-                created_by=author.user,
-                status=Bounty.CLOSED,
-            ).aggregate(total_amount=Sum("amount"))["total_amount"]
-            or 0
-        )
-
-        peer_review_count = RhCommentModel.objects.filter(
-            created_by=author.user,
-            comment_type="REVIEW",
-            is_removed=False,
-        ).aggregate(count=Count("id"))["count"]
-        return {
-            "works_count": paper_count or 0,
-            "citation_count": citation_count or 0,
+        stats = {
+            "works_count": author.paper_count,
+            "citation_count": author.citation_count,
             "two_year_mean_citedness": author.two_year_mean_citedness or 0,
-            "upvote_count": upvote_count,
-            "amount_funded": amount_funded,
-            "peer_review_count": peer_review_count,
+            "upvote_count": author.user.upvote_count if author.user else 0,
+            "amount_funded": author.user.amount_funded,
+            "peer_review_count": author.user.peer_review_count if author.user else 0,
+            "open_access_pct": author.open_access_pct,
         }
+
+        return stats
 
     def get_activity_by_year(self, author):
         context = self.context
@@ -1251,17 +1189,6 @@ class DynamicAuthorProfileSerializer(DynamicModelFieldSerializer):
             **_context_fields,
         )
         return serializer.data
-
-    def get_open_access_pct(self, author):
-        total_paper_count = author.authored_papers.count()
-
-        if total_paper_count == 0:
-            return 0
-        else:
-            return (
-                author.authored_papers.filter(is_open_access=True).count()
-                / total_paper_count
-            )
 
     def get_reputation(self, author):
         score = Score.objects.filter(author=author).order_by("-score").first()

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -1103,7 +1103,6 @@ class DynamicAuthorProfileSerializer(DynamicModelFieldSerializer):
     reputation_list = SerializerMethodField()
     activity_by_year = SerializerMethodField()
     summary_stats = SerializerMethodField()
-    open_access_pct = SerializerMethodField()
     achievements = SerializerMethodField()
     headline = SerializerMethodField()
     user = SerializerMethodField()

--- a/src/user/tests/test_author_view.py
+++ b/src/user/tests/test_author_view.py
@@ -1,0 +1,61 @@
+import json
+from unittest.mock import patch
+
+from django.test import TestCase
+from rest_framework.test import APITestCase
+
+from paper.openalex_util import process_openalex_works
+from paper.related_models.authorship_model import Authorship
+from paper.related_models.paper_model import Paper
+from reputation.models import Score
+from user.models import UserVerification
+from user.related_models.author_model import Author
+from user.tests.helpers import (
+    create_random_authenticated_user,
+    create_random_default_user,
+    create_user,
+)
+from utils.openalex import OpenAlex
+from utils.test_helpers import (
+    get_authenticated_get_response,
+    get_authenticated_patch_response,
+)
+
+
+class AuthorApiTests(APITestCase):
+    def setUp(self):
+        self.user_with_published_works = create_user(
+            email="random@researchhub.com",
+            first_name="Yang",
+            last_name="Wang",
+        )
+
+        paper1 = Paper.objects.create(
+            title="title1",
+            citations=10,
+        )
+        paper2 = Paper.objects.create(
+            title="title2",
+            citations=20,
+        )
+        Authorship.objects.create(
+            author=self.user_with_published_works.author_profile, paper=paper1
+        )
+        Authorship.objects.create(
+            author=self.user_with_published_works.author_profile, paper=paper2
+        )
+
+    def test_get_author_summary_stats(self):
+        url = f"/api/author/{self.user_with_published_works.author_profile.id}/summary_stats/"
+        response = self.client.get(url, {})
+        self.assertIn("summary_stats", response.data)
+
+    def test_get_achievements(self):
+        url = f"/api/author/{self.user_with_published_works.author_profile.id}/achievements/"
+        response = self.client.get(url, {})
+        self.assertIn("achievements", response.data)
+
+    def test_get_profile(self):
+        url = f"/api/author/{self.user_with_published_works.author_profile.id}/profile/"
+        response = self.client.get(url, {})
+        self.assertIn("profile", response.data)

--- a/src/user/tests/test_author_view.py
+++ b/src/user/tests/test_author_view.py
@@ -58,4 +58,4 @@ class AuthorApiTests(APITestCase):
     def test_get_profile(self):
         url = f"/api/author/{self.user_with_published_works.author_profile.id}/profile/"
         response = self.client.get(url, {})
-        self.assertIn("profile", response.data)
+        self.assertIn("id", response.data)

--- a/src/user/tests/test_models.py
+++ b/src/user/tests/test_models.py
@@ -1,18 +1,45 @@
 from unittest import skip
-from django.test import TestCase
 
 from allauth.socialaccount.providers.orcid.provider import OrcidProvider
+from django.test import TestCase
 
 from oauth.tests.helpers import create_social_account
-from user.tests.helpers import create_random_default_user
+from paper.related_models.authorship_model import Authorship
+from paper.related_models.paper_model import Paper
+from user.tests.helpers import create_random_default_user, create_user
 
 
-@skip('Need to fix orcid oauth')
-class UserModelsTests(TestCase):
+class AuthorModelsTests(TestCase):
+    def setUp(self):
+        self.user = create_user(
+            email="random@researchhub.com",
+            first_name="random",
+            last_name="user",
+        )
 
-    # TODO: Update orcid oauth implementation so that this doesn't fail
-    def test_user_orcid_id(self):
-        user = create_random_default_user('orcid')
-        orcid_id = '0000-0002-0729-2718'
-        create_social_account(OrcidProvider.id, user, uid=orcid_id)
-        self.assertEqual(user.author_profile.orcid_id, orcid_id)
+        paper1 = Paper.objects.create(
+            title="title1",
+            citations=10,
+            is_open_access=True,
+        )
+
+        paper2 = Paper.objects.create(
+            title="title2",
+            citations=20,
+            is_open_access=False,
+        )
+
+        Authorship.objects.create(author=self.user.author_profile, paper=paper1)
+        Authorship.objects.create(author=self.user.author_profile, paper=paper2)
+
+    def test_citation_count_property(self):
+        self.assertEqual(self.user.author_profile.citation_count, 30)
+
+    def test_paper_count_property(self):
+        self.assertEqual(self.user.author_profile.paper_count, 2)
+
+    def test_open_access_pct_property(self):
+        self.assertEqual(self.user.author_profile.open_access_pct, 0.5)
+
+    def test_achievements(self):
+        self.assertIn("CITED_AUTHOR", self.user.author_profile.achievements)

--- a/src/user/tests/test_serializers.py
+++ b/src/user/tests/test_serializers.py
@@ -155,6 +155,7 @@ class UserSerializersTests(TestCase):
                 "two_year_mean_citedness": 0,
                 "upvote_count": 50,
                 "works_count": 2,
+                "open_access_pct": 0.0,
             },
         )
 

--- a/src/user/tests/test_serializers.py
+++ b/src/user/tests/test_serializers.py
@@ -175,5 +175,6 @@ class UserSerializersTests(TestCase):
                 "two_year_mean_citedness": 0,
                 "upvote_count": 0,
                 "works_count": 0,
+                "open_access_pct": 0.0,
             },
         )

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -1,4 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
 from django.db.models import Q, Sum
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status, viewsets
@@ -88,6 +89,47 @@ class AuthorViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
     @action(detail=True, methods=["get"], permission_classes=[AllowAny])
+    def summary_stats(self, request, pk=None):
+        author = self.get_object()
+        cache_key = f"author-{author.id}-summary-stats"
+        cache_hit = cache.get(cache_key)
+
+        if cache_hit:
+            return Response(cache_hit)
+
+        serializer = DynamicAuthorProfileSerializer(
+            author,
+            _include_fields=[
+                "summary_stats",
+            ],
+        )
+
+        cache.set(cache_key, serializer.data, timeout=3600)
+
+        return Response(serializer.data, status=200)
+
+    @action(detail=True, methods=["get"], permission_classes=[AllowAny])
+    def achievements(self, request, pk=None):
+        author = self.get_object()
+        cache_key = f"author-{author.id}-achievements"
+        cache_hit = cache.get(cache_key)
+
+        if cache_hit:
+            return Response(cache_hit)
+
+        author = self.get_object()
+        serializer = DynamicAuthorProfileSerializer(
+            author,
+            _include_fields=[
+                "achievements",
+            ],
+        )
+
+        cache.set(cache_key, serializer.data, timeout=3600)
+
+        return Response(serializer.data, status=200)
+
+    @action(detail=True, methods=["get"], permission_classes=[AllowAny])
     def profile(self, request, pk=None):
         author = self.get_object()
         serializer = DynamicAuthorProfileSerializer(
@@ -171,9 +213,6 @@ class AuthorViewSet(viewsets.ModelViewSet):
                 "coauthors",
                 "reputation",
                 "reputation_list",
-                "summary_stats",
-                "activity_by_year",
-                "open_access_pct",
                 "achievements",
                 "education",
                 "user",

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -95,7 +95,7 @@ class AuthorViewSet(viewsets.ModelViewSet):
         cache_hit = cache.get(cache_key)
 
         if cache_hit:
-            return Response(cache_hit)
+            return Response(cache_hit, 200)
 
         serializer = DynamicAuthorProfileSerializer(
             author,
@@ -115,7 +115,7 @@ class AuthorViewSet(viewsets.ModelViewSet):
         cache_hit = cache.get(cache_key)
 
         if cache_hit:
-            return Response(cache_hit)
+            return Response(cache_hit, 200)
 
         author = self.get_object()
         serializer = DynamicAuthorProfileSerializer(

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -199,6 +199,7 @@ class AuthorViewSet(viewsets.ModelViewSet):
                 "first_name",
                 "last_name",
                 "description",
+                "activity_by_year",
                 "headline",
                 "profile_image",
                 "orcid_id",

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -213,7 +213,6 @@ class AuthorViewSet(viewsets.ModelViewSet):
                 "coauthors",
                 "reputation",
                 "reputation_list",
-                "achievements",
                 "education",
                 "user",
             ),


### PR DESCRIPTION
- Separate profile endpoint into 3 endpoints: profile, achievements, summary_stats
- Cache summary_stats, achievements for an hour to optimize (no purge mechanism, just TTL of one hour)