### PR TITLE
feat: Add view for creating Stripe Checkout Sessions

### DIFF
--- a/src/purchase/serializers/checkout_serializer.py
+++ b/src/purchase/serializers/checkout_serializer.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+
+import paper
+
+
+class CheckoutSerializer(serializers.Serializer):
+    success_url = serializers.CharField(required=True)
+    failure_url = serializers.CharField(required=True)
+    paper = serializers.PrimaryKeyRelatedField(
+        queryset=paper.models.Paper.objects.all(),
+        required=True,
+    )

--- a/src/purchase/serializers/checkout_serializer.py
+++ b/src/purchase/serializers/checkout_serializer.py
@@ -4,8 +4,8 @@ import paper
 
 
 class CheckoutSerializer(serializers.Serializer):
-    success_url = serializers.CharField(required=True)
-    failure_url = serializers.CharField(required=True)
+    success_url = serializers.URLField(required=True)
+    failure_url = serializers.URLField(required=True)
     paper = serializers.PrimaryKeyRelatedField(
         queryset=paper.models.Paper.objects.all(),
         required=True,

--- a/src/purchase/tests/test_checkout_view.py
+++ b/src/purchase/tests/test_checkout_view.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from paper.related_models.paper_model import Paper
+from user.tests.helpers import create_user
+
+
+class CheckoutSessionViewTest(APITestCase):
+    def setUp(self):
+        self.url = reverse("payment_view")
+        self.user = create_user()
+
+    @patch("stripe.checkout.Session.create")
+    def test_create_checkout_session_success(self, mock_stripe_session_create):
+        # Arrange
+        mock_stripe_session_create.return_value = {
+            "id": "sessionId1",
+            "url": "https://checkout.stripe.com/session/sessionId1",
+        }
+
+        paper = Paper.objects.create(title="title1")
+
+        data = {
+            "paper": paper.id,
+            "success_url": "https://researchhub.com/success",
+            "failure_url": "https://researchhub.com/failure",
+        }
+
+        self.client.force_authenticate(user=self.user)
+
+        # Act
+        response = self.client.post(self.url, data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {
+                "id": "sessionId1",
+                "url": "https://checkout.stripe.com/session/sessionId1",
+            },
+        )
+
+    @patch("stripe.checkout.Session.create")
+    def test_create_checkout_session_missing_mandatory_parameter(
+        self, mock_stripe_session_create
+    ):
+        # Arrange
+        data = {
+            # paper is missing!
+            "success_url": "https://researchhub.com/success",
+            "failure_url": "https://researchhub.com/failure",
+        }
+
+        self.client.force_authenticate(user=self.user)
+
+        # Act
+        response = self.client.post(self.url, data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {
+                "paper": ["This field is required."],
+            },
+        )
+        mock_stripe_session_create.assert_not_called()

--- a/src/purchase/views/__init__.py
+++ b/src/purchase/views/__init__.py
@@ -1,4 +1,5 @@
 from .balance_view import BalanceViewSet
+from .checkout_view import CheckoutView
 from .fundraise_view import FundraiseViewSet
 from .purchase_view import PurchaseViewSet
 from .rsc_exchange_rate_view import RscExchangeRateViewSet

--- a/src/purchase/views/checkout_view.py
+++ b/src/purchase/views/checkout_view.py
@@ -1,0 +1,63 @@
+import logging
+
+import stripe
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from purchase.serializers.checkout_serializer import CheckoutSerializer
+
+logger = logging.getLogger(__name__)
+
+
+class CheckoutView(APIView):
+    """
+    View for creating Stripe checkout sessions.
+    """
+
+    permission_classes = [IsAuthenticated]
+    serializer_class = CheckoutSerializer
+
+    def post(self, request, *args, **kwargs):
+        user_id = request.user.id
+        serializer = CheckoutSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.data
+
+        try:
+            # FIXME: Current data is for testing purposes only.
+            session = stripe.checkout.Session.create(
+                payment_method_types=["card"],
+                line_items=[
+                    {
+                        "price_data": {
+                            "currency": "usd",
+                            "product_data": {
+                                "name": "Paper APC Fee",
+                            },
+                            "unit_amount": 100000,
+                        },
+                        "quantity": 1,
+                    },
+                ],
+                mode="payment",
+                success_url=data["success_url"],
+                cancel_url=data["failure_url"],
+                metadata={
+                    "user_id": user_id,
+                    "paper_id": data["paper"],
+                },
+            )
+            return Response(
+                {
+                    "id": session.get("id"),
+                    "url": session.get("url"),
+                },
+                status=status.HTTP_200_OK,
+            )
+        except Exception as e:
+            logger.error("Error creating checkout session: %s", e)
+            return Response(
+                {"message": "Failed to create checkout session"}, status=500
+            )

--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -274,6 +274,11 @@ urlpatterns = [
         stripe_webhook_view.StripeWebhookView.as_view(),
         name="stripe_webhook",
     ),
+    path(
+        "api/payment/checkout-session/",
+        purchase.views.CheckoutView.as_view(),
+        name="payment_view",
+    ),
 ]
 
 if "silk" in settings.INSTALLED_APPS:


### PR DESCRIPTION
This change adds a new view for creating Stripe Checkout sessions. Checkout sessions will be used for accepting payments for paper APCs, at least initially.

Note that this is an initial version that mainly serves to unblock frontend development. There will be further iterations to address the hard-coded data and also encapsulate Stripe better.

Closes https://github.com/ResearchHub/issues/issues/165.