### PR TITLE
fix: Refresh feed entries after purchase transaction is committed

### DIFF
--- a/src/feed/tests/signals/test_comment_signals.py
+++ b/src/feed/tests/signals/test_comment_signals.py
@@ -6,9 +6,7 @@ from django.test import TestCase
 from feed.models import FeedEntry
 from hub.models import Hub
 from paper.related_models.paper_model import Paper
-from reputation.related_models.escrow import Escrow
 from researchhub_comment.constants.rh_comment_thread_types import (
-    ANSWER,
     GENERIC_COMMENT,
     PEER_REVIEW,
 )


### PR DESCRIPTION
Currently, fundraise-related feed entries are not correctly updated since the related task is triggered before the purchase transaction is committed. This leads to amounts not being reflected in the corresponding feed entries.