### PR TITLE
Fetch papers from core sources

### DIFF
--- a/src/paper/openalex_tasks.py
+++ b/src/paper/openalex_tasks.py
@@ -171,12 +171,14 @@ def _pull_openalex_works(self, fetch_type, retry=0, paper_fetch_log_id=None) -> 
                     types=["article"],
                     since_date=date_to_fetch_from,
                     next_cursor=next_cursor,
+                    core_sources_only=True,
                 )
             elif fetch_type == PaperFetchLog.FETCH_UPDATE:
                 works, next_cursor = open_alex.get_works(
                     types=["article"],
                     from_updated_date=date_to_fetch_from,
                     next_cursor=next_cursor,
+                    core_sources_only=True,
                 )
 
             # if we've reached the end of the results, exit the loop

--- a/src/utils/openalex.py
+++ b/src/utils/openalex.py
@@ -361,11 +361,15 @@ class OpenAlex:
         source=None,
         openalex_author_id=None,
         from_updated_date=None,
+        core_sources_only: bool = False,
     ):
         """
         Fetches works from OpenAlex based on the given criteria.
 
         Works published on ResearchHub are filtered out (by DOI).
+
+        Args:
+            core_sources_only (bool): If True, only fetch works from "core sources".
         """
         # Build the filter
         oa_filters = []
@@ -380,6 +384,11 @@ class OpenAlex:
 
         if source_id:
             oa_filters.append(f"primary_location.source.id:{source_id}")
+
+        if core_sources_only:
+            # Only fetch works that are from "core sources".
+            # See: https://docs.openalex.org/api-entities/sources/source-object#is_core
+            oa_filters.append("primary_location.source.is_core:true")
 
         if since_date:
             # Format the date in YYYY-MM-DD format


### PR DESCRIPTION
Only pull papers from _core sources_ [1] for the automated paper ingestion job.

- Add parameter to OpenAlex `get_works` to control if only papers from core sources should be pulled.
- Set the parameter to `True` for automated paper ingestion.
- Add tests

[1]: https://docs.openalex.org/api-entities/sources/source-object#is_core