### PR TITLE
Add `image_url` from posts to unified document list

### DIFF
--- a/src/researchhub_document/serializers/researchhub_post_serializer.py
+++ b/src/researchhub_document/serializers/researchhub_post_serializer.py
@@ -230,6 +230,7 @@ class DynamicPostSerializer(DynamicModelFieldSerializer):
     score = SerializerMethodField()
     unified_document = SerializerMethodField()
     user_vote = SerializerMethodField()
+    image_url = SerializerMethodField()
 
     class Meta:
         model = ResearchhubPost
@@ -368,3 +369,9 @@ class DynamicPostSerializer(DynamicModelFieldSerializer):
             return vote
         except Vote.DoesNotExist:
             return None
+
+    def get_image_url(self, post):
+        if not post.image:
+            return None
+
+        return default_storage.url(post.image)

--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -170,6 +170,7 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
                     "paper_publish_date",
                     "paper_title",
                     "pdf_url",
+                    "image_url",
                     "is_open_access",
                     "oa_status",
                     "pdf_copyright_allows_display",


### PR DESCRIPTION
This change includes the new `image_url` field (that has been added as a calculated field to the RH post model) in the RH unified documents list.

URL: `/api/researchhub_unified_document/get_unified_documents?type=posts`

```
[...]
          "image_url": "https://researchhub-dev-storage.s3.amazonaws.com/comment_files/jpeg/9a78709fdc3712c90d17864bcdc17f11.jpeg",
          "created_date": "2025-03-26T15:50:37.418943Z",
          "discussion_count": 0,
          "preview_img": null,
          "renderable_text": "some text",
          "title": "Some random post title",
          "slug": ""
        }
      ],
[...]
```