### PR TITLE
Fix S3 file path for uploaded papers

### DIFF
--- a/src/paper/services/storage_service.py
+++ b/src/paper/services/storage_service.py
@@ -26,7 +26,7 @@ class StorageService:
         Create a presigned URL for uploading a file to S3 that is time-limited.
         """
 
-        s3_filename = f"/uploads/{user_id}/{uuid.uuid4()}/{filename}"
+        s3_filename = f"uploads/papers/users/{user_id}/{uuid.uuid4()}/{filename}"
 
         s3_client = aws_utils.create_client("s3")
 

--- a/src/paper/tests/test_storage_service.py
+++ b/src/paper/tests/test_storage_service.py
@@ -31,7 +31,7 @@ class StorageServiceTest(TestCase):
             "put_object",
             Params={
                 "Bucket": settings.AWS_STORAGE_BUCKET_NAME,
-                "Key": f"/uploads/userId1/{uuid1}/file1.pdf",
+                "Key": f"uploads/papers/users/userId1/{uuid1}/file1.pdf",
                 "ContentType": "application/pdf",
                 "Metadata": {
                     "created-by-id": "userId1",
@@ -45,6 +45,6 @@ class StorageServiceTest(TestCase):
             url,
             storage_service.PresignedUrl(
                 url="https://presignedUrl1",
-                object_key=f"/uploads/userId1/{uuid1}/file1.pdf",
+                object_key=f"uploads/papers/users/userId1/{uuid1}/file1.pdf",
             ),
         )


### PR DESCRIPTION
- Remove leading `/` to avoid double `/`s.
- Add intermediary folders `/papers/users`.