### PR TITLE
fix: Reuse and add prefetched querysets for feed

### DIFF
--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -58,7 +58,7 @@ class ContentObjectSerializer(serializers.Serializer):
 
     def get_hub(self, obj):
         # FIXME: get primary hub
-        hub = obj.hubs.first()
+        hub = next(iter(obj.hubs.all()), None)
         if hub:
             return SimpleHubSerializer(hub).data
         return None
@@ -86,9 +86,11 @@ class PaperSerializer(ContentObjectSerializer):
     metrics = PaperMetricsSerializer(source="*")
 
     def get_journal(self, obj):
-        journal_hub = obj.hubs.filter(
-            namespace=Hub.Namespace.JOURNAL,
-        ).first()
+        journal_hub = next(
+            (hub for hub in obj.hubs.all() if hub.namespace == Hub.Namespace.JOURNAL),
+            None,
+        )
+
         if journal_hub:
             return {
                 "id": journal_hub.id,

--- a/src/feed/views.py
+++ b/src/feed/views.py
@@ -38,6 +38,7 @@ class FeedViewSet(viewsets.ModelViewSet):
             )
             .prefetch_related(
                 "item__authors",
+                "item__authors__user",
                 "item__hubs",
             )
         )


### PR DESCRIPTION
- Reuse prefetched querysets (instead of creating new querysets when calling `.first()`.
- Add prefetch for author's user relation.

=> Reduces the number of queries for a single feed page from 78 to 6 queries.