### PR TITLE
Fix content flagging error

### DIFF
--- a/src/discussion/reaction_views.py
+++ b/src/discussion/reaction_views.py
@@ -3,6 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError, transaction
 from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -133,7 +134,7 @@ class ReactionViewActionMixin:
             content_id = f"{type(item).__name__}_{item.id}"
             events_api.track_flag_content(item.created_by, content_id, user.id)
             return Response(flag_data, status=201)
-        except IntegrityError:
+        except (IntegrityError, ValidationError):
             return Response(
                 {
                     "msg": "Already flagged",

--- a/src/discussion/reaction_views.py
+++ b/src/discussion/reaction_views.py
@@ -124,7 +124,7 @@ class ReactionViewActionMixin:
         reason_choice = request.data.get("reason_choice")
 
         try:
-            flag, flag_data = create_flag(user, item, reason, reason_choice)
+            _, flag_data = create_flag(user, item, reason, reason_choice)
 
             content_id = f"{type(item).__name__}_{item.id}"
             events_api.track_flag_content(item.created_by, content_id, user.id)

--- a/src/discussion/reaction_views.py
+++ b/src/discussion/reaction_views.py
@@ -32,12 +32,7 @@ from researchhub_document.related_models.constants.document_type import (
     SORT_DISCUSSED,
     SORT_UPVOTED,
 )
-from researchhub_document.related_models.constants.filters import (
-    DISCUSSED,
-    HOT,
-    UPVOTED,
-)
-from researchhub_document.utils import get_doc_type_key, reset_unified_document_cache
+from researchhub_document.related_models.constants.filters import HOT, UPVOTED
 from user.models import User
 from utils.models import SoftDeletableModel
 from utils.permissions import CreateOrUpdateIfAllowed

--- a/src/discussion/tests/test_reaction_views.py
+++ b/src/discussion/tests/test_reaction_views.py
@@ -1,0 +1,66 @@
+from django.test import TestCase, override_settings
+from django.urls import include, path, reverse
+from rest_framework import status
+from rest_framework.routers import DefaultRouter
+from rest_framework.test import APIClient
+from rest_framework.viewsets import GenericViewSet
+
+from discussion.constants.flag_reasons import NOT_SPECIFIED
+from discussion.reaction_serializers import FlagSerializer
+from discussion.reaction_views import ReactionViewActionMixin
+from paper.related_models.paper_model import Paper
+from user.related_models.user_model import User
+
+
+# Dummy view for testing the mixin
+class DummyPaperView(ReactionViewActionMixin, GenericViewSet):
+    queryset = Paper.objects.all()
+    serializer_class = FlagSerializer
+
+
+# Register a router for testing the mixin
+router = DefaultRouter()
+router.register(r"dummy", DummyPaperView, basename="dummy")
+
+urlpatterns = [
+    path("api/", include(router.urls)),
+]
+
+
+@override_settings(ROOT_URLCONF=__name__)
+class ReactionViewTests(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testUser1")
+        self.paper = Paper.objects.create(title="testPaper1")
+
+        # API client
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def test_flag(self):
+        # Arrange
+        url = reverse("dummy-flag", kwargs={"pk": self.paper.id})
+
+        # Act
+        response = self.client.post(
+            url, {"reason": "Inappropriate", "reason_choice": NOT_SPECIFIED}
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_flag_already_flagged(self):
+        # Arrange
+        url = reverse("dummy-flag", kwargs={"pk": self.paper.id})
+
+        # Act
+        self.client.post(
+            url, {"reason": "Inappropriate", "reason_choice": NOT_SPECIFIED}
+        )
+        response = self.client.post(
+            url, {"reason": "Inappropriate", "reason_choice": NOT_SPECIFIED}
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)


### PR DESCRIPTION
The existing code is supposed to return a _HTTP 409 Conflict_ error when a content item is already flagged. With the current implementation, it returns a _HTTP 500 Error_ instead. This change resolves the issue by handling the correct exception.