### PR TITLE
Deposits and withdrawals of RSC on Base

### DIFF
--- a/src/ethereum/lib.py
+++ b/src/ethereum/lib.py
@@ -1,4 +1,5 @@
 import json
+import os
 from decimal import Decimal
 
 from smart_open import open
@@ -125,11 +126,6 @@ def transact(w3, method_call, sender, sender_signing_key, gas=None):
 
 
 def get_private_key():
-    url = f"s3://{AWS_ACCESS_KEY_ID}:{AWS_SECRET_ACCESS_KEY}@{WEB3_KEYSTORE_BUCKET}/{WEB3_KEYSTORE_FILE}"
-
-    with open(url) as keyfile:
-        encrypted_key = keyfile.read()
-        if WEB3_KEYSTORE_PASSWORD:
-            return w3.eth.account.decrypt(encrypted_key, WEB3_KEYSTORE_PASSWORD)
-        else:
-            return encrypted_key
+    return bytes.fromhex(
+        os.environ.get("BURNER_PRIVATE_KEY")
+    )  # Avoid using AWS during testing

--- a/src/reputation/lib.py
+++ b/src/reputation/lib.py
@@ -330,11 +330,7 @@ contract_abi = [
     },
 ]
 
-try:
-    PRIVATE_KEY = get_private_key() if WEB3_KEYSTORE_BUCKET else None
-except Exception as e:
-    PRIVATE_KEY = None
-    log_error(e)
+PRIVATE_KEY = get_private_key()  # I know this works during testing
 
 
 class PendingWithdrawal:

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -614,7 +614,9 @@ ELASTICSEARCH_DSL_SIGNAL_PROCESSOR = "search.celery.CelerySignalProcessor"
 # https://web3py.readthedocs.io/en/stable/
 
 # Mainnet
-WEB3_RSC_ADDRESS = os.environ.get("WEB3_RSC_ADDRESS", keys.WEB3_RSC_ADDRESS)
+WEB3_RSC_ADDRESS = os.environ.get(
+    "WEB3_RSC_ADDRESS"
+)  # This loads the address of RSC on Base (i.e., 0xFbB75A59193A3525a8825BeBe7D4b56899E2f7e1)
 
 # Redis
 # redis://:password@hostname:port/db_number


### PR DESCRIPTION
This draft PR is a follow up to [my comment](https://github.com/ResearchHub/issues/issues/63#issuecomment-2248048851) in https://github.com/ResearchHub/issues/issues/63. This code shouldn't be merged. Instead, I'm just sharing that what changes I did to be able to withdraw RSC on Base when running the app locally.

I updated the `WEB3_RSC_ADDRESS` environment variable to have the address of RSC on Base, I used a Base provider URL by Alchemy, and I replaced the ResearchHub hot wallet (https://etherscan.io/address/0x7f57d306a9422ee8175adc25898b1b2ebf1010cb) by another account that had a small amount of ETH and RSC on Base.

I then ran the backend and frontend locally, and I was able to withdraw RSC on Base without any problems:

![image](https://github.com/user-attachments/assets/ecc78ad9-e911-4dab-9527-ebbd52e55e39)

Here is the transaction: https://basescan.org/tx/0xbf612b0ebe2c67048364e3437f45d0345b90f258ad54177892d4c8aaee42a83f
