### PR TITLE
Ignore database migrations for code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,7 @@ coverage:
         target: auto
         threshold: 0.5%
 ignore:
+  - "**/migrations/*.py"
   - "**/tests/*"
   - "**/tests.py"
   - "**/test_*.py"


### PR DESCRIPTION
Automatically generated database migrations should be ignored when calculating code coverage.