### PR TITLE
Add support for role-based AWS authentication

### DIFF
--- a/src/config/ci/keys.py
+++ b/src/config/ci/keys.py
@@ -6,6 +6,7 @@ AWS_ACCOUNT_ID = os.environ.get("AWS_ACCOUNT_ID", "awsAccountId1")
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "NOT_REAL")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "NOT_REAL")
 AWS_REGION_NAME = os.environ.get("AWS_REGION_NAME", "awsRegionName1")
+AWS_ROLE_ARN = os.environ.get("AWS_ROLE_ARN", "")
 AWS_SES_REGION_ENDPOINT = os.environ.get("AWS_SES_REGION_ENDPOINT", "")
 
 GHOSTSCRIPT_LAMBDA_ARN = os.environ.get("GHOSTSCRIPT_LAMBDA_ARN", "NOT_REAL")

--- a/src/config/keys.py
+++ b/src/config/keys.py
@@ -6,6 +6,7 @@ AWS_ACCOUNT_ID = os.environ.get("AWS_ACCOUNT_ID", "")
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
 AWS_REGION_NAME = os.environ.get("AWS_REGION_NAME", "")
+AWS_ROLE_ARN = os.environ.get("AWS_ROLE_ARN", "")
 AWS_SES_REGION_ENDPOINT = os.environ.get("AWS_SES_REGION_ENDPOINT", "")
 
 GHOSTSCRIPT_LAMBDA_ARN = os.environ.get("GHOSTSCRIPT_LAMBDA_ARN", "")

--- a/src/paper/services/storage_service.py
+++ b/src/paper/services/storage_service.py
@@ -1,8 +1,7 @@
 import uuid
 
-from boto3 import session
-
 from researchhub import settings
+from utils import aws as aws_utils
 
 
 class StorageService:
@@ -23,12 +22,7 @@ class StorageService:
 
         s3_filename = f"/uploads/{user_id}/{uuid.uuid4()}/{filename}"
 
-        boto3_session = session.Session()
-        s3_client = boto3_session.client(
-            "s3",
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-        )
+        s3_client = aws_utils.create_client("s3")
 
         url = s3_client.generate_presigned_url(
             "put_object",

--- a/src/paper/tests/test_storage_service.py
+++ b/src/paper/tests/test_storage_service.py
@@ -8,15 +8,15 @@ from researchhub import settings
 
 class StorageServiceTest(TestCase):
 
-    @patch("paper.services.storage_service.session.Session")
+    @patch("paper.services.storage_service.aws_utils.create_client")
     @patch("paper.services.storage_service.uuid.uuid4")
-    def test_create_presigned_url(self, mock_uuid, mock_session):
+    def test_create_presigned_url(self, mock_uuid, mock_create_client):
         # Arrange
         uuid1 = uuid.uuid4()
         mock_uuid.return_value = uuid1
 
         mock_s3_client = Mock()
-        mock_session.return_value.client.return_value = mock_s3_client
+        mock_create_client.return_value = mock_s3_client
 
         mock_s3_client.generate_presigned_url.return_value = "https://presignedUrl1"
 

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -474,6 +474,7 @@ AWS_SECRET_ACCESS_KEY = os.environ.get(
 )
 AWS_ACCOUNT_ID = os.environ.get("AWS_ACCOUNT_ID", keys.AWS_ACCOUNT_ID)
 AWS_REGION_NAME = os.environ.get("AWS_REGION_NAME", keys.AWS_REGION_NAME)
+AWS_ROLE_ARN = os.environ.get("AWS_ROLE_ARN", keys.AWS_ROLE_ARN)
 
 # AWS Lambda
 


### PR DESCRIPTION
- Add `AWS_ROLE_ARN` to global settings.
- Add utility function that supports role-based authentication when creating AWS clients.