### PR TITLE
Fix authors lookup for posts

### DIFF
--- a/src/citation/schema.py
+++ b/src/citation/schema.py
@@ -84,7 +84,7 @@ def generate_json_for_rh_post(post):
         else:
             value = ""
             if field == "author":
-                authors = post.authorship_authors.all()
+                authors = post.authors.all()
                 author_array = []
                 if authors.count():
                     for author in authors.iterator():


### PR DESCRIPTION
Fix the following error:

```
AttributeError: 'ResearchhubPost' object has no attribute 'authorship_authors'
```

This is because a post has a separate post-author relationship and does not use authorships.

Introduced with #1812.

Also see: https://researchhub.sentry.io/issues/5739883966/?environment=production&project=1797024&query=AttributeError&referrer=issue-stream&statsPeriod=24h&stream_index=0