### PR TITLE
fix: Always return document metadata

### DIFF
--- a/src/researchhub_document/tests/test_view.py
+++ b/src/researchhub_document/tests/test_view.py
@@ -548,3 +548,18 @@ class ViewTests(APITestCase):
 
         self.assertEqual(doc_response.status_code, 200)
         self.assertEqual(int(author.get_balance()), 5)
+
+    def test_get_document_metadata(self):
+        # Arrange
+        self.client.force_authenticate(self.non_member)
+
+        paper = create_paper(title="title1", uploaded_by=self.non_member)
+
+        # Act
+        response = self.client.get(
+            f"/api/researchhub_unified_document/{paper.unified_document.id}/get_document_metadata/"
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["id"], paper.unified_document.id)

--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -1,8 +1,6 @@
-from time import perf_counter
 from urllib.parse import urlencode
 
 import boto3
-from dateutil import parser
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.urls import reverse
@@ -11,16 +9,14 @@ from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.utils.urls import replace_query_param
 from rest_framework.viewsets import ModelViewSet
 
 from discussion.models import Vote as GrmVote
 from discussion.reaction_serializers import VoteSerializer as GrmVoteSerializer
-from hub.models import Hub
 from paper.models import Paper
 from paper.utils import get_cache_key
 from researchhub.settings import AWS_REGION_NAME
-from researchhub_document.filters import TIME_SCOPE_CHOICES, UnifiedDocumentFilter
+from researchhub_document.filters import UnifiedDocumentFilter
 from researchhub_document.models import (
     FeaturedContent,
     ResearchhubPost,
@@ -43,14 +39,9 @@ from researchhub_document.serializers import (
     DynamicUnifiedDocumentSerializer,
     ResearchhubUnifiedDocumentSerializer,
 )
-from researchhub_document.utils import (
-    get_date_ranges_by_time_scope,
-    get_doc_type_key,
-    reset_unified_document_cache,
-)
+from researchhub_document.utils import get_doc_type_key, reset_unified_document_cache
 from researchhub_document.views.custom.unified_document_pagination import (
     UNIFIED_DOC_PAGE_SIZE,
-    UnifiedDocPagination,
 )
 from user.permissions import IsModerator
 from user.utils import reset_latest_acitvity_cache

--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -3,6 +3,7 @@ from urllib.parse import urlencode
 import boto3
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
@@ -824,7 +825,7 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
 
     @action(detail=True, methods=["get"], permission_classes=[AllowAny])
     def get_document_metadata(self, request, pk=None):
-        unified_document = self.get_object()
+        unified_document = get_object_or_404(ResearchhubUnifiedDocument, pk=pk)
         metadata_context = self._get_document_metadata_context()
 
         serializer = self.dynamic_serializer_class(


### PR DESCRIPTION
The metadata endpoint should return a document's metadata even if the document is excluded from feed (`is_excluded_in_feed` in table `researchhub_document_documentfilter`).

Closes https://github.com/ResearchHub/issues/issues/157