### PR TITLE
chore: Enable database connection pooling

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -471,8 +471,8 @@ if ELASTIC_BEANSTALK:
     # Connection pooling
     # See: https://docs.djangoproject.com/en/5.1/ref/databases/#connection-pool
     # See: https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool
-    DB_POOL_MIN_SIZE = os.environ.get("DB_POOL_MIN_SIZE", 10)
-    DB_POOL_MAX_SIZE = os.environ.get("DB_POOL_MAX_SIZE", 50)
+    DB_POOL_MIN_SIZE = int(os.environ.get("DB_POOL_MIN_SIZE", 10))
+    DB_POOL_MAX_SIZE = int(os.environ.get("DB_POOL_MAX_SIZE", 50))
 
     DATABASES["default"].setdefault("OPTIONS", {})
     DATABASES["default"]["OPTIONS"]["pool"] = {

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -468,10 +468,6 @@ DATABASES = {
 }
 
 if ELASTIC_BEANSTALK:
-    # Persistent database connections.
-    # See: https://docs.djangoproject.com/en/4.2/ref/databases/#persistent-database-connections
-    DATABASES["default"]["MAX_CONN_AGE"] = 180
-
     # Connection pooling
     # See: https://docs.djangoproject.com/en/5.1/ref/databases/#connection-pool
     # See: https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -467,10 +467,22 @@ DATABASES = {
     }
 }
 
-# Persistent database connections.
-# See: https://docs.djangoproject.com/en/4.2/ref/databases/#persistent-database-connections
 if ELASTIC_BEANSTALK:
+    # Persistent database connections.
+    # See: https://docs.djangoproject.com/en/4.2/ref/databases/#persistent-database-connections
     DATABASES["default"]["MAX_CONN_AGE"] = 180
+
+    # Connection pooling
+    # See: https://docs.djangoproject.com/en/5.1/ref/databases/#connection-pool
+    # See: https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool
+    DB_POOL_MIN_SIZE = os.environ.get("DB_POOL_MIN_SIZE", 10)
+    DB_POOL_MAX_SIZE = os.environ.get("DB_POOL_MAX_SIZE", 50)
+
+    DATABASES["default"].setdefault("OPTIONS", {})
+    DATABASES["default"]["OPTIONS"]["pool"] = {
+        "min_size": DB_POOL_MIN_SIZE,
+        "max_size": DB_POOL_MAX_SIZE,
+    }
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators


### PR DESCRIPTION
Enable database connection pooling introduced with Django 5.1:
- Upgrade Python Postgres driver to 3.x.
- Add binary and pool dependenices.
- Configure min and max size of the connection pool in settings. Read values from environment (`DB_POOL_MIN_SIZE`, `DB_POOL_MAX_SIZE`)

See: https://docs.djangoproject.com/en/5.1/releases/5.1/?utm_source=chatgpt.com#postgresql-connection-pools

TODO:
- [x] Set `DB_POOL_MIN_SIZE`, `DB_POOL_MAX_SIZE` in infrastructure.