### PR TITLE
chore: Limit concurrent deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ on:
         required: false
         default: master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.deploy_env }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Concurrent deployments to the same environment fail due to the Beantalk environment not being in healthy state yet. This change limits the concurrency to a single deployment per environment.