### PR TITLE
Filter queryset on given filter parameters

### DIFF
--- a/src/reputation/views/bounty_view.py
+++ b/src/reputation/views/bounty_view.py
@@ -447,7 +447,9 @@ class BountyViewSet(viewsets.ModelViewSet):
                 request.user, include_unrelated=True
             )
         else:
-            bounties = Bounty.objects.all()
+            bounties = self.filter_queryset(self.get_queryset()).order_by(
+                "-created_date"
+            )
 
         page = self.paginate_queryset(bounties)
         context = self._get_retrieve_context()


### PR DESCRIPTION
Apply given filters on bounties resultset. With this change, it is possible to e.g. only query open bounties:

`/api/bounty/?status=OPEN`

Please note that filtering will only apply to unauthenticated requests. In a follow up PR, we'll also allow to filter the resultset in the authenticated use case, but this is not a priority for now.