### PR TITLE
Stop lowercasing hub names

### DIFF
--- a/src/hub/management/commands/update_hub_names_title_case.py
+++ b/src/hub/management/commands/update_hub_names_title_case.py
@@ -1,0 +1,19 @@
+from django.core.management.base import BaseCommand
+
+from hub.models import Hub
+
+
+class Command(BaseCommand):
+    """
+    One-off command to update all hub names to title case
+    (e.g., from 'computer science' to 'Computer Science').
+    """
+
+    def handle(self, *args, **options):
+        hubs = Hub.objects.all()
+        for hub in hubs:
+            title = hub.name.title()
+            if hub.name != title:
+                print(f"Updating hub name '{hub.name}' to '{title}' (id: {hub.id})")
+                hub.name = hub.name.title()
+                hub.save()

--- a/src/hub/tests/test_models.py
+++ b/src/hub/tests/test_models.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 
 from hub.models import Hub
+from tag.models import Concept
+from topic.models import Subfield
 
 
 class HubModelsTests(TestCase):
@@ -8,7 +10,7 @@ class HubModelsTests(TestCase):
     def test_hub_str(self):
         # Arrange
         hub = Hub.objects.create(
-            name="Test Hub 1",
+            name="testHub1",
             namespace=Hub.Namespace.JOURNAL,
         )
 
@@ -16,4 +18,94 @@ class HubModelsTests(TestCase):
         actual = str(hub)
 
         # Assert
-        self.assertEqual(actual, "journal:test hub 1, locked: False")
+        self.assertEqual(actual, "journal:testHub1, locked: False")
+
+    def test_get_from_subfield(self):
+        # Arrange
+        subfield = Subfield.objects.create(
+            display_name="testSubfield1",
+        )
+
+        expected = Hub.objects.create(
+            name=subfield.display_name,
+            subfield=subfield,
+        )
+
+        # Act
+        actual = Hub.get_from_subfield(subfield)
+
+        # Assert
+        self.assertEqual(actual, expected)
+
+    def test_get_from_subfield_with_different_cases(self):
+        # Arrange
+        subfield = Subfield.objects.create(
+            display_name="testSubfield1",
+        )
+
+        expected = Hub.objects.create(
+            name="TESTSUBFIELD1",
+            subfield=subfield,
+        )
+
+        # Act & Assert
+        actual = Hub.get_from_subfield(subfield)
+
+        # Assert
+        self.assertEqual(actual, expected)
+
+    def test_get_from_subfield_not_found(self):
+        # Arrange
+        subfield = Subfield.objects.create(
+            display_name="testSubfield1",
+        )
+
+        # Act & Assert
+        with self.assertRaises(Hub.DoesNotExist):
+            Hub.get_from_subfield(subfield)
+
+    def test_create_or_update_hub_from_concept(self):
+        # Arrange
+        concept = Concept.objects.create(
+            display_name="testConcept1",
+        )
+
+        # Act
+        actual = Hub.create_or_update_hub_from_concept(concept)
+
+        # Assert
+        expected = Hub.objects.get(concept=concept)
+        self.assertIsNotNone(expected)
+        self.assertEqual(actual, expected)
+
+    def test_create_or_update_hub_from_concept_when_hub_already_exists(self):
+        # Arrange
+        hub = Hub.objects.create(
+            name="testConcept1",
+        )
+
+        concept = Concept.objects.create(
+            display_name=hub.name,
+        )
+
+        # Act
+        actual = Hub.create_or_update_hub_from_concept(concept)
+
+        # Assert
+        self.assertEqual(actual, hub)
+
+    def test_create_or_update_hub_from_concept_with_different_cases(self):
+        # Arrange
+        hub = Hub.objects.create(
+            name="testConcept1",
+        )
+
+        concept = Concept.objects.create(
+            display_name="TESTCONCEPT1",
+        )
+
+        # Act
+        actual = Hub.create_or_update_hub_from_concept(concept)
+
+        # Assert
+        self.assertEqual(actual, hub)


### PR DESCRIPTION
- Stop lowercasing hub names when saving hubs.
- Update lookup methods that expect lowercase to ignore casing.
- Add unit tests for existing functionality for lookup up hubs.
- Add one-off command to update all hub names to title case (e.g., _computer science_ to _Computer Science_).

Closes https://github.com/ResearchHub/issues/issues/117