### PR TITLE
feat: Add reviews to paper and post feed entries

### DIFF
--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -1,11 +1,9 @@
-from django.contrib.contenttypes.models import ContentType
 from django.core.files.storage import default_storage
 from rest_framework import serializers
 
 from hub.models import Hub
 from paper.models import Paper
 from purchase.serializers.fundraise_serializer import DynamicFundraiseSerializer
-from researchhub_comment.related_models.rh_comment_model import RhCommentModel
 from researchhub_document.related_models.constants import document_type
 from researchhub_document.related_models.constants.document_type import PREREGISTRATION
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost

--- a/src/feed/signals/comment_signals.py
+++ b/src/feed/signals/comment_signals.py
@@ -9,7 +9,6 @@ from django.dispatch import receiver
 from feed.models import FeedEntry
 from feed.serializers import serialize_feed_metrics
 from feed.tasks import create_feed_entry, delete_feed_entry, update_feed_metrics
-from researchhub_comment.constants.rh_comment_thread_types import PEER_REVIEW
 from researchhub_comment.related_models.rh_comment_model import RhCommentModel
 
 """

--- a/src/feed/tasks.py
+++ b/src/feed/tasks.py
@@ -6,7 +6,6 @@ from django.contrib.contenttypes.models import ContentType
 
 from feed.models import FeedEntry, FeedEntryLatest, FeedEntryPopular
 from feed.serializers import serialize_feed_item, serialize_feed_metrics
-from reputation.related_models.bounty import Bounty
 from researchhub.celery import app
 from researchhub_document.related_models.researchhub_unified_document_model import (
     ResearchhubUnifiedDocument,


### PR DESCRIPTION
Add a `reviews` field with the following data to papers and posts:
- `author` (using the existing simple author serializer including `headline`, `profile_image` and `user`)
- `id` (the review ID)
- `score` (the given score)