### PR TITLE
[Social login] - add internal user id to the response

### DIFF
--- a/src/oauth/helpers.py
+++ b/src/oauth/helpers.py
@@ -159,7 +159,7 @@ def _send_response(original_request, default_response):
 
 def _respond_with_token(user):
     token = get_or_create_user_token(user)
-    response = JsonResponse({"key": token})
+    response = JsonResponse({"key": token, "user_id": user.id})
     return response
 
 


### PR DESCRIPTION
We simplified the `/session` endpoint to store only `userId` in the session token. However, for social logins, the `userId` is based on the Google account and doesn’t match our internal user ID. To fix this, we now include the internal ID in the RH token response and _*update the web app session accordingly._ 