### PR TITLE
Avoid individual subqueries in unified document

### DIFF
--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -679,11 +679,11 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
     def get_unified_documents(self, request):
         is_anonymous = request.user.is_anonymous
         query_params = request.query_params
-        subscribed_hubs = query_params.get("subscribed_hubs", "false")
+        subscribed_hubs = query_params.get("subscribed_hubs", "false").lower() == "true"
         filtering = query_params.get("ordering", HOT)
         time_scope = query_params.get("time", "today")
 
-        if subscribed_hubs == "true" and not is_anonymous:
+        if subscribed_hubs and not is_anonymous:
             return self._get_subscribed_unified_documents(request)
 
         document_request_type = query_params.get("type", "all")

--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -708,7 +708,7 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
                 date_ranges=[time_scope],
             )
 
-        documents = self.get_filtered_queryset()
+        documents = self.get_filtered_queryset().prefetch_related("fundraises")
         context = self._get_serializer_context()
         context["hub_id"] = hub_id
         page = self.paginate_queryset(documents)


### PR DESCRIPTION
Avoid individual subqueries for fundraises for each document returned by the unified document serializer.

Without this change:
<img width="1741" alt="image" src="https://github.com/user-attachments/assets/c0eafb90-2070-4e9c-a7f6-51e7e777d087">


With this change:
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/becaab7d-af53-45f8-8af3-5ea6fb938aef">
