### PR TITLE
chore: Fix linter warnings about hardcoded passwords

### DIFF
--- a/src/invite/tests/test_views.py
+++ b/src/invite/tests/test_views.py
@@ -1,11 +1,7 @@
 from allauth.utils import get_user_model
-from django.contrib.contenttypes.models import ContentType
-from rest_framework.test import APITestCase
 
-from invite.related_models.invitation_model import Invitation
 from invite.related_models.note_invitation import NoteInvitation
 from invite.related_models.organization_invitation import OrganizationInvitation
-from researchhub_access_group.models import Permission
 from utils.test_helpers import APITestCaseWithOrg
 
 

--- a/src/invite/tests/test_views.py
+++ b/src/invite/tests/test_views.py
@@ -1,3 +1,5 @@
+import uuid
+
 from allauth.utils import get_user_model
 
 from invite.related_models.note_invitation import NoteInvitation
@@ -10,12 +12,12 @@ class OrganizationInvitationViewsTest(APITestCaseWithOrg):
         # Create + auth user
         self.sender = get_user_model().objects.create_user(
             username="user1@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="user1@researchhub_test.com",
         )
         self.recipient = get_user_model().objects.create_user(
             username="user2@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="user2@researchhub_test.com",
         )
 
@@ -59,12 +61,12 @@ class NoteInvitationViewsTest(APITestCaseWithOrg):
         # Create + auth user
         self.sender = get_user_model().objects.create_user(
             username="user1@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="user1@researchhub_test.com",
         )
         self.recipient = get_user_model().objects.create_user(
             username="user2@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="user2@researchhub_test.com",
         )
 

--- a/src/note/tests/test_note_api.py
+++ b/src/note/tests/test_note_api.py
@@ -788,7 +788,7 @@ class NoteTests(APITestCase):
         note = response.data
 
         # Change note to workspace
