### PR TITLE
feat: Add signal handlers for creating post feed entries

### DIFF
--- a/src/feed/signals/__init__.py
+++ b/src/feed/signals/__init__.py
@@ -1,2 +1,3 @@
 from .bounty_signals import *  # noqa: F401, F403
 from .paper_signals import *  # noqa: F401, F403
+from .post_signals import *  # noqa: F401, F403

--- a/src/feed/signals/post_signals.py
+++ b/src/feed/signals/post_signals.py
@@ -9,6 +9,7 @@ from feed.tasks import create_feed_entry, delete_feed_entry
 from researchhub_document.models import ResearchhubPost
 from researchhub_document.related_models.constants import document_type
 from researchhub_document.related_models.researchhub_unified_document_model import ResearchhubUnifiedDocument
+from django.db.models.signals import m2m_changed
 
 """
 Signal handlers for ResearchhubPost model.
@@ -16,7 +17,6 @@ Signal handlers for ResearchhubPost model.
 The signal handlers are responsbile for creating and deleting feed entries
 when posts are created and deleted, respectively.
 """
-
 
 @receiver(post_save, sender=ResearchhubPost, dispatch_uid="post_create_feed_entry")
 def handle_post_create_feed_entry(sender, instance, **kwargs):
@@ -69,3 +69,43 @@ def handle_post_delete_feed_entry(sender, instance, **kwargs):
             for hub in hubs
         ]
         transaction.on_commit(lambda: [task() for task in tasks])
+
+@receiver(m2m_changed, sender=ResearchhubUnifiedDocument.hubs.through, dispatch_uid="post_hubs_changed")
+def handle_post_hubs_changed(sender, instance, action, pk_set, **kwargs):
+    """
+    Create or delete feed entries when a hub is added or removed from a unified document that
+    is associated with a post.
+    """
+    if action == "post_add":
+        for hub_id in pk_set:
+            unified_document = instance
+            hub = unified_document.hubs.get(id=hub_id)
+            
+            # Create feed entries for all posts associated with this unified document
+            for post in unified_document.posts.all():
+                create_feed_entry.apply_async(
+                    args=(
+                        post.id,
+                        ContentType.objects.get_for_model(post).id,
+                        "PUBLISH",
+                        hub.id,
+                        ContentType.objects.get_for_model(hub).id,
+                    ),
+                    priority=1,
+                )
+    elif action == "pre_remove":
+        for hub_id in pk_set:
+            unified_document = instance
+            hub = unified_document.hubs.get(id=hub_id)
+            
+            # Delete feed entries for all posts associated with this unified document
+            for post in unified_document.posts.all():
+                delete_feed_entry.apply_async(
+                    args=(
+                        post.id,
+                        ContentType.objects.get_for_model(post).id,
+                        hub.id,
+                        ContentType.objects.get_for_model(hub).id,
+                    ),
+                    priority=1,
+                )

--- a/src/feed/signals/post_signals.py
+++ b/src/feed/signals/post_signals.py
@@ -10,6 +10,14 @@ from researchhub_document.models import ResearchhubPost
 from researchhub_document.related_models.constants import document_type
 from researchhub_document.related_models.researchhub_unified_document_model import ResearchhubUnifiedDocument
 
