### PR TITLE
chore: Add base feed view with common functionality

### DIFF
--- a/src/feed/tests/test_serializers.py
+++ b/src/feed/tests/test_serializers.py
@@ -13,7 +13,7 @@ from feed.serializers import (
     PaperSerializer,
     PostSerializer,
 )
-from feed.views.common import get_common_serializer_context
+from feed.views.base_feed_view import BaseFeedView
 from hub.models import Hub
 from hub.serializers import SimpleHubSerializer
 from hub.tests.helpers import create_hub
@@ -268,7 +268,7 @@ class PostSerializerTests(TestCase):
         )
 
         # Get the context with the field specifications
-        context = get_common_serializer_context()
+        context = BaseFeedView().get_common_serializer_context()
 
         # Mock the RscExchangeRate.usd_to_rsc method to avoid database dependency
         with patch.object(

--- a/src/feed/tests/views/test_base_feed_view.py
+++ b/src/feed/tests/views/test_base_feed_view.py
@@ -2,19 +2,14 @@ from unittest.mock import Mock
 
 from django.test import TestCase
 
-from feed.views.feed_view import FeedViewSet
+from feed.views.base_feed_view import BaseFeedView
 
 
-class FeedCommonTests(TestCase):
+class BaseFeedViewTests(TestCase):
     def test_get_cache_key(self):
         """Test cache key generation method with various inputs"""
         # Arrange
-        viewset = FeedViewSet()
-        viewset.pagination_class = type(
-            "TestPagination",
-            (),
-            {"page_size": 20, "page_size_query_param": "page_size"},
-        )
+        view = BaseFeedView()
 
         test_cases = [
             # (query_params, is_authenticated, user_id, expected_key)
@@ -75,7 +70,7 @@ class FeedCommonTests(TestCase):
             mock_request.user.id = user_id
 
             # Act
-            cache_key = viewset.get_cache_key(
+            cache_key = view.get_cache_key(
                 mock_request,
             )
 

--- a/src/feed/tests/views/test_common.py
+++ b/src/feed/tests/views/test_common.py
@@ -2,7 +2,6 @@ from unittest.mock import Mock
 
 from django.test import TestCase
 
-from feed.views.common import get_cache_key
 from feed.views.feed_view import FeedViewSet
 
 
@@ -76,7 +75,7 @@ class FeedCommonTests(TestCase):
             mock_request.user.id = user_id
 
             # Act
-            cache_key = get_cache_key(
+            cache_key = viewset.get_cache_key(
                 mock_request,
             )
 

--- a/src/feed/tests/views/test_funding_feed_view.py
+++ b/src/feed/tests/views/test_funding_feed_view.py
@@ -12,7 +12,6 @@ from rest_framework.request import Request
 from rest_framework.test import APIClient, APIRequestFactory
 
 from discussion.reaction_models import Vote as GrmVote
-from feed.views.common import get_cache_key
 from hub.models import Hub
 from purchase.related_models.constants.currency import USD
 from purchase.related_models.constants.rsc_exchange_currency import MORALIS
@@ -294,7 +293,7 @@ class FundingFeedViewSetTests(TestCase):
         anon_user.id = None
         request.user = anon_user
 
-        cache_key = get_cache_key(request, "funding")
+        cache_key = viewset.get_cache_key(request, "funding")
         self.assertEqual(cache_key, "funding_feed:latest:all:all:none:1-20")
 
         # Authenticated user
@@ -307,7 +306,7 @@ class FundingFeedViewSetTests(TestCase):
         mock_user.id = self.user.id
         request.user = mock_user
 
-        cache_key = get_cache_key(request, "funding")
+        cache_key = viewset.get_cache_key(request, "funding")
         self.assertEqual(cache_key, "funding_feed:latest:all:all:none:1-20")
 
         # Custom page and page size
@@ -315,7 +314,7 @@ class FundingFeedViewSetTests(TestCase):
         request = Request(request)
         request.user = mock_user
 
-        cache_key = get_cache_key(request, "funding")
+        cache_key = viewset.get_cache_key(request, "funding")
         self.assertEqual(cache_key, "funding_feed:latest:all:all:none:3-10")
 
     def test_preregistration_post_only(self):

--- a/src/feed/views/base_feed_view.py
+++ b/src/feed/views/base_feed_view.py
@@ -1,0 +1,34 @@
+from django.contrib.contenttypes.models import ContentType
+from rest_framework import viewsets
+
+from hub.models import Hub
+from paper.related_models.paper_model import Paper
+from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
+
+
+class BaseFeedView(viewsets.ModelViewSet):
+    """
+    Base class for feed-related viewsets.
+    """
+
+    _content_types = {}
+
+    @property
+    def _hub_content_type(self):
+        return self._get_content_type(Hub)
+
+    @property
+    def _paper_content_type(self):
+        return self._get_content_type(Paper)
+
+    @property
+    def _post_content_type(self):
+        return self._get_content_type(ResearchhubPost)
+
+    def _get_content_type(self, model_class):
+        model_name = model_class.__name__.lower()
+        if model_name not in self._content_types:
+            self._content_types[model_name] = ContentType.objects.get_for_model(
+                model_class
+            )
+        return self._content_types[model_name]

--- a/src/feed/views/base_feed_view.py
+++ b/src/feed/views/base_feed_view.py
@@ -48,22 +48,10 @@ class BaseFeedView(viewsets.ModelViewSet):
             user: The authenticated user
             response_data: The response data containing feed items
         """
-        # Get content types once to avoid repeated database queries
-        paper_content_type = ContentType.objects.get_for_model(Paper)
-        post_content_type = ContentType.objects.get_for_model(ResearchhubPost)
-        comment_content_type = ContentType.objects.get_for_model(RhCommentModel)
-
         # Get uppercase model names from ContentType objects
-        paper_type_str = paper_content_type.model.upper()
-        post_type_str = post_content_type.model.upper()
-        comment_type_str = comment_content_type.model.upper()
-
-        # Map content type strings to their ContentType objects
-        content_type_map = {
-            paper_type_str: paper_content_type,
-            post_type_str: post_content_type,
-            comment_type_str: comment_content_type,
-        }
+        paper_type_str = self._paper_content_type.model.upper()
+        post_type_str = self._post_content_type.model.upper()
+        comment_type_str = self._comment_content_type.model.upper()
 
         paper_ids = []
         post_ids = []
@@ -84,7 +72,7 @@ class BaseFeedView(viewsets.ModelViewSet):
             paper_votes = get_user_votes(
                 user,
                 paper_ids,
-                content_type_map[paper_type_str],
+                self._paper_content_type,
             )
 
             paper_votes_map = {}
@@ -102,7 +90,7 @@ class BaseFeedView(viewsets.ModelViewSet):
             post_votes = get_user_votes(
                 user,
                 post_ids,
-                content_type_map[post_type_str],
+                self._post_content_type,
             )
 
             post_votes_map = {}
@@ -120,7 +108,7 @@ class BaseFeedView(viewsets.ModelViewSet):
             comment_votes = get_user_votes(
                 user,
                 comment_ids,
-                content_type_map[comment_type_str],
+                self._comment_content_type,
             )
 
             comment_votes_map = {}

--- a/src/feed/views/base_feed_view.py
+++ b/src/feed/views/base_feed_view.py
@@ -1,7 +1,9 @@
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import viewsets
+from rest_framework.request import Request
 
 from discussion.reaction_serializers import VoteSerializer
+from feed.views.common import FeedPagination
 from hub.models import Hub
 from paper.related_models.paper_model import Paper
 from researchhub_comment.related_models.rh_comment_model import RhCommentModel
@@ -13,6 +15,9 @@ class BaseFeedView(viewsets.ModelViewSet):
     """
     Base class for feed-related viewsets.
     """
+
+    # Cache timeout (30 minutes)
+    DEFAULT_CACHE_TIMEOUT = 60 * 30
 
     _content_types = {}
 
@@ -120,3 +125,56 @@ class BaseFeedView(viewsets.ModelViewSet):
                     comment_id = int(item["content_object"]["id"])
                     if comment_id in comment_votes_map:
                         item["user_vote"] = comment_votes_map[comment_id]
+
+    def get_common_serializer_context(self):
+        """
+        Returns common serializer context used across feed-related viewsets.
+        """
+        context = {}
+        context["pch_dfs_get_created_by"] = {
+            "_include_fields": (
+                "id",
+                "author_profile",
+                "first_name",
+                "last_name",
+            )
+        }
+        context["usr_dus_get_author_profile"] = {
+            "_include_fields": (
+                "id",
+                "first_name",
+                "last_name",
+                "created_date",
+                "updated_date",
+                "profile_image",
+                "is_verified",
+            )
+        }
+        return context
+
+    def get_cache_key(self, request: Request, feed_type: str = "") -> str:
+        feed_view = request.query_params.get("feed_view", "latest")
+        hub_slug = request.query_params.get("hub_slug")
+        user_id = request.user.id if request.user.is_authenticated else None
+        fundraise_status = request.query_params.get("fundraise_status", None)
+
+        page = request.query_params.get("page", "1")
+        page_size = request.query_params.get(
+            FeedPagination.page_size_query_param,
+            str(FeedPagination.page_size),
+        )
+
+        hub_part = hub_slug or "all"
+        user_part = (
+            "none"
+            if feed_view == "popular" or feed_view == "latest"
+            else f"{user_id or 'anonymous'}"
+        )
+        pagination_part = f"{page}-{page_size}"
+        status_part = f"-{fundraise_status}" if fundraise_status else ""
+        feed_type_part = f"{feed_type}_" if feed_type else ""
+
+        source = request.query_params.get("source")
+        source_part = f"{source}" if source else "all"
+
+        return f"{feed_type_part}feed:{feed_view}:{hub_part}:{source_part}:{user_part}:{pagination_part}{status_part}"

--- a/src/feed/views/common.py
+++ b/src/feed/views/common.py
@@ -2,11 +2,7 @@
 Common functionality shared between feed ViewSets.
 """
 
-from requests import Request
 from rest_framework.pagination import PageNumberPagination
-
-# Cache timeout (30 minutes)
-DEFAULT_CACHE_TIMEOUT = 60 * 30
 
 
 class FeedPagination(PageNumberPagination):
@@ -17,58 +13,3 @@ class FeedPagination(PageNumberPagination):
     page_size = 20
     page_size_query_param = "page_size"
     max_page_size = 100
-
-
-def get_common_serializer_context():
-    """
-    Returns common serializer context used across feed-related viewsets.
-    """
-    context = {}
-    context["pch_dfs_get_created_by"] = {
-        "_include_fields": (
-            "id",
-            "author_profile",
-            "first_name",
-            "last_name",
-        )
-    }
-    context["usr_dus_get_author_profile"] = {
-        "_include_fields": (
-            "id",
-            "first_name",
-            "last_name",
-            "created_date",
-            "updated_date",
-            "profile_image",
-            "is_verified",
-        )
-    }
-    return context
-
-
-def get_cache_key(request: Request, feed_type: str = "") -> str:
-    feed_view = request.query_params.get("feed_view", "latest")
-    hub_slug = request.query_params.get("hub_slug")
-    user_id = request.user.id if request.user.is_authenticated else None
-    fundraise_status = request.query_params.get("fundraise_status", None)
-
-    page = request.query_params.get("page", "1")
-    page_size = request.query_params.get(
-        FeedPagination.page_size_query_param,
-        str(FeedPagination.page_size),
-    )
-
-    hub_part = hub_slug or "all"
-    user_part = (
-        "none"
-        if feed_view == "popular" or feed_view == "latest"
-        else f"{user_id or 'anonymous'}"
-    )
-    pagination_part = f"{page}-{page_size}"
-    status_part = f"-{fundraise_status}" if fundraise_status else ""
-    feed_type_part = f"{feed_type}_" if feed_type else ""
-
-    source = request.query_params.get("source")
-    source_part = f"{source}" if source else "all"
-
-    return f"{feed_type_part}feed:{feed_view}:{hub_part}:{source_part}:{user_part}:{pagination_part}{status_part}"

--- a/src/feed/views/common.py
+++ b/src/feed/views/common.py
@@ -2,15 +2,8 @@
 Common functionality shared between feed ViewSets.
 """
 
-from django.contrib.contenttypes.models import ContentType
 from requests import Request
 from rest_framework.pagination import PageNumberPagination
-
-from discussion.reaction_serializers import VoteSerializer as GrmVoteSerializer
-from paper.related_models.paper_model import Paper
-from researchhub_comment.related_models.rh_comment_model import RhCommentModel
-from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
-from researchhub_document.views.researchhub_unified_document_views import get_user_votes
 
 # Cache timeout (30 minutes)
 DEFAULT_CACHE_TIMEOUT = 60 * 30
@@ -79,97 +72,3 @@ def get_cache_key(request: Request, feed_type: str = "") -> str:
     source_part = f"{source}" if source else "all"
 
     return f"{feed_type_part}feed:{feed_view}:{hub_part}:{source_part}:{user_part}:{pagination_part}{status_part}"
-
-
-def add_user_votes_to_response(user, response_data):
-    """
-    Add user votes to feed items in the response data.
-
-    Args:
-        user: The authenticated user
-        response_data: The response data containing feed items
-    """
-    # Get content types once to avoid repeated database queries
-    paper_content_type = ContentType.objects.get_for_model(Paper)
-    post_content_type = ContentType.objects.get_for_model(ResearchhubPost)
-    comment_content_type = ContentType.objects.get_for_model(RhCommentModel)
-
-    # Get uppercase model names from ContentType objects
-    paper_type_str = paper_content_type.model.upper()
-    post_type_str = post_content_type.model.upper()
-    comment_type_str = comment_content_type.model.upper()
-
-    # Map content type strings to their ContentType objects
-    content_type_map = {
-        paper_type_str: paper_content_type,
-        post_type_str: post_content_type,
-        comment_type_str: comment_content_type,
-    }
-
-    paper_ids = []
-    post_ids = []
-    comment_ids = []
-
-    # Collect IDs for each content type
-    for item in response_data["results"]:
-        content_type_str = item.get("content_type")
-        if content_type_str == paper_type_str:
-            paper_ids.append(int(item["content_object"]["id"]))
-        elif content_type_str == post_type_str:
-            post_ids.append(int(item["content_object"]["id"]))
-        elif content_type_str == comment_type_str:
-            comment_ids.append(int(item["content_object"]["id"]))
-
-    # Process paper votes
-    if paper_ids:
-        paper_votes = get_user_votes(
-            user,
-            paper_ids,
-            content_type_map[paper_type_str],
-        )
-
-        paper_votes_map = {}
-        for vote in paper_votes:
-            paper_votes_map[int(vote.object_id)] = GrmVoteSerializer(vote).data
-
-        for item in response_data["results"]:
-            if item.get("content_type") == paper_type_str:
-                paper_id = int(item["content_object"]["id"])
-                if paper_id in paper_votes_map:
-                    item["user_vote"] = paper_votes_map[paper_id]
-
-    # Process post votes
-    if post_ids:
-        post_votes = get_user_votes(
-            user,
-            post_ids,
-            content_type_map[post_type_str],
-        )
-
-        post_votes_map = {}
-        for vote in post_votes:
-            post_votes_map[int(vote.object_id)] = GrmVoteSerializer(vote).data
-
-        for item in response_data["results"]:
-            if item.get("content_type") == post_type_str:
-                post_id = int(item["content_object"]["id"])
-                if post_id in post_votes_map:
-                    item["user_vote"] = post_votes_map[post_id]
-
-    # Process comment votes
-    if comment_ids:
-        comment_votes = get_user_votes(
-            user,
-            comment_ids,
-            content_type_map[comment_type_str],
-        )
-
-        comment_votes_map = {}
-        for vote in comment_votes:
-            comment_votes_map[int(vote.object_id)] = GrmVoteSerializer(vote).data
-
-        for item in response_data["results"]:
-            if item.get("content_type") == comment_type_str:
-                comment_id = int(item["content_object"]["id"])
-                if comment_id in comment_votes_map:
-                    item["user_vote"] = comment_votes_map[comment_id]

--- a/src/feed/views/feed_view.py
+++ b/src/feed/views/feed_view.py
@@ -17,7 +17,6 @@ from ..serializers import FeedEntrySerializer
 from .common import (
     DEFAULT_CACHE_TIMEOUT,
     FeedPagination,
-    add_user_votes_to_response,
     get_cache_key,
     get_common_serializer_context,
 )
@@ -50,7 +49,7 @@ class FeedViewSet(BaseFeedView):
             cached_response = cache.get(cache_key)
             if cached_response:
                 if request.user.is_authenticated:
-                    add_user_votes_to_response(request.user, cached_response)
+                    self.add_user_votes_to_response(request.user, cached_response)
                 return Response(cached_response)
 
         response = super().list(request, *args, **kwargs)
@@ -60,7 +59,7 @@ class FeedViewSet(BaseFeedView):
             cache.set(cache_key, response.data, timeout=DEFAULT_CACHE_TIMEOUT)
 
         if request.user.is_authenticated:
-            add_user_votes_to_response(request.user, response.data)
+            self.add_user_votes_to_response(request.user, response.data)
 
         return response
 

--- a/src/feed/views/feed_view.py
+++ b/src/feed/views/feed_view.py
@@ -14,12 +14,7 @@ from hub.models import Hub
 
 from ..models import FeedEntryLatest, FeedEntryPopular
 from ..serializers import FeedEntrySerializer
-from .common import (
-    DEFAULT_CACHE_TIMEOUT,
-    FeedPagination,
-    get_cache_key,
-    get_common_serializer_context,
-)
+from .common import FeedPagination
 
 
 class FeedViewSet(BaseFeedView):
@@ -35,13 +30,13 @@ class FeedViewSet(BaseFeedView):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context.update(get_common_serializer_context())
+        context.update(self.get_common_serializer_context())
         return context
 
     def list(self, request, *args, **kwargs):
         page = request.query_params.get("page", "1")
         page_num = int(page)
-        cache_key = get_cache_key(request)
+        cache_key = self.get_cache_key(request)
         use_cache = self.cache_enabled and page_num < 4
 
         if use_cache:
@@ -56,7 +51,7 @@ class FeedViewSet(BaseFeedView):
 
         if use_cache:
             # cache response
-            cache.set(cache_key, response.data, timeout=DEFAULT_CACHE_TIMEOUT)
+            cache.set(cache_key, response.data, timeout=self.DEFAULT_CACHE_TIMEOUT)
 
         if request.user.is_authenticated:
             self.add_user_votes_to_response(request.user, response.data)

--- a/src/feed/views/funding_feed_view.py
+++ b/src/feed/views/funding_feed_view.py
@@ -23,7 +23,6 @@ from ..serializers import PostSerializer
 from .common import (
     DEFAULT_CACHE_TIMEOUT,
     FeedPagination,
-    add_user_votes_to_response,
     get_cache_key,
     get_common_serializer_context,
 )
@@ -62,7 +61,7 @@ class FundingFeedViewSet(BaseFeedView):
             cached_response = cache.get(cache_key)
             if cached_response:
                 if request.user.is_authenticated:
-                    add_user_votes_to_response(request.user, cached_response)
+                    self.add_user_votes_to_response(request.user, cached_response)
                 return Response(cached_response)
 
         # Get paginated posts
@@ -88,7 +87,7 @@ class FundingFeedViewSet(BaseFeedView):
         response_data = self.get_paginated_response(serializer.data).data
 
         if request.user.is_authenticated:
-            add_user_votes_to_response(request.user, response_data)
+            self.add_user_votes_to_response(request.user, response_data)
 
         if use_cache:
             cache.set(cache_key, response_data, timeout=DEFAULT_CACHE_TIMEOUT)

--- a/src/feed/views/funding_feed_view.py
+++ b/src/feed/views/funding_feed_view.py
@@ -8,14 +8,13 @@ This is done for three reasons:
 3. Older feed entries are not in the feed table.
 """
 
-from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.db.models import Q
-from rest_framework import viewsets
 from rest_framework.response import Response
 
 from feed.models import FeedEntry
 from feed.serializers import FeedEntrySerializer
+from feed.views.base_feed_view import BaseFeedView
 from purchase.related_models.fundraise_model import Fundraise
 from researchhub_document.related_models.constants.document_type import PREREGISTRATION
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
@@ -30,7 +29,7 @@ from .common import (
 )
 
 
-class FundingFeedViewSet(viewsets.ModelViewSet):
+class FundingFeedViewSet(BaseFeedView):
     """
     ViewSet for accessing entries specifically related to preregistration documents.
     This provides a dedicated endpoint for clients to fetch and display preregistration
@@ -70,15 +69,12 @@ class FundingFeedViewSet(viewsets.ModelViewSet):
         queryset = self.get_queryset()
         page = self.paginate_queryset(queryset)
 
-        # Create content type for posts
-        post_content_type = ContentType.objects.get_for_model(ResearchhubPost)
-
         feed_entries = []
         for post in page:
             # Create an unsaved FeedEntry instance
             feed_entry = FeedEntry(
                 id=post.id,  # We can use the post ID as a temporary ID
-                content_type=post_content_type,
+                content_type=self._post_content_type,
                 object_id=post.id,
                 action="PUBLISH",
                 action_date=post.created_date,

--- a/src/feed/views/funding_feed_view.py
+++ b/src/feed/views/funding_feed_view.py
@@ -20,12 +20,7 @@ from researchhub_document.related_models.constants.document_type import PREREGIS
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 
 from ..serializers import PostSerializer
-from .common import (
-    DEFAULT_CACHE_TIMEOUT,
-    FeedPagination,
-    get_cache_key,
-    get_common_serializer_context,
-)
+from .common import FeedPagination
 
 
 class FundingFeedViewSet(BaseFeedView):
@@ -47,13 +42,13 @@ class FundingFeedViewSet(BaseFeedView):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context.update(get_common_serializer_context())
+        context.update(self.get_common_serializer_context())
         return context
 
     def list(self, request, *args, **kwargs):
         page = request.query_params.get("page", "1")
         page_num = int(page)
-        cache_key = get_cache_key(request, "funding")
+        cache_key = self.get_cache_key(request, "funding")
         use_cache = page_num < 4
 
         if use_cache:
@@ -90,7 +85,7 @@ class FundingFeedViewSet(BaseFeedView):
             self.add_user_votes_to_response(request.user, response_data)
 
         if use_cache:
-            cache.set(cache_key, response_data, timeout=DEFAULT_CACHE_TIMEOUT)
+            cache.set(cache_key, response_data, timeout=self.DEFAULT_CACHE_TIMEOUT)
 
         return Response(response_data)
 


### PR DESCRIPTION
This PR moves the common feed functionality from the `common.py` file into a newly created base feed class. This base class introduces properties for Django content types that are reused across the common functionality without re-querying the database for these types on every request.