### PR TITLE
Remove `raw_authors` from document serializer

### DIFF
--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -479,7 +479,6 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
                     "title",
                     "uploaded_by",
                     "uploaded_date",
-                    "twitter_score",
                     "citations",
                     "authorships",
                     "work_type",

--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -479,7 +479,6 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
                     "title",
                     "uploaded_by",
                     "uploaded_date",
-                    "raw_authors",
                     "twitter_score",
                     "citations",
                     "authorships",


### PR DESCRIPTION
Remove `raw_authors` from the document serializer, so https://backend.staging.researchhub.com/api/researchhub_unified_document/get_unified_documents/ does not return this field that is no longer used by the frontend.

Additionally, remove `twitter_score` that had been deprecated and removed with https://github.com/ResearchHub/researchhub-backend/pull/1520.