### PR TITLE
Fix censor comment causing negative discussion count

### DIFF
--- a/src/researchhub_comment/views/rh_comment_view.py
+++ b/src/researchhub_comment/views/rh_comment_view.py
@@ -83,7 +83,7 @@ def censor_comment(comment):
             WHERE child.parent_id = comments.id AND child.is_removed = FALSE
         )
         SELECT id
-        FROM comments
+        FROM comments;
     """
 
     for bounty in comment.bounties.iterator():

--- a/src/researchhub_comment/views/rh_comment_view.py
+++ b/src/researchhub_comment/views/rh_comment_view.py
@@ -100,10 +100,15 @@ def censor_comment(comment):
 
 
 def has_deleted_parent(comment):
+    """Check if any parent comment is deleted/removed."""
     current = comment
     while current.parent_id:
-        current = RhCommentModel.objects.get(id=current.parent_id)
-        if current.is_removed:
+        try:
+            current = RhCommentModel.objects.get(id=current.parent_id)
+            if current.is_removed:
+                return True
+        except RhCommentModel.DoesNotExist:
+            # If we can't find the parent, treat it as deleted
             return True
     return False
 

--- a/src/researchhub_comment/views/rh_comment_view.py
+++ b/src/researchhub_comment/views/rh_comment_view.py
@@ -83,7 +83,8 @@ def censor_comment(comment):
             WHERE child.parent_id = comments.id AND child.is_removed = FALSE
         )
         SELECT id
-        FROM comments;
+        FROM comments
+        WHERE is_removed = FALSE;
     """
 
     for bounty in comment.bounties.iterator():

--- a/src/researchhub_comment/views/rh_comment_view.py
+++ b/src/researchhub_comment/views/rh_comment_view.py
@@ -84,7 +84,6 @@ def censor_comment(comment):
         )
         SELECT id
         FROM comments
-        WHERE is_removed = FALSE;
     """
 
     for bounty in comment.bounties.iterator():
@@ -93,8 +92,9 @@ def censor_comment(comment):
             raise Exception("Failed to close bounties on comment")
 
     # Only update discussion count if no parent is deleted since if a parent is deleted,
-    # we've already reduced the count for this comment and children.
-    if not has_deleted_parent(comment):
+    # we've already reduced the count for this comment and children. Same for if the comment
+    # is deleted.
+    if not has_deleted_parent(comment) and not comment.is_removed:
         comment_count = len(RhCommentModel.objects.raw(query, [comment.id]))
         comment._update_related_discussion_count(-comment_count)
 


### PR DESCRIPTION
- We are double counting deletions. When a user is flagged as spam we delete all the comments they've made. If those comments are children of the other comments we were double decrementing the discussion count on deletion.