### PR TITLE
Improve process openalex performance

### DIFF
--- a/src/paper/openalex_util.py
+++ b/src/paper/openalex_util.py
@@ -222,6 +222,9 @@ def process_openalex_works(works):
 def fetch_authors_for_works(openalex_works):
     open_alex = OpenAlex()
     all_authors_to_fetch = set()
+    # When filtering by id, the max batch size is 100
+    batch_size = 100
+
     oa_authors = []
 
     for work in openalex_works:
@@ -231,15 +234,10 @@ def fetch_authors_for_works(openalex_works):
             just_id = author_openalex_id.split("/")[-1]
             all_authors_to_fetch.add(just_id)
 
-    next_cursor = "*"
-    while next_cursor is not None:
-        oa_authors_batch, next_cursor = open_alex.get_authors(
-            openalex_ids=list(all_authors_to_fetch)
-        )
+    for i in range(0, len(all_authors_to_fetch), batch_size):
+        batch = list(all_authors_to_fetch)[i : i + batch_size]
+        oa_authors_batch = open_alex.get_authors(openalex_ids=batch)
         oa_authors.extend(oa_authors_batch)
-
-        if oa_authors_batch is None and len(oa_authors_batch) == 0:
-            break
 
     return oa_authors
 

--- a/src/paper/openalex_util.py
+++ b/src/paper/openalex_util.py
@@ -131,6 +131,7 @@ def process_openalex_works(works):
                 "openalex_concepts": openalex_concepts,
                 "openalex_topics": openalex_topics,
                 "openalex_work": work,
+                "paper": paper,
             }
         except IntegrityError as e:
             sentry.log_error(
@@ -175,6 +176,7 @@ def process_openalex_works(works):
             "openalex_concepts": openalex_concepts,
             "openalex_topics": openalex_topics,
             "openalex_work": work,
+            "paper": existing_paper,
         }
 
     # perform batch update
@@ -191,7 +193,9 @@ def process_openalex_works(works):
         work = paper_data["openalex_work"]
 
         create_paper_related_tags(
-            paper_id, paper_data["openalex_concepts"], paper_data["openalex_topics"]
+            paper_data["paper"],
+            paper_data["openalex_concepts"],
+            paper_data["openalex_topics"],
         )
 
         openalex_authorships = work.get("authorships")

--- a/src/paper/openalex_util.py
+++ b/src/paper/openalex_util.py
@@ -333,12 +333,17 @@ def process_openalex_authorships(openalex_authorships, related_paper_id):
             continue
 
     # Create co-author relationships
+    coauthor_objects = []
     for i, author in enumerate(authors_in_this_work):
         for coauthor in authors_in_this_work:
             if author != coauthor:
