### PR TITLE
Add fundraise and document_type to note serializer

### DIFF
--- a/src/note/serializers/note_serializer.py
+++ b/src/note/serializers/note_serializer.py
@@ -105,6 +105,19 @@ class NoteSerializer(ModelSerializer):
                     "name",
                 ]
             },
+            "doc_dps_get_unified_document": {"_include_fields": ["fundraise"]},
+            "doc_duds_get_fundraise": {
+                "_include_fields": [
+                    "id",
+                    "status",
+                    "goal_amount",
+                    "goal_currency",
+                    "start_date",
+                    "end_date",
+                    "amount_raised",
+                    "contributors",
+                ]
+            },
         }
         serializer = DynamicPostSerializer(
             note.post,
@@ -115,6 +128,8 @@ class NoteSerializer(ModelSerializer):
                 "hubs",
                 "id",
                 "slug",
+                "document_type",
+                "unified_document",
             ],
         )
         return serializer.data
@@ -199,10 +214,49 @@ class DynamicNoteSerializer(DynamicModelFieldSerializer):
     def get_post(self, note):
         from researchhub_document.serializers import DynamicPostSerializer
 
-        context = self.context
-        _context_fields = context.get("nte_dns_get_post", {})
+        if not hasattr(note, "post"):
+            return None
+
+        context = {
+            "doc_dps_get_authors": {
+                "_include_fields": [
+                    "id",
+                    "first_name",
+                    "last_name",
+                    "user",
+                ]
+            },
+            "doc_dps_get_hubs": {
+                "_include_fields": [
+                    "id",
+                    "name",
+                ]
+            },
+            "doc_dps_get_unified_document": {"_include_fields": ["fundraise"]},
+            "doc_duds_get_fundraise": {
+                "_include_fields": [
+                    "id",
+                    "status",
+                    "goal_amount",
+                    "goal_currency",
+                    "start_date",
+                    "end_date",
+                    "amount_raised",
+                ]
+            },
+        }
         serializer = DynamicPostSerializer(
-            note.post, context=context, **_context_fields
+            note.post,
+            context=context,
+            _include_fields=[
+                "authors",
+                "doi",
+                "hubs",
+                "id",
+                "slug",
+                "document_type",
+                "unified_document",
+            ],
         )
         return serializer.data
 

--- a/src/note/tests/test_note_api.py
+++ b/src/note/tests/test_note_api.py
@@ -949,3 +949,100 @@ class NoteTests(APITestCase):
         note = response.data
         self.assertEqual(note["latest_version"]["json"], test_json)
         self.assertIsNone(note["latest_version"]["src"])
+
+    def test_note_without_post(self):
+        # Create a note without an associated post
+        response = self.client.post(
+            "/api/note/",
+            {
+                "grouping": "WORKSPACE",
+                "organization_slug": self.org["slug"],
+                "title": "Note without post",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        note = response.data
+
+        # Verify that post is None
+        self.assertIsNone(note["post"])
+
+    def test_note_with_post(self):
+        # Create a note first
+        response = self.client.post(
+            "/api/note/",
+            {
+                "grouping": "WORKSPACE",
+                "organization_slug": self.org["slug"],
+                "title": "Note with post",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        note = response.data
+
+        # Create a post associated with the note
+        post_response = self.client.post(
+            "/api/researchhubpost/",
+            {
+                "document_type": "DISCUSSION",
+                "created_by": self.user.id,
+                "full_src": "Test post content",
+                "is_public": True,
+                "note_id": note["id"],
+                "renderable_text": "Test post content that is sufficiently long for validation",
+                "title": "Test post title that is sufficiently long",
+                "hubs": [],
+            },
+        )
+        self.assertEqual(post_response.status_code, 200)
+
+        # Re-fetch the note to verify post data
+        response = self.client.get(f"/api/note/{note['id']}/")
+        self.assertEqual(response.status_code, 200)
+        note = response.data
+
+        # Verify post data is present and correctly structured
+        self.assertIsNotNone(note["post"])
+        self.assertIn("authors", note["post"])
+        self.assertIn("hubs", note["post"])
+        self.assertIn("unified_document", note["post"])
+
+    def test_note_with_preregistration_post_fundraise(self):
+        # Create a note first
+        response = self.client.post(
+            "/api/note/",
+            {
+                "grouping": "WORKSPACE",
+                "organization_slug": self.org["slug"],
+                "title": "Note with preregistration post",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        note = response.data
+
+        # Create a preregistration post with fundraise
+        post_response = self.client.post(
+            "/api/researchhubpost/",
+            {
+                "document_type": "PREREGISTRATION",
+                "created_by": self.user.id,
+                "full_src": "Test post content",
+                "is_public": True,
+                "note_id": note["id"],
+                "renderable_text": "Test post content that is sufficiently long for validation",
+                "title": "Test post title that is sufficiently long",
+                "hubs": [],
+                "fundraise_goal_amount": 1000,
+            },
+        )
+        self.assertEqual(post_response.status_code, 200)
+
+        # Re-fetch the note to verify post data
+        response = self.client.get(f"/api/note/{note['id']}/")
+        self.assertEqual(response.status_code, 200)
+        note = response.data
+
+        # Verify fundraise data is present
+        self.assertIsNotNone(note["post"]["unified_document"]["fundraise"])
+        self.assertEqual(
+            note["post"]["unified_document"]["fundraise"]["goal_amount"]["usd"], 1000.0
+        )

--- a/src/note/tests/test_note_api.py
+++ b/src/note/tests/test_note_api.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from rest_framework.test import APITestCase
 
 from note.models import Note
+from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
 from researchhub_access_group.models import Permission
 from researchhub_document.models import ResearchhubUnifiedDocument
 from user.models import Organization
@@ -26,6 +27,9 @@ class NoteTests(APITestCase):
         # Create org
         response = self.client.post("/api/organization/", {"name": "some org"})
         self.org = response.data
+
+        # Create exchange rate
+        RscExchangeRate.objects.create(rate=4.99014625)
 
     def test_user_can_list_created_notes(self):
         # Arrange

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -259,8 +259,8 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
 
         created_by = request.user
         created_by_author = created_by.author_profile
-        hubs = data.pop("hubs", None)
-        renderable_text = data.pop("renderable_text", "")
+        hubs = data.get("hubs", None)
+        renderable_text = data.get("renderable_text", "")
         title = data.get("title", "")
         assign_doi = data.get("assign_doi", False)
         doi = DOI() if assign_doi else None


### PR DESCRIPTION
- In the new web we have a Notebook page where the suer should be able to re-publish existing preregistration posts. and on the right sidebar, we should display the fundraise information for the post
![image](https://github.com/user-attachments/assets/b056876c-1664-47b7-abaf-2db05ec92deb)
For doing this we need to include the `fundraise` property to the `note` serializer. 
And it will be `note.post.unified_document.fundraise` 
This is because the fundraise is actually related to the unified document, not directly to the post. The relationship chain is:
`Note -> Post -> UnifiedDocument -> Fundraise`
- Small fixes to the `update_existing_researchhub_posts`
`request.data.pop => request.data.get`
because it caused errors when these props are missing in the payload