### PR TITLE
Remove gzip middleware

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -236,7 +236,6 @@ INSTALLED_APPS = [
 SITE_ID = 1
 
 MIDDLEWARE = [
-    "django.middleware.gzip.GZipMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "researchhub.middleware.csrf_disable.DisableCSRF",
     "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION
Compression of responses will be done by the reverse proxy instead.