### PR TITLE
Housekeeping | Remove paper cache

### DIFF
--- a/src/discussion/reaction_views.py
+++ b/src/discussion/reaction_views.py
@@ -87,9 +87,6 @@ def censor(requestor, item):
             filters=[DISCUSSED, HOT],
         )
 
-    # Commenting out paper cache
-    # if item.paper:
-    #     item.paper.reset_cache()
     return True
 
 
@@ -578,13 +575,6 @@ def update_or_create_vote(request, user, item, vote_type):
             target_vote=vote,
         )
 
-    # potential_paper = vote.item
-    # from paper.models import Paper
-
-    # Commenting out paper cache
-    # if isinstance(potential_paper, Paper):
-    #     potential_paper.reset_cache()
-
     app_label = item._meta.app_label
     model = item._meta.model.__name__.lower()
     create_contribution.apply_async(
@@ -607,9 +597,3 @@ def update_relavent_doc_caches_on_vote(cache_filters_to_reset, target_vote):
     reset_unified_document_cache(
         document_type=[doc_type, "all"], filters=cache_filters_to_reset
     )
-
-    # Commenting out paper cache
-    # from paper.models import Paper
-
-    # if isinstance(item, Paper):
-    #     item.reset_cache()

--- a/src/discussion/signals.py
+++ b/src/discussion/signals.py
@@ -32,44 +32,24 @@ def create_thread_notification(sender, instance, created, **kwargs):
 
 @receiver(post_save, sender=Thread, dispatch_uid="thread_post_save_signal")
 def thread_post_save_signal(sender, instance, created, update_fields, **kwargs):
-    # paper = instance.paper
     instance.update_discussion_count()
-    # Commenting out paper cache
-    # if paper:
-    #     paper.reset_cache()
 
 
 @receiver(post_delete, sender=Thread, dispatch_uid="recalc_dis_count_del_thr")
 def recalc_dis_count_thread_delete(sender, instance, **kwargs):
-    # paper = instance.paper
     instance.update_discussion_count()
-    # Commenting out paper cache
-    # if paper:
-    #     paper.reset_cache()
 
 
 @receiver(post_save, sender=Comment, dispatch_uid="comment_post_save_signal")
 def comment_post_save_signal(sender, instance, created, update_fields, **kwargs):
-    # paper = instance.paper
     instance.update_discussion_count()
-    # Commenting out paper cache
-    # if paper:
-    #     paper.reset_cache()
 
 
 @receiver(post_delete, sender=Comment, dispatch_uid="recalc_dis_count_del_com")
 def recalc_dis_count_comment_delete(sender, instance, **kwargs):
-    # paper = instance.paper
     instance.update_discussion_count()
-    # Commenting out paper cache
-    # if paper:
-    #     paper.reset_cache()
 
 
 @receiver(post_save, sender=Reply, dispatch_uid="reply_post_save_signal")
 def reply_post_save_signal(sender, instance, created, update_fields, **kwargs):
-    # paper = instance.paper
     instance.update_discussion_count()
-    # Commenting out paper cache
-    # if paper:
-    #     paper.reset_cache()

--- a/src/paper/related_models/paper_model.py
+++ b/src/paper/related_models/paper_model.py
@@ -835,9 +835,6 @@ class Paper(AbstractGenericReactionModel):
             return boost_amount
         return 0
 
-    def reset_cache(self, use_celery=True):
-        return
-
     def get_license(self, save=True):
         pdf_license = self.pdf_license
         if pdf_license:

--- a/src/paper/related_models/paper_model.py
+++ b/src/paper/related_models/paper_model.py
@@ -836,11 +836,6 @@ class Paper(AbstractGenericReactionModel):
         return 0
 
     def reset_cache(self, use_celery=True):
-        # Commenting out paper cache
-        # if use_celery:
-        #     celery_paper_reset_cache.apply_async((self.id,), priority=2)
-        # else:
-        #     celery_paper_reset_cache(self.id)
         return
 
     def get_license(self, save=True):

--- a/src/paper/tasks.py
+++ b/src/paper/tasks.py
@@ -148,8 +148,6 @@ def download_pdf(paper_id, retry=0):
             paper.file.save(filename, pdf)
             paper.save(update_fields=["file"])
             paper.extract_pdf_preview(use_celery=True)
-            # Commenting out paper cache
-            # paper.reset_cache(use_celery=False)
             paper.set_paper_completeness()
             paper.compress_and_linearize_file()
             celery_extract_pdf_sections.apply_async(

--- a/src/paper/tasks.py
+++ b/src/paper/tasks.py
@@ -36,74 +36,14 @@ from paper.utils import (
     merge_paper_bulletpoints,
     merge_paper_threads,
     merge_paper_votes,
-    reset_paper_cache,
 )
-from researchhub.celery import (
-    QUEUE_CACHES,
-    QUEUE_CERMINE,
-    QUEUE_PAPER_MISC,
-    QUEUE_PULL_PAPERS,
-    app,
-)
+from researchhub.celery import QUEUE_CERMINE, QUEUE_PAPER_MISC, QUEUE_PULL_PAPERS, app
 from researchhub.settings import APP_ENV, PRODUCTION, TESTING
 from utils import sentry
 from utils.http import check_url_contains_pdf
 from utils.openalex import OpenAlex
 
 logger = get_task_logger(__name__)
-
-
-@app.task(queue=QUEUE_CACHES)
-def celery_paper_reset_cache(paper_id):
-    from paper.serializers import DynamicPaperSerializer
-    from paper.views.paper_views import PaperViewSet
-
-    context = PaperViewSet()._get_paper_context()
-
-    Paper = apps.get_model("paper.Paper")
-    paper = Paper.objects.get(id=paper_id)
-    serializer = DynamicPaperSerializer(
-        paper,
-        context=context,
-        _include_fields=[
-            "abstract_src_markdown",
-            "abstract_src_type",
-            "abstract_src",
-            "abstract",
-            "authors",
-            "boost_amount",
-            "bounties",
-            "created_date",
-            "discussion_count",
-            "doi",
-            "external_source",
-            "file",
-            "first_preview",
-            "hubs",
-            "id",
-            "is_open_access",
-            "oa_status",
-            "paper_publish_date",
-            "paper_title",
-            "pdf_file_extract",
-            "pdf_license",
-            "pdf_url",
-            "raw_authors",
-            "score",
-            "slug",
-            "title",
-            "unified_document",
-            "uploaded_by",
-            "uploaded_date",
-            "uploaded_date",
-            "url",
-        ],
-    )
-    data = serializer.data
-
-    cache_key = get_cache_key("paper", paper_id)
-    reset_paper_cache(cache_key, data)
-    return data
 
 
 @app.task(queue=QUEUE_PAPER_MISC)

--- a/src/paper/utils.py
+++ b/src/paper/utils.py
@@ -607,10 +607,6 @@ def merge_paper_bulletpoints(original_paper, new_paper):
                 new_bullet_point.delete()
 
 
-def reset_paper_cache(cache_key, data):
-    cache.set(cache_key, data, timeout=60 * 60 * 24 * 7)
-
-
 def get_cache_key(obj_type, pk):
     return f"{obj_type}_{pk}"
 

--- a/src/paper/views/paper_views.py
+++ b/src/paper/views/paper_views.py
@@ -459,8 +459,6 @@ class PaperViewSet(ReactionViewActionMixin, viewsets.ModelViewSet):
         )
         decisions_api.apply_bad_user_decision(content_creator, "MANUAL_REVIEW", user)
 
-        # Commenting out paper cache
-        # paper.reset_cache(use_celery=False)
         return Response(self.get_serializer(instance=paper).data, status=200)
 
     @action(

--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -363,8 +363,6 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
         if isinstance(inner_doc, Paper):
             inner_doc.is_removed = True
             inner_doc.save()
-            # Commenting out paper cache
-            # inner_doc.reset_cache(use_celery=False)
 
         action = inner_doc.actions
         if action.exists():
@@ -394,9 +392,6 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
         if isinstance(inner_doc, Paper):
             inner_doc.is_removed = False
             inner_doc.save()
-            # Commenting out paper cache
-            # inner_doc.reset_cache(use_celery=False)
-
         action = inner_doc.actions
         if action.exists():
             action = action.first()


### PR DESCRIPTION
Paper cache hasn't been used for almost two years. This change removes:
- All commented out paper cache reset invocations.
- A Celery task for resetting the paper cache.