### PR TITLE
[temp] Point email confirmation to new web application

### DIFF
--- a/src/user/custom_allauth.py
+++ b/src/user/custom_allauth.py
@@ -2,16 +2,12 @@ from allauth.account.adapter import DefaultAccountAdapter, get_adapter
 from allauth.account.forms import ResetPasswordForm
 from allauth.account.utils import user_pk_to_url_str
 from dj_rest_auth.serializers import PasswordResetSerializer
-
-from researchhub.settings import (
-    ASSETS_BASE_URL,
-    BASE_FRONTEND_URL,
-)
+from django.conf import settings
 
 
 class CustomAccountAdapter(DefaultAccountAdapter):
     def get_email_confirmation_url(self, request, emailconfirmation):
-        return f"{BASE_FRONTEND_URL}/verify/{emailconfirmation.key}"
+        return f"{settings.BASE_FRONTEND_URL}/verify/{emailconfirmation.key}"
 
 
 class CustomPasswordResetSerializer(PasswordResetSerializer):
@@ -34,9 +30,9 @@ class CustomResetPasswordForm(ResetPasswordForm):
         for user in self.users:
             uid = user_pk_to_url_str(user)
             token = token_generator.make_token(user)
-            reset_url = f"{BASE_FRONTEND_URL}/reset/{uid}/{token}"
+            reset_url = f"{settings.BASE_FRONTEND_URL}/reset/{uid}/{token}"
             context = {
-                "assets_base_url": ASSETS_BASE_URL,
+                "assets_base_url": settings.ASSETS_BASE_URL,
                 "user": user,
                 "request": request,
                 "email": email,

--- a/src/user/custom_allauth.py
+++ b/src/user/custom_allauth.py
@@ -7,7 +7,16 @@ from django.conf import settings
 
 class CustomAccountAdapter(DefaultAccountAdapter):
     def get_email_confirmation_url(self, request, emailconfirmation):
-        return f"{settings.BASE_FRONTEND_URL}/verify/{emailconfirmation.key}"
+        # TEMPORARY:
+        # Use hard-coded URL pointing to the new web application for email confirmation.
+        # Will be replaced with `BASE_FRONTEND_URL` after moving the new web application to www.
+        base_url = settings.BASE_FRONTEND_URL
+        if settings.PRODUCTION:
+            base_url = "https://new.researchhub.com"
+        elif settings.STAGING:
+            base_url = "https://v2.staging.researchhub.com"
+
+        return f"{base_url}/verify/{emailconfirmation.key}"
 
 
 class CustomPasswordResetSerializer(PasswordResetSerializer):

--- a/src/user/custom_allauth.py
+++ b/src/user/custom_allauth.py
@@ -1,7 +1,6 @@
 from allauth.account.adapter import DefaultAccountAdapter, get_adapter
 from allauth.account.forms import ResetPasswordForm
 from allauth.account.utils import user_pk_to_url_str
-from dj_rest_auth.registration.serializers import RegisterSerializer
 from dj_rest_auth.serializers import PasswordResetSerializer
 
 from researchhub.settings import (

--- a/src/user/tests/test_custom_allauth.py
+++ b/src/user/tests/test_custom_allauth.py
@@ -1,0 +1,56 @@
+from django.http import HttpRequest
+from django.test import SimpleTestCase, override_settings
+
+from user.custom_allauth import CustomAccountAdapter
+
+
+class DummyEmailConfirmation:
+    def __init__(self, key):
+        self.key = key
+
+
+class CustomAccountAdapterTests(SimpleTestCase):
+    def setUp(self):
+        self.request = HttpRequest()
+        self.adapter = CustomAccountAdapter()
+
+    @override_settings(
+        PRODUCTION=True,
+        BASE_FRONTEND_URL="https://www.researchhub.com",
+    )
+    def test_get_email_confirmation_url_production(self):
+        # Arrange
+        confirm = DummyEmailConfirmation("prod")
+
+        # Act
+        url = self.adapter.get_email_confirmation_url(self.request, confirm)
+
+        # Assert
+        self.assertEqual(url, "https://new.researchhub.com/verify/prod")
+
+    @override_settings(
+        STAGING=True,
+        BASE_FRONTEND_URL="https://www.researchhub.com",
+    )
+    def test_get_email_confirmation_url_staging(self):
+        # Arrange
+        confirm = DummyEmailConfirmation("staging")
+
+        # Act
+        url = self.adapter.get_email_confirmation_url(self.request, confirm)
+
+        # Assert
+        self.assertEqual(url, "https://v2.staging.researchhub.com/verify/staging")
+
+    @override_settings(
+        BASE_FRONTEND_URL="https://default.researchhub.com",
+    )
+    def test_get_email_confirmation_url_default(self):
+        # Arrange
+        confirm = DummyEmailConfirmation("default")
+
+        # Act
+        url = self.adapter.get_email_confirmation_url(self.request, confirm)
+
+        # Assert
+        self.assertEqual(url, "https://default.researchhub.com/verify/default")


### PR DESCRIPTION
- Use hard-coded URL pointing to the new web application for email confirmation.
- Will be replaced with `BASE_FRONTEND_URL` after moving the new web application to www.