### PR TITLE
Align author fields in paper and RH post serializers

### DIFF
--- a/src/paper/serializers/paper_serializers.py
+++ b/src/paper/serializers/paper_serializers.py
@@ -797,7 +797,14 @@ class DynamicAuthorshipSerializer(DynamicModelFieldSerializer):
 
     def to_representation(self, authorship):
         context = self.context
-        context_fields = {"_include_fields": ["id", "first_name", "last_name"]}
+        context_fields = {
+            "_include_fields": [
+                "id",
+                "first_name",
+                "last_name",
+                "user",
+            ]
+        }
         author_data = DynamicAuthorSerializer(
             authorship.author,
             context=context,

--- a/src/researchhub_document/serializers/researchhub_post_serializer.py
+++ b/src/researchhub_document/serializers/researchhub_post_serializer.py
@@ -226,7 +226,14 @@ class DynamicPostSerializer(DynamicModelFieldSerializer):
 
     def get_authors(self, post):
         context = self.context
-        _context_fields = context.get("doc_dps_get_authors", {})
+        _context_fields = {
+            "_include_fields": [
+                "id",
+                "first_name",
+                "last_name",
+                "user",
+            ]
+        }
         serializer = DynamicAuthorSerializer(
             post.authors, context=context, many=True, **_context_fields
         )


### PR DESCRIPTION
1) Reduce number of author fields returned array of RH post serializer to the following:

- author ID
- first_name
- last_name
- user ID

New structure:
```
"authors": [
    {
        "id": 1,
        "first_name": "Gregor",
        "last_name": "Zurowski",
        "user": 1
    }
],
[...]
```
Old structure:
```
"authors": [
    {
        "id": 1,
        "first_name": "Gregor",
        "last_name": "Zurowski",
        "created_date": "2024-03-13T19:04:04.387149Z",
        "updated_date": "2024-03-13T19:04:04.387156Z",
        "description": null,
        "h_index": 0,
        "i10_index": 0,
        "profile_image": null,
        "author_score": 0,
        "orcid_id": null,
        "openalex_ids": [],
        "education": [],
        "headline": null,
        "facebook": null,
        "twitter": null,
        "linkedin": null,
        "google_scholar": null,
        "claimed": true,
        "is_verified": false,
        "country_code": null,
        "created_source": "RESEARCHHUB",
        "last_full_fetch_from_openalex": null,
        "two_year_mean_citedness": 0.0,
        "user": 1,
        "university": null,
        "merged_with_author": null
    }
],
[...]
```

2) Include user ID for authors returned by the paper serializer.

Example:
```
"authors": [
    {
        "id": 3,
        "first_name": "Gregor",
        "last_name": "Zurowski",
        "user": 3,
        "authorship": {
            "position": "first",
            "is_corresponding": true
        }
    }
],
[...]
```