-        perm_response = self.client.patch(
+        self.client.patch(
             f"/api/note/{note['id']}/update_permissions/",
             {
                 "access_type": "ADMIN",

--- a/src/note/tests/test_note_api.py
+++ b/src/note/tests/test_note_api.py
@@ -1,13 +1,13 @@
-from rest_framework.test import APITestCase
-from allauth.utils import (
-    get_user_model,
-)
-from researchhub_document.models import ResearchhubUnifiedDocument
-from researchhub_access_group.models import Permission
-from django.contrib.contenttypes.models import ContentType
-from note.models import Note
-from user.models import Organization
+import uuid
 
+from allauth.utils import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from rest_framework.test import APITestCase
+
+from note.models import Note
+from researchhub_access_group.models import Permission
+from researchhub_document.models import ResearchhubUnifiedDocument
+from user.models import Organization
 
 unified_doc_content_type = ContentType.objects.get_for_model(ResearchhubUnifiedDocument)
 organization_content_type = ContentType.objects.get_for_model(Organization)
@@ -17,7 +17,7 @@ class NoteTests(APITestCase):
     def setUp(self):
         # Create + auth user
         username = "test@researchhub_test.com"
-        password = "password"
+        password = uuid.uuid4().hex
         self.user = get_user_model().objects.create_user(
             username=username, password=password, email=username
         )
@@ -57,7 +57,7 @@ class NoteTests(APITestCase):
         self.assertEqual(response.status_code, 200)
 
         other_user = get_user_model().objects.create_user(
-            username="other1", password="password1", email="other1@researchhub.com"
+            username="other1", password=uuid.uuid4().hex, email="other1@researchhub.com"
         )
 
         # Act
@@ -82,7 +82,7 @@ class NoteTests(APITestCase):
 
         member_user = get_user_model().objects.create_user(
             username="member1",
-            password="password1",
+            password=uuid.uuid4().hex,
             email="email1@researchhub.com",
         )
 
@@ -116,7 +116,7 @@ class NoteTests(APITestCase):
 
         viewer_user = get_user_model().objects.create_user(
             username="viewer1",
-            password="password1",
+            password=uuid.uuid4().hex,
             email="viewer1@researchhub.com",
         )
 
@@ -205,7 +205,7 @@ class NoteTests(APITestCase):
         # Create another user
         editor_user = get_user_model().objects.create_user(
             username="editor@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="editor@researchhub_test.com",
         )
 
@@ -246,7 +246,7 @@ class NoteTests(APITestCase):
         # Create another user
         editor_user = get_user_model().objects.create_user(
             username="editor@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="editor@researchhub_test.com",
         )
 
@@ -298,7 +298,7 @@ class NoteTests(APITestCase):
         # Create another user
         viewer_user = get_user_model().objects.create_user(
             username="editor@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="editor@researchhub_test.com",
         )
 
@@ -355,7 +355,7 @@ class NoteTests(APITestCase):
         # Create another user
         invited_viewer = get_user_model().objects.create_user(
             username="editor@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="editor@researchhub_test.com",
         )
 
@@ -396,7 +396,7 @@ class NoteTests(APITestCase):
         # Create another user
         invited_note_admin = get_user_model().objects.create_user(
             username="admin@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="admin@researchhub_test.com",
         )
 
@@ -440,7 +440,7 @@ class NoteTests(APITestCase):
         # Create another user
         invited_note_admin = get_user_model().objects.create_user(
             username="admin@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="admin@researchhub_test.com",
         )
 
@@ -570,7 +570,7 @@ class NoteTests(APITestCase):
         # Create viewer user
         viewer_user = get_user_model().objects.create_user(
             username="user_b@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="user_b@researchhub_test.com",
         )
 
@@ -615,7 +615,7 @@ class NoteTests(APITestCase):
         # Create another user
         admin_user = get_user_model().objects.create_user(
             username="admin@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="admin@researchhub_test.com",
         )
 
@@ -654,7 +654,7 @@ class NoteTests(APITestCase):
         # Create another user
         editor_user = get_user_model().objects.create_user(
             username="editor@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="editor@researchhub_test.com",
         )
 
@@ -688,7 +688,7 @@ class NoteTests(APITestCase):
         # Create another user
         member_user = get_user_model().objects.create_user(
             username="member@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="member@researchhub_test.com",
         )
 
@@ -723,7 +723,7 @@ class NoteTests(APITestCase):
         # Create another user
         member_user = get_user_model().objects.create_user(
             username="member@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="member@researchhub_test.com",
         )
 
@@ -756,7 +756,7 @@ class NoteTests(APITestCase):
         # Create a user
         alice = get_user_model().objects.create_user(
             username="alice@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="alice@researchhub_test.com",
         )
         alice_org = alice.organization
@@ -765,7 +765,7 @@ class NoteTests(APITestCase):
 
         bob = get_user_model().objects.create_user(
             username="bob@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="bob@researchhub_test.com",
         )
         # Add Bob as Admin to Alice Org

--- a/src/reputation/tests/test_initialize_reputation.py
+++ b/src/reputation/tests/test_initialize_reputation.py
@@ -1,5 +1,6 @@
 import json
 import os
+import uuid
 from unittest.mock import PropertyMock, patch
 
 from django.conf import settings
@@ -21,10 +22,14 @@ from utils.openalex import OpenAlex
 class InitializeReputationCommandTestCase(TestCase):
     def setUp(self):
         # Add user, an author is automatically created for this user.
-        self.user_author = User.objects.create_user(username="user1", password="pass1")
-        self.user_basic = User.objects.create_user(username="user2", password="pass2")
+        self.user_author = User.objects.create_user(
+            username="user1", password=uuid.uuid4().hex
+        )
+        self.user_basic = User.objects.create_user(
+            username="user2", password=uuid.uuid4().hex
+        )
         self.user_no_author = User.objects.create_user(
-            username="user3", password="pass3"
+            username="user3", password=uuid.uuid4().hex
         )
 
     def test_initialize_reputation_command(self):

--- a/src/researchhub_access_group/tests/test_permissions.py
+++ b/src/researchhub_access_group/tests/test_permissions.py
@@ -1,12 +1,13 @@
 import uuid
 
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
-from researchhub_access_group.permissions import IsOrganizationUser
-from user.models import User, Organization
+
 from researchhub_access_group.models import Permission
-from django.contrib.contenttypes.models import ContentType
+from researchhub_access_group.permissions import IsOrganizationUser
+from user.models import Organization, User
 
 
 class IsOrganizationUserTest(TestCase):

--- a/src/researchhub_access_group/tests/test_permissions.py
+++ b/src/researchhub_access_group/tests/test_permissions.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
@@ -12,9 +14,13 @@ class IsOrganizationUserTest(TestCase):
         self.factory = APIRequestFactory()
 
         self.anonymous = AnonymousUser()
-        self.user = User.objects.create_user(username="user1", password="pass1")
+        self.user = User.objects.create_user(
+            username="user1", password=uuid.uuid4().hex
+        )
 
-        self.member = User.objects.create_user(username="member1", password="pass1")
+        self.member = User.objects.create_user(
+            username="member1", password=uuid.uuid4().hex
+        )
         self.organization = Organization.objects.create(name="org1")
         Permission.objects.create(
             access_type="MEMBER",

--- a/src/researchhub_comment/tests/test_rh_comment_thread_model.py
+++ b/src/researchhub_comment/tests/test_rh_comment_thread_model.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
@@ -19,7 +21,9 @@ User = get_user_model()
 class TestRhCommentThreadModel(TestCase):
     def setUp(self):
         # Create a test user
-        self.user = User.objects.create_user(username="testuser", password="12345")
+        self.user = User.objects.create_user(
+            username="testuser", password=uuid.uuid4().hex
+        )
 
         # Create a paper to attach threads to
         self.paper = Paper.objects.create(title="Test Paper")

--- a/src/user/tests/helpers.py
+++ b/src/user/tests/helpers.py
@@ -11,6 +11,7 @@ from researchhub_access_group.constants import ASSOCIATE_EDITOR
 from researchhub_access_group.models import Permission
 from user.models import Action, Author, University, User
 from user.related_models.organization_model import Organization
+from utils.test_helpers import generate_password
 
 
 class TestData:
@@ -27,7 +28,7 @@ class TestData:
     invalid_email = "testuser@gmail"
     invalid_password = "pass"
     valid_email = "testuser@gmail.com"
-    valid_password = "ReHub940@"
+    valid_password = generate_password()
 
     university_name = "Hogwarts"
     university_country = "England"

--- a/src/user/tests/helpers.py
+++ b/src/user/tests/helpers.py
@@ -26,7 +26,7 @@ class TestData:
     author_linkedin = "linkedin.com/in/regulusblack"
 
     invalid_email = "testuser@gmail"
-    invalid_password = "pass"
+    invalid_password = "pass"  # NOSONAR
     valid_email = "testuser@gmail.com"
     valid_password = generate_password()
 

--- a/src/user/tests/test_org_api.py
+++ b/src/user/tests/test_org_api.py
@@ -1,3 +1,5 @@
+import uuid
+
 from allauth.utils import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from rest_framework.test import APITestCase
@@ -14,22 +16,22 @@ class OrganizationTests(APITestCase):
         # Create + auth user
         self.org_a_admin = get_user_model().objects.create_user(
             username="admin@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="admin@researchhub_test.com",
         )
         self.org_a_member_user = get_user_model().objects.create_user(
             username="test1@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="test1@researchhub_test.com",
         )
         self.org_b_admin = get_user_model().objects.create_user(
             username="org_b_admin@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="org_b_admin@researchhub_test.com",
         )
         self.note_b_user = get_user_model().objects.create_user(
             username="test2@researchhub_test.com",
-            password="password",
+            password=uuid.uuid4().hex,
             email="test2@researchhub_test.com",
         )
         self.client.force_authenticate(self.org_a_admin)

--- a/src/user/tests/tests.py
+++ b/src/user/tests/tests.py
@@ -1,8 +1,7 @@
-import json
-
 from django.test import Client, TestCase
 
 from user.models import Author, University, User
+from utils.test_helpers import generate_password
 
 
 class BaseTests(TestCase):
@@ -14,7 +13,7 @@ class BaseTests(TestCase):
     invalid_email = "testuser@gmail"
     invalid_password = "pass"
     valid_email = "testuser@gmail.com"
-    valid_password = "ReHub940@"
+    valid_password = generate_password()
 
     university_name = "Hogwarts"
     university_country = "England"

--- a/src/user/tests/tests.py
+++ b/src/user/tests/tests.py
@@ -1,3 +1,5 @@
+import json
+
 from django.test import Client, TestCase
 
 from user.models import Author, University, User
@@ -11,7 +13,7 @@ class BaseTests(TestCase):
     author_last_name = "Black"
 
     invalid_email = "testuser@gmail"
-    invalid_password = "pass"
+    invalid_password = "pass"  # NOSONAR
     valid_email = "testuser@gmail.com"
     valid_password = generate_password()
 

--- a/src/utils/test_helpers.py
+++ b/src/utils/test_helpers.py
@@ -17,7 +17,21 @@ from discussion.models import Vote as GrmVote
 from hub.models import Hub
 from paper.models import Paper
 from user.models import Author, University, User
-from utils.test_helpers import generate_password
+
+
+def generate_password(length=16):
+    """
+    Generates a password with at least one letter, one digit and one special character.
+    """
+    return "".join(
+        secrets.choice(string.ascii_letters)  # 1 letter
+        + secrets.choice(string.digits)  # 1 digit
+        + secrets.choice(string.punctuation)  # 1 special char
+        + "".join(
+            secrets.choice(string.ascii_letters + string.digits + string.punctuation)
+            for _ in range(length - 3)
+        )
+    )
 
 
 class TestData:
@@ -234,21 +248,6 @@ class IntegrationTestHelper(TestData):
 
     def _create_authenticated_client(self, auth_token):
         return Client(HTTP_AUTHORIZATION=f"Token {auth_token}")
-
-
-def generate_password(length=16):
-    """
-    Generates a password with at least one letter, one digit and one special character.
-    """
-    return "".join(
-        secrets.choice(string.ascii_letters)  # 1 letter
-        + secrets.choice(string.digits)  # 1 digit
-        + secrets.choice(string.punctuation)  # 1 special char
-        + "".join(
-            secrets.choice(string.ascii_letters + string.digits + string.punctuation)
-            for _ in range(length - 3)
-        )
-    )
 
 
 def bytes_to_json(data_bytes):

--- a/src/utils/test_helpers.py
+++ b/src/utils/test_helpers.py
@@ -1,5 +1,7 @@
 import json
 import random
+import secrets
+import string
 import threading
 import time
 
@@ -15,6 +17,7 @@ from discussion.models import Vote as GrmVote
 from hub.models import Hub
 from paper.models import Paper
 from user.models import Author, University, User
+from utils.test_helpers import generate_password
 
 
 class TestData:
@@ -24,9 +27,9 @@ class TestData:
     author_last_name = "Black"
 
     invalid_email = "testuser@gmail"
-    invalid_password = "pass"
+    invalid_password = "pass"  # NOSONAR
     valid_email = "testuser@gmail.com"
-    valid_password = "ReHub940@"
+    valid_password = generate_password()
 
     university_name = "Hogwarts"
     university_country = "England"
@@ -231,6 +234,21 @@ class IntegrationTestHelper(TestData):
 
     def _create_authenticated_client(self, auth_token):
         return Client(HTTP_AUTHORIZATION=f"Token {auth_token}")
+
+
+def generate_password(length=16):
+    """
+    Generates a password with at least one letter, one digit and one special character.
+    """
+    return "".join(
+        secrets.choice(string.ascii_letters)  # 1 letter
+        + secrets.choice(string.digits)  # 1 digit
+        + secrets.choice(string.punctuation)  # 1 special char
+        + "".join(
+            secrets.choice(string.ascii_letters + string.digits + string.punctuation)
+            for _ in range(length - 3)
+        )
+    )
 
 
 def bytes_to_json(data_bytes):

--- a/src/utils/tests/test_test_helpers.py
+++ b/src/utils/tests/test_test_helpers.py
@@ -1,0 +1,21 @@
+import string
+
+from django.test import TestCase
+
+from utils.test_helpers import generate_password
+
+
+class TestTestHelpers(TestCase):
+    def test_generate_password(self):
+        password = generate_password()
+        self.assertGreater(len(password), 16)
+        self.assertIn(any(c.isalpha() for c in password), True)
+        self.assertIn(any(c.isdigit() for c in password), True)
+        self.assertIn(any(c in string.punctuation for c in password), True)
+
+    def test_generate_password_with_custom_length(self):
+        password = generate_password(length=12)
+        self.assertGreater(len(password), 12)
+        self.assertIn(any(c.isalpha() for c in password), True)
+        self.assertIn(any(c.isdigit() for c in password), True)
+        self.assertIn(any(c in string.punctuation for c in password), True)

--- a/src/utils/tests/test_test_helpers.py
+++ b/src/utils/tests/test_test_helpers.py
@@ -8,14 +8,14 @@ from utils.test_helpers import generate_password
 class TestTestHelpers(TestCase):
     def test_generate_password(self):
         password = generate_password()
-        self.assertGreater(len(password), 16)
-        self.assertIn(any(c.isalpha() for c in password), True)
-        self.assertIn(any(c.isdigit() for c in password), True)
-        self.assertIn(any(c in string.punctuation for c in password), True)
+        self.assertEqual(len(password), 16)
+        self.assertTrue(any(c.isalpha() for c in password))
+        self.assertTrue(any(c.isdigit() for c in password))
+        self.assertTrue(any(c in string.punctuation for c in password))
 
     def test_generate_password_with_custom_length(self):
-        password = generate_password(length=12)
-        self.assertGreater(len(password), 12)
-        self.assertIn(any(c.isalpha() for c in password), True)
-        self.assertIn(any(c.isdigit() for c in password), True)
-        self.assertIn(any(c in string.punctuation for c in password), True)
+        password = generate_password(length=3)
+        self.assertEqual(len(password), 3)
+        self.assertTrue(any(c.isalpha() for c in password))
+        self.assertTrue(any(c.isdigit() for c in password))
+        self.assertTrue(any(c in string.punctuation for c in password))


### PR DESCRIPTION
- Stop using hardcoded passwords in tests. Instead generate a dummy password (using UUIDs) in most tests. 
- In more specific tests that verify authentication, use a valid random password (containing characters, digits and special characters).
- Add linter ignore annotations to hardcoded passwords that are supposed to fail password rules.