### PR TITLE
ACK after long running tasks complete

### DIFF
--- a/src/paper/openalex_tasks.py
+++ b/src/paper/openalex_tasks.py
@@ -18,7 +18,7 @@ from utils.openalex import OpenAlex
 logger = logging.getLogger(__name__)
 
 
-@app.task(bind=True, max_retries=3)
+@app.task(bind=True, late_acks=True, max_retries=3)
 def pull_new_openalex_works(self, retry=0, paper_fetch_log_id=None) -> bool:
     key = lock.name(PaperFetchLog.FETCH_NEW)
     if not lock.acquire(key):
@@ -33,7 +33,7 @@ def pull_new_openalex_works(self, retry=0, paper_fetch_log_id=None) -> bool:
         lock.release(key)
 
 
-@app.task(bind=True, max_retries=3)
+@app.task(bind=True, late_acks=True, max_retries=3)
 def pull_updated_openalex_works(self, retry=0, paper_fetch_log_id=None) -> bool:
     key = lock.name(PaperFetchLog.FETCH_UPDATE)
     if not lock.acquire(key):


### PR DESCRIPTION
The default behavior is to ACK tasks when they start. Sending an ACK at the end of processing allows the task to be picked up again in scenarios where the celery broker crashes.