### PR TITLE
Add raw author to feed paper

### DIFF
--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -97,6 +97,7 @@ class PostMetricsSerializer(serializers.Serializer):
 class PaperSerializer(ContentObjectSerializer):
     journal = serializers.SerializerMethodField()
     authors = SimpleAuthorSerializer(many=True)
+    raw_authors = serializers.ListField()
     title = serializers.CharField()
     abstract = serializers.CharField()
     doi = serializers.CharField()

--- a/src/feed/tests/test_serializers.py
+++ b/src/feed/tests/test_serializers.py
@@ -81,6 +81,7 @@ class PaperSerializerTests(TestCase):
         self.paper = create_paper(
             uploaded_by=self.user,
             title="Test Paper",
+            raw_authors=["Test Author", "Test Author 2"],
         )
         self.paper.abstract = "Test Abstract"
         self.paper.doi = "10.1234/test"
@@ -124,6 +125,8 @@ class PaperSerializerTests(TestCase):
         self.assertEqual(
             data["authors"][0]["profile_image"], "https://example.com/profile.jpg"
         )
+        self.assertIn("raw_authors", data)
+        self.assertEqual(data["raw_authors"], ["Test Author", "Test Author 2"])
 
     def test_serializes_paper_with_journal_without_image(self):
         # Create a new journal hub without an image


### PR DESCRIPTION
- Papers don't always have authors, in that case we should use the raw authors