### PR TITLE
Return serialized feed content

### DIFF
--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -372,29 +372,7 @@ class FeedEntrySerializer(serializers.ModelSerializer):
         return None
 
     def get_content_object(self, obj):
-        """Return the appropriate serialized content object based on type"""
-        match obj.content_type.model:
-            case "bounty":
-                # Use prefetched bounty if available
-                if hasattr(obj, "_prefetched_bounty"):
-                    return BountySerializer(obj._prefetched_bounty).data
-                return BountySerializer(obj.item).data
-            case "rhcommentmodel":
-                # Use prefetched comment if available
-                if hasattr(obj, "_prefetched_comment"):
-                    return CommentSerializer(obj._prefetched_comment).data
-                return CommentSerializer(obj.item).data
-            case "paper":
-                # Use prefetched paper if available
-                if hasattr(obj, "_prefetched_paper"):
-                    return PaperSerializer(obj._prefetched_paper).data
-                return PaperSerializer(obj.item).data
-            case "researchhubpost":
-                # Use prefetched post if available
-                if hasattr(obj, "_prefetched_post"):
-                    return PostSerializer(obj._prefetched_post).data
-                return PostSerializer(obj.item).data
-        return None
+        return obj.content
 
     def get_content_type(self, obj):
         return obj.content_type.model.upper()

--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -372,6 +372,9 @@ class FeedEntrySerializer(serializers.ModelSerializer):
         return None
 
     def get_content_object(self, obj):
+        if obj.content == {}:
+            # Serialize if serialized content is not already present
+            return serialize_feed_item(obj.item, obj.content_type)
         return obj.content
 
     def get_content_type(self, obj):

--- a/src/feed/views.py
+++ b/src/feed/views.py
@@ -210,7 +210,6 @@ class FeedViewSet(viewsets.ModelViewSet):
             .prefetch_related(
                 "unified_document",
                 "unified_document__hubs",
-                "unified_document__fundraises",
             )
         )
 


### PR DESCRIPTION
- Retrieve serialized feed item from `content` field.
- Allow fallback to create serialization if none is available.
- Create new feed entry or update existing once when processing feed signals.
- Remove unneeded prefetches (no longer needed due to serialized data in `content`).