### PR TITLE
Use AWS profile for local development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,8 +59,12 @@
 				"remote.autoForwardPorts": false
 			}
 		}
-	}
+	},
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
+
+	"mounts": [
+		"source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,readonly"
+	]
 }

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -526,6 +526,10 @@ STATICFILES_DIRS = ["stylesheets"]
 
 AWS_REGION_NAME = os.environ.get("AWS_REGION_NAME", keys.AWS_REGION_NAME)
 
+if not (CLOUD or TESTING) and os.environ.get("AWS_PROFILE") is None:
+    # Set AWS profile for local development
+    os.environ["AWS_PROFILE"] = keys.AWS_PROFILE
+
 # AWS Lambda
 
 GHOSTSCRIPT_LAMBDA_ARN = os.environ.get(


### PR DESCRIPTION
Since we have some hard AWS dependencies, this change allow to set a local AWS profile in order to connect to required AWS services.

- Mount the `~/.aws` folder from host into the devcontainer.
- Activate the AWS profile by setting the `AWS_PROFILE` variable if configured in `keys.py`. This is so boto3 can pick it up and it works for both the boto3 code in the project as well as Django extensions.