### PR TITLE
Print exception when running into indexing errors

### DIFF
--- a/src/search/management/commands/index_papers_in_es.py
+++ b/src/search/management/commands/index_papers_in_es.py
@@ -81,8 +81,8 @@ def index_papers_in_bulk(es, from_id, to_id, max_attempts=5):
 
                 actions.append(action)
 
-            except:
-                print(f"Error processing paper {paper.id}")
+            except Exception as e:
+                print(f"Error processing paper {paper.id}: {e}")
                 pass
 
         for attempt in range(1, max_attempts + 1):


### PR DESCRIPTION
Include the exception when printing errors during reindexing. Currently the output does not include the error:

```
Error processing paper 1394997
Error processing paper 1394998
Error processing paper 1394999
Error processing paper 1395000
Error processing paper 1395001
```