### PR TITLE
Put paper creation in transaction to avoid creation of paper without unified document

### DIFF
--- a/src/paper/openalex_util.py
+++ b/src/paper/openalex_util.py
@@ -95,7 +95,7 @@ def create_and_update_papers(open_alex, works) -> Dict[int, Dict[str, Any]]:
     # batch fetch existing papers
     existing_papers_query = (
         Paper.objects.filter(Q(doi__in=dois) | Q(openalex_id__in=openalex_ids))
-        .only("doi", "id")
+        .only("doi", "id", "unified_document")
         .distinct()
     )
     existing_paper_map = {paper.doi: paper for paper in existing_papers_query}
@@ -161,7 +161,9 @@ def create_papers(open_alex, works) -> Dict[int, Dict[str, Any]]:
             continue
 
         try:
-            paper.save()
+            with transaction.atomic():
+                paper.save()
+
             Citation(
                 paper=paper,
                 total_citation_count=paper.citations,

--- a/src/paper/paper_upload_tasks.py
+++ b/src/paper/paper_upload_tasks.py
@@ -577,7 +577,8 @@ def celery_create_paper(self, celery_data):
         paper.full_clean()
         paper.get_abstract_backup(should_save=False)
         paper.get_pdf_link(should_save=False)
-        paper.save()
+        with transaction.atomic():
+            paper.save()
 
         paper_id = paper.id
         paper_submission.set_complete_status(save=False)


### PR DESCRIPTION
- Unified documents are created in post_save signals. If they fail we want the paper creation to fail. Putting paper creation in a transaction should do that. 