### PR TITLE
chore: Check for previously completed task executions

### DIFF
--- a/src/paper/openalex_tasks.py
+++ b/src/paper/openalex_tasks.py
@@ -117,9 +117,11 @@ def _pull_openalex_works(self, fetch_type, retry=0, paper_fetch_log_id=None) -> 
             ).exists()
 
             if pending_log:
-                logger.info(f"Success log already exists for {fetch_type} works")
+                logger.info(
+                    f"Success log {pending_log.id} already exists for {fetch_type} works"
+                )
                 sentry.log_info(
-                    message=f"Success log already exists for {fetch_type} works"
+                    message=f"Success log {pending_log.id} already exists for {fetch_type} works"
                 )
                 return False
         except Exception as e:

--- a/src/paper/openalex_tasks.py
+++ b/src/paper/openalex_tasks.py
@@ -117,8 +117,10 @@ def _pull_openalex_works(self, fetch_type, retry=0, paper_fetch_log_id=None) -> 
             ).exists()
 
             if pending_log:
-                logger.info("Success log already exists for updated works")
-                sentry.log_info(message="Success log already exists for updated works")
+                logger.info(f"Success log already exists for {fetch_type} works")
+                sentry.log_info(
+                    message=f"Success log already exists for {fetch_type} works"
+                )
                 return False
         except Exception as e:
             logger.error("Failed to get pending log")

--- a/src/paper/openalex_tasks.py
+++ b/src/paper/openalex_tasks.py
@@ -114,14 +114,15 @@ def _pull_openalex_works(self, fetch_type, retry=0, paper_fetch_log_id=None) -> 
                 status=PaperFetchLog.SUCCESS,
                 started_date__date=timezone.now().date(),
                 journal=None,
-            ).exists()
+            )
 
-            if pending_log:
+            if pending_log.exists():
+                pl = pending_log.first()
                 logger.info(
-                    f"Success log {pending_log.id} already exists for {fetch_type} works"
+                    f"Success log {pl.id} already exists for {fetch_type} works"
                 )
                 sentry.log_info(
-                    message=f"Success log {pending_log.id} already exists for {fetch_type} works"
+                    message=f"Success log {pl.id} already exists for {fetch_type} works"
                 )
                 return False
         except Exception as e:
@@ -182,6 +183,7 @@ def _pull_openalex_works(self, fetch_type, retry=0, paper_fetch_log_id=None) -> 
             if next_cursor is None or works is None or len(works) == 0:
                 break
 
+            logger.info(f"Processing {len(works)} works...")
             process_openalex_works(works)
 
             total_papers_processed += len(works)

--- a/src/paper/tests/test_pull_openalex_works.py
+++ b/src/paper/tests/test_pull_openalex_works.py
@@ -88,14 +88,14 @@ class TestPullNewOpenAlexWorks(TestCase):
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True, CELERY_TASK_EAGER_PROPAGATES=True)
     @patch("paper.openalex_tasks.OpenAlex")
     @patch("paper.openalex_tasks.process_openalex_works")
-    def test_pull_new_openalex_works_existing_pending_log(
+    def test_pull_new_openalex_works_existing_success_log(
         self, mock_process_works, mock_openalex
     ):
-        # Create a pending log
+        # Create a success log
         PaperFetchLog.objects.create(
             source=PaperFetchLog.OPENALEX,
             fetch_type=PaperFetchLog.FETCH_NEW,
-            status=PaperFetchLog.PENDING,
+            status=PaperFetchLog.SUCCESS,
             started_date=timezone.now(),
         )
 
@@ -284,14 +284,14 @@ class TestPullUpdatedOpenAlexWorks(TestCase):
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True, CELERY_TASK_EAGER_PROPAGATES=True)
     @patch("paper.openalex_tasks.OpenAlex")
     @patch("paper.openalex_tasks.process_openalex_works")
-    def test_pull_updated_openalex_works_existing_pending_log(
+    def test_pull_updated_openalex_works_existing_success_log(
         self, mock_process_works, mock_openalex
     ):
-        # Create a pending log
+        # Create a success log
         PaperFetchLog.objects.create(
             source=PaperFetchLog.OPENALEX,
             fetch_type=PaperFetchLog.FETCH_UPDATE,
-            status=PaperFetchLog.PENDING,
+            status=PaperFetchLog.SUCCESS,
             started_date=timezone.now(),
         )
 

--- a/src/paper/tests/test_pull_openalex_works.py
+++ b/src/paper/tests/test_pull_openalex_works.py
@@ -67,7 +67,7 @@ class TestPullNewOpenAlexWorks(TestCase):
     @patch("paper.openalex_tasks.OpenAlex")
     @patch("paper.openalex_tasks.process_openalex_works")
     @patch("paper.openalex_tasks.lock.acquire")
-    def test_pull_new_openalex_works_existing_success_log(
+    def test_pull_new_openalex_works_locked(
         self, mock_lock, mock_process_works, mock_openalex
     ):
         # Arrange
@@ -263,7 +263,7 @@ class TestPullUpdatedOpenAlexWorks(TestCase):
     @patch("paper.openalex_tasks.OpenAlex")
     @patch("paper.openalex_tasks.process_openalex_works")
     @patch("paper.openalex_tasks.lock.acquire")
-    def test_pull_updated_openalex_works_existing_success_log(
+    def test_pull_updated_openalex_works_locked(
         self, mock_lock, mock_process_works, mock_openalex
     ):
         # Arrange


### PR DESCRIPTION
Before adding the late ACK (see #2041), this change checks if there was a previous successful execution of the OpenAlex pull tasks for the current day. This replaces the check for `PENDING` entries within a 24 hour time window since this is covered by the locking mechanism.