### PR TITLE
Use `localhost` for feed refresh requests

### DIFF
--- a/src/feed/tasks.py
+++ b/src/feed/tasks.py
@@ -226,6 +226,7 @@ def refresh_popular_feed_entries():
         {
             "feed_view": "popular",
         },
+        HTTP_HOST="localhost",
     )
 
     drf_request = Request(django_request)


### PR DESCRIPTION
Use `localhost` for HTTP `HOST` header when making internal requests directed to the feed view.