### PR TITLE
Add Auth Token to Email Verification Endpoint Response

### DIFF
--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -43,6 +43,7 @@ from researchhub_comment.views.rh_comment_view import RhCommentViewSet
 from review.views.peer_review_view import PeerReviewViewSet
 from review.views.review_view import ReviewViewSet
 from user.views import author_views, editor_views, moderator_view, persona_webhook_view
+from user.views.custom_verify_email_view import CustomVerifyEmailView
 
 router = routers.DefaultRouter()
 
@@ -250,6 +251,11 @@ urlpatterns = [
     path("api/auth/captcha_verify/", oauth.views.captcha_verify, name="captcha_verify"),
     path(
         "api/auth/google/login/", oauth.views.GoogleLogin.as_view(), name="google_login"
+    ),
+    path(
+        "api/auth/register/verify-email/",
+        CustomVerifyEmailView.as_view(),
+        name="rest_verify_email",
     ),
     re_path(r"api/auth/register/", include("dj_rest_auth.registration.urls")),
     re_path(

--- a/src/user/tests/test_custom_verify_email_view.py
+++ b/src/user/tests/test_custom_verify_email_view.py
@@ -1,0 +1,103 @@
+from allauth.account.models import EmailAddress, EmailConfirmation
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITransactionTestCase
+
+User = get_user_model()
+
+
+class CustomVerifyEmailViewTest(APITransactionTestCase):
+    reset_sequences = False
+
+    def setUp(self):
+        self.user = User.objects.create(
+            username="testuser@example.com",
+            email="testuser@example.com",
+            password="testpassword123",
+            first_name="Test",
+            last_name="User",
+        )
+
+        self.email_address = EmailAddress.objects.create(
+            user=self.user, email=self.user.email, primary=True, verified=False
+        )
+
+        self.confirmation = EmailConfirmation.create(self.email_address)
+        self.confirmation.sent = timezone.now()
+        self.confirmation.save()
+        self.key = self.confirmation.key
+
+        self.verify_url = "/api/auth/register/verify-email/"
+
+    def test_email_verification_success(self):
+        """
+        Test successful email verification with token in response.
+        """
+        response = self.client.post(self.verify_url, {"key": self.key}, format="json")
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.data
+
+        self.assertIn("detail", data)
+        self.assertEqual(data["detail"], "ok")
+
+        self.assertIn("key", data)  # Should have token key
+
+        self.assertIn("user", data)
+        self.assertEqual(data["user"]["id"], self.user.id)
+
+        token = Token.objects.get(key=data["key"])
+        self.assertEqual(token.user.id, self.user.id)
+
+        email_address = EmailAddress.objects.get(user=self.user)
+        self.assertTrue(email_address.verified)
+
+    def test_email_verification_invalid_key(self):
+        """
+        Test email verification with invalid key.
+        """
+        user2 = User.objects.create(
+            username="testuser2@example.com",
+            email="testuser2@example.com",
+            password="testpassword123",
+            first_name="Test2",
+            last_name="User2",
+        )
+
+        email_address2 = EmailAddress.objects.create(
+            user=user2, email=user2.email, primary=True, verified=False
+        )
+
+        response = self.client.post(
+            self.verify_url, {"key": "invalid-key"}, format="json"
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+        email_address2.refresh_from_db()
+        self.assertFalse(email_address2.verified)
+
+    def test_email_verification_missing_key(self):
+        """
+        Test email verification without a key.
+        """
+        user3 = User.objects.create(
+            username="testuser3@example.com",
+            email="testuser3@example.com",
+            password="testpassword123",
+            first_name="Test3",
+            last_name="User3",
+        )
+
+        email_address3 = EmailAddress.objects.create(
+            user=user3, email=user3.email, primary=True, verified=False
+        )
+
+        response = self.client.post(self.verify_url, {}, format="json")
+
+        self.assertEqual(response.status_code, 400)
+
+        email_address3.refresh_from_db()
+        self.assertFalse(email_address3.verified)

--- a/src/user/views/custom_verify_email_view.py
+++ b/src/user/views/custom_verify_email_view.py
@@ -1,30 +1,60 @@
 from allauth.account.models import EmailConfirmation, EmailConfirmationHMAC
 from dj_rest_auth.registration.views import VerifyEmailView
+from django.contrib.auth import get_user_model
 from rest_framework.authtoken.models import Token
 from rest_framework.response import Response
+
+User = get_user_model()
 
 
 class CustomVerifyEmailView(VerifyEmailView):
     def post(self, request, *args, **kwargs):
+
         key = request.data.get("key")
+
+        if not key:
+            return Response({"detail": "Invalid key"}, status=400)
+
+        # Store user info BEFORE calling parent method
+        # because the parent method will override it
+        user_id = None
+
         confirmation = EmailConfirmationHMAC.from_key(key)
+
         if not confirmation:
-            # fallback to DB lookup (for older keys)
             confirmation = EmailConfirmation.objects.filter(key=key.lower()).first()
+
         if confirmation:
-            confirmation.confirm(request)
             user = confirmation.email_address.user
-            token, _ = Token.objects.get_or_create(user=user)
-            return Response(
-                {
-                    "detail": "ok",
-                    "key": token.key,
-                    "user": {
-                        "id": user.id,
-                        "email": user.email,
-                        "first_name": user.first_name,
-                        "last_name": user.last_name,
-                    },
-                }
-            )
-        return Response({"detail": "Invalid key"}, status=400)
+            user_id = user.id
+
+        # Call parent method to handle verification
+        parent_response = super().post(request, *args, **kwargs)
+
+        # If parent verification was successful AND we have user info
+        if parent_response.status_code == 200 and user_id:
+
+            try:
+                user = User.objects.get(id=user_id)
+                token, created = Token.objects.get_or_create(user=user)
+
+                # Return the response with token
+                return Response(
+                    {
+                        "detail": "ok",
+                        "key": token.key,
+                        "user": {
+                            "id": user_id,
+                        },
+                    }
+                )
+            except Exception as e:
+                # Log the error but don't raise it - just continue to return parent response
+                print(f"NOTE: Could not generate token response: {str(e)}")
+                print("Falling back to parent response.")
+
+        # Return parent response if:
+        # - Parent verification failed, OR
+        # - We don't have user info, OR
+        # - We couldn't generate the token response
+        return parent_response

--- a/src/user/views/custom_verify_email_view.py
+++ b/src/user/views/custom_verify_email_view.py
@@ -1,0 +1,30 @@
+from allauth.account.models import EmailConfirmation, EmailConfirmationHMAC
+from dj_rest_auth.registration.views import VerifyEmailView
+from rest_framework.authtoken.models import Token
+from rest_framework.response import Response
+
+
+class CustomVerifyEmailView(VerifyEmailView):
+    def post(self, request, *args, **kwargs):
+        key = request.data.get("key")
+        confirmation = EmailConfirmationHMAC.from_key(key)
+        if not confirmation:
+            # fallback to DB lookup (for older keys)
+            confirmation = EmailConfirmation.objects.filter(key=key.lower()).first()
+        if confirmation:
+            confirmation.confirm(request)
+            user = confirmation.email_address.user
+            token, _ = Token.objects.get_or_create(user=user)
+            return Response(
+                {
+                    "detail": "ok",
+                    "key": token.key,
+                    "user": {
+                        "id": user.id,
+                        "email": user.email,
+                        "first_name": user.first_name,
+                        "last_name": user.last_name,
+                    },
+                }
+            )
+        return Response({"detail": "Invalid key"}, status=400)

--- a/src/user/views/custom_verify_email_view.py
+++ b/src/user/views/custom_verify_email_view.py
@@ -1,3 +1,5 @@
+import logging
+
 from allauth.account.models import EmailConfirmation, EmailConfirmationHMAC
 from dj_rest_auth.registration.views import VerifyEmailView
 from django.contrib.auth import get_user_model
@@ -5,15 +7,22 @@ from rest_framework.authtoken.models import Token
 from rest_framework.response import Response
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
+# CustomVerifyEmailView enhances the default email verification endpoint.
+# In addition to verifying the user's email, it returns an authentication token
+# (so the user can be automatically logged in after verification) and basic user info.
+# This is useful for SPA flows where you want to log the user in immediately
+# after they click the verification link.
 class CustomVerifyEmailView(VerifyEmailView):
     def post(self, request, *args, **kwargs):
 
         key = request.data.get("key")
 
         if not key:
-            return Response({"detail": "Invalid key"}, status=400)
+            logger.warning("No key provided in request.")
+            return Response({"detail": "No key provided"}, status=400)
 
         # Store user info BEFORE calling parent method
         # because the parent method will override it
@@ -31,27 +40,25 @@ class CustomVerifyEmailView(VerifyEmailView):
         # Call parent method to handle verification
         parent_response = super().post(request, *args, **kwargs)
 
-        # If parent verification was successful AND we have user info
-        if parent_response.status_code == 200 and user_id:
+        if parent_response.status_code != 200 or not user_id:
+            return parent_response
 
-            try:
-                user = User.objects.get(id=user_id)
-                token, created = Token.objects.get_or_create(user=user)
+        try:
+            user = User.objects.get(id=user_id)
+            token, _ = Token.objects.get_or_create(user=user)
 
-                # Return the response with token
-                return Response(
-                    {
-                        "detail": "ok",
-                        "key": token.key,
-                        "user": {
-                            "id": user_id,
-                        },
-                    }
-                )
-            except Exception as e:
-                # Log the error but don't raise it - just continue to return parent response
-                print(f"NOTE: Could not generate token response: {str(e)}")
-                print("Falling back to parent response.")
+            # Return the response with token
+            return Response(
+                {
+                    "detail": "ok",
+                    "key": token.key,
+                    "user": {
+                        "id": user_id,
+                    },
+                }
+            )
+        except Exception as e:
+            logger.error(f"Could not generate token response: {str(e)}")
 
         # Return parent response if:
         # - Parent verification failed, OR


### PR DESCRIPTION
This PR enhances the `/api/auth/register/verify-email/` endpoint to return an authentication token (key) in the response upon successful email verification. This allows clients to automatically log in users immediately after they verify their email, streamlining the onboarding process.

<img width="763" alt="image" src="https://github.com/user-attachments/assets/4e3c8e33-409b-48b6-965b-cd645d03ed6d" />


