### PR TITLE
Include feed `source` parameter into cache key

### DIFF
--- a/src/feed/tests/views/test_common.py
+++ b/src/feed/tests/views/test_common.py
@@ -1,0 +1,68 @@
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+from feed.views.common import get_cache_key
+from feed.views.feed_view import FeedViewSet
+
+
+class FeedCommonTests(TestCase):
+    def test_get_cache_key(self):
+        """Test cache key generation method with various inputs"""
+        # Arrange
+        viewset = FeedViewSet()
+        viewset.pagination_class = type(
+            "TestPagination",
+            (),
+            {"page_size": 20, "page_size_query_param": "page_size"},
+        )
+
+        test_cases = [
+            # (query_params, is_authenticated, user_id, expected_key)
+            ({}, False, None, "feed:latest:all:none:1-20"),
+            ({"feed_view": "following"}, True, 123, "feed:following:all:123:1-20"),
+            (
+                {"hub_slug": "science"},
+                False,
+                None,
+                "feed:latest:science:none:1-20",
+            ),
+            ({"feed_view": "popular"}, True, 123, "feed:popular:all:none:1-20"),
+            (
+                {"page": "3", "page_size": "50"},
+                False,
+                None,
+                "feed:latest:all:none:3-50",
+            ),
+            (
+                {
+                    "feed_view": "following",
+                    "hub_slug": "computer-science",
+                    "page": "2",
+                    "page_size": "30",
+                },
+                True,
+                456,
+                "feed:following:computer-science:456:2-30",
+            ),
+        ]
+
+        for query_params, is_authenticated, user_id, expected_key in test_cases:
+            mock_request = Mock()
+            mock_request.query_params = query_params
+            mock_request.user = Mock()
+            mock_request.user.is_authenticated = is_authenticated
+            mock_request.user.id = user_id
+
+            # Act
+            cache_key = get_cache_key(
+                mock_request,
+            )
+
+            # Assert
+            self.assertEqual(
+                cache_key,
+                expected_key,
+                f"Failed with params: {query_params}, auth: {is_authenticated}, "
+                f"user_id: {user_id}",
+            )

--- a/src/feed/tests/views/test_common.py
+++ b/src/feed/tests/views/test_common.py
@@ -19,20 +19,41 @@ class FeedCommonTests(TestCase):
 
         test_cases = [
             # (query_params, is_authenticated, user_id, expected_key)
-            ({}, False, None, "feed:latest:all:none:1-20"),
-            ({"feed_view": "following"}, True, 123, "feed:following:all:123:1-20"),
+            (
+                {},
+                False,
+                None,
+                "feed:latest:all:all:none:1-20",
+            ),
+            (
+                {"source": "researchhub"},
+                False,
+                None,
+                "feed:latest:all:researchhub:none:1-20",
+            ),
+            (
+                {"feed_view": "following"},
+                True,
+                123,
+                "feed:following:all:all:123:1-20",
+            ),
             (
                 {"hub_slug": "science"},
                 False,
                 None,
-                "feed:latest:science:none:1-20",
+                "feed:latest:science:all:none:1-20",
             ),
-            ({"feed_view": "popular"}, True, 123, "feed:popular:all:none:1-20"),
+            (
+                {"feed_view": "popular"},
+                True,
+                123,
+                "feed:popular:all:all:none:1-20",
+            ),
             (
                 {"page": "3", "page_size": "50"},
                 False,
                 None,
-                "feed:latest:all:none:3-50",
+                "feed:latest:all:all:none:3-50",
             ),
             (
                 {
@@ -43,7 +64,7 @@ class FeedCommonTests(TestCase):
                 },
                 True,
                 456,
-                "feed:following:computer-science:456:2-30",
+                "feed:following:computer-science:all:456:2-30",
             ),
         ]
 

--- a/src/feed/tests/views/test_feed_view.py
+++ b/src/feed/tests/views/test_feed_view.py
@@ -463,66 +463,6 @@ class FeedViewSetTests(TestCase):
         content_object_ids = [result["content_object"]["id"] for result in results]
         self.assertIn(high_score_paper.id, content_object_ids)
 
