### PR TITLE
Limit results on top author publications

### DIFF
--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -790,8 +790,10 @@ class AuthorViewSet(viewsets.ModelViewSet):
             authored_doc_ids = list(
                 Authorship.objects.filter(author=author)
                 .order_by("-paper__citations")
-                .values_list("paper__unified_document_id", flat=True)
-            )[:NUM_DOCUMENTS_TO_FETCH]
+                .values_list("paper__unified_document_id", flat=True)[
+                    :NUM_DOCUMENTS_TO_FETCH
+                ]
+            )
 
             docs = ResearchhubUnifiedDocument.objects.filter(id__in=authored_doc_ids)
 


### PR DESCRIPTION
Apply limit clause on queryset (`LIMIT` clause of the resulting SQL statement), not on the resulting list in Python.