### PR TITLE
chore: Remove latest activities

### DIFF
--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -43,7 +43,6 @@ from researchhub_document.views.custom.unified_document_pagination import (
     UNIFIED_DOC_PAGE_SIZE,
 )
 from user.permissions import IsModerator
-from user.utils import reset_latest_acitvity_cache
 from utils.permissions import ReadOnly
 
 
@@ -162,8 +161,6 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
 
         hub_ids = list(self.get_object().hubs.values_list("pk", flat=True))
         hub_ids.append(0)
-
-        reset_latest_acitvity_cache(",".join([str(hub_id) for hub_id in hub_ids]))
 
         doc = self.get_object()
         doc_type = get_doc_type_key(doc)

--- a/src/user/utils.py
+++ b/src/user/utils.py
@@ -5,7 +5,6 @@ from django.db.models import Case, When
 from paper.openalex_util import merge_openalex_author_with_researchhub_author
 from user.aggregates import TenPercentile, TwoPercentile
 from user.models import Organization, User
-from user.tasks import preload_latest_activity
 from utils.openalex import OpenAlex
 
 
@@ -90,24 +89,6 @@ def calculate_eligible_enhanced_upvotes(user):
     reputation = user.reputation
     eligible = float(reputation) >= percentage
     return eligible
-
-
-def reset_latest_acitvity_cache(
-    hub_ids="", ordering="-created_date", include_default=True, use_celery=True
-):
-    # Resets the 'all' feed
-    if include_default:
-        if use_celery:
-            preload_latest_activity.apply_async(("", ordering), priority=1)
-        else:
-            preload_latest_activity("", ordering)
-
-    hub_ids_list = hub_ids.split(",")
-    for hub_id in hub_ids_list:
-        if use_celery:
-            preload_latest_activity.apply_async((hub_id, ordering), priority=1)
-        else:
-            preload_latest_activity(hub_id, ordering)
 
 
 def get_user_organizations(user):


### PR DESCRIPTION
Remove the `following_latest_activity` endpoint and the related signal and task logic. `following_latest_activity` is not used by the frontend and the existing logic populates/invalidates a cache that is not consumed.

FE changes are removed with https://github.com/ResearchHub/researchhub-web/pull/1904.

