### PR TITLE
Use full doi when creating doi

### DIFF
--- a/src/utils/doi.py
+++ b/src/utils/doi.py
@@ -92,7 +92,7 @@ class DOI:
             "publication_month": dt.month,
             "publication_day": dt.day,
             "publication_year": dt.year,
-            "doi": self.base_doi,
+            "doi": self.doi,
             "url": url,
         }
         crossref_xml = render_to_string("crossref.xml", context)


### PR DESCRIPTION
- We were using the base doi instead of the doi when creating dois. This causes the version to be missing.