### PR TITLE
Prefetch related models for bounties and papers

### DIFF
--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -188,8 +188,14 @@ class FeedEntrySerializer(serializers.ModelSerializer):
         """Return the appropriate serialized content object based on type"""
         match obj.content_type.model:
             case "bounty":
+                # Use prefetched bounty if available
+                if hasattr(obj, "_prefetched_bounty"):
+                    return BountySerializer(obj._prefetched_bounty).data
                 return BountySerializer(obj.item).data
             case "paper":
+                # Use prefetched paper if available
+                if hasattr(obj, "_prefetched_paper"):
+                    return PaperSerializer(obj._prefetched_paper).data
                 return PaperSerializer(obj.item).data
         return None
 


### PR DESCRIPTION
The current implementation breaks view requests once bounties are added to the feed items tables. This is due to the fact that only papers have the fields `authors` and `hubs` which causes errors when processing bounty items.

This change adds prefetching relations for bounties and papers in a safe manner where prefetched relations are stored in new `prefetched_*` fields. These fields are then accessed by the feed serializer.

Supersedes #2109 