### PR TITLE
Fix author profile cache invalidation

### DIFF
--- a/src/user/tasks.py
+++ b/src/user/tasks.py
@@ -278,7 +278,13 @@ def execute_rsc_exchange_rate_record_tasks():
 
 
 @app.task
-def invalidate_author_profile_caches(author_id):
+def invalidate_author_profile_caches(_ignore, author_id):
+    """
+    Invalidates all caches related to an author profile.
+    This task is designed to be called from a chain when other tasks complete.
+    Celery requires the first argument to be the result of the previous task.
+    It is ignore in this case.
+    """
     cache.delete(f"author-{author_id}-achievements")
     cache.delete(f"author-{author_id}-overview")
     cache.delete(f"author-{author_id}-publications")

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -760,7 +760,7 @@ class AuthorViewSet(viewsets.ModelViewSet):
             # if True:
             if TESTING:
                 pull_openalex_author_works_batch(openalex_ids, request.user.id)
-                invalidate_author_profile_caches(author.id)
+                invalidate_author_profile_caches(None, author.id)
             else:
                 chain(
                     pull_openalex_author_works_batch.s(openalex_ids, request.user.id),
@@ -782,7 +782,7 @@ class AuthorViewSet(viewsets.ModelViewSet):
         )
 
         count, _ = authorships.delete()
-        invalidate_author_profile_caches(request.user.author_profile.id)
+        invalidate_author_profile_caches(None, request.user.author_profile.id)
         return Response({"count": count}, status=status.HTTP_200_OK)
 
     @action(


### PR DESCRIPTION
The cache invalidation gets called from another chained task. Celery will call it with the result of the previous task as a first argument. Add a first dummy argument, so calling the invalidation tasks will not fail.