### PR TITLE
Add Stripe library for Python

### DIFF
--- a/src/poetry.lock
+++ b/src/poetry.lock
@@ -5406,6 +5406,21 @@ pure-eval = "*"
 tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
+name = "stripe"
+version = "11.2.0"
+description = "Python bindings for the Stripe API"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "stripe-11.2.0-py2.py3-none-any.whl", hash = "sha256:dec812eabc95488862be40e6c799acdaf2e1225d686490a793f949fab745fdd0"},
+    {file = "stripe-11.2.0.tar.gz", hash = "sha256:4c53d61d7b596070324bfa5d7215843145fe5466e48973d828aab41ad209b5ce"},
+]
+
+[package.dependencies]
+requests = {version = ">=2.20", markers = "python_version >= \"3.0\""}
+typing-extensions = {version = ">=4.5.0", markers = "python_version >= \"3.7\""}
+
+[[package]]
 name = "tenacity"
 version = "9.0.0"
 description = "Retry code until it succeeds"
@@ -6120,4 +6135,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "72293cf05322404618c82500bc7f22460cbd81f538230481f55c2e60afe4f270"
+content-hash = "6e34eb45199da3a28cd4a3064c01b578c7415589c3c9c99023ebbed3a040d396"

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -74,6 +74,7 @@ sentry-sdk = "1.45.1"
 setuptools = "^75.4.0"
 Sift = "^5.6.1"
 smart-open = "5.2.1"
+stripe = "^11.2.0"
 watchdog = "2.1.9"
 web3 = {version = "6.17.1", extras = ["tester"]}
 xmltodict = "0.12.0"

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2433,6 +2433,9 @@ sqlparse==0.5.1 ; python_version >= "3.11" and python_version < "4.0" \
 stack-data==0.6.3 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
+stripe==11.2.0 ; python_version >= "3.11" and python_version < "4.0" \
+    --hash=sha256:4c53d61d7b596070324bfa5d7215843145fe5466e48973d828aab41ad209b5ce \
+    --hash=sha256:dec812eabc95488862be40e6c799acdaf2e1225d686490a793f949fab745fdd0
 tenacity==9.0.0 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b \
     --hash=sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539


### PR DESCRIPTION
Add the latest version of the Stripe library for Python 11.2.0 to the project dependencies.

- [x] Rebase after https://github.com/ResearchHub/researchhub-backend/pull/1991 is merged.

Closes https://github.com/ResearchHub/issues/issues/161