### PR TITLE
fix: Check if document exists before updating

### DIFF
--- a/src/hub/management/commands/assign_journal_hubs.py
+++ b/src/hub/management/commands/assign_journal_hubs.py
@@ -41,5 +41,8 @@ class Command(BaseCommand):
             journal_hub = source_to_journalhub[paper.external_source]
             if not paper.hubs.filter(id=journal_hub.id).exists():
                 paper.hubs.add(journal_hub)
-                paper.unified_document.hubs.add(journal_hub)
-                print(f"Added paper {paper.id} to hub {journal_hub.name}")
+                if paper.unified_document:
+                    paper.unified_document.hubs.add(journal_hub)
+                print(
+                    f"Added paper {paper.id} (doc {paper.unified_document.id if paper.unified_document else 'none'}) to hub {journal_hub.name}"
+                )


### PR DESCRIPTION
Check if a unified document is associated with a given paper before attempting to assign a journal hub to it. This is necessary because some papers may not have a unified document associated with them.