+"""
+Signal handlers for ResearchhubPost model.
+
+The signal handlers are responsbile for creating and deleting feed entries
+when posts are created and deleted, respectively.
+"""
+
+
 @receiver(post_save, sender=ResearchhubPost, dispatch_uid="post_create_feed_entry")
 def handle_post_create_feed_entry(sender, instance, **kwargs):
     """
@@ -23,7 +31,7 @@ def handle_post_create_feed_entry(sender, instance, **kwargs):
             args=(
                 post.id,
                 ContentType.objects.get_for_model(post).id,
-                FeedEntry.OPEN,
+                FeedEntry.PUBLISH,
                 hub.id,
                 ContentType.objects.get_for_model(hub).id,
                 post.created_by.id,

--- a/src/feed/signals/post_signals.py
+++ b/src/feed/signals/post_signals.py
@@ -1,0 +1,63 @@
+from functools import partial
+from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from feed.models import FeedEntry
+from feed.tasks import create_feed_entry, delete_feed_entry
+from researchhub_document.models import ResearchhubPost
+from researchhub_document.related_models.constants import document_type
+from researchhub_document.related_models.researchhub_unified_document_model import ResearchhubUnifiedDocument
+
+@receiver(post_save, sender=ResearchhubPost, dispatch_uid="post_create_feed_entry")
+def handle_post_create_feed_entry(sender, instance, **kwargs):
+    """
+    When a post is created, create feed entries for all hubs associated with the
+    researchhub document that the post is associated with.
+    """
+    post = instance
+    tasks = [
+        partial(
+            create_feed_entry.apply_async,
+            args=(
+                post.id,
+                ContentType.objects.get_for_model(post).id,
+                FeedEntry.OPEN,
+                hub.id,
+                ContentType.objects.get_for_model(hub).id,
+                post.created_by.id,
+            ),
+            priority=1,
+        )
+        for hub in post.unified_document.hubs.all()
+    ]
+    transaction.on_commit(lambda: [task() for task in tasks])
+
+@receiver(post_save, sender=ResearchhubUnifiedDocument, dispatch_uid="post_delete_feed_entry")
+def handle_post_delete_feed_entry(sender, instance, **kwargs):
+    """
+    When a post is deleted, delete feed entries for all hubs associated with the
+    researchhub document that the post is associated with.
+    """
+    unified_document = instance
+
+    if unified_document.document_type == document_type.DISCUSSION and unified_document.is_removed == True:
+        posts = unified_document.posts.all()
+        hubs = unified_document.hubs.all()
+
+        tasks = [
+            partial(
+                delete_feed_entry.apply_async,
+                args=(
+                    post.id,
+                    ContentType.objects.get_for_model(post).id,
+                    hub.id,
+                    ContentType.objects.get_for_model(hub).id,
+                ),
+                priority=1,
+            )
+            for post in posts
+            for hub in hubs
+        ]
+        transaction.on_commit(lambda: [task() for task in tasks])

--- a/src/feed/tests/signals/test_post_signals.py
+++ b/src/feed/tests/signals/test_post_signals.py
@@ -45,7 +45,7 @@ class TestPostSignals(TestCase):
                     args=(
                         post.id,
                         ContentType.objects.get_for_model(post).id,
-                        FeedEntry.OPEN,
+                        FeedEntry.PUBLISH,
                         self.hub1.id,
                         ContentType.objects.get_for_model(Hub).id,
                         post.created_by.id,
@@ -56,7 +56,7 @@ class TestPostSignals(TestCase):
                     args=(
                         post.id,
                         ContentType.objects.get_for_model(post).id,
-                        FeedEntry.OPEN,
+                        FeedEntry.PUBLISH,
                         self.hub2.id,
                         ContentType.objects.get_for_model(Hub).id,
                         post.created_by.id,
@@ -83,7 +83,7 @@ class TestPostSignals(TestCase):
                     args=(
                         self.post.id,
                         ContentType.objects.get_for_model(self.post).id,
-                        FeedEntry.OPEN,
+                        FeedEntry.PUBLISH,
                         self.hub1.id,
                         ContentType.objects.get_for_model(Hub).id,
                         self.post.created_by.id,

--- a/src/feed/tests/signals/test_post_signals.py
+++ b/src/feed/tests/signals/test_post_signals.py
@@ -1,0 +1,166 @@
+from django.test import TestCase
+from django.contrib.contenttypes.models import ContentType
+from unittest.mock import MagicMock, call, patch
+from feed.models import FeedEntry
+from feed.signals.post_signals import handle_post_create_feed_entry, handle_post_delete_feed_entry
+from feed.tests.test_views import User
+from hub.models import Hub
+from researchhub_document.related_models.constants import document_type
+from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
+from researchhub_document.related_models.researchhub_unified_document_model import ResearchhubUnifiedDocument
+
+
+class TestPostSignals(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="testUser1")
+        self.hub1 = Hub.objects.create(name="testHub1")
+        self.hub2 = Hub.objects.create(name="testHub2")
+        self.unified_document = ResearchhubUnifiedDocument.objects.create(
+            document_type=document_type.DISCUSSION,
+        )
+        self.unified_document.hubs.add(self.hub1)
+        self.unified_document.hubs.add(self.hub2)
+        self.post = ResearchhubPost.objects.create(
+            created_by=self.user,
+            unified_document=self.unified_document,
+        )
+
+    @patch("feed.signals.post_signals.create_feed_entry")
+    @patch("feed.signals.post_signals.transaction")
+    def test_post_create_feed_entry(self, mock_transaction, mock_create_feed_entry):
+        # Arrange
+        mock_transaction.on_commit = lambda func: func()
+        mock_create_feed_entry.apply_async = MagicMock()
+
+        # Act
+        post = ResearchhubPost.objects.create(
+            created_by=self.user,
+            unified_document=self.unified_document,
+        )
+
+        # Assert
+        mock_create_feed_entry.apply_async.assert_has_calls(
+            [
+                call(
+                    args=(
+                        post.id,
+                        ContentType.objects.get_for_model(post).id,
+                        FeedEntry.OPEN,
+                        self.hub1.id,
+                        ContentType.objects.get_for_model(Hub).id,
+                        post.created_by.id,
+                    ),
+                    priority=1,
+                ),
+                call(
+                    args=(
+                        post.id,
+                        ContentType.objects.get_for_model(post).id,
+                        FeedEntry.OPEN,
+                        self.hub2.id,
+                        ContentType.objects.get_for_model(Hub).id,
+                        post.created_by.id,
+                    ),
+                    priority=1,
+                ),
+            ]
+        )
+
+    @patch("feed.signals.post_signals.create_feed_entry")
+    @patch("feed.signals.post_signals.transaction")
+    def test_handle_post_create_feed_entry(self, mock_transaction, mock_create_feed_entry):
+        # Arrange
+        mock_transaction.on_commit = lambda func: func()
+        mock_create_feed_entry.apply_async = MagicMock()
+
+        # Act
+        handle_post_create_feed_entry(sender=ResearchhubPost, instance=self.post)
+
+        # Assert
+        mock_create_feed_entry.apply_async.assert_has_calls(
+            [
+                call(
+                    args=(
+                        self.post.id,
+                        ContentType.objects.get_for_model(self.post).id,
+                        FeedEntry.OPEN,
+                        self.hub1.id,
+                        ContentType.objects.get_for_model(Hub).id,
+                        self.post.created_by.id,
+                    ),
+                    priority=1,
+                ),
+            ]
+        )
+
+    @patch("feed.signals.post_signals.delete_feed_entry")
+    @patch("feed.signals.post_signals.transaction")
+    def test_post_delete_feed_entry(self, mock_transaction, mock_delete_feed_entry):
+        # Arrange
+        mock_transaction.on_commit = lambda func: func()
+        mock_delete_feed_entry.apply_async = MagicMock()
+
+        self.unified_document.is_removed = True
+        self.unified_document.save()
+
+        # Act
+        handle_post_delete_feed_entry(sender=ResearchhubPost, instance=self.unified_document)
+
+        # Assert
+        mock_delete_feed_entry.apply_async.assert_has_calls(
+            [
+                call(
+                    args=(
+                        self.post.id,
+                        ContentType.objects.get_for_model(self.post).id,
+                        self.hub1.id,
+                        ContentType.objects.get_for_model(Hub).id,
+                    ),
+                    priority=1,
+                ),
+                call(
+                    args=(
+                        self.post.id,
+                        ContentType.objects.get_for_model(self.post).id,
+                        self.hub2.id,
+                        ContentType.objects.get_for_model(Hub).id,
+                    ),
+                    priority=1,
+                ),
+            ]
+        )
+
+    @patch("feed.signals.post_signals.delete_feed_entry")
+    @patch("feed.signals.post_signals.transaction")
+    def test_handle_post_delete_feed_entry(self, mock_transaction, mock_delete_feed_entry):
+        # Arrange
+        mock_transaction.on_commit = lambda func: func()
+        mock_delete_feed_entry.apply_async = MagicMock()
+        self.unified_document.is_removed = True
+
+        # Act
+        handle_post_delete_feed_entry(sender=ResearchhubPost, instance=self.unified_document)
+
+        # Assert
+        mock_delete_feed_entry.apply_async.assert_has_calls(
+            [
+                call(
+                    args=(
+                        self.post.id,
+                        ContentType.objects.get_for_model(self.post).id,
+                        self.hub1.id,
+                        ContentType.objects.get_for_model(Hub).id,
+                    ),
+                    priority=1,
+                ),
+                call(
+                    args=(
+                        self.post.id,
+                        ContentType.objects.get_for_model(self.post).id,
+                        self.hub2.id,
+                        ContentType.objects.get_for_model(Hub).id,
+                    ),
+                    priority=1,
+                ),
+            ]
+        )


### PR DESCRIPTION
- Create signal handlers for handling post creations and deletions.
- Create feed entries for every hub associated with a post (via the associated researchhub document instance).