### PR TITLE
feat: Add feed serializer for posts

### DIFF
--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from hub.models import Hub
 from paper.models import Paper
 from researchhub_document.related_models.constants import document_type
+from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 from user.models import Author, User
 
 from .models import FeedEntry
@@ -120,6 +121,15 @@ class PaperSerializer(ContentObjectSerializer):
             "metrics",
         ]
 
+class PostSerializer(ContentObjectSerializer):
+    """Serializer for researchhub posts"""
+    renderable_text = serializers.CharField()
+    title = serializers.CharField()
+
+    class Meta(ContentObjectSerializer.Meta):
+        model = ResearchhubPost
+        fields = ContentObjectSerializer.Meta.fields + ["title", "renderable_text"]
+
 
 class BountySerializer(serializers.Serializer):
     amount = serializers.FloatField()
@@ -205,6 +215,10 @@ class FeedEntrySerializer(serializers.ModelSerializer):
                 if hasattr(obj, "_prefetched_paper"):
                     return PaperSerializer(obj._prefetched_paper).data
                 return PaperSerializer(obj.item).data
+            case "researchhubpost":
+                if hasattr(obj, "_prefetched_post"):
+                    return PostSerializer(obj._prefetched_post).data
+                return PostSerializer(obj.item).data
         return None
 
     def get_content_type(self, obj):

--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -123,8 +123,14 @@ class PaperSerializer(ContentObjectSerializer):
 
 class PostSerializer(ContentObjectSerializer):
     """Serializer for researchhub posts"""
-    renderable_text = serializers.CharField()
+    renderable_text = serializers.SerializerMethodField()
     title = serializers.CharField()
+
+    def get_renderable_text(self, obj):
+        text = obj.renderable_text[:255]
+        if len(obj.renderable_text) > 255:
+            text += "..."
+        return text
 
     class Meta(ContentObjectSerializer.Meta):
         model = ResearchhubPost

--- a/src/feed/tests/test_serializers.py
+++ b/src/feed/tests/test_serializers.py
@@ -8,6 +8,7 @@ from feed.serializers import (
     ContentObjectSerializer,
     FeedEntrySerializer,
     PaperSerializer,
+    PostSerializer,
 )
 from hub.models import Hub
 from hub.serializers import SimpleHubSerializer
@@ -21,6 +22,8 @@ from researchhub_comment.related_models.rh_comment_model import RhCommentModel
 from researchhub_comment.related_models.rh_comment_thread_model import (
     RhCommentThreadModel,
 )
+from researchhub_document.related_models.constants import document_type
+from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 from researchhub_document.related_models.researchhub_unified_document_model import (
     ResearchhubUnifiedDocument,
 )
@@ -128,6 +131,33 @@ class PaperSerializerTests(TestCase):
         self.assertIn("journal", data)
         self.assertEqual(data["journal"]["name"], journal_without_image.name)
         self.assertEqual(data["journal"]["image"], None)
+
+
+class PostSerializerTests(TestCase):
+    def setUp(self):
+        self.user = create_random_default_user("post_creator")
+        self.unified_document = ResearchhubUnifiedDocument.objects.create(
+            document_type=document_type.DISCUSSION,
+        )
+
+        self.post = ResearchhubPost.objects.create(
+            title="title1",
+            created_by=self.user,
+            document_type=document_type.DISCUSSION,
+            renderable_text="renderableText1",
+            unified_document=self.unified_document,
+        )
+        self.post.save()
+
+    def test_serializes_post(self):
+        serializer = PostSerializer(self.post)
+        data = serializer.data
+
+        self.assertEqual(data["id"], self.post.id)
+        self.assertEqual(data["hub"], None)
+        self.assertEqual(data["renderable_text"], self.post.renderable_text)
+        self.assertEqual(data["slug"], self.post.slug)
+        self.assertEqual(data["title"], self.post.title)
 
 
 class BountySerializerTests(TestCase):

--- a/src/feed/views.py
+++ b/src/feed/views.py
@@ -6,6 +6,7 @@ from rest_framework.pagination import PageNumberPagination
 
 from paper.related_models.paper_model import Paper
 from reputation.related_models.bounty import Bounty
+from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 
 from .models import FeedEntry
 from .serializers import FeedEntrySerializer
@@ -65,6 +66,14 @@ class FeedViewSet(viewsets.ModelViewSet):
                         "authors__user",
                     ),
                     to_attr="_prefetched_paper",
+                ),
+                Prefetch(
+                    "item",
+                    ResearchhubPost.objects.prefetch_related(
+                        "unified_document",
+                        "unified_document__hubs",
+                    ),
+                    to_attr="_prefetched_post",
                 ),
             )
         )


### PR DESCRIPTION
- Add feed serializer for posts (title, renderable_text).
- Prefetch post relations for serializer.

Based on #2116 

```
{
  "id": 253,
  "content_type": "RESEARCHHUBPOST",
  "content_object": {
    "id": 23,
    "created_date": "2025-02-19T11:13:34.401876Z",
    "hub": {
      "name": "Plant Science",
      "slug": "plant-science"
    },
    "slug": "trying-out-post-signals-trying-out-post-signals",
    "renderable_text": "sample text",
    "title": "Trying out post signals ** Trying out post signals **"
  },
  "created_date": "2025-02-19T11:29:34.799165Z",
  "action_date": "2025-02-19T11:13:34.401876Z",
  "action": "PUBLISH",
  "author": {
    "id": 3,
    "first_name": "Gregor",
    "last_name": "Zurowski",
    "profile_image": "",
    "headline": {
      "title": "headline",
      "isPublic": true
    },
    "user": {
      "id": 3,
      "first_name": "Gregor",
      "last_name": "Zurowski",
      "email": "gregor@test",
      "is_verified": false
    }
  }
}
```