### PR TITLE
feat: Add serializer for comments in feed

### DIFF
--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -208,6 +208,8 @@ class CommentSerializer(serializers.Serializer):
             "comment_content_type",
             "comment_content_json",
             "comment_type",
+            "document_type",
+            "hub",
             "id",
             "parent_id",
             "thread_id",

--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -121,8 +121,10 @@ class PaperSerializer(ContentObjectSerializer):
             "metrics",
         ]
 
+
 class PostSerializer(ContentObjectSerializer):
     """Serializer for researchhub posts"""
+
     renderable_text = serializers.SerializerMethodField()
     title = serializers.CharField()
 
@@ -179,6 +181,39 @@ class BountySerializer(serializers.Serializer):
         ]
 
 
+class CommentSerializer(serializers.Serializer):
+    comment_content_json = serializers.JSONField()
+    comment_content_type = serializers.CharField()
+    comment_type = serializers.CharField()
+    document_type = serializers.SerializerMethodField()
+    hub = serializers.SerializerMethodField()
+    id = serializers.IntegerField()
+    parent_id = serializers.IntegerField()
+    thread_id = serializers.IntegerField()
+
+    def get_document_type(self, obj):
+        if obj.unified_document:
+            return obj.unified_document.document_type
+        return None
+
+    def get_hub(self, obj):
+        if obj.unified_document and obj.unified_document.hubs:
+            # FIXMEL get primary hub
+            hub = obj.unified_document.hubs.first()
+            return SimpleHubSerializer(hub).data
+        return None
+
+    class Meta:
+        fields = [
+            "comment_content_type",
+            "comment_content_json",
+            "comment_type",
+            "id",
+            "parent_id",
+            "thread_id",
+        ]
+
+
 class FeedEntrySerializer(serializers.ModelSerializer):
     """Serializer for feed entries that can reference different content types"""
 
@@ -216,12 +251,18 @@ class FeedEntrySerializer(serializers.ModelSerializer):
                 if hasattr(obj, "_prefetched_bounty"):
                     return BountySerializer(obj._prefetched_bounty).data
                 return BountySerializer(obj.item).data
+            case "rhcommentmodel":
+                # Use prefetched comment if available
+                if hasattr(obj, "_prefetched_comment"):
+                    return CommentSerializer(obj._prefetched_comment).data
+                return CommentSerializer(obj.item).data
             case "paper":
                 # Use prefetched paper if available
                 if hasattr(obj, "_prefetched_paper"):
                     return PaperSerializer(obj._prefetched_paper).data
                 return PaperSerializer(obj.item).data
             case "researchhubpost":
+                # Use prefetched post if available
                 if hasattr(obj, "_prefetched_post"):
                     return PostSerializer(obj._prefetched_post).data
                 return PostSerializer(obj.item).data

--- a/src/feed/signals/__init__.py
+++ b/src/feed/signals/__init__.py
@@ -1,3 +1,4 @@
 from .bounty_signals import *  # noqa: F401, F403
+from .comment_signals import *  # noqa: F401, F403
 from .paper_signals import *  # noqa: F401, F403
 from .post_signals import *  # noqa: F401, F403

--- a/src/feed/signals/comment_signals.py
+++ b/src/feed/signals/comment_signals.py
@@ -1,0 +1,60 @@
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.contrib.contenttypes.models import ContentType
+from researchhub_comment.related_models.rh_comment_model import RhCommentModel
+from feed.models import FeedEntry
+from feed.tasks import create_feed_entry, delete_feed_entry
+from django.db import transaction
+
+"""
+Signal handlers for Comment model.
+
+The signal handlers are responsbile for creating and deleting feed entries
+when comments are created and removed, respectively.
+"""
+
+@receiver(post_save, sender=RhCommentModel)
+def handle_comment_created_or_removed(sender, instance, created, **kwargs):
+    """
+    When a comment is created or removed, create or delete a feed entry.
+    """
+    comment = instance
+    
+    if created:
+        _handle_comment_created(comment)
+    elif comment.is_removed:
+        _handle_comment_removed(comment)
+
+    
+def _handle_comment_created(comment):
+    tasks = [
+        create_feed_entry.apply_async(
+            args=(
+                comment.id,
+                ContentType.objects.get_for_model(comment).id,
+                FeedEntry.PUBLISH,
+                hub.id,
+                ContentType.objects.get_for_model(hub).id,
+                comment.created_by.id,
+            ),
+            priority=1,
+        )
+        for hub in comment.unified_document.hubs.all()
+    ]
+    transaction.on_commit(lambda: [task() for task in tasks])
+
+def _handle_comment_removed(comment):
+    tasks = [
+        delete_feed_entry.apply_async(
+            args=(
+                comment.id,
+                ContentType.objects.get_for_model(comment).id,
+                hub.id,
+                ContentType.objects.get_for_model(hub).id,
+            ),
+            priority=1,
+        )
+        for hub in comment.unified_document.hubs.all()
+    ]
+    transaction.on_commit(lambda: [task() for task in tasks])

