### PR TITLE
Add popular feed

### DIFF
--- a/src/feed/tests/test_views.py
+++ b/src/feed/tests/test_views.py
@@ -262,7 +262,7 @@ class FeedViewSetTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         results = response.data["results"]
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 5)
 
         content_object_ids = [result["content_object"]["id"] for result in results]
 

--- a/src/feed/tests/test_views.py
+++ b/src/feed/tests/test_views.py
@@ -191,3 +191,208 @@ class FeedViewSetTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # Should see all content since user has no follows
         self.assertEqual(len(response.data["results"]), 2)
+
+    def test_popular_feed_view(self):
+        """Test that popular feed view sorts by unified_document.hot_score"""
+        high_score_doc = ResearchhubUnifiedDocument.objects.create(
+            document_type="PAPER", hot_score=100
+        )
+        medium_score_doc = ResearchhubUnifiedDocument.objects.create(
+            document_type="PAPER", hot_score=50
+        )
+        low_score_doc = ResearchhubUnifiedDocument.objects.create(
+            document_type="PAPER", hot_score=10
+        )
+
+        high_score_paper = Paper.objects.create(
+            title="High Score Paper",
+            paper_publish_date=timezone.now(),
+            unified_document=high_score_doc,
+        )
+        medium_score_paper = Paper.objects.create(
+            title="Medium Score Paper",
+            paper_publish_date=timezone.now(),
+            unified_document=medium_score_doc,
+        )
+        low_score_paper = Paper.objects.create(
+            title="Low Score Paper",
+            paper_publish_date=timezone.now(),
+            unified_document=low_score_doc,
+        )
+
+        high_score_doc.hubs.add(self.hub)
+        medium_score_doc.hubs.add(self.hub)
+        low_score_doc.hubs.add(self.hub)
+
+        # Create feed entries for each paper
+        FeedEntry.objects.create(
+            user=self.user,
+            action="PUBLISH",
+            action_date=timezone.now(),
+            content_type=self.paper_content_type,
+            object_id=high_score_paper.id,
+            parent_content_type=self.hub_content_type,
+            parent_object_id=self.hub.id,
+            unified_document=high_score_doc,
+        )
+        FeedEntry.objects.create(
+            user=self.user,
+            action="PUBLISH",
+            action_date=timezone.now(),
+            content_type=self.paper_content_type,
+            object_id=medium_score_paper.id,
+            parent_content_type=self.hub_content_type,
+            parent_object_id=self.hub.id,
+            unified_document=medium_score_doc,
+        )
+        FeedEntry.objects.create(
+            user=self.user,
+            action="PUBLISH",
+            action_date=timezone.now(),
+            content_type=self.paper_content_type,
+            object_id=low_score_paper.id,
+            parent_content_type=self.hub_content_type,
+            parent_object_id=self.hub.id,
+            unified_document=low_score_doc,
+        )
+
+        url = reverse("feed-list")
+        response = self.client.get(url, {"feed_view": "popular"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.data["results"]
+        self.assertEqual(len(results), 3)
+
+        content_object_ids = [result["content_object"]["id"] for result in results]
+
+        self.assertEqual(content_object_ids[0], high_score_paper.id)
+        self.assertEqual(content_object_ids[1], medium_score_paper.id)
+        self.assertEqual(content_object_ids[2], low_score_paper.id)
+
+    def test_popular_feed_view_with_multiple_entries(self):
+        """Test that popular feed view handles multiple entries per document correctly"""
+        # Create a paper with high hot score
+        high_score_doc = ResearchhubUnifiedDocument.objects.create(
+            document_type="PAPER", hot_score=100
+        )
+        high_score_paper = Paper.objects.create(
+            title="High Score Paper",
+            paper_publish_date=timezone.now(),
+            unified_document=high_score_doc,
+        )
+
+        high_score_doc.hubs.add(self.hub)
+
+        user2 = User.objects.create_user(
+            username="testuser2", email="test2@example.com", password="password123"
+        )
+        user3 = User.objects.create_user(
+            username="testuser3", email="test3@example.com", password="password123"
+        )
+
+        FeedEntry.objects.create(
+            user=user2,
+            action="PUBLISH",
+            action_date=timezone.now() - timezone.timedelta(days=10),
+            content_type=self.paper_content_type,
+            object_id=high_score_paper.id,
+            parent_content_type=self.hub_content_type,
+            parent_object_id=self.hub.id,
+            unified_document=high_score_doc,
+        )
+
+        FeedEntry.objects.create(
+            user=user3,
+            action="PUBLISH",
+            action_date=timezone.now() - timezone.timedelta(days=5),
+            content_type=self.paper_content_type,
+            object_id=high_score_paper.id,
+            parent_content_type=self.hub_content_type,
+            parent_object_id=self.hub.id,
+            unified_document=high_score_doc,
+        )
+
+        # Create the most recent entry
+        FeedEntry.objects.create(
+            user=self.user,
+            action="PUBLISH",
+            action_date=timezone.now(),
+            content_type=self.paper_content_type,
+            object_id=high_score_paper.id,
+            parent_content_type=self.hub_content_type,
+            parent_object_id=self.hub.id,
+            unified_document=high_score_doc,
+        )
+
+        url = reverse("feed-list")
+        response = self.client.get(url, {"feed_view": "popular"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.data["results"]
+        content_object_ids = [result["content_object"]["id"] for result in results]
+
+        high_score_paper_count = content_object_ids.count(high_score_paper.id)
+        self.assertEqual(
+            high_score_paper_count,
+            1,
+            f"Expected 1 entry for high score paper, got {high_score_paper_count}",
+        )
+
+        self.assertIn(
+            high_score_paper.id,
+            content_object_ids,
+            f"High score paper not found in results: {content_object_ids}",
+        )
+
+    def test_popular_feed_view_with_hub_filter(self):
+        """Test that popular feed view works with hub filter"""
+        high_score_doc = ResearchhubUnifiedDocument.objects.create(
+            document_type="PAPER", hot_score=100
+        )
+
+        another_hub = Hub.objects.create(name="Another Hub")
+
+        high_score_paper = Paper.objects.create(
+            title="High Score Paper",
+            paper_publish_date=timezone.now(),
+            unified_document=high_score_doc,
+        )
+
+        high_score_doc.hubs.add(another_hub)
+
+        FeedEntry.objects.create(
+            user=self.user,
+            action="PUBLISH",
+            action_date=timezone.now(),
+            content_type=self.paper_content_type,
+            object_id=high_score_paper.id,
+            parent_content_type=self.hub_content_type,
+            parent_object_id=another_hub.id,
+            unified_document=high_score_doc,
+        )
+
+        url = reverse("feed-list")
+        response = self.client.get(
+            url, {"feed_view": "popular", "hub_slug": self.hub.slug}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Should not include the high_score_paper since it's not in self.hub
+        results = response.data["results"]
+        content_object_ids = [result["content_object"]["id"] for result in results]
+        self.assertNotIn(high_score_paper.id, content_object_ids)
+
+        # Test with the new hub filter
+        response = self.client.get(
+            url, {"feed_view": "popular", "hub_slug": another_hub.slug}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Should include the high_score_paper since it's in another_hub
+        results = response.data["results"]
+        content_object_ids = [result["content_object"]["id"] for result in results]
+        self.assertIn(high_score_paper.id, content_object_ids)

--- a/src/feed/views.py
+++ b/src/feed/views.py
@@ -6,6 +6,7 @@ from rest_framework import status, viewsets
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
+from hub.models import Hub
 from paper.related_models.paper_model import Paper
 from reputation.related_models.bounty import Bounty
 from researchhub_comment.related_models.rh_comment_model import RhCommentModel
@@ -105,13 +106,13 @@ class FeedViewSet(viewsets.ModelViewSet):
 
             # Apply any additional filters
             if hub_slug:
-                from hub.models import Hub
-
-                hub = Hub.objects.get(slug=hub_slug)
-                if not hub:
+                try:
+                    hub = Hub.objects.get(slug=hub_slug)
+                except Hub.DoesNotExist:
                     return Response(
                         {"error": "Hub not found"}, status=status.HTTP_404_NOT_FOUND
                     )
+
                 top_unified_docs = top_unified_docs.filter(hubs=hub)
 
             # Since there can be multiple feed entries per unified document,
@@ -135,10 +136,9 @@ class FeedViewSet(viewsets.ModelViewSet):
         # For other feed views (latest, following with hub filter)
         # Apply hub filter if hub_id is provided
         if hub_slug:
-            from hub.models import Hub
-
-            hub = Hub.objects.get(slug=hub_slug)
-            if not hub:
+            try:
+                hub = Hub.objects.get(slug=hub_slug)
+            except Hub.DoesNotExist:
                 return Response(
                     {"error": "Hub not found"}, status=status.HTTP_404_NOT_FOUND
                 )

--- a/src/feed/views.py
+++ b/src/feed/views.py
@@ -99,6 +99,13 @@ class FeedViewSet(viewsets.ModelViewSet):
                     parent_object_id__in=following.values("object_id"),
                 )
 
+        # Set ordering based on feed_view
+        order_by_hot_score = False
+        if feed_view == "popular":
+            # Filter out entries without a unified_document
+            queryset = queryset.filter(unified_document__isnull=False)
+            order_by_hot_score = True
+
         # Apply hub filter if hub_id is provided
         if hub_slug:
             from hub.models import Hub
@@ -133,7 +140,11 @@ class FeedViewSet(viewsets.ModelViewSet):
                 )
             )
             .filter(row_number=1)
-            .order_by("-action_date")
+            .order_by(
+                "-unified_document__hot_score_v2"
+                if order_by_hot_score
+                else "-action_date"
+            )
         )
 
         return queryset

--- a/src/feed/views.py
+++ b/src/feed/views.py
@@ -98,12 +98,7 @@ class FeedViewSet(viewsets.ModelViewSet):
                     parent_object_id__in=following.values("object_id"),
                 )
 
-        # Handle different feed view types
         if feed_view == "popular":
-            # For popular feed, we can optimize by directly querying unified documents
-            # ordered by hot_score and then joining with feed entries
-            # This approach leverages the hot_score index
-
             top_unified_docs = ResearchhubUnifiedDocument.objects.filter(
                 is_removed=False
             ).order_by("-hot_score")
@@ -131,7 +126,6 @@ class FeedViewSet(viewsets.ModelViewSet):
                 .values_list("latest_id", flat=True)
             )
 
-            # Filter the queryset to include only these latest entries
             queryset = queryset.filter(
                 id__in=Subquery(latest_entries_subquery), unified_document__isnull=False
             ).order_by("-unified_document__hot_score")

--- a/src/feed/views.py
+++ b/src/feed/views.py
@@ -8,10 +8,7 @@ from rest_framework.response import Response
 from paper.related_models.paper_model import Paper
 from reputation.related_models.bounty import Bounty
 from researchhub_comment.related_models.rh_comment_model import RhCommentModel
-from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
-from researchhub_document.related_models.researchhub_unified_document import (
-    ResearchhubUnifiedDocument,
-)
+from researchhub_document.models import ResearchhubPost, ResearchhubUnifiedDocument
 
 from .models import FeedEntry
 from .serializers import FeedEntrySerializer


### PR DESCRIPTION
- Based on https://github.com/ResearchHub/researchhub-backend/pull/2145 to utilize unified document for feed sorting.
  - Rebased on master to include the hot_score_v2 -> hot_score changes.
- Add popular view, go from unified document sorted by hot score to feed entries since hot_score is on the unified doc.