### PR TITLE
Reduce number of queries for user verification in feed

### DIFF
--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -36,8 +36,8 @@ class SimpleUserSerializer(serializers.ModelSerializer):
         if obj is None:
             return False
 
-        user_verification = UserVerification.objects.filter(user=obj).last()
-        return user_verification.is_verified if user_verification else False
+        verification = getattr(obj, "user_verification", None)
+        return verification.is_verified if verification else False
 
 
 class SimpleAuthorSerializer(serializers.ModelSerializer):

--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -4,7 +4,6 @@ from rest_framework import serializers
 
 from hub.models import Hub
 from paper.models import Paper
-from purchase.models import Purchase
 from purchase.serializers import DynamicPurchaseSerializer
 from purchase.serializers.fundraise_serializer import DynamicFundraiseSerializer
 from researchhub_document.related_models.constants import document_type
@@ -12,7 +11,6 @@ from researchhub_document.related_models.constants.document_type import PREREGIS
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 from review.serializers.review_serializer import ReviewSerializer
 from user.models import Author, User
-from user.related_models.user_verification_model import UserVerification
 
 from .models import FeedEntry
 

--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -20,7 +20,9 @@ from .models import FeedEntry
 class SimpleUserSerializer(serializers.ModelSerializer):
     """Minimal user serializer with just essential fields"""
 
-    is_verified = serializers.SerializerMethodField()
+    is_verified = serializers.BooleanField(
+        source="userverification.is_verified", default=False
+    )
 
     class Meta:
         model = User
@@ -31,13 +33,6 @@ class SimpleUserSerializer(serializers.ModelSerializer):
             "email",
             "is_verified",
         ]
-
-    def get_is_verified(self, obj):
-        if obj is None:
-            return False
-
-        verification = getattr(obj, "user_verification", None)
-        return verification.is_verified if verification else False
 
 
 class SimpleAuthorSerializer(serializers.ModelSerializer):

--- a/src/feed/views/feed_view.py
+++ b/src/feed/views/feed_view.py
@@ -90,6 +90,7 @@ class FeedViewSet(BaseFeedView):
             "parent_content_type",
             "user",
             "user__author_profile",
+            "user__userverification",
         )
 
         # Apply source filter


### PR DESCRIPTION
Currently, one query for the user verification status is issues per feed entry. This change adds the user verification status to the list of `select_related`, essentially adding it as a join in the query. This removes all extra queries.

Before:
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/b132e92f-3813-46c2-a62e-27ae76196b15" />

After:
<img width="1205" alt="image" src="https://github.com/user-attachments/assets/e655eb12-cf38-409b-81dd-f0c0e3e2d2bd" />
