### PR TITLE
Lock deposit/withdrawal check on task level and on deposit entry level

### DIFF
--- a/src/reputation/tasks.py
+++ b/src/reputation/tasks.py
@@ -241,9 +241,16 @@ def _check_deposits():
 
 @app.task
 def check_pending_withdrawals():
-    logger.info("Starting check pending withdrawals task")
-    check_pending_withdrawal()
-    logger.info("Starting check pending withdrawals task")
+    key = lock.name("check_pending_withdrawals")
+    if not lock.acquire(key):
+        logger.warning(f"Already locked {key}, skipping task")
+        return False
+
+    try:
+        check_pending_withdrawal()
+    finally:
+        lock.release(key)
+        logger.info(f"Released lock {key}")
 
 
 @app.task

--- a/src/reputation/views/deposit_view.py
+++ b/src/reputation/views/deposit_view.py
@@ -5,7 +5,6 @@ from rest_framework.response import Response
 
 from reputation.models import Deposit
 from reputation.serializers import DepositSerializer
-from reputation.tasks import check_deposits
 
 
 class DepositViewSet(viewsets.ReadOnlyModelViewSet):
@@ -30,12 +29,6 @@ class DepositViewSet(viewsets.ReadOnlyModelViewSet):
         Create a pending deposit that will be updated by a celery task
         """
 
-        # Temorarily disable deposits
-        return Response(
-            "Deposits are suspended for the time being. Please be patient as we work to turn deposits back on",
-            status=400,
-        )
-
         Deposit.objects.create(
             user=request.user,
             amount=request.data.get("amount"),
@@ -43,7 +36,5 @@ class DepositViewSet(viewsets.ReadOnlyModelViewSet):
             transaction_hash=request.data.get("transaction_hash"),
             network=request.data.get("network"),
         )
-
-        check_deposits.delay()
 
         return Response(200)

--- a/src/researchhub/celery.py
+++ b/src/researchhub/celery.py
@@ -128,7 +128,7 @@ app.conf.beat_schedule = {
     # Reputation
     "reputation_check-deposits": {
         "task": "reputation.tasks.check_deposits",
-        "schedule": crontab(minute="*/5"),
+        "schedule": crontab(minute="*/1"),
         "options": {
             "priority": 2,
             "queue": QUEUE_PURCHASES,


### PR DESCRIPTION
- Make sure only one check_deposits/check_pending_withdrawal task is running at a time.
- Make sure the deposit/withdrawal entry that is only being processed once at a time.