-                CoAuthor.objects.get_or_create(
-                    author=author, coauthor=coauthor, paper_id=related_paper_id
+                coauthor_objects.append(
+                    CoAuthor(
+                        author=author, coauthor=coauthor, paper_id=related_paper_id
+                    )
                 )
+
+    CoAuthor.objects.bulk_create(coauthor_objects, ignore_conflicts=True)
 
 
 def merge_openalex_author_with_researchhub_author(openalex_author, researchhub_author):

--- a/src/paper/paper_upload_tasks.py
+++ b/src/paper/paper_upload_tasks.py
@@ -648,9 +648,8 @@ def create_paper_related_tags(paper_id, openalex_concepts=[], openalex_topics=[]
 
     from paper.models import Paper
 
-    paper = None
     try:
-        paper = Paper.objects.get(id=paper_id)
+        paper = Paper.objects.select_related("unified_document").get(id=paper_id)
     except Paper.DoesNotExist:
         sentry.log_info(f"Paper {paper_id} does not exist. Could not assign tags to it")
         return

--- a/src/paper/tests/test_process_openalex_works.py
+++ b/src/paper/tests/test_process_openalex_works.py
@@ -48,11 +48,12 @@ class ProcessOpenAlexWorksTests(APITestCase):
 
             dois = [work.get("doi") for work in self.works]
             dois = [doi.replace("https://doi.org/", "") for doi in dois]
-            created_papers = Paper.objects.filter(doi__in=dois)
+            created_papers = Paper.objects.filter(doi__in=dois).order_by("doi")
 
-            # Sample the first paper to ensure it has concepts
-            paper_concepts = created_papers.first().unified_document.concepts.all()
-            self.assertGreater(len(paper_concepts), 0)
+            paper_concepts = created_papers[0].unified_document.concepts.all()
+            self.assertEqual(len(paper_concepts), 15)
+            paper_concepts = created_papers[1].unified_document.concepts.all()
+            self.assertEqual(len(paper_concepts), 20)
 
     @patch.object(OpenAlex, "get_authors")
     def test_creating_papers_should_create_related_topics(self, mock_get_authors):
@@ -64,11 +65,12 @@ class ProcessOpenAlexWorksTests(APITestCase):
 
             dois = [work.get("doi") for work in self.works]
             dois = [doi.replace("https://doi.org/", "") for doi in dois]
-            created_papers = Paper.objects.filter(doi__in=dois)
+            created_papers = Paper.objects.filter(doi__in=dois).order_by("doi")
 
-            # Sample the first paper to ensure it has topics
-            paper_topics = created_papers.first().unified_document.topics.all()
-            self.assertGreater(len(paper_topics), 0)
+            paper_topics = created_papers[0].unified_document.topics.all()
+            self.assertEqual(len(paper_topics), 3)
+            paper_topics = created_papers[1].unified_document.topics.all()
+            self.assertEqual(len(paper_topics), 4)
 
     @patch.object(OpenAlex, "get_authors")
     def test_creating_papers_should_create_related_hubs(self, mock_get_authors):
@@ -80,11 +82,12 @@ class ProcessOpenAlexWorksTests(APITestCase):
 
             dois = [work.get("doi") for work in self.works]
             dois = [doi.replace("https://doi.org/", "") for doi in dois]
-            created_papers = Paper.objects.filter(doi__in=dois)
+            created_papers = Paper.objects.filter(doi__in=dois).order_by("doi")
 
-            # Sample the first paper to ensure it has topics
-            paper_hubs = created_papers.first().unified_document.hubs.all()
-            self.assertGreater(len(paper_hubs), 0)
+            paper_hubs = created_papers[0].unified_document.hubs.all()
+            self.assertEqual(len(paper_hubs), 15)
+            paper_hubs = created_papers[1].unified_document.hubs.all()
+            self.assertEqual(len(paper_hubs), 22)
 
     @patch.object(OpenAlex, "get_authors")
     def test_creating_papers_should_tag_with_reputation_hubs(self, mock_get_authors):
@@ -96,13 +99,16 @@ class ProcessOpenAlexWorksTests(APITestCase):
 
             dois = [work.get("doi") for work in self.works]
             dois = [doi.replace("https://doi.org/", "") for doi in dois]
-            created_papers = Paper.objects.filter(doi__in=dois)
+            created_papers = Paper.objects.filter(doi__in=dois).order_by("doi")
 
-            # Sample the first paper to ensure it has topics
-            paper_hubs = created_papers.first().unified_document.hubs.filter(
+            paper_hubs = created_papers[0].unified_document.hubs.filter(
                 is_used_for_rep=True
             )
-            self.assertGreater(len(paper_hubs), 0)
+            self.assertEqual(len(paper_hubs), 1)
+            paper_hubs = created_papers[1].unified_document.hubs.filter(
+                is_used_for_rep=True
+            )
+            self.assertEqual(len(paper_hubs), 2)
 
     @patch.object(OpenAlex, "get_authors")
     def test_updating_existing_papers_from_openalex_works(self, mock_get_authors):
@@ -146,11 +152,12 @@ class ProcessOpenAlexWorksTests(APITestCase):
 
             dois = [work.get("doi") for work in self.works]
             dois = [doi.replace("https://doi.org/", "") for doi in dois]
-            created_papers = Paper.objects.filter(doi__in=dois)
+            created_papers = Paper.objects.filter(doi__in=dois).order_by("doi")
 
-            # Sample the first paper to ensure it has authors
             paper_authors = created_papers.first().authors.all()
-            self.assertGreater(len(paper_authors), 0)
+            self.assertEqual(len(paper_authors), 2)
+            paper_authors = created_papers.last().authors.all()
+            self.assertEqual(len(paper_authors), 3)
 
     @patch.object(OpenAlex, "get_authors")
     def test_create_authorships_when_processing_work(self, mock_get_authors):
@@ -162,9 +169,11 @@ class ProcessOpenAlexWorksTests(APITestCase):
 
             dois = [work.get("doi") for work in self.works]
             dois = [doi.replace("https://doi.org/", "") for doi in dois]
-            paper = Paper.objects.filter(doi__in=dois).first()
+            paper = Paper.objects.filter(doi__in=dois).order_by("doi")
 
-            authorships = paper.authorships.all()
+            authorships = paper[0].authorships.all()
+            self.assertEqual(len(authorships), 2)
+            authorships = paper[1].authorships.all()
             self.assertEqual(len(authorships), 3)
 
     @patch.object(OpenAlex, "get_authors")
@@ -182,9 +191,11 @@ class ProcessOpenAlexWorksTests(APITestCase):
             # Assert
             dois = [work.get("doi") for work in self.works]
             dois = [doi.replace("https://doi.org/", "") for doi in dois]
-            paper = Paper.objects.filter(doi__in=dois).first()
+            paper = Paper.objects.filter(doi__in=dois).order_by("doi")
 
-            authorships = paper.authorships.all()
+            authorships = paper[0].authorships.all()
+            self.assertEqual(len(authorships), 2)
+            authorships = paper[1].authorships.all()
             self.assertEqual(len(authorships), 3)
 
     @patch.object(OpenAlex, "get_authors")
@@ -222,7 +233,9 @@ class ProcessOpenAlexWorksTests(APITestCase):
                 self.assertEqual(authorship.raw_author_name, "name1")
 
     @patch.object(OpenAlex, "get_authors")
-    def create_authorship_institutions_when_processing_work(self, mock_get_authors):
+    def test_create_authorship_institutions_when_processing_work(
+        self, mock_get_authors
+    ):
         with open("./paper/tests/openalex_authors.json", "r") as file:
             mock_data = json.load(file)
             mock_get_authors.return_value = (mock_data["results"], None)
@@ -231,11 +244,21 @@ class ProcessOpenAlexWorksTests(APITestCase):
 
             dois = [work.get("doi") for work in self.works]
             dois = [doi.replace("https://doi.org/", "") for doi in dois]
-            paper = Paper.objects.filter(doi__in=dois).first()
+            paper = Paper.objects.filter(doi__in=dois).order_by("doi")
 
-            authorship = paper.authorships.first()
-            institutions = authorship.institutions.all()
-            self.assertGreater(len(institutions), 0)
+            authorships = paper[0].authorships.all()
+            institutions = authorships[0].institutions.all()
+            self.assertEqual(len(institutions), 0)
+            institutions = authorships[1].institutions.all()
+            self.assertEqual(len(institutions), 1)
+
+            authorships = paper[1].authorships.all()
+            institutions = authorships[0].institutions.all()
+            self.assertEqual(len(institutions), 1)
+            institutions = authorships[1].institutions.all()
+            self.assertEqual(len(institutions), 1)
+            institutions = authorships[2].institutions.all()
+            self.assertEqual(len(institutions), 1)
 
     @patch.object(OpenAlex, "get_authors")
     def test_add_orcid_to_author_when_processing_work(self, mock_get_authors):


### PR DESCRIPTION
- Speed up processing of new OpenAlex works.
- We currently can't process all new papers because of how slow this code is.
- This code cuts processing time by about 50%.



Next steps will be to make authors more easily searchable by openalex id.