### PR TITLE
Include S3 object key in payload for presigned URL

### DIFF
--- a/src/config/ci/keys.py
+++ b/src/config/ci/keys.py
@@ -6,6 +6,7 @@ AWS_ACCOUNT_ID = os.environ.get("AWS_ACCOUNT_ID", "awsAccountId1")
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "NOT_REAL")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "NOT_REAL")
 AWS_REGION_NAME = os.environ.get("AWS_REGION_NAME", "awsRegionName1")
+AWS_ROLE_ARN = os.environ.get("AWS_ROLE_ARN", "")
 AWS_SES_REGION_ENDPOINT = os.environ.get("AWS_SES_REGION_ENDPOINT", "")
 
 GHOSTSCRIPT_LAMBDA_ARN = os.environ.get("GHOSTSCRIPT_LAMBDA_ARN", "NOT_REAL")

--- a/src/config/keys.py
+++ b/src/config/keys.py
@@ -6,6 +6,7 @@ AWS_ACCOUNT_ID = os.environ.get("AWS_ACCOUNT_ID", "")
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
 AWS_REGION_NAME = os.environ.get("AWS_REGION_NAME", "")
+AWS_ROLE_ARN = os.environ.get("AWS_ROLE_ARN", "")
 AWS_SES_REGION_ENDPOINT = os.environ.get("AWS_SES_REGION_ENDPOINT", "")
 
 GHOSTSCRIPT_LAMBDA_ARN = os.environ.get("GHOSTSCRIPT_LAMBDA_ARN", "")

--- a/src/paper/services/storage_service.py
+++ b/src/paper/services/storage_service.py
@@ -1,7 +1,13 @@
 import uuid
+from typing import NamedTuple
 
 from researchhub import settings
 from utils import aws as aws_utils
+
+
+class PresignedUrl(NamedTuple):
+    object_key: str
+    url: str
 
 
 class StorageService:
@@ -15,7 +21,7 @@ class StorageService:
         user_id: str,
         content_type: str = "application/pdf",
         valid_for: int = 2,
-    ) -> str:
+    ) -> PresignedUrl:
         """
         Create a presigned URL for uploading a file to S3 that is time-limited.
         """
@@ -38,4 +44,4 @@ class StorageService:
             ExpiresIn=60 * valid_for,
         )
 
-        return url
+        return PresignedUrl(url=url, object_key=s3_filename)

--- a/src/paper/services/storage_service.py
+++ b/src/paper/services/storage_service.py
@@ -1,8 +1,7 @@
 import uuid
 
-from boto3 import session
-
 from researchhub import settings
+from utils import aws as aws_utils
 
 
 class StorageService:
@@ -23,12 +22,7 @@ class StorageService:
 
         s3_filename = f"/uploads/{user_id}/{uuid.uuid4()}/{filename}"
 
-        boto3_session = session.Session()
-        s3_client = boto3_session.client(
-            "s3",
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-        )
+        s3_client = aws_utils.create_client("s3")
 
         url = s3_client.generate_presigned_url(
             "put_object",

--- a/src/paper/tests/test_paper_upload_view.py
+++ b/src/paper/tests/test_paper_upload_view.py
@@ -33,7 +33,8 @@ class PaperUploadViewTest(APITestCase):
         self.assertEqual(
             response.data,
             {
-                "presigned_url": self.mock_storage_service.create_presigned_url.return_value,
+                "presigned_url": self.mock_storage_service.create_presigned_url.return_value.url,
+                "object_key": self.mock_storage_service.create_presigned_url.return_value.object_key,
             },
         )
         self.mock_storage_service.create_presigned_url.assert_called_once_with(

--- a/src/paper/tests/test_storage_service.py
+++ b/src/paper/tests/test_storage_service.py
@@ -8,15 +8,15 @@ from researchhub import settings
 
 class StorageServiceTest(TestCase):
 
-    @patch("paper.services.storage_service.session.Session")
+    @patch("paper.services.storage_service.aws_utils.create_client")
     @patch("paper.services.storage_service.uuid.uuid4")
-    def test_create_presigned_url(self, mock_uuid, mock_session):
+    def test_create_presigned_url(self, mock_uuid, mock_create_client):
         # Arrange
         uuid1 = uuid.uuid4()
         mock_uuid.return_value = uuid1
 
         mock_s3_client = Mock()
-        mock_session.return_value.client.return_value = mock_s3_client
+        mock_create_client.return_value = mock_s3_client
 
         mock_s3_client.generate_presigned_url.return_value = "https://presignedUrl1"
 

--- a/src/paper/tests/test_storage_service.py
+++ b/src/paper/tests/test_storage_service.py
@@ -2,6 +2,7 @@ import uuid
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
+from paper.services import storage_service
 from paper.services.storage_service import StorageService
 from researchhub import settings
 
@@ -40,4 +41,10 @@ class StorageServiceTest(TestCase):
             ExpiresIn=60 * 2,
         )
 
-        self.assertEqual(url, "https://presignedUrl1")
+        self.assertEqual(
+            url,
+            storage_service.PresignedUrl(
+                url="https://presignedUrl1",
+                object_key=f"/uploads/userId1/{uuid1}/file1.pdf",
+            ),
+        )

--- a/src/paper/views/paper_upload_views.py
+++ b/src/paper/views/paper_upload_views.py
@@ -35,6 +35,7 @@ class PaperUploadView(APIView):
 
         return Response(
             {
-                "presigned_url": presigned_url,
+                "presigned_url": presigned_url.url,
+                "object_key": presigned_url.object_key,
             }
         )

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -474,6 +474,7 @@ AWS_SECRET_ACCESS_KEY = os.environ.get(
 )
 AWS_ACCOUNT_ID = os.environ.get("AWS_ACCOUNT_ID", keys.AWS_ACCOUNT_ID)
 AWS_REGION_NAME = os.environ.get("AWS_REGION_NAME", keys.AWS_REGION_NAME)
+AWS_ROLE_ARN = os.environ.get("AWS_ROLE_ARN", keys.AWS_ROLE_ARN)
 
 # AWS Lambda
 


### PR DESCRIPTION
Include the object key when returning a presigned URL from `POST` `/paper/upload/`:

```
{
    "presigned_url": "https://<RETRACTED>",
    "object_key": "/uploads/<USERID>/a424c3ee-6bd1-4af0-800c-802a266c4052/gregor.pdf"
}
```

Based on https://github.com/ResearchHub/researchhub-backend/pull/1948