### PR TITLE
Authorships for paper serializer

### DIFF
--- a/src/paper/views/paper_views.py
+++ b/src/paper/views/paper_views.py
@@ -247,6 +247,15 @@ class PaperViewSet(ReactionViewActionMixin, viewsets.ModelViewSet):
                     "last_name",
                 ]
             },
+            "author::get_authorship": {
+                "_include_fields": [
+                    "id",
+                    "raw_author_name",
+                    "author_position",
+                    "is_corresponding",
+                    "author_id",
+                ]
+            },
         }
         return context
 
@@ -260,6 +269,7 @@ class PaperViewSet(ReactionViewActionMixin, viewsets.ModelViewSet):
                 "abstract",
                 "abstract_src_markdown",
                 "authors",
+                # "author_count",
                 "boost_amount",
                 "created_date",
                 "discussion_count",
@@ -288,6 +298,7 @@ class PaperViewSet(ReactionViewActionMixin, viewsets.ModelViewSet):
                 "url",
             ],
         )
+
         serializer_data = serializer.data
         vote = self.dynamic_serializer_class(context=context).get_user_vote(instance)
         serializer_data["user_vote"] = vote

--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -489,7 +489,7 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
                     "raw_authors",
                     "twitter_score",
                     "citations",
-                    "authorships",
+                    # "authorships",
                     "work_type",
                 ]
             },
@@ -528,16 +528,16 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
                     "bounty_total_amount",
                 ]
             },
-            "pap_dps_get_authorships": {
-                "_include_fields": [
-                    "id",
-                    "author",
-                    "author_position",
-                    "author_id",
-                    "raw_author_name",
-                    "is_corresponding",
-                ]
-            },
+            # "pap_dps_get_authorships": {
+            #     "_include_fields": [
+            #         "id",
+            #         "author",
+            #         "author_position",
+            #         "author_id",
+            #         "raw_author_name",
+            #         "is_corresponding",
+            #     ]
+            # },
             "authorship::get_author": {"_include_fields": ["id", "profile_image"]},
             "doc_dps_get_hubs": {
                 "_include_fields": [
@@ -557,6 +557,24 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
                     "slug",
                     "is_removed",
                     "hub_image",
+                ]
+            },
+            "pap_dps_get_authors": {
+                "_include_fields": [
+                    "id",
+                    "first_name",
+                    "last_name",
+                    "profile_image",
+                    "authorship",
+                ]
+            },
+            "author::get_authorship": {
+                "_include_fields": [
+                    "id",
+                    "raw_author_name",
+                    "author_position",
+                    "is_corresponding",
+                    "author_id",
                 ]
             },
             "pap_dps_get_unified_document": {
@@ -584,9 +602,9 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
                     "author_profile",
                 ]
             },
-            "pap_dps_get_authors": {
-                "_include_fields": ["id", "first_name", "last_name"]
-            },
+            # "pap_dps_get_authors": {
+            #     "_include_fields": ["id", "first_name", "last_name"]
+            # },
             "usr_dus_get_author_profile": {
                 "_include_fields": [
                     "id",


### PR DESCRIPTION
Need to discuss this further in person. No tests yet. Here is the gist:


- Realized that we should return a list of `author_profiles` (called `authors`) instead of `authorships`
- Then, within each `author_profile`, we can include `authorship` if it is available
- That is due to the fact that not every paper or post have an `authorship` association, but they all have `author_profile` association. This makes things more predictable on the frontend.
- Papers have this association through `paper.authors`. Posts have this association through `post.authors`
- Doing so also avoids circular dependency on both frontend and backend. See code:

```
export type Authorship = {
  id: ID;
  …
  author: AuthorProfile; // Should remove to avoid circular dependency
};


export type AuthorProfile = {
  …
  authorship?: Authorship;
   …
};
```
We should remove `AuthorProfile;` from `Authorship`


This leads to the question of what to do with `paper.authors` association. This is an association we wanted to eliminate in favor of authorship. As a matter of fact, author profiles use authorship instead of paper.authors relation.

- When it comes to author profiles, I think we should revert back to using paper.authors for consistency.
- Similarly, we can include authorship within each author object

Important note is that once we backfill every paper with openalex info, we seldom have instances of authorship not set
