### PR TITLE
Update sift events

### DIFF
--- a/src/user/views/persona_webhook_view.py
+++ b/src/user/views/persona_webhook_view.py
@@ -10,6 +10,7 @@ from rest_framework.views import APIView
 
 from notification.models import Notification
 from user.models import User, UserVerification
+from utils.siftscience import events_api, update_user_risk_score
 
 
 class PersonaWebhookView(APIView):
@@ -105,6 +106,11 @@ class PersonaWebhookView(APIView):
         )
         user_verification.save()
 
+        user = User.objects.get(id=user_verification.user_id)
+        tracked_account = events_api.track_account(user, request, update=True)
+        update_user_risk_score(user, tracked_account)
+
+        self._create_notification(user_verification)
         self._create_notification(user_verification)
 
     def _create_notification(self, user_verification: UserVerification):

--- a/src/user/views/persona_webhook_view.py
+++ b/src/user/views/persona_webhook_view.py
@@ -106,12 +106,11 @@ class PersonaWebhookView(APIView):
         )
         user_verification.save()
 
+        self._create_notification(user_verification)
+
         user = User.objects.get(id=user_verification.user_id)
         tracked_account = events_api.track_account(user, request, update=True)
         update_user_risk_score(user, tracked_account)
-
-        self._create_notification(user_verification)
-        self._create_notification(user_verification)
 
     def _create_notification(self, user_verification: UserVerification):
         user = User.objects.get(id=user_verification.user_id)

--- a/src/utils/siftscience.py
+++ b/src/utils/siftscience.py
@@ -189,7 +189,6 @@ class EventsApi:
             (user.id, meta, login_status), priority=4, countdown=10
         )
         tracked_login = celery_response.get()
-        self.track_account(request.user, request, update=True)
         return tracked_login
 
     @staticmethod
@@ -222,7 +221,6 @@ class EventsApi:
             priority=4,
             countdown=3,
         )
-        self.track_account(request.user, request, update=True)
         return celery_response
 
     @staticmethod
@@ -278,7 +276,6 @@ class EventsApi:
             priority=4,
             countdown=5,
         )
-        self.track_account(request.user, request, update=True)
         return celery_response
 
     @staticmethod
@@ -328,7 +325,6 @@ class EventsApi:
             priority=4,
             countdown=5,
         )
-        self.track_account(request.user, request, update=True)
         return celery_response
 
     @staticmethod
@@ -376,7 +372,6 @@ class EventsApi:
         celery_response = self.celery_track_content_vote.apply_async(
             (response_data, meta, is_update), priority=4, countdown=10
         )
-        self.track_account(request.user, request, update=True)
         return celery_response
 
     @staticmethod


### PR DESCRIPTION
- We were calling account tracking events in excess to notify SIFT of user verification.
- Only notify sift of user verification on user verification.