### PR TITLE
Assign journal hubs when loading documents from OpenAlex

### DIFF
--- a/src/paper/exceptions.py
+++ b/src/paper/exceptions.py
@@ -27,7 +27,3 @@ class DOINotFoundError(Exception):
 
 class ManubotProcessingError(Exception):
     pass
-
-
-class CrossrefSearchError(Exception):
-    pass

--- a/src/paper/openalex_util.py
+++ b/src/paper/openalex_util.py
@@ -48,6 +48,23 @@ PAPER_FIELDS_ALLOWED_TO_UPDATE = [
     "retrieved_from_external_source",
 ]
 
+"""
+This dictionary maps OpenAlex sources (`external_source`) to ResearchHub journal hubs. 
+It is used to automatically tag papers with the appropriate journal hub when they are fetched from OpenAlex.
+Note: If the name of the journal hub changes, this dictionary will need to be updated.
+"""
+OPENALEX_SOURCES_TO_JOURNAL_HUBS: Dict[str, str] = {
+    "arXiv (Cornell University)": "Arxiv",
+    "bioRxiv (Cold Spring Harbor Laboratory)": "Biorxiv",
+    "medRxiv (Cold Spring Harbor Laboratory)": "Medrxiv",
+    "ChemRxiv": "Chemrxiv",
+    "Research Square (Research Square)": "Research Square",
+    "OSF Preprints (OSF Preprints)": "Osf Preprints",
+    "PeerJ": "Peerj",
+    "Authorea (Authorea)": "Authorea",
+    "SSRN Electronic Journal": "Ssrn",
+}
+
 
 def process_openalex_works(works):
     open_alex = OpenAlex()

--- a/src/paper/paper_upload_tasks.py
+++ b/src/paper/paper_upload_tasks.py
@@ -743,7 +743,10 @@ def _get_or_create_journal_hub(external_source: str) -> Hub:
 
 
 def _get_journal_hub(journal: str) -> Hub:
-    return Hub.objects.filter(name=journal, namespace=Hub.Namespace.JOURNAL).first()
+    return Hub.objects.filter(
+        name__iexact=journal,
+        namespace=Hub.Namespace.JOURNAL,
+    ).first()
 
 
 @app.task(queue=QUEUE_PAPER_METADATA)

--- a/src/paper/paper_upload_tasks.py
+++ b/src/paper/paper_upload_tasks.py
@@ -27,6 +27,7 @@ from paper.exceptions import (
     DuplicatePaperError,
     ManubotProcessingError,
 )
+from paper.openalex_util import OPENALEX_SOURCES_TO_JOURNAL_HUBS
 from paper.tasks import download_pdf, pull_openalex_author_works_batch
 from paper.utils import (
     DOI_REGEX,
@@ -703,14 +704,46 @@ def create_paper_related_tags(paper, openalex_concepts=[], openalex_topics=[]):
     concept_hubs = Hub.objects.filter(concept__id__in=concept_ids)
     paper.unified_document.hubs.add(*concept_hubs)
 
-    # Add to bioRxiv hub if applicable
-    if paper.external_source and "bioRxiv" in paper.external_source:
-        biorxiv_hub_id = 436
-        if Hub.objects.filter(id=biorxiv_hub_id).exists():
-            paper.unified_document.hubs.add(biorxiv_hub_id)
+    if paper.external_source:
+        journal = _get_or_create_journal_hub(paper.external_source)
+        paper.unified_document.hubs.add(journal)
+
+        # Add to bioRxiv hub if applicable
+        if "bioRxiv" in paper.external_source:
+            biorxiv_hub_id = 436
+            if Hub.objects.filter(id=biorxiv_hub_id).exists():
+                paper.unified_document.hubs.add(biorxiv_hub_id)
 
     # Sync hubs to paper (if needed)
     paper.hubs.set(paper.unified_document.hubs.all())
+
+
+def _get_or_create_journal_hub(external_source: str) -> Hub:
+    """
+    Get or create a journal hub from the given journal name.
+    This function also considers the managed mapping of OpenAlex sources to journal hubs
+    in `OPENALEX_SOURCES_TO_JOURNAL_HUBS`.
+    """
+    journal_hub = None
+
+    if external_source in OPENALEX_SOURCES_TO_JOURNAL_HUBS.keys():
+        journal_hub = _get_journal_hub(
+            OPENALEX_SOURCES_TO_JOURNAL_HUBS[external_source]
+        )
+
+    if journal_hub is None:
+        journal_hub = _get_journal_hub(external_source)
+        if journal_hub is None:
+            journal_hub = Hub.objects.create(
+                name=external_source,
+                namespace=Hub.Namespace.JOURNAL,
+            )
+
+    return journal_hub
+
+
+def _get_journal_hub(journal: str) -> Hub:
+    return Hub.objects.filter(name=journal, namespace=Hub.Namespace.JOURNAL).first()
 
 
 @app.task(queue=QUEUE_PAPER_METADATA)


### PR DESCRIPTION
When loading document from OpenAlex, journal hubs are assigned to the documents. The target journal hub is identified by the `external_source` field provided by OpenAlex. If a corresponding journal hub does not exists, it will get created on-the-fly.

Closes https://github.com/ResearchHub/issues/issues/119