### PR TITLE
fix: Avoid removal and addition of all hubs when updating papers

### DIFF
--- a/src/paper/serializers/paper_serializers.py
+++ b/src/paper/serializers/paper_serializers.py
@@ -515,7 +515,7 @@ class PaperSerializer(BasePaperSerializer):
 
         validated_data.pop("authors", [None])
         file = validated_data.pop("file", None)
-        hubs = validated_data.pop("hubs", [])
+        hubs = validated_data.pop("hubs", None)
         pdf_license = validated_data.get("pdf_license", None)
         validated_data.pop("raw_authors", [])
 


### PR DESCRIPTION
The previous implementation worked with different datatypes (list of IDs and list of hubs) and therefore always created a complete delta, resulting in the removal and addition of all hubs.