### PR TITLE
Add balance check when making a withdrawal

### DIFF
--- a/src/reputation/lib.py
+++ b/src/reputation/lib.py
@@ -415,12 +415,7 @@ def check_hotwallet():
     Alerts admins if the hotwallet is low on eth or RSC
     """
 
-    contract = w3.eth.contract(
-        abi=contract_abi, address=Web3.to_checksum_address(RSC_CONTRACT_ADDRESS)
-    )
-    rsc_balance_wei = contract.functions.balanceOf(WEB3_WALLET_ADDRESS).call()
-    decimals = contract.functions.decimals().call()
-    rsc_balance_eth = rsc_balance_wei / (10**decimals)
+    rsc_balance_eth = get_hotwallet_rsc_balance()
     eth_balance_wei = w3.eth.get_balance(WEB3_WALLET_ADDRESS)
     eth_balanace_eth = eth_balance_wei / (10**18)
     send_email = False
@@ -449,6 +444,16 @@ def check_hotwallet():
             context,
             html_template="general_email_message.html",
         )
+
+
+def get_hotwallet_rsc_balance():
+    contract = w3.eth.contract(
+        abi=contract_abi, address=Web3.to_checksum_address(RSC_CONTRACT_ADDRESS)
+    )
+    rsc_balance_wei = contract.functions.balanceOf(WEB3_WALLET_ADDRESS).call()
+    decimals = contract.functions.decimals().call()
+    rsc_balance_eth = rsc_balance_wei / (10**decimals)
+    return rsc_balance_eth
 
 
 def gwei_to_eth(gwei):

--- a/src/reputation/views/withdrawal_view.py
+++ b/src/reputation/views/withdrawal_view.py
@@ -378,7 +378,7 @@ class WithdrawalViewSet(viewsets.ModelViewSet):
 
         return True, None, net_amount
 
-    def _check_hotwallet_balance(self, amount):
+    def _check_hotwallet_balance(self, amount) -> tuple[bool, str | None]:
         rsc_balance_eth = get_hotwallet_rsc_balance()
         if rsc_balance_eth < amount:
             return (False, "Hotwallet balance is lower than the withdrawal amount")

--- a/src/reputation/views/withdrawal_view.py
+++ b/src/reputation/views/withdrawal_view.py
@@ -19,7 +19,12 @@ from rest_framework.response import Response
 from analytics.tasks import track_revenue_event
 from purchase.models import Balance, RscExchangeRate
 from reputation.exceptions import WithdrawalError
-from reputation.lib import WITHDRAWAL_MINIMUM, PendingWithdrawal, gwei_to_eth
+from reputation.lib import (
+    WITHDRAWAL_MINIMUM,
+    PendingWithdrawal,
+    get_hotwallet_rsc_balance,
+    gwei_to_eth,
+)
 from reputation.models import Withdrawal
 from reputation.permissions import AllowWithdrawalIfNotSuspecious
 from reputation.serializers import WithdrawalSerializer
@@ -97,6 +102,10 @@ class WithdrawalViewSet(viewsets.ModelViewSet):
             valid, message, amount = self._check_withdrawal_amount(
                 amount, transaction_fee, user
             )
+
+        if valid:
+            valid, message = self._check_hotwallet_balance(amount)
+
         if valid:
             try:
                 withdrawal = Withdrawal.objects.create(
@@ -368,3 +377,9 @@ class WithdrawalViewSet(viewsets.ModelViewSet):
             return (False, "You do not have enough RSC to make this withdrawal", None)
 
         return True, None, net_amount
+
+    def _check_hotwallet_balance(self, amount):
+        rsc_balance_eth = get_hotwallet_rsc_balance()
+        if rsc_balance_eth < amount:
+            return (False, "Hotwallet balance is lower than the withdrawal amount")
+        return (True, None)


### PR DESCRIPTION
- We have withdrawals that look like they succeeded but actually failed. 
- Check hotwallet balance before withdrawing.