### PR TITLE
Add description to transaction export

### DIFF
--- a/src/purchase/tests/test_balance_view.py
+++ b/src/purchase/tests/test_balance_view.py
@@ -19,7 +19,9 @@ class BalanceViewTests(APITestCase):
             price_source="COIN_GECKO",
             target_currency="USD",
         )
-        vote_content_type = ContentType.objects.get(model="vote", app_label="paper")
+        vote_content_type = ContentType.objects.get(
+            model="vote", app_label="discussion"
+        )
         self.transaction = Balance.objects.create(
             amount=1000, user=self.user, content_type=vote_content_type
         )

--- a/src/purchase/tests/test_balance_view.py
+++ b/src/purchase/tests/test_balance_view.py
@@ -1,0 +1,58 @@
+import csv
+from io import StringIO
+
+from django.contrib.contenttypes.models import ContentType
+from rest_framework.test import APITestCase
+
+from purchase.related_models.balance_model import Balance
+from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
+from user.tests.helpers import create_random_authenticated_user
+
+
+class BalanceViewTests(APITestCase):
+
+    def setUp(self):
+        self.user = create_random_authenticated_user("balance_user")
+        self.rsc_exchange_rate = RscExchangeRate.objects.create(
+            rate=0.5,
+            real_rate=0.5,
+            price_source="COIN_GECKO",
+            target_currency="USD",
+        )
+        vote_content_type = ContentType.objects.get(model="vote", app_label="paper")
+        self.transaction = Balance.objects.create(
+            amount=1000, user=self.user, content_type=vote_content_type
+        )
+
+    def test_list_csv(self):
+        # Arrange
+        self.client.force_authenticate(self.user)
+
+        # Act
+        response = self.client.get("/api/transactions/list_csv/")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+        self.assertEqual(
+            response["Content-Disposition"],
+            'attachment; filename="transactions.csv"',
+        )
+
+        content = response.content.decode("utf-8")
+        csv_file = StringIO(content)
+        reader = csv.reader(csv_file)
+        expected = [
+            ["date", "rsc_amount", "rsc_to_usd", "usd_value", "description"],
+            [
+                self.transaction.created_date.isoformat(
+                    timespec="microseconds", sep=" "
+                ),
+                str(self.transaction.amount),
+                str(self.rsc_exchange_rate.real_rate),
+                f"{self.transaction.amount*self.rsc_exchange_rate.real_rate:.2f}",
+                self.transaction.content_type.name,
+            ],
+        ]
+        actual = list(reader)
+        self.assertEqual(expected, actual)

--- a/src/purchase/views/balance_view.py
+++ b/src/purchase/views/balance_view.py
@@ -86,7 +86,9 @@ class BalanceViewSet(viewsets.ReadOnlyModelViewSet):
         response["Content-Disposition"] = 'attachment; filename="transactions.csv"'
 
         writer = csv.writer(response)
-        writer.writerow(["date", "rsc_amount", "rsc_to_usd", "usd_value"])
+        writer.writerow(
+            ["date", "rsc_amount", "rsc_to_usd", "usd_value", "description"]
+        )
 
         for balance in self.get_queryset().iterator():
             exchange_rate = RscExchangeRate.objects.filter(
@@ -111,6 +113,7 @@ class BalanceViewSet(viewsets.ReadOnlyModelViewSet):
                     balance.amount,
                     rate,
                     f"{(decimal.Decimal(balance.amount) * decimal.Decimal(rate)):.2f}",
+                    balance.content_type.name,
                 ]
             )
 

--- a/src/purchase/views/balance_view.py
+++ b/src/purchase/views/balance_view.py
@@ -3,7 +3,6 @@ import decimal
 import time
 from datetime import datetime
 
-import pandas as pd
 import pytz
 from django.contrib.contenttypes.models import ContentType
 from django.http import HttpResponse

--- a/src/purchase/views/balance_view.py
+++ b/src/purchase/views/balance_view.py
@@ -1,3 +1,4 @@
+import csv
 import decimal
 import time
 from datetime import datetime
@@ -5,6 +6,7 @@ from datetime import datetime
 import pandas as pd
 import pytz
 from django.contrib.contenttypes.models import ContentType
+from django.http import HttpResponse
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
@@ -72,19 +74,23 @@ class BalanceViewSet(viewsets.ReadOnlyModelViewSet):
         permission_classes=[IsAuthenticated],
     )
     def list_csv(self, request):
-        queryset = self.get_queryset().values_list("created_date", "amount")
         default_exchange_rate = RscExchangeRate.objects.first()
 
-        data = []
         before_exchange_rate_date = "11-10-2022"
         before_exchange_datetime = datetime.strptime(
             before_exchange_rate_date, "%m-%d-%Y"
         )
         specific_date_aware = pytz.utc.localize(before_exchange_datetime)
-        for obj in queryset.iterator():
-            date, rsc = obj
+
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = 'attachment; filename="transactions.csv"'
+
+        writer = csv.writer(response)
+        writer.writerow(["date", "rsc_amount", "rsc_to_usd", "usd_value"])
+
+        for balance in self.get_queryset().iterator():
             exchange_rate = RscExchangeRate.objects.filter(
-                created_date__lte=date
+                created_date__lte=balance.created_date
             ).last()
             if exchange_rate is None:
                 rate = default_exchange_rate.real_rate
@@ -93,21 +99,19 @@ class BalanceViewSet(viewsets.ReadOnlyModelViewSet):
                 rate = exchange_rate.real_rate or exchange_rate.rate
 
             if (
-                date <= specific_date_aware
+                balance.created_date <= specific_date_aware
                 and exchange_rate is None
                 or not exchange_rate.real_rate
             ):
                 rate = 0
 
-            data.append(
-                (
-                    date,
-                    rsc,
+            writer.writerow(
+                [
+                    balance.created_date,
+                    balance.amount,
                     rate,
-                    f"{(decimal.Decimal(rsc) * decimal.Decimal(rate)):.2f}",
-                )
+                    f"{(decimal.Decimal(balance.amount) * decimal.Decimal(rate)):.2f}",
+                ]
             )
-        df = pd.DataFrame(
-            data, columns=("date", "rsc_amount", "rsc_to_usd", "usd_value")
-        )
-        return Response(df.to_csv(index=False), status=200)
+
+        return response


### PR DESCRIPTION
This change adds a new _description_ column to the transaction report that shows the type of the transaction (balance) for each entry in the exported CSV file.

Additionally, write the export CSV file as a native CSV file instead of wrapping it into a JSON object.

Closes ResearchHub/issues/issues/114