### PR TITLE
Allow uploads to `posts` folder

### DIFF
--- a/src/researchhub/serializers/__init__.py
+++ b/src/researchhub/serializers/__init__.py
@@ -1,2 +1,2 @@
-from .asset_upload_serializer import AssetUploadSerializer
+from .asset_upload_serializer import AssetUploadRequestSerializer
 from .serializers import DynamicModelFieldSerializer

--- a/src/researchhub/serializers/asset_upload_serializer.py
+++ b/src/researchhub/serializers/asset_upload_serializer.py
@@ -6,7 +6,7 @@ from researchhub.services.storage_service import (
 )
 
 
-class AssetUploadSerializer(serializers.Serializer):
+class AssetUploadRequestSerializer(serializers.Serializer):
     """
     Serializer for uploading an asset into ResearchHub storage.
     Used to validate request data.

--- a/src/researchhub/services/storage_service.py
+++ b/src/researchhub/services/storage_service.py
@@ -13,7 +13,7 @@ class PresignedUrl(NamedTuple):
 
 
 SUPPORTED_CONTENT_TYPES = ["application/pdf", "image/png", "image/jpeg"]
-SUPPORTED_ENTITIES = ["comment", "note", "paper"]
+SUPPORTED_ENTITIES = ["comment", "note", "paper", "post"]
 
 
 class StorageService:

--- a/src/researchhub/views/asset_upload_view.py
+++ b/src/researchhub/views/asset_upload_view.py
@@ -3,7 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from researchhub.serializers.asset_upload_serializer import AssetUploadSerializer
+from researchhub.serializers.asset_upload_serializer import AssetUploadRequestSerializer
 from researchhub.services.storage_service import S3StorageService
 
 
@@ -26,7 +26,7 @@ class AssetUploadView(APIView):
         data = request.data
 
         # Validate request data
-        serializer = AssetUploadSerializer(data=request.data)
+        serializer = AssetUploadRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         content_type = data.get("content_type")


### PR DESCRIPTION
Allow asset uploads for posts via the `/api/asset/upload/` endpoint.

This change adds `post` to the supported entity string, so an uploaded asset is stored in the corresponding `posts` location in the storage bucket.