### PR TITLE
Only include specified fields for feed fundraise created_by

### DIFF
--- a/src/feed/views/common.py
+++ b/src/feed/views/common.py
@@ -27,6 +27,33 @@ class FeedPagination(PageNumberPagination):
     max_page_size = 100
 
 
+def get_common_serializer_context():
+    """
+    Returns common serializer context used across feed-related viewsets.
+    """
+    context = {}
+    context["pch_dfs_get_created_by"] = {
+        "_include_fields": (
+            "id",
+            "author_profile",
+            "first_name",
+            "last_name",
+        )
+    }
+    context["usr_dus_get_author_profile"] = {
+        "_include_fields": (
+            "id",
+            "first_name",
+            "last_name",
+            "created_date",
+            "updated_date",
+            "profile_image",
+            "is_verified",
+        )
+    }
+    return context
+
+
 def get_cache_key(request: Request, feed_type: str = "") -> str:
     feed_view = request.query_params.get("feed_view", "latest")
     hub_slug = request.query_params.get("hub_slug")

--- a/src/feed/views/feed_view.py
+++ b/src/feed/views/feed_view.py
@@ -18,6 +18,7 @@ from .common import (
     FeedPagination,
     add_user_votes_to_response,
     get_cache_key,
+    get_common_serializer_context,
 )
 
 
@@ -30,6 +31,11 @@ class FeedViewSet(viewsets.ModelViewSet):
     serializer_class = FeedEntrySerializer
     permission_classes = []
     pagination_class = FeedPagination
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context.update(get_common_serializer_context())
+        return context
 
     def list(self, request, *args, **kwargs):
         page = request.query_params.get("page", "1")

--- a/src/feed/views/funding_feed_view.py
+++ b/src/feed/views/funding_feed_view.py
@@ -26,6 +26,7 @@ from .common import (
     FeedPagination,
     add_user_votes_to_response,
     get_cache_key,
+    get_common_serializer_context,
 )
 
 
@@ -45,6 +46,11 @@ class FundingFeedViewSet(viewsets.ModelViewSet):
     serializer_class = PostSerializer
     permission_classes = []
     pagination_class = FeedPagination
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context.update(get_common_serializer_context())
+        return context
 
     def list(self, request, *args, **kwargs):
         page = request.query_params.get("page", "1")


### PR DESCRIPTION
- If you don't include context fields in the dynamic user serializer, it includes all fields.