### PR TITLE
chore: Add initial logging configuration

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -59,6 +59,40 @@ elif CLOUD:
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
+# Logging
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "simple": {
+            "format": "{levelname} {message}",
+            "style": "{",
+        },
+        "verbose": {
+            "format": "{asctime} {levelname} {name} [{filename}:{lineno}] {message}",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+    },
+    "root": {
+        "level": "INFO",
+        "handlers": ["console"],
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": os.environ.get("DJANGO_LOG_LEVEL", "ERROR"),
+            "propagate": False,
+        },
+    },
+}
+
 # Django Debug Toolbar
 USE_DEBUG_TOOLBAR = os.environ.get("USE_DEBUG_TOOLBAR", "False") == "True"
 


### PR DESCRIPTION
With this configuration, logs will get written to the console including basic logging details such as timestamp, log level, logger name, filename, line number, and the actual log message. For example:
```
2024-11-01 17:11:32,699 INFO daphne.server [server.py:113] HTTP/2 support not enabled (install the http2 and tls Twisted extras)
2024-11-01 17:11:32,700 INFO daphne.server [server.py:122] Configuring endpoint tcp:port=8000:interface=\:\:
2024-11-01 17:11:32,701 INFO daphne.server [server.py:153] Listening on TCP address :::8000
2024-11-01 17:14:03,824 WARNING review.views.peer_review_view [peer_review_view.py:33] User [3] already has a peer review on comment thread [1]: duplicate key value violates unique constraint "unique_comment_thread_reviewer"
```