### PR TITLE
Add `debugpy` extension to devcontainers setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,6 +32,7 @@
 		"vscode": {
 			"extensions": [
 				"ms-python.black-formatter",
+				"ms-python.debugpy",
 				"ms-python.flake8",
 				"ms-python.isort"
 			],


### PR DESCRIPTION
Automatically install the Python debugger extension `debugpy` that currently requires a manual extension installation step.