### PR TITLE
fix: Bounties endpoint returns error

### DIFF
--- a/src/reputation/related_models/bounty.py
+++ b/src/reputation/related_models/bounty.py
@@ -91,6 +91,14 @@ class Bounty(DefaultModel):
             ),
         )
 
+    # Used for analytics such as Amazon Personalize
+    def get_analytics_type(self):
+        return "bounty"
+
+    # Used for analytics such as Amazon Personalize
+    def get_analytics_id(self):
+        return self.get_analytics_type() + "_" + str(self.id)
+
     def __str__(self):
         return f"Bounty: {self.id}"
 

--- a/src/reputation/related_models/bounty.py
+++ b/src/reputation/related_models/bounty.py
@@ -91,14 +91,6 @@ class Bounty(DefaultModel):
             ),
         )
 
-    # Used for analytics such as Amazon Personalize
-    def get_analytics_type(self):
-        return "bounty"
-
-    # Used for analytics such as Amazon Personalize
-    def get_analytics_id(self):
-        return self.get_analytics_type() + "_" + str(self.id)
-
     def __str__(self):
         return f"Bounty: {self.id}"
 

--- a/src/reputation/tests/test_bounties.py
+++ b/src/reputation/tests/test_bounties.py
@@ -670,6 +670,41 @@ class BountyViewTests(APITestCase):
         self.assertEqual(res.status_code, 200)
         self.assertEqual(len(res.data["results"]), 2)
 
+    def test_get_bounties_personalized(self):
+        # Arrange
+        self.client.force_authenticate(self.user)
+        self.thread2 = create_rh_comment(created_by=self.user)
+
+        res = self.client.post(
+            "/api/bounty/",
+            {
+                "amount": 1000,
+                "item_content_type": self.thread._meta.model_name,
+                "item_object_id": self.thread.id,
+            },
+        )
+
+        self.assertEqual(res.status_code, 201)
+
+        self.client.force_authenticate(self.user_2)
+        res = self.client.post(
+            "/api/bounty/",
+            {
+                "amount": 2000,
+                "item_content_type": self.thread2._meta.model_name,
+                "item_object_id": self.thread2.id,
+            },
+        )
+
+        self.assertEqual(res.status_code, 201)
+
+        # Act
+        res = self.client.get("/api/bounty/?personalized=true")
+
+        # Assert
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.data["results"]), 2)
+
     def test_filter_official_account_bounties(self):
         self.client.force_authenticate(self.rh_official)
 

--- a/src/reputation/views/bounty_view.py
+++ b/src/reputation/views/bounty_view.py
@@ -27,8 +27,6 @@ from reputation.serializers import (
 from reputation.tasks import create_contribution
 from reputation.utils import calculate_bounty_fees, deduct_bounty_fees
 from researchhub_document.related_models.constants.document_type import (
-    ALL,
-    BOUNTY,
     FILTER_BOUNTY_CLOSED,
     FILTER_BOUNTY_OPEN,
     FILTER_HAS_BOUNTY,

--- a/src/reputation/views/bounty_view.py
+++ b/src/reputation/views/bounty_view.py
@@ -489,38 +489,54 @@ class BountyViewSet(viewsets.ModelViewSet):
     def list(self, request, *args, **kwargs):
         sort = self.request.query_params.get("sort", "-created_date")
 
-        queryset = self.filter_queryset(self.get_queryset())
+        # If sort is personalized but user is logged out, default to created_date
+        if sort == "personalized" and not request.user.is_authenticated:
+            sort = "-created_date"
 
-        # Sorting by amount requires us to do some math and add up all of the child bounties
-        if sort == "-total_amount":
-            # Subquery to calculate the sum of children amounts
-            children_sum = (
-                Bounty.objects.filter(parent=OuterRef("pk"))
-                .values("parent")
-                .annotate(
-                    sum=Coalesce(
-                        Sum("amount"),
+        if sort == "personalized":
+            bounties = Bounty.find_bounties_for_user(
+                user=request.user,
+                include_unrelated=True,
+            )
+
+            queryset = Bounty.objects.filter(id__in=[b.id for b in bounties])
+            queryset = self.filter_queryset(queryset)
+        else:
+            queryset = self.filter_queryset(self.get_queryset())
+
+            # Sorting by amount requires us to do some math and add up all of the child bounties
+            if sort == "-total_amount":
+                # Subquery to calculate the sum of children amounts
+                children_sum = (
+                    Bounty.objects.filter(parent=OuterRef("pk"))
+                    .values("parent")
+                    .annotate(
+                        sum=Coalesce(
+                            Sum("amount"),
+                            Value(
+                                0,
+                                output_field=DecimalField(
+                                    max_digits=19, decimal_places=10
+                                ),
+                            ),
+                        )
+                    )
+                    .values("sum")
+                )
+
+                # Annotate queryset with total_amount for all cases
+                queryset = queryset.annotate(
+                    total_amount=F("amount")
+                    + Coalesce(
+                        Subquery(children_sum),
                         Value(
                             0,
                             output_field=DecimalField(max_digits=19, decimal_places=10),
                         ),
                     )
                 )
-                .values("sum")
-            )
-            # Annotate queryset with total_amount for all cases
-            queryset = queryset.annotate(
-                total_amount=F("amount")
-                + Coalesce(
-                    Subquery(children_sum),
-                    Value(
-                        0,
-                        output_field=DecimalField(max_digits=19, decimal_places=10),
-                    ),
-                )
-            )
 
-        queryset = queryset.order_by(sort)
+            queryset = queryset.order_by(sort)
 
         page = self.paginate_queryset(queryset)
         context = self._get_retrieve_context()


### PR DESCRIPTION
Grants (bounties) are not rendered on the website. When the `/bounty` endpoint is called with parameters, it returns a HTTP 500 error.