### PR TITLE
Remove unused Amplitude code

### DIFF
--- a/src/analytics/tasks.py
+++ b/src/analytics/tasks.py
@@ -1,37 +1,10 @@
 from typing import Literal
 
-import segment.analytics as analytics
-
 from analytics.amplitude import Amplitude
-from analytics.utils.analytics_mapping_utils import (
-    build_bounty_event,
-    build_comment_event,
-    build_vote_event,
-)
-from discussion.reaction_models import Vote
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
 from researchhub.celery import QUEUE_EXTERNAL_REPORTING, app
 from researchhub.settings import DEVELOPMENT
 from utils.sentry import log_error
-
-
-@app.task(queue=QUEUE_EXTERNAL_REPORTING)
-def log_analytics_event(action_id):
-    from user.related_models.action_model import Action
-
-    try:
-        action = Action.objects.get(id=action_id)
-        if action.content_type.model == "vote" and action.item.vote_type == Vote.UPVOTE:
-            properties = build_vote_event(action)
-            analytics.track(properties["USER_ID"], properties["EVENT_TYPE"], properties)
-        elif action.content_type.model == "bounty":
-            properties = build_bounty_event(action)
-            analytics.track(properties["USER_ID"], properties["EVENT_TYPE"], properties)
-        elif action.content_type.model == "rhcommentmodel":
-            properties = build_comment_event(action)
-            analytics.track(properties["USER_ID"], properties["EVENT_TYPE"], properties)
-    except Exception as e:
-        print("Error logging analytics event: {}".format(e))
 
 
 @app.task(queue=QUEUE_EXTERNAL_REPORTING)

--- a/src/analytics/tasks.py
+++ b/src/analytics/tasks.py
@@ -57,7 +57,7 @@ def track_revenue_event(
 
     try:
         user = User.objects.get(id=user_id)
-    except User.DoesNotExist:
+    except User.DoesNotExist as e:
         handle_log_error(e, "Error tracking revenue event")
         return
 

--- a/src/analytics/views.py
+++ b/src/analytics/views.py
@@ -2,10 +2,8 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
-from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
-from analytics.amplitude import Amplitude
 from analytics.models import PaperEvent, WebsiteVisits
 from analytics.permissions import UpdateOrDelete
 from analytics.serializers import PaperEventSerializer, WebsiteVisitsSerializer
@@ -101,14 +99,3 @@ class PaperEventViewSet(viewsets.ModelViewSet):
 
         PaperEvent.objects.bulk_create(events)
         return Response({"msg": "Events Created"}, 201)
-
-
-# TODO: Delete this view
-class AmplitudeViewSet(viewsets.ViewSet):
-    authentication_classes = ()
-
-    def get_permissions(self):
-        return [AllowAny()]
-
-    def create(self, request, *args, **kwargs):
-        return Response(status=200)

--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -109,12 +109,6 @@ router.register(
     r"events/paper", analytics.views.PaperEventViewSet, basename="events_paper"
 )
 
-router.register(
-    r"events/amplitude/forward_event",
-    analytics.views.AmplitudeViewSet,
-    basename="events_amplitude",
-)
-
 router.register(r"purchase", purchase.views.PurchaseViewSet, basename="purchase")
 
 router.register(r"transactions", purchase.views.BalanceViewSet, basename="transactions")


### PR DESCRIPTION
- Remove unused task.
- Remove unused `AmplitudeViewSet` (routed at `events/amplitude/forward_event`).

Depends on https://github.com/ResearchHub/researchhub-web/pull/1858