-    def test_get_cache_key(self):
-        """Test cache key generation method with various inputs"""
-        # Arrange
-        viewset = FeedViewSet()
-        viewset.pagination_class = type(
-            "TestPagination",
-            (),
-            {"page_size": 20, "page_size_query_param": "page_size"},
-        )
-
-        test_cases = [
-            # (query_params, is_authenticated, user_id, expected_key)
-            ({}, False, None, "feed:latest:all:none:1-20"),
-            ({"feed_view": "following"}, True, 123, "feed:following:all:123:1-20"),
-            (
-                {"hub_slug": "science"},
-                False,
-                None,
-                "feed:latest:science:none:1-20",
-            ),
-            ({"feed_view": "popular"}, True, 123, "feed:popular:all:none:1-20"),
-            (
-                {"page": "3", "page_size": "50"},
-                False,
-                None,
-                "feed:latest:all:none:3-50",
-            ),
-            (
-                {
-                    "feed_view": "following",
-                    "hub_slug": "computer-science",
-                    "page": "2",
-                    "page_size": "30",
-                },
-                True,
-                456,
-                "feed:following:computer-science:456:2-30",
-            ),
-        ]
-
-        for query_params, is_authenticated, user_id, expected_key in test_cases:
-            mock_request = Mock()
-            mock_request.query_params = query_params
-            mock_request.user = Mock()
-            mock_request.user.is_authenticated = is_authenticated
-            mock_request.user.id = user_id
-
-            # Act
-            cache_key = get_cache_key(
-                mock_request,
-            )
-
-            # Assert
-            self.assertEqual(
-                cache_key,
-                expected_key,
-                f"Failed with params: {query_params}, auth: {is_authenticated}, "
-                f"user_id: {user_id}",
-            )
-
     def test_feed_includes_user_votes(self):
         """Test that feed response includes user votes"""
         # Arrange

--- a/src/feed/tests/views/test_feed_view.py
+++ b/src/feed/tests/views/test_feed_view.py
@@ -1,6 +1,5 @@
 import uuid
-from unittest import mock
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
@@ -13,8 +12,6 @@ from rest_framework.test import APIClient
 
 from discussion.reaction_models import Vote as GrmVote
 from feed.models import FeedEntry
-from feed.views.common import get_cache_key
-from feed.views.feed_view import FeedViewSet
 from hub.models import Hub
 from paper.models import Paper
 from reputation.related_models.bounty import Bounty

--- a/src/feed/tests/views/test_funding_feed_view.py
+++ b/src/feed/tests/views/test_funding_feed_view.py
@@ -295,7 +295,7 @@ class FundingFeedViewSetTests(TestCase):
         request.user = anon_user
 
         cache_key = get_cache_key(request, "funding")
-        self.assertEqual(cache_key, "funding_feed:latest:all:none:1-20")
+        self.assertEqual(cache_key, "funding_feed:latest:all:all:none:1-20")
 
         # Authenticated user
         request = request_factory.get("/api/funding_feed/")
@@ -308,7 +308,7 @@ class FundingFeedViewSetTests(TestCase):
         request.user = mock_user
 
         cache_key = get_cache_key(request, "funding")
-        self.assertEqual(cache_key, "funding_feed:latest:all:none:1-20")
+        self.assertEqual(cache_key, "funding_feed:latest:all:all:none:1-20")
 
         # Custom page and page size
         request = request_factory.get("/api/funding_feed/?page=3&page_size=10")
@@ -316,7 +316,7 @@ class FundingFeedViewSetTests(TestCase):
         request.user = mock_user
 
         cache_key = get_cache_key(request, "funding")
-        self.assertEqual(cache_key, "funding_feed:latest:all:none:3-10")
+        self.assertEqual(cache_key, "funding_feed:latest:all:all:none:3-10")
 
     def test_preregistration_post_only(self):
         """Test that funding feed only returns preregistration posts"""

--- a/src/feed/views/common.py
+++ b/src/feed/views/common.py
@@ -49,7 +49,10 @@ def get_cache_key(request: Request, feed_type: str = "") -> str:
     status_part = f"-{fundraise_status}" if fundraise_status else ""
     feed_type_part = f"{feed_type}_" if feed_type else ""
 
-    return f"{feed_type_part}feed:{feed_view}:{hub_part}:{user_part}:{pagination_part}{status_part}"
+    source = request.query_params.get("source")
+    source_part = f"{source}" if source else "all"
+
+    return f"{feed_type_part}feed:{feed_view}:{hub_part}:{source_part}:{user_part}:{pagination_part}{status_part}"
 
 
 def add_user_votes_to_response(user, response_data):


### PR DESCRIPTION
The `source` query string parameter must be included in the cache key, so different requests for different sources (all, researchhub) are cached separately.