--- a/src/feed/signals/comment_signals.py
+++ b/src/feed/signals/comment_signals.py
@@ -1,11 +1,11 @@
-
+from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.contrib.contenttypes.models import ContentType
-from researchhub_comment.related_models.rh_comment_model import RhCommentModel
+
 from feed.models import FeedEntry
 from feed.tasks import create_feed_entry, delete_feed_entry
-from django.db import transaction
+from researchhub_comment.related_models.rh_comment_model import RhCommentModel
 
 """
 Signal handlers for Comment model.
@@ -14,19 +14,20 @@ The signal handlers are responsbile for creating and deleting feed entries
 when comments are created and removed, respectively.
 """
 
+
 @receiver(post_save, sender=RhCommentModel)
 def handle_comment_created_or_removed(sender, instance, created, **kwargs):
     """
     When a comment is created or removed, create or delete a feed entry.
     """
     comment = instance
-    
+
     if created:
         _handle_comment_created(comment)
     elif comment.is_removed:
         _handle_comment_removed(comment)
 
-    
+
 def _handle_comment_created(comment):
     tasks = [
         create_feed_entry.apply_async(
@@ -43,6 +44,7 @@ def _handle_comment_created(comment):
         for hub in comment.unified_document.hubs.all()
     ]
     transaction.on_commit(lambda: [task() for task in tasks])
+
 
 def _handle_comment_removed(comment):
     tasks = [

--- a/src/feed/signals/comment_signals.py
+++ b/src/feed/signals/comment_signals.py
@@ -29,6 +29,12 @@ def handle_comment_created_or_removed(sender, instance, created, **kwargs):
 
 
 def _handle_comment_created(comment):
+    # Validate that the comment is associated with a unified document with hubs
+    if not getattr(comment, "unified_document", None) or not hasattr(
+        comment.unified_document, "hubs"
+    ):
+        return
+
     tasks = [
         create_feed_entry.apply_async(
             args=(
@@ -47,6 +53,12 @@ def _handle_comment_created(comment):
 
 
 def _handle_comment_removed(comment):
+    # Validate that the comment is associated with a unified document with hubs
+    if not getattr(comment, "unified_document", None) or not hasattr(
+        comment.unified_document, "hubs"
+    ):
+        return
+
     tasks = [
         delete_feed_entry.apply_async(
             args=(

--- a/src/feed/tasks.py
+++ b/src/feed/tasks.py
@@ -1,12 +1,14 @@
+import logging
+
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError
-import logging
+
 from feed.models import FeedEntry
 from researchhub.celery import app
 from user.models import User
 
-
 logger = logging.getLogger(__name__)
+
 
 @app.task
 def create_feed_entry(
@@ -36,19 +38,21 @@ def create_feed_entry(
     # Create and return the feed entry
     try:
         return FeedEntry.objects.create(
-        user=user,
-        item=item,
-        content_type=item_content_type,
-        object_id=item_id,
-        action=action,
-        action_date=action_date,
-        parent_item=parent_item,
-        parent_content_type=parent_content_type,
+            user=user,
+            item=item,
+            content_type=item_content_type,
+            object_id=item_id,
+            action=action,
+            action_date=action_date,
+            parent_item=parent_item,
+            parent_content_type=parent_content_type,
             parent_object_id=parent_item_id,
         )
     except IntegrityError:
         # Ignore error if feed entry already exists
-        logger.warning(f"Feed entry already exists for item_id={item_id} content_type={item_content_type.model} parent_item_id={parent_item_id} parent_content_type={parent_content_type.model}")
+        logger.warning(
+            f"Feed entry already exists for item_id={item_id} content_type={item_content_type.model} parent_item_id={parent_item_id} parent_content_type={parent_content_type.model}"
+        )
 
 
 @app.task

--- a/src/feed/tests/signals/test_bounty_signals.py
+++ b/src/feed/tests/signals/test_bounty_signals.py
@@ -9,7 +9,6 @@ from feed.signals.bounty_signals import (
     handle_bounty_create_feed_entry,
 )
 from hub.models import Hub
-from paper.related_models.paper_model import Paper
 from paper.tests.helpers import create_paper
 from reputation.related_models.bounty import Bounty
 from reputation.related_models.escrow import Escrow

--- a/src/feed/tests/signals/test_comment_signals.py
+++ b/src/feed/tests/signals/test_comment_signals.py
@@ -1,0 +1,122 @@
+from unittest.mock import MagicMock, call, patch
+from django.test import TestCase
+
+from feed.models import FeedEntry
+from feed.tests.test_views import User
+from hub.models import Hub
+from paper.related_models.paper_model import Paper
+from researchhub_comment.constants.rh_comment_thread_types import GENERIC_COMMENT
+from researchhub_comment.related_models.rh_comment_model import RhCommentModel
+from researchhub_comment.related_models.rh_comment_thread_model import RhCommentThreadModel
+from researchhub_document.related_models.constants import document_type
+from researchhub_document.related_models.researchhub_unified_document_model import ResearchhubUnifiedDocument
+from django.contrib.contenttypes.models import ContentType
+
+class CommentSignalsTests(TestCase):
+    
+    def setUp(self):
+        self.user = User.objects.create_user(username="user1")
+        self.hub1 = Hub.objects.create(name="hub1")
+        self.hub2 = Hub.objects.create(name="hub2")
+        self.unified_document = ResearchhubUnifiedDocument.objects.create(
+            document_type=document_type.DISCUSSION,
+        )
+        self.unified_document.hubs.add(self.hub1)
+        self.unified_document.hubs.add(self.hub2)
+        self.paper = Paper.objects.create(title="paper1", unified_document=self.unified_document)
+        
+        self.content_type = ContentType.objects.get_for_model(Paper)
+        self.thread = RhCommentThreadModel.objects.create(
+            thread_type=GENERIC_COMMENT,
+            content_type=self.content_type,
+            object_id=self.paper.id,
+            created_by=self.user,
+        )
+        self.comment = RhCommentModel.objects.create(
+            comment_content_json={"ops": [{"insert": "comment1"}]},
+            created_by=self.user,
+            thread=self.thread,
+        )
+
+    @patch("feed.signals.comment_signals.create_feed_entry")
+    @patch("feed.signals.comment_signals.transaction")
+    def test_handle_comment_created_signal(self, mock_transaction, mock_create_feed_entry):
+        """
+        Test that a feed entry is created when a comment is created.
+        """
+        # Arrange
+        mock_transaction.on_commit = lambda func: func()
+        mock_create_feed_entry.apply_async = MagicMock()
+
+        # Act
+        comment =  RhCommentModel.objects.create(
+            comment_content_json={"ops": [{"insert": "comment1"}]},
+            created_by=self.user,
+            thread=self.thread,
+        )
+
+        # Assert
+        mock_create_feed_entry.apply_async.assert_has_calls(
+            [
+                call(
+                    args=(
+                        comment.id,
+                        ContentType.objects.get_for_model(RhCommentModel).id,
+                        FeedEntry.PUBLISH,
+                        self.hub1.id,
+                        ContentType.objects.get_for_model(Hub).id,
+                        self.user.id,
+                    ),
+                    priority=1,
+                ),
+                call(
+                    args=(
+                        comment.id,
+                        ContentType.objects.get_for_model(RhCommentModel).id,
+                        FeedEntry.PUBLISH,
+                        self.hub2.id,
+                        ContentType.objects.get_for_model(Hub).id,
+                        self.user.id,
+                    ),
+                    priority=1,
+                ),
+            ]
+        )
+    
+    @patch("feed.signals.comment_signals.delete_feed_entry")
+    @patch("feed.signals.comment_signals.transaction")
+    def test_handle_comment_removed_signal(self, mock_transaction, mock_delete_feed_entry):
+        """
+        Test that a feed entry is deleted when a comment is removed.
+        """
+        # Arrange
+        mock_transaction.on_commit = lambda func: func()
+        mock_delete_feed_entry.apply_async = MagicMock()
+
+        # Act
+        self.comment.is_removed = True
+        self.comment.save()
+
+        # Assert
+        mock_delete_feed_entry.apply_async.assert_has_calls(
+            [
+                call(
+                    args=(
+                        self.comment.id,
+                        ContentType.objects.get_for_model(RhCommentModel).id,
+                        self.hub1.id,
+                        ContentType.objects.get_for_model(Hub).id,
+                    ),
+                    priority=1,
+                ),
+                call(
+                    args=(
+                        self.comment.id,
+                        ContentType.objects.get_for_model(RhCommentModel).id,
+                        self.hub2.id,
+                        ContentType.objects.get_for_model(Hub).id,
+                    ),
+                    priority=1,
+                ),
+            ]
+        )

--- a/src/feed/tests/signals/test_comment_signals.py
+++ b/src/feed/tests/signals/test_comment_signals.py
@@ -1,4 +1,6 @@
 from unittest.mock import MagicMock, call, patch
+
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from feed.models import FeedEntry
@@ -7,13 +9,17 @@ from hub.models import Hub
 from paper.related_models.paper_model import Paper
 from researchhub_comment.constants.rh_comment_thread_types import GENERIC_COMMENT
 from researchhub_comment.related_models.rh_comment_model import RhCommentModel
-from researchhub_comment.related_models.rh_comment_thread_model import RhCommentThreadModel
+from researchhub_comment.related_models.rh_comment_thread_model import (
+    RhCommentThreadModel,
+)
 from researchhub_document.related_models.constants import document_type
-from researchhub_document.related_models.researchhub_unified_document_model import ResearchhubUnifiedDocument
-from django.contrib.contenttypes.models import ContentType
+from researchhub_document.related_models.researchhub_unified_document_model import (
+    ResearchhubUnifiedDocument,
+)
+
 
 class CommentSignalsTests(TestCase):
-    
+
     def setUp(self):
         self.user = User.objects.create_user(username="user1")
         self.hub1 = Hub.objects.create(name="hub1")
@@ -23,8 +29,10 @@ class CommentSignalsTests(TestCase):
         )
         self.unified_document.hubs.add(self.hub1)
         self.unified_document.hubs.add(self.hub2)
-        self.paper = Paper.objects.create(title="paper1", unified_document=self.unified_document)
-        
+        self.paper = Paper.objects.create(
+            title="paper1", unified_document=self.unified_document
+        )
+
         self.content_type = ContentType.objects.get_for_model(Paper)
         self.thread = RhCommentThreadModel.objects.create(
             thread_type=GENERIC_COMMENT,
@@ -40,7 +48,9 @@ class CommentSignalsTests(TestCase):
 
     @patch("feed.signals.comment_signals.create_feed_entry")
     @patch("feed.signals.comment_signals.transaction")
-    def test_handle_comment_created_signal(self, mock_transaction, mock_create_feed_entry):
+    def test_handle_comment_created_signal(
+        self, mock_transaction, mock_create_feed_entry
+    ):
         """
         Test that a feed entry is created when a comment is created.
         """
@@ -49,7 +59,7 @@ class CommentSignalsTests(TestCase):
         mock_create_feed_entry.apply_async = MagicMock()
 
         # Act
-        comment =  RhCommentModel.objects.create(
+        comment = RhCommentModel.objects.create(
             comment_content_json={"ops": [{"insert": "comment1"}]},
             created_by=self.user,
             thread=self.thread,
@@ -82,10 +92,12 @@ class CommentSignalsTests(TestCase):
                 ),
             ]
         )
-    
+
     @patch("feed.signals.comment_signals.delete_feed_entry")
     @patch("feed.signals.comment_signals.transaction")
-    def test_handle_comment_removed_signal(self, mock_transaction, mock_delete_feed_entry):
+    def test_handle_comment_removed_signal(
+        self, mock_transaction, mock_delete_feed_entry
+    ):
         """
         Test that a feed entry is deleted when a comment is removed.
         """

--- a/src/feed/views.py
+++ b/src/feed/views.py
@@ -6,6 +6,7 @@ from rest_framework.pagination import PageNumberPagination
 
 from paper.related_models.paper_model import Paper
 from reputation.related_models.bounty import Bounty
+from researchhub_comment.related_models.rh_comment_model import RhCommentModel
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 
 from .models import FeedEntry
@@ -74,6 +75,16 @@ class FeedViewSet(viewsets.ModelViewSet):
                         "unified_document__hubs",
                     ),
                     to_attr="_prefetched_post",
+                ),
+                Prefetch(
+                    "item",
+                    RhCommentModel.objects.prefetch_related(
+                        "thread",
+                        "thread__content_object",
+                        "thread__content_object__unified_document",
+                        "thread__content_object__unified_document__hubs",
+                    ),
+                    to_attr="_prefetched_comment",
                 ),
             )
         )


### PR DESCRIPTION
Add an initial implementation of a serializer for comments:

Example:
```
 {
      "id": 363,
      "content_type": "RHCOMMENTMODEL",
      "content_object": {
        "comment_content_json": {
          "ops": [
            {
              "insert": "Letsfdohsdgfshousfdg oh;\n"
            }
          ]
        },
        "comment_content_type": "QUILL_EDITOR",
        "comment_type": "GENERIC_COMMENT",
        "document_type": "PAPER",
        "hub": {
          "name": "Neuroscience",
          "slug": "neuroscience"
        },
        "id": 80,
        "parent_id": null,
        "thread_id": 80
      }
```