### PR TITLE
Remove 'Insufficient Funds' check when creating a new post

### DIFF
--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -143,9 +143,6 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
                 created_by_author = created_by.author_profile
                 doi = DOI() if assign_doi else None
 
-                if assign_doi and created_by.get_balance() - CROSSREF_DOI_RSC_FEE < 0:
-                    return Response("Insufficient Funds", status=402)
-
                 # logical ordering & not using signals to avoid race-conditions
                 access_group = self.create_access_group(request)
                 unified_document = self.create_unified_doc(request)
@@ -281,9 +278,6 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
                 },
                 400,
             )
-
-        if assign_doi and created_by.get_balance() - CROSSREF_DOI_RSC_FEE < 0:
-            return Response("Insufficient Funds", status=402)
 
         rh_post.doi = doi.doi if doi else rh_post.doi
         rh_post.save(update_fields=["doi"])


### PR DESCRIPTION
We do not charge clients during the post-creation so we should remove this check. 
Currently, users with a balance 0 RSC are getting "Insufficient Funds" when they try to post a new `PREREGISTRATION` 