### PR TITLE
Fix tip division on paper

### DIFF
--- a/src/paper/related_models/paper_model.py
+++ b/src/paper/related_models/paper_model.py
@@ -538,11 +538,6 @@ class Paper(AbstractGenericReactionModel):
     def get_analytics_id(self):
         return self.get_analytics_type() + "_" + str(self.id)
 
-    def true_author_count(self):
-        registered_author_count = self.authorship_authors.count()
-        raw_author_count = self.raw_author_count()
-        return raw_author_count + registered_author_count
-
     def raw_author_count(self):
         raw_author_count = 0
 

--- a/src/purchase/utils.py
+++ b/src/purchase/utils.py
@@ -8,7 +8,6 @@ from reputation.models import Escrow
 def distribute_support_to_authors(paper, purchase, amount):
     registered_authors = paper.authorship_authors.all()
     total_author_count = registered_authors.count()
-    print("total_author_count", total_author_count)
 
     rewarded_rsc = 0
     if total_author_count:

--- a/src/purchase/utils.py
+++ b/src/purchase/utils.py
@@ -7,7 +7,8 @@ from reputation.models import Escrow
 
 def distribute_support_to_authors(paper, purchase, amount):
     registered_authors = paper.authorship_authors.all()
-    total_author_count = paper.true_author_count()
+    total_author_count = registered_authors.count()
+    print("total_author_count", total_author_count)
 
     rewarded_rsc = 0
     if total_author_count:


### PR DESCRIPTION
Closes: https://github.com/ResearchHub/issues/issues/143 
- The issue with reward is a formatting confusion caused by the use of a comma as a decimal separator which arises because of the use of toLocaleString. 