### PR TITLE
fix: Stop lowercasing subfield hubs

### DIFF
--- a/src/topic/models.py
+++ b/src/topic/models.py
@@ -211,7 +211,7 @@ class Topic(DefaultModel):
         # Subfield hubs will be used for reputation calculation.
         try:
             hub, created = Hub.objects.get_or_create(
-                name=subfield.display_name.lower(),
+                name=subfield.display_name,
                 defaults={"subfield": subfield, "is_used_for_rep": True},
             )
 


### PR DESCRIPTION
This is a bugfix for #1891 that stops lowercasing hub names.