### PR TITLE
Prevent concurrent OpenAlex import tasks

### DIFF
--- a/src/paper/openalex_tasks.py
+++ b/src/paper/openalex_tasks.py
@@ -59,7 +59,7 @@ def _pull_openalex_works(self, fetch_type, retry=0, paper_fetch_log_id=None) -> 
     4. Log the results
     """
     if not (PRODUCTION or TESTING):
-        return
+        return False
 
     date_to_fetch_from = timezone.now() - timedelta(days=1)
     # openalex uses a cursor to paginate through results,
@@ -118,7 +118,7 @@ def _pull_openalex_works(self, fetch_type, retry=0, paper_fetch_log_id=None) -> 
 
             if pending_log:
                 sentry.log_info(message="Pending log exists for updated works")
-                return
+                return False
         except Exception as e:
             sentry.log_error(e, message="Failed to get pending log")
 

--- a/src/utils/locking.py
+++ b/src/utils/locking.py
@@ -1,0 +1,31 @@
+from django.core.cache import cache
+
+LOCK_TIMEOUT = 3600
+
+
+def name(lock_key: str) -> str:
+    """
+    Get a lock key including the specified string.
+    """
+    return f"lock:{lock_key}"
+
+
+def acquire(lock_key: str, timeout: int = LOCK_TIMEOUT) -> bool:
+    """
+    Acquire a lock using the specified name.
+    """
+    return cache.add(lock_key, True, timeout)
+
+
+def extend(lock_key: str, timeout: int = LOCK_TIMEOUT) -> bool:
+    """
+    Extend the lock using the specified name.
+    """
+    return cache.touch(lock_key, timeout)
+
+
+def release(lock_key: str) -> None:
+    """
+    Release the lock using the specified name.
+    """
+    cache.delete(lock_key)

--- a/src/utils/tests/test_locking.py
+++ b/src/utils/tests/test_locking.py
@@ -1,0 +1,95 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from utils.locking import LOCK_TIMEOUT, acquire, extend, name, release
+
+
+class TestLockingFunctions(TestCase):
+    @patch("django.core.cache.cache.add")
+    def test_acquire_lock_success(self, mock_add):
+        """
+        Test that acquiring a lock is successful when the key does not exist.
+        """
+        # Arrange
+        mock_add.return_value = True
+        lock_key = name("test_lock")
+
+        # Act
+        actual = acquire(lock_key, timeout=LOCK_TIMEOUT)
+
+        # Assert
+        self.assertTrue(actual)
+        mock_add.assert_called_once_with(lock_key, True, LOCK_TIMEOUT)
+
+    @patch("django.core.cache.cache.add")
+    def test_acquire_lock_failure(self, mock_add):
+        """
+        Test that acquiring a lock is unsuccessful when the key already exists.
+        """
+        # Arrange
+        mock_add.return_value = False
+        lock_key = name("test_lock")
+
+        # Act
+        actual = acquire(lock_key, timeout=LOCK_TIMEOUT)
+
+        # Assert
+        self.assertFalse(actual)
+        mock_add.assert_called_once_with(lock_key, True, LOCK_TIMEOUT)
+
+    @patch("django.core.cache.cache.touch")
+    def test_extend_lock_success(self, mock_touch):
+        """
+        Test that extending a lock is successful when the key exists.
+        """
+        # Arrange
+        mock_touch.return_value = True
+        lock_key = name("test_lock")
+
+        # Act
+        actual = extend(lock_key, timeout=LOCK_TIMEOUT)
+
+        # Assert
+        self.assertTrue(actual)
+        mock_touch.assert_called_once_with(lock_key, LOCK_TIMEOUT)
+
+    @patch("django.core.cache.cache.touch")
+    def test_extend_lock_failure(self, mock_touch):
+        """
+        Test that extending a lock is unsuccessful when the key does not exist.
+        """
+        # Arrange
+        mock_touch.return_value = False
+        lock_key = name("test_lock")
+
+        # Act
+        actual = extend(lock_key, timeout=LOCK_TIMEOUT)
+
+        # Assert
+        self.assertFalse(actual)
+        mock_touch.assert_called_once_with(lock_key, LOCK_TIMEOUT)
+
+    @patch("django.core.cache.cache.delete")
+    def test_release_lock(self, mock_delete):
+        """
+        Test that releasing a lock is successful.
+        """
+        # Arrange
+        lock_key = name("test_lock")
+
+        # Act
+        release(lock_key)
+
+        # Assert
+        mock_delete.assert_called_once_with(lock_key)
+
+    def test_name_function(self):
+        """
+        Test that the name function formats the lock key correctly.
+        """
+        # Act
+        result = name("test_lock")
+
+        # Assert
+        self.assertEqual(result, "lock:test_lock")


### PR DESCRIPTION
Use a distributed lock to prevent concurrent executions of (long-running) OpenAlex import tasks.