### PR TITLE
chore: Use AWS utilities instead of smart open

### DIFF
--- a/src/citation/views/citation_entry_view.py
+++ b/src/citation/views/citation_entry_view.py
@@ -41,8 +41,8 @@ from paper.exceptions import DOINotFoundError
 from paper.models import Paper
 from paper.serializers import PaperCitationSerializer
 from paper.utils import DOI_REGEX, clean_dois, pdf_copyright_allows_display
+from researchhub import settings
 from researchhub.pagination import FasterDjangoPaginator
-from researchhub.settings import AWS_STORAGE_BUCKET_NAME
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 from user.related_models.user_model import User
 from user.utils import get_user_organizations
@@ -105,7 +105,7 @@ class CitationEntryViewSet(ModelViewSet):
         res = s3_client.generate_presigned_url(
             "put_object",
             Params={
-                "Bucket": AWS_STORAGE_BUCKET_NAME,
+                "Bucket": settings.AWS_STORAGE_BUCKET_NAME,
                 "Key": f"uploads/citation_pdfs/{user_key}_{cleaned_filename}",
                 "ContentType": "application/pdf",
                 "Metadata": {

--- a/src/citation/views/citation_entry_view.py
+++ b/src/citation/views/citation_entry_view.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from urllib.parse import urlparse
 
 import cloudscraper
-from boto3 import session
 from bs4 import BeautifulSoup
 from django.db import transaction
 from django.utils.crypto import get_random_string
@@ -43,15 +42,11 @@ from paper.models import Paper
 from paper.serializers import PaperCitationSerializer
 from paper.utils import DOI_REGEX, clean_dois, pdf_copyright_allows_display
 from researchhub.pagination import FasterDjangoPaginator
-from researchhub.settings import (
-    AWS_ACCESS_KEY_ID,
-    AWS_SECRET_ACCESS_KEY,
-    AWS_STORAGE_BUCKET_NAME,
-)
+from researchhub.settings import AWS_STORAGE_BUCKET_NAME
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 from user.related_models.user_model import User
 from user.utils import get_user_organizations
-from utils.aws import get_s3_object_name
+from utils.aws import create_client, get_s3_object_name
 from utils.bibtex import BibTeXParser
 from utils.openalex import OpenAlex
 from utils.parsers import clean_filename
@@ -104,14 +99,9 @@ class CitationEntryViewSet(ModelViewSet):
 
         cleaned_filename = clean_filename(f"{get_random_string(8)}_{filename}")
         user_key = f"user_{request.user.id}"
-        boto3_session = session.Session()
-        s3_client = boto3_session.client(
-            "s3",
-            aws_access_key_id=AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-        )
         ascii_cleaned_filename = filename.encode("ascii", "ignore").decode()
 
+        s3_client = create_client("s3")
         res = s3_client.generate_presigned_url(
             "put_object",
             Params={
@@ -211,12 +201,7 @@ class CitationEntryViewSet(ModelViewSet):
                     f"{get_random_string(8)}_{get_s3_object_name(file.name)}"
                 )
                 key = f"{bucket}/{filename}"
-                boto3_session = session.Session()
-                s3_client = boto3_session.client(
-                    "s3",
-                    aws_access_key_id=AWS_ACCESS_KEY_ID,
-                    aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-                )
+                s3_client = create_client("s3")
                 s3_client.copy(
                     {"Bucket": AWS_STORAGE_BUCKET_NAME, "Key": file.name},
                     AWS_STORAGE_BUCKET_NAME,

--- a/src/ethereum/lib.py
+++ b/src/ethereum/lib.py
@@ -1,4 +1,3 @@
-import json
 from decimal import Decimal
 
 from smart_open import open

--- a/src/ethereum/lib.py
+++ b/src/ethereum/lib.py
@@ -4,20 +4,13 @@ from smart_open import open
 from web3 import Web3
 
 from ethereum.utils import decimal_to_token_amount
-from researchhub.settings import (
-    AWS_ACCESS_KEY_ID,
-    AWS_SECRET_ACCESS_KEY,
-    WEB3_KEYSTORE_BUCKET,
-    WEB3_KEYSTORE_FILE,
-    WEB3_KEYSTORE_PASSWORD,
-    WEB3_RSC_ADDRESS,
-    w3,
-)
+from researchhub import settings
+from researchhub.settings import w3
 
 TOKENS = {
     "RSC": {
         "name": "ResearchCoin",
-        "contract_address": WEB3_RSC_ADDRESS,
+        "contract_address": settings.WEB3_RSC_ADDRESS,
         "ticker": "RSC",
         "denomination": 18,
         "reputation_exchange_rate": "1.0",
@@ -124,11 +117,13 @@ def transact(w3, method_call, sender, sender_signing_key, gas=None):
 
 
 def get_private_key():
-    url = f"s3://{AWS_ACCESS_KEY_ID}:{AWS_SECRET_ACCESS_KEY}@{WEB3_KEYSTORE_BUCKET}/{WEB3_KEYSTORE_FILE}"
+    url = f"s3://{settings.AWS_ACCESS_KEY_ID}:{settings.AWS_SECRET_ACCESS_KEY}@{settings.WEB3_KEYSTORE_BUCKET}/{settings.WEB3_KEYSTORE_FILE}"
 
     with open(url) as keyfile:
         encrypted_key = keyfile.read()
-        if WEB3_KEYSTORE_PASSWORD:
-            return w3.eth.account.decrypt(encrypted_key, WEB3_KEYSTORE_PASSWORD)
+        if settings.WEB3_KEYSTORE_PASSWORD:
+            return w3.eth.account.decrypt(
+                encrypted_key, settings.WEB3_KEYSTORE_PASSWORD
+            )
         else:
             return encrypted_key

--- a/src/ethereum/lib.py
+++ b/src/ethereum/lib.py
@@ -1,11 +1,11 @@
 from decimal import Decimal
 
-from smart_open import open
 from web3 import Web3
 
 from ethereum.utils import decimal_to_token_amount
 from researchhub import settings
 from researchhub.settings import w3
+from utils.aws import create_client
 
 TOKENS = {
     "RSC": {
@@ -117,13 +117,14 @@ def transact(w3, method_call, sender, sender_signing_key, gas=None):
 
 
 def get_private_key():
-    url = f"s3://{settings.AWS_ACCESS_KEY_ID}:{settings.AWS_SECRET_ACCESS_KEY}@{settings.WEB3_KEYSTORE_BUCKET}/{settings.WEB3_KEYSTORE_FILE}"
+    s3_client = create_client("s3")
+    response = s3_client.get_object(
+        Bucket=settings.WEB3_KEYSTORE_BUCKET,
+        Key=settings.WEB3_KEYSTORE_FILE,
+    )
+    encrypted_key = response["Body"].read().decode("utf-8")
 
-    with open(url) as keyfile:
-        encrypted_key = keyfile.read()
-        if settings.WEB3_KEYSTORE_PASSWORD:
-            return w3.eth.account.decrypt(
-                encrypted_key, settings.WEB3_KEYSTORE_PASSWORD
-            )
-        else:
-            return encrypted_key
+    if settings.WEB3_KEYSTORE_PASSWORD:
+        return w3.eth.account.decrypt(encrypted_key, settings.WEB3_KEYSTORE_PASSWORD)
+    else:
+        return encrypted_key

--- a/src/poetry.lock
+++ b/src/poetry.lock
@@ -5303,26 +5303,6 @@ files = [
 ]
 
 [[package]]
-name = "smart-open"
-version = "5.2.1"
-description = "Utils for streaming large files (S3, HDFS, GCS, Azure Blob Storage, gzip, bz2...)"
-optional = false
-python-versions = ">=3.6,<4.0"
-files = [
-    {file = "smart_open-5.2.1-py3-none-any.whl", hash = "sha256:71d14489da58b60ce12fc3ecb823facc59a8b23cd1b58edb97175640350d3a62"},
-    {file = "smart_open-5.2.1.tar.gz", hash = "sha256:75abf758717a92a8f53aa96953f0c245c8cedf8e1e4184903db3659b419d4c17"},
-]
-
-[package.extras]
-all = ["azure-common", "azure-core", "azure-storage-blob", "boto3", "google-cloud-storage", "requests"]
-azure = ["azure-common", "azure-core", "azure-storage-blob"]
-gcs = ["google-cloud-storage"]
-http = ["requests"]
-s3 = ["boto3"]
-test = ["azure-common", "azure-core", "azure-storage-blob", "boto3", "google-cloud-storage", "moto[server] (==1.3.14)", "parameterizedtestcase", "paramiko", "pathlib2", "pytest", "pytest-rerunfailures", "requests", "responses"]
-webhdfs = ["requests"]
-
-[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -6109,4 +6089,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "5aa8c21e897454a7df902ebd4ca0f6172ae8588a2e2102b3d3ef0a05953dec0d"
+content-hash = "f212f57b2225828361eb7215970a094d5d0f67d2a727b28bf9179c2d8f025cca"

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -72,7 +72,6 @@ segment-analytics-python = "^2.2.3"
 sentry-sdk = "1.45.1"
 setuptools = "^75.4.0"
 Sift = "^5.6.1"
-smart-open = "5.2.1"
 stripe = "^11.2.0"
 watchdog = "2.1.9"
 web3 = {version = "6.17.1", extras = ["tester"]}

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2390,9 +2390,6 @@ sift==5.6.1 ; python_version >= "3.11" and python_version < "4.0" \
 six==1.16.0 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
-smart-open==5.2.1 ; python_version >= "3.11" and python_version < "4.0" \
-    --hash=sha256:71d14489da58b60ce12fc3ecb823facc59a8b23cd1b58edb97175640350d3a62 \
-    --hash=sha256:75abf758717a92a8f53aa96953f0c245c8cedf8e1e4184903db3659b419d4c17
 sortedcontainers==2.4.0 ; python_version >= "3.11" and python_version < "4" \
     --hash=sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88 \
     --hash=sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0


### PR DESCRIPTION
Stop using smart open for accessing S3 objects. Instead, use the AWS client from the utility package.