### PR TITLE
Encode spaces in OpenAlex pdf_url

### DIFF
--- a/src/paper/openalex_util.py
+++ b/src/paper/openalex_util.py
@@ -95,8 +95,12 @@ def create_and_update_papers(open_alex, works) -> Dict[int, Dict[str, Any]]:
     openalex_ids = [work.get("id") for work in works]
 
     # batch fetch existing papers
+    doi_q_objects = Q()
+    for doi in dois:
+        doi_q_objects |= Q(doi__iexact=doi)
+
     existing_papers_query = (
-        Paper.objects.filter(Q(doi__iexact__in=dois) | Q(openalex_id__in=openalex_ids))
+        Paper.objects.filter(doi_q_objects | Q(openalex_id__in=openalex_ids))
         .only("doi", "id", "unified_document")
         .distinct()
     )

--- a/src/paper/openalex_util.py
+++ b/src/paper/openalex_util.py
@@ -96,7 +96,7 @@ def create_and_update_papers(open_alex, works) -> Dict[int, Dict[str, Any]]:
 
     # batch fetch existing papers
     existing_papers_query = (
-        Paper.objects.filter(Q(doi__in=dois) | Q(openalex_id__in=openalex_ids))
+        Paper.objects.filter(Q(doi__iexact__in=dois) | Q(openalex_id__in=openalex_ids))
         .only("doi", "id", "unified_document")
         .distinct()
     )

--- a/src/paper/paper_upload_tasks.py
+++ b/src/paper/paper_upload_tasks.py
@@ -16,6 +16,7 @@ from django.contrib.postgres.search import SearchQuery
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Q
+from django.db.utils import IntegrityError
 from habanero import Crossref
 from requests.exceptions import HTTPError
 
@@ -690,6 +691,8 @@ def create_paper_related_tags(paper, openalex_concepts=[], openalex_topics=[]):
                     "level": openalex_concept["level"],
                 },
             )
+        except IntegrityError:
+            pass
         except Exception as e:
             sentry.log_error(
                 e, message=f"Failed to process concept for paper {paper.id}"

--- a/src/paper/tests/openalex_works.json
+++ b/src/paper/tests/openalex_works.json
@@ -24,7 +24,7 @@
             "primary_location": {
                 "is_oa": false,
                 "landing_page_url": "https://doi.org/10.1103/physrevlett.77.3865",
-                "pdf_url": null,
+                "pdf_url": "https://ejournal.indo-intellectual.id/index.php/imeij/article/download/1012/636",
                 "source": {
                     "id": "https://openalex.org/S24807848",
                     "display_name": "Physical review letters",
@@ -825,7 +825,7 @@
             "primary_location": {
                 "is_oa": false,
                 "landing_page_url": "https://doi.org/10.1103/physrevlett.77.3865",
-                "pdf_url": null,
+                "pdf_url": "http://projects.nfstc.org/workshops/resources/literature/Amplification/17_An investigation of the rigor of interpretation rules.pdf",
                 "source": {
                     "id": "https://openalex.org/S24807848",
                     "display_name": "Physical review letters",

--- a/src/paper/tests/test_process_openalex_works.py
+++ b/src/paper/tests/test_process_openalex_works.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from rest_framework.test import APITestCase
 
 from paper.models import Paper
-from paper.openalex_util import process_openalex_works
+from paper.openalex_util import clean_url, process_openalex_works
 from paper.related_models.citation_model import Citation
 from user.related_models.author_model import Author
 from utils.openalex import OpenAlex
@@ -347,3 +347,9 @@ class ProcessOpenAlexWorksTests(APITestCase):
             ).first()
 
             self.assertGreater(len(author.contribution_summaries.all()), 0)
+
+    def test_clean_url(self):
+        url = "https://abc.com/def ghi"
+
+        cleaned_url = clean_url(url)
+        self.assertEqual(cleaned_url, "https://abc.com/def%20ghi")


### PR DESCRIPTION
- Some papers are failing to be created because of spaces in url returned by OpenAlex (not url encoded)
- Stop logging https://researchhub.sentry.io/issues/5938183677/?environment=production&project=1797024&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=6&utc=true as it is in expected error