### PR TITLE
Return all comments for all versions of paper

### DIFF
--- a/src/paper/related_models/paper_model.py
+++ b/src/paper/related_models/paper_model.py
@@ -557,17 +557,12 @@ class Paper(AbstractGenericReactionModel):
     def get_discussion_count(self):
         from paper.services.paper_version_service import PaperService
 
-        # Check if this paper has versions by checking if it's part of a paper series
-        # or if it has version relations
         if hasattr(self, "version") and self.version is not None:
-            # Use the paper service to get all versions
             paper_service = PaperService()
             all_paper_versions = paper_service.get_all_paper_versions(self.id)
 
-            # Get content type for Paper model
             paper_content_type = ContentType.objects.get_for_model(self)
 
-            # Get threads for all paper versions
             thread_queryset = RhCommentThreadModel.objects.filter(
                 content_type=paper_content_type,
                 object_id__in=all_paper_versions.values_list("id", flat=True),

--- a/src/paper/serializers/paper_serializers.py
+++ b/src/paper/serializers/paper_serializers.py
@@ -905,7 +905,7 @@ class DynamicPaperSerializer(
     def get_discussions(self, paper):
         from django.contrib.contenttypes.models import ContentType
 
-        from paper.services.paper_version_service import PaperVersionService
+        from paper.services.paper_version_service import PaperService
         from researchhub_comment.serializers import DynamicRhThreadSerializer
 
         context = self.context
@@ -913,8 +913,11 @@ class DynamicPaperSerializer(
         _select_related_fields = context.get("pap_dps_get_discussions_select", [])
         _prefetch_related_fields = context.get("pap_dps_get_discussions_prefetch", [])
 
+        # Get paper service from context or create default instance
+        paper_service = context.get("paper_service", PaperService())
+
         # Get all versions of this paper
-        paper_versions = PaperVersionService.get_all_paper_versions(paper.id)
+        paper_versions = paper_service.get_all_paper_versions(paper.id)
 
         # Get content type for Paper model
         paper_content_type = ContentType.objects.get_for_model(paper)
@@ -942,11 +945,14 @@ class DynamicPaperSerializer(
     def get_discussion_aggregates(self, paper):
         from django.contrib.contenttypes.models import ContentType
 
-        from paper.services.paper_version_service import PaperVersionService
+        from paper.services.paper_version_service import PaperService
         from researchhub_comment.models import RhCommentThreadModel
 
+        # Get paper service from context or create default instance
+        paper_service = self.context.get("paper_service", PaperService())
+
         # Get all versions of this paper
-        paper_versions = PaperVersionService.get_all_paper_versions(paper.id)
+        paper_versions = paper_service.get_all_paper_versions(paper.id)
 
         # Get content type for Paper model
         paper_content_type = ContentType.objects.get_for_model(paper)

--- a/src/paper/services/paper_version_service.py
+++ b/src/paper/services/paper_version_service.py
@@ -1,0 +1,47 @@
+from paper.models import Paper
+from paper.related_models.paper_version import PaperVersion
+
+
+class PaperVersionService:
+    @staticmethod
+    def get_all_paper_versions(paper_id):
+        """
+        Get all versions of a paper including the original.
+
+        Args:
+            paper_id: ID of any paper in the version chain
+
+        Returns:
+            List of Paper objects that are versions of the same paper
+        """
+        try:
+            # Try to get the paper
+            paper = Paper.objects.get(id=paper_id)
+
+            # First try to get this paper's version to find the original
+            try:
+                paper_version = PaperVersion.objects.get(paper=paper)
+
+                # If this is a version, get the original paper
+                if paper_version.original_paper:
+                    original_paper_id = paper_version.original_paper.id
+                else:
+                    original_paper_id = paper_id
+            except PaperVersion.DoesNotExist:
+                # If this paper has no version, check if it's an original paper for other versions
+                original_paper_id = paper_id
+
+            # Get all papers related to this original paper
+            paper_versions = PaperVersion.objects.filter(
+                original_paper_id=original_paper_id
+            )
+
+            # Collect all paper IDs (original + versions)
+            paper_ids = [original_paper_id]
+            paper_ids.extend([version.paper_id for version in paper_versions])
+
+            # Remove duplicates and fetch actual papers
+            return Paper.objects.filter(id__in=set(paper_ids))
+        except Paper.DoesNotExist:
+            # If the paper doesn't exist, return an empty queryset
+            return Paper.objects.none()

--- a/src/paper/services/paper_version_service.py
+++ b/src/paper/services/paper_version_service.py
@@ -2,9 +2,26 @@ from paper.models import Paper
 from paper.related_models.paper_version import PaperVersion
 
 
-class PaperVersionService:
-    @staticmethod
-    def get_all_paper_versions(paper_id):
+class PaperService:
+    """
+    Service for paper-related operations including version management.
+
+    This service handles both regular paper operations and paper version management,
+    making it easier to test and extend with dependency injection.
+    """
+
+    def __init__(self, paper_model=None, paper_version_model=None):
+        """
+        Initialize the service with optional model dependencies for testing.
+
+        Args:
+            paper_model: Paper model class (defaults to Paper)
+            paper_version_model: PaperVersion model class (defaults to PaperVersion)
+        """
+        self.paper_model = paper_model or Paper
+        self.paper_version_model = paper_version_model or PaperVersion
+
+    def get_all_paper_versions(self, paper_id):
         """
         Get all versions of a paper including the original.
 
@@ -12,27 +29,27 @@ class PaperVersionService:
             paper_id: ID of any paper in the version chain
 
         Returns:
-            List of Paper objects that are versions of the same paper
+            QuerySet of Paper objects that are versions of the same paper
         """
         try:
             # Try to get the paper
-            paper = Paper.objects.get(id=paper_id)
+            paper = self.paper_model.objects.get(id=paper_id)
 
             # First try to get this paper's version to find the original
             try:
-                paper_version = PaperVersion.objects.get(paper=paper)
+                paper_version = self.paper_version_model.objects.get(paper=paper)
 
                 # If this is a version, get the original paper
                 if paper_version.original_paper:
                     original_paper_id = paper_version.original_paper.id
                 else:
                     original_paper_id = paper_id
-            except PaperVersion.DoesNotExist:
+            except self.paper_version_model.DoesNotExist:
                 # If this paper has no version, check if it's an original paper for other versions
                 original_paper_id = paper_id
 
             # Get all papers related to this original paper
-            paper_versions = PaperVersion.objects.filter(
+            paper_versions = self.paper_version_model.objects.filter(
                 original_paper_id=original_paper_id
             )
 
@@ -41,7 +58,46 @@ class PaperVersionService:
             paper_ids.extend([version.paper_id for version in paper_versions])
 
             # Remove duplicates and fetch actual papers
-            return Paper.objects.filter(id__in=set(paper_ids))
-        except Paper.DoesNotExist:
+            return self.paper_model.objects.filter(id__in=set(paper_ids))
+        except self.paper_model.DoesNotExist:
             # If the paper doesn't exist, return an empty queryset
-            return Paper.objects.none()
+            return self.paper_model.objects.none()
+
+    def get_original_paper(self, paper_id):
+        """
+        Get the original paper for a given paper ID.
+
+        Args:
+            paper_id: ID of any paper in the version chain
+
+        Returns:
+            Paper object that is the original paper, or None if not found
+        """
+        try:
+            paper = self.paper_model.objects.get(id=paper_id)
+
+            try:
+                paper_version = self.paper_version_model.objects.get(paper=paper)
+                return paper_version.original_paper or paper
+            except self.paper_version_model.DoesNotExist:
+                # This paper is either the original or has no versions
+                return paper
+        except self.paper_model.DoesNotExist:
+            return None
+
+    def is_paper_version(self, paper_id):
+        """
+        Check if a paper is a version of another paper.
+
+        Args:
+            paper_id: ID of the paper to check
+
+        Returns:
+            bool: True if the paper is a version, False otherwise
+        """
+        try:
+            paper = self.paper_model.objects.get(id=paper_id)
+            paper_version = self.paper_version_model.objects.get(paper=paper)
+            return paper_version.original_paper is not None
+        except (self.paper_model.DoesNotExist, self.paper_version_model.DoesNotExist):
+            return False

--- a/src/paper/tests/test_paper_serializer_versions.py
+++ b/src/paper/tests/test_paper_serializer_versions.py
@@ -1,0 +1,298 @@
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from paper.related_models.paper_version import PaperVersion
+from paper.serializers.paper_serializers import DynamicPaperSerializer
+from paper.tests.helpers import create_paper
+from researchhub_comment.models import RhCommentModel, RhCommentThreadModel
+from user.tests.helpers import create_random_default_user
+
+
+class PaperSerializerVersionTests(TestCase):
+    def setUp(self):
+        """Set up test data for paper serializer version tests."""
+        self.user = create_random_default_user("test_user")
+        self.factory = APIRequestFactory()
+
+        # Create original paper
+        self.original_paper = create_paper(title="Original Paper")
+
+        # Create version 1
+        self.version_1_paper = create_paper(title="Paper Version 1")
+        self.version_1 = PaperVersion.objects.create(
+            paper=self.version_1_paper,
+            version=1,
+            base_doi="10.1234/test",
+            message="First version",
+            original_paper=self.original_paper,
+            publication_status=PaperVersion.PREPRINT,
+        )
+
+        # Create version 2
+        self.version_2_paper = create_paper(title="Paper Version 2")
+        self.version_2 = PaperVersion.objects.create(
+            paper=self.version_2_paper,
+            version=2,
+            base_doi="10.1234/test",
+            message="Second version",
+            original_paper=self.original_paper,
+            publication_status=PaperVersion.PUBLISHED,
+        )
+
+    def _create_comment_thread(self, paper, thread_type="GENERIC_COMMENT"):
+        """Helper method to create a comment thread for a paper."""
+        content_type = ContentType.objects.get_for_model(paper)
+        thread = RhCommentThreadModel.objects.create(
+            content_type=content_type,
+            object_id=paper.id,
+            thread_type=thread_type,
+            created_by=self.user,
+        )
+        return thread
+
+    def _create_comment(self, thread, text="Test comment"):
+        """Helper method to create a comment in a thread."""
+        comment = RhCommentModel.objects.create(
+            thread=thread,
+            created_by=self.user,
+            comment_content_json={"ops": [{"insert": text}]},
+        )
+        return comment
+
+    def test_get_discussions_returns_all_version_discussions(self):
+        """Test that get_discussions returns discussions from all paper
+        versions."""
+        # Create threads for each paper version
+        original_thread = self._create_comment_thread(self.original_paper)
+        version_1_thread = self._create_comment_thread(self.version_1_paper)
+        version_2_thread = self._create_comment_thread(self.version_2_paper)
+
+        # Create comments in each thread
+        self._create_comment(original_thread, "Comment on original")
+        self._create_comment(version_1_thread, "Comment on version 1")
+        self._create_comment(version_2_thread, "Comment on version 2")
+
+        # Test serializer with original paper
+        request = self.factory.get("/")
+        request.user = self.user
+        serializer = DynamicPaperSerializer(
+            self.original_paper, context={"request": request}
+        )
+
+        discussions = serializer.get_discussions(self.original_paper)
+
+        # Should return discussions from all versions
+        thread_ids = {discussion["id"] for discussion in discussions}
+        expected_thread_ids = {
+            original_thread.id,
+            version_1_thread.id,
+            version_2_thread.id,
+        }
+
+        self.assertEqual(thread_ids, expected_thread_ids)
+        self.assertEqual(len(discussions), 3)
+
+    def test_get_discussions_with_version_paper(self):
+        """Test that get_discussions works when called with a version paper."""
+        # Create threads for each paper version
+        original_thread = self._create_comment_thread(self.original_paper)
+        version_1_thread = self._create_comment_thread(self.version_1_paper)
+        version_2_thread = self._create_comment_thread(self.version_2_paper)
+
+        # Test serializer with version 1 paper
+        request = self.factory.get("/")
+        request.user = self.user
+        serializer = DynamicPaperSerializer(
+            self.version_1_paper, context={"request": request}
+        )
+
+        discussions = serializer.get_discussions(self.version_1_paper)
+
+        # Should return discussions from all versions
+        thread_ids = {discussion["id"] for discussion in discussions}
+        expected_thread_ids = {
+            original_thread.id,
+            version_1_thread.id,
+            version_2_thread.id,
+        }
+
+        self.assertEqual(thread_ids, expected_thread_ids)
+        self.assertEqual(len(discussions), 3)
+
+    def test_get_discussions_single_paper_no_versions(self):
+        """Test get_discussions with a standalone paper (no versions)."""
+        standalone_paper = create_paper(title="Standalone Paper")
+        standalone_thread = self._create_comment_thread(standalone_paper)
+        self._create_comment(standalone_thread, "Standalone comment")
+
+        request = self.factory.get("/")
+        request.user = self.user
+        serializer = DynamicPaperSerializer(
+            standalone_paper, context={"request": request}
+        )
+
+        discussions = serializer.get_discussions(standalone_paper)
+
+        # Should return only the standalone paper's discussions
+        thread_ids = {discussion["id"] for discussion in discussions}
+        expected_thread_ids = {standalone_thread.id}
+
+        self.assertEqual(thread_ids, expected_thread_ids)
+        self.assertEqual(len(discussions), 1)
+
+    def test_get_discussion_aggregates_includes_all_versions(self):
+        """Test that get_discussion_aggregates aggregates data from all paper
+        versions."""
+        # Create threads and comments for each paper version
+        original_thread = self._create_comment_thread(self.original_paper)
+        version_1_thread = self._create_comment_thread(self.version_1_paper)
+        version_2_thread = self._create_comment_thread(self.version_2_paper)
+
+        # Create comments in each thread
+        self._create_comment(original_thread, "Comment on original")
+        self._create_comment(version_1_thread, "Comment on version 1")
+        self._create_comment(version_2_thread, "Comment on version 2")
+
+        # Test serializer with original paper
+        request = self.factory.get("/")
+        request.user = self.user
+        serializer = DynamicPaperSerializer(
+            self.original_paper, context={"request": request}
+        )
+
+        aggregates = serializer.get_discussion_aggregates(self.original_paper)
+
+        # Should include aggregates from all versions
+        # The exact structure depends on the get_discussion_aggregates
+        # implementation
+        self.assertIsInstance(aggregates, dict)
+        self.assertIn("discussion_count", aggregates)
+
+        # The discussion count should reflect comments from all versions
+        # (this depends on how the paper's discussion_count property works)
+
+    def test_get_discussion_aggregates_with_version_paper(self):
+        """Test that get_discussion_aggregates works when called with a version
+        paper."""
+        # Create threads and comments for each paper version
+        original_thread = self._create_comment_thread(self.original_paper)
+        version_1_thread = self._create_comment_thread(self.version_1_paper)
+        version_2_thread = self._create_comment_thread(self.version_2_paper)
+
+        # Create comments in each thread
+        self._create_comment(original_thread, "Comment on original")
+        self._create_comment(version_1_thread, "Comment on version 1")
+        self._create_comment(version_2_thread, "Comment on version 2")
+
+        # Test serializer with version 1 paper
+        request = self.factory.get("/")
+        request.user = self.user
+        serializer = DynamicPaperSerializer(
+            self.version_1_paper, context={"request": request}
+        )
+
+        aggregates = serializer.get_discussion_aggregates(self.version_1_paper)
+
+        # Should include aggregates from all versions
+        self.assertIsInstance(aggregates, dict)
+        self.assertIn("discussion_count", aggregates)
+
+    def test_discussions_from_different_paper_families_not_mixed(self):
+        """Test that discussions from different paper families are not mixed."""
+        # Create a completely separate paper family
+        other_original = create_paper(title="Other Original Paper")
+        other_version_paper = create_paper(title="Other Version Paper")
+        PaperVersion.objects.create(
+            paper=other_version_paper,
+            version=1,
+            base_doi="10.9999/other",
+            message="Other version",
+            original_paper=other_original,
+            publication_status=PaperVersion.PREPRINT,
+        )
+
+        # Create threads and comments for our original paper family
+        original_thread = self._create_comment_thread(self.original_paper)
+        version_1_thread = self._create_comment_thread(self.version_1_paper)
+
+        # Create threads and comments for the other paper family
+        other_original_thread = self._create_comment_thread(other_original)
+        other_version_thread = self._create_comment_thread(other_version_paper)
+
+        self._create_comment(original_thread, "Our comment")
+        self._create_comment(version_1_thread, "Our version comment")
+        self._create_comment(other_original_thread, "Other comment")
+        self._create_comment(other_version_thread, "Other version comment")
+
+        # Test serializer with our paper family
+        request = self.factory.get("/")
+        request.user = self.user
+        serializer = DynamicPaperSerializer(
+            self.original_paper, context={"request": request}
+        )
+
+        discussions = serializer.get_discussions(self.original_paper)
+
+        # Should only return discussions from our paper family
+        thread_ids = {discussion["id"] for discussion in discussions}
+        expected_thread_ids = {original_thread.id, version_1_thread.id}
+        unexpected_thread_ids = {other_original_thread.id, other_version_thread.id}
+
+        self.assertEqual(thread_ids, expected_thread_ids)
+        self.assertTrue(thread_ids.isdisjoint(unexpected_thread_ids))
+        self.assertEqual(len(discussions), 2)
+
+    def test_serializer_context_fields_respected(self):
+        """Test that serializer context fields are properly passed through."""
+        # Create a thread and comment
+        original_thread = self._create_comment_thread(self.original_paper)
+        self._create_comment(original_thread, "Test comment")
+
+        # Test with specific context fields
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {
+            "request": request,
+            "pap_dps_get_discussions": {"_include_fields": ["id", "thread_type"]},
+            "pap_dps_get_discussions_select": ["content_type"],
+            "pap_dps_get_discussions_prefetch": ["rh_comments"],
+        }
+
+        serializer = DynamicPaperSerializer(self.original_paper, context=context)
+
+        discussions = serializer.get_discussions(self.original_paper)
+
+        # Should still return discussions, context fields should be applied
+        self.assertGreater(len(discussions), 0)
+
+        # Verify that the context fields were used (basic check)
+        for discussion in discussions:
+            self.assertIn("id", discussion)
+
+    def test_empty_paper_versions_chain(self):
+        """Test behavior with papers that have no comments or threads."""
+        # Create papers with no comments
+        empty_original = create_paper(title="Empty Original")
+        empty_version_paper = create_paper(title="Empty Version")
+        PaperVersion.objects.create(
+            paper=empty_version_paper,
+            version=1,
+            base_doi="10.1111/empty",
+            message="Empty version",
+            original_paper=empty_original,
+            publication_status=PaperVersion.PREPRINT,
+        )
+
+        request = self.factory.get("/")
+        request.user = self.user
+        serializer = DynamicPaperSerializer(
+            empty_original, context={"request": request}
+        )
+
+        discussions = serializer.get_discussions(empty_original)
+        aggregates = serializer.get_discussion_aggregates(empty_original)
+
+        # Should return empty results
+        self.assertEqual(len(discussions), 0)
+        self.assertIsInstance(aggregates, dict)

--- a/src/paper/tests/test_paper_version_comments.py
+++ b/src/paper/tests/test_paper_version_comments.py
@@ -1,0 +1,112 @@
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from paper.related_models.paper_version import PaperSeries, PaperVersion
+from paper.tests.helpers import create_paper
+from researchhub_comment.constants.rh_comment_thread_types import GENERIC_COMMENT
+from researchhub_comment.models import RhCommentModel, RhCommentThreadModel
+from user.tests.helpers import create_random_default_user
+
+
+class PaperVersionDiscussionCountTests(TestCase):
+    def setUp(self):
+        """Set up test data for paper version discussion count tests."""
+        self.user = create_random_default_user("test_user")
+
+        # Create paper series
+        self.paper_series = PaperSeries.objects.create()
+
+        # Create version 1
+        self.version_1_paper = create_paper(title="Paper Version 1")
+        self.version_1_paper.paper_series = self.paper_series
+        self.version_1_paper.save()
+
+        self.version_1 = PaperVersion.objects.create(
+            paper=self.version_1_paper,
+            version=1,
+            base_doi="10.1234/test",
+            message="First version",
+            original_paper=self.version_1_paper,
+            publication_status=PaperVersion.PREPRINT,
+        )
+
+        # Create version 2
+        self.version_2_paper = create_paper(title="Paper Version 2")
+        self.version_2_paper.paper_series = self.paper_series
+        self.version_2_paper.save()
+
+        self.version_2 = PaperVersion.objects.create(
+            paper=self.version_2_paper,
+            version=2,
+            base_doi="10.1234/test",
+            message="Second version",
+            original_paper=self.version_1_paper,
+            publication_status=PaperVersion.PUBLISHED,
+        )
+
+    def _create_comment_thread_and_comments(self, paper, num_comments=1):
+        """Helper method to create a comment thread and comments for a paper."""
+        content_type = ContentType.objects.get_for_model(paper)
+        thread = RhCommentThreadModel.objects.create(
+            content_type=content_type,
+            object_id=paper.id,
+            thread_type=GENERIC_COMMENT,
+            created_by=self.user,
+        )
+
+        comments = []
+        for i in range(num_comments):
+            comment = RhCommentModel.objects.create(
+                thread=thread,
+                comment_content_json={"ops": [{"insert": f"Test comment {i+1}"}]},
+                created_by=self.user,
+            )
+            comments.append(comment)
+
+        return thread, comments
+
+    def test_discussion_count_single_paper_no_versions(self):
+        """Test discussion count for a paper with no versions."""
+        # Create a standalone paper (not part of any series)
+        standalone_paper = create_paper(title="Standalone Paper")
+
+        # Create comments on the standalone paper
+        self._create_comment_thread_and_comments(standalone_paper, 3)
+
+        # Discussion count should only include comments from this paper
+        self.assertEqual(standalone_paper.get_discussion_count(), 3)
+
+    def test_discussion_count_paper_with_versions(self):
+        """Test discussion count for papers that are part of a version series."""
+        # Create comments on version 1
+        self._create_comment_thread_and_comments(self.version_1_paper, 3)
+
+        # Create comments on version 2
+        self._create_comment_thread_and_comments(self.version_2_paper, 1)
+
+        # Each paper should return the total count from all versions (3 + 1 = 4)
+        self.assertEqual(self.version_1_paper.get_discussion_count(), 4)
+        self.assertEqual(self.version_2_paper.get_discussion_count(), 4)
+
+    def test_discussion_count_fallback_on_error(self):
+        """Test that the method falls back to original behavior on error."""
+        # Create a paper with paper_series but simulate an error condition
+        paper_with_series = create_paper(title="Paper with Series")
+        paper_with_series.paper_series = self.paper_series
+        paper_with_series.save()
+
+        # Create comments on this paper
+        self._create_comment_thread_and_comments(paper_with_series, 2)
+
+        # Mock the PaperService to raise an exception
+        import unittest.mock
+
+        mock_path = "paper.services.paper_version_service.PaperService"
+        with unittest.mock.patch(mock_path) as mock_service:
+            mock_service.side_effect = Exception("Simulated error")
+
+            # Should fall back to original behavior (counting only this paper's threads)
+            discussion_count = paper_with_series.get_discussion_count()
+            # This should still work because it falls back to
+            # self.rh_threads.get_discussion_count()
+            self.assertEqual(discussion_count, 2)

--- a/src/paper/tests/test_paper_version_service.py
+++ b/src/paper/tests/test_paper_version_service.py
@@ -1,0 +1,166 @@
+from django.test import TestCase
+
+from paper.related_models.paper_version import PaperVersion
+from paper.services.paper_version_service import PaperVersionService
+from paper.tests.helpers import create_paper
+
+
+class PaperVersionServiceTests(TestCase):
+    def setUp(self):
+        """Set up test data for paper version service tests."""
+        # Create original paper
+        self.original_paper = create_paper(title="Original Paper")
+
+        # Create version 1 (first version)
+        self.version_1_paper = create_paper(title="Paper Version 1")
+        self.version_1 = PaperVersion.objects.create(
+            paper=self.version_1_paper,
+            version=1,
+            base_doi="10.1234/test",
+            message="First version",
+            original_paper=self.original_paper,
+            publication_status=PaperVersion.PREPRINT,
+        )
+
+        # Create version 2 (second version)
+        self.version_2_paper = create_paper(title="Paper Version 2")
+        self.version_2 = PaperVersion.objects.create(
+            paper=self.version_2_paper,
+            version=2,
+            base_doi="10.1234/test",
+            message="Second version",
+            original_paper=self.original_paper,
+            publication_status=PaperVersion.PUBLISHED,
+        )
+
+    def test_get_all_paper_versions_with_original_paper_id(self):
+        """Test getting all versions when providing the original paper ID."""
+        result = PaperVersionService.get_all_paper_versions(self.original_paper.id)
+
+        # Should return all papers: original + versions
+        paper_ids = set(result.values_list("id", flat=True))
+        expected_ids = {
+            self.original_paper.id,
+            self.version_1_paper.id,
+            self.version_2_paper.id,
+        }
+
+        self.assertEqual(paper_ids, expected_ids)
+        self.assertEqual(result.count(), 3)
+
+    def test_get_all_paper_versions_with_version_paper_id(self):
+        """Test getting all versions when providing a version paper ID."""
+        result = PaperVersionService.get_all_paper_versions(self.version_1_paper.id)
+
+        # Should return all papers: original + versions
+        paper_ids = set(result.values_list("id", flat=True))
+        expected_ids = {
+            self.original_paper.id,
+            self.version_1_paper.id,
+            self.version_2_paper.id,
+        }
+
+        self.assertEqual(paper_ids, expected_ids)
+        self.assertEqual(result.count(), 3)
+
+    def test_get_all_paper_versions_with_another_version_paper_id(self):
+        """Test getting all versions when providing another version paper ID."""
+        result = PaperVersionService.get_all_paper_versions(self.version_2_paper.id)
+
+        # Should return all papers: original + versions
+        paper_ids = set(result.values_list("id", flat=True))
+        expected_ids = {
+            self.original_paper.id,
+            self.version_1_paper.id,
+            self.version_2_paper.id,
+        }
+
+        self.assertEqual(paper_ids, expected_ids)
+        self.assertEqual(result.count(), 3)
+
+    def test_get_all_paper_versions_single_paper_no_versions(self):
+        """Test getting versions for a paper that has no versions."""
+        standalone_paper = create_paper(title="Standalone Paper")
+
+        result = PaperVersionService.get_all_paper_versions(standalone_paper.id)
+
+        # Should return only the standalone paper
+        paper_ids = set(result.values_list("id", flat=True))
+        expected_ids = {standalone_paper.id}
+
+        self.assertEqual(paper_ids, expected_ids)
+        self.assertEqual(result.count(), 1)
+
+    def test_get_all_paper_versions_nonexistent_paper(self):
+        """Test getting versions for a paper that doesn't exist."""
+        nonexistent_id = 99999
+
+        result = PaperVersionService.get_all_paper_versions(nonexistent_id)
+
+        # Should return empty queryset
+        self.assertEqual(result.count(), 0)
+        self.assertFalse(result.exists())
+
+    def test_get_all_paper_versions_removes_duplicates(self):
+        """Test that the service removes duplicate paper IDs."""
+        # This test ensures the set() operation works correctly
+        result = PaperVersionService.get_all_paper_versions(self.original_paper.id)
+
+        # Convert to list to check for duplicates
+        paper_ids = list(result.values_list("id", flat=True))
+        unique_paper_ids = list(set(paper_ids))
+
+        # Should have no duplicates
+        self.assertEqual(len(paper_ids), len(unique_paper_ids))
+
+    def test_get_all_paper_versions_with_complex_chain(self):
+        """Test with a more complex version chain."""
+        # Create version 3
+        version_3_paper = create_paper(title="Paper Version 3")
+        PaperVersion.objects.create(
+            paper=version_3_paper,
+            version=3,
+            base_doi="10.1234/test",
+            message="Third version",
+            original_paper=self.original_paper,
+            publication_status=PaperVersion.PREPRINT,
+        )
+
+        result = PaperVersionService.get_all_paper_versions(self.original_paper.id)
+
+        # Should return all papers: original + 3 versions
+        paper_ids = set(result.values_list("id", flat=True))
+        expected_ids = {
+            self.original_paper.id,
+            self.version_1_paper.id,
+            self.version_2_paper.id,
+            version_3_paper.id,
+        }
+
+        self.assertEqual(paper_ids, expected_ids)
+        self.assertEqual(result.count(), 4)
+
+    def test_get_all_paper_versions_original_paper_without_version_record(self):
+        """Test original paper that doesn't have a PaperVersion record itself."""
+        # Create a new original paper without a PaperVersion record
+        original_only = create_paper(title="Original Only Paper")
+
+        # Create a version that references this original
+        version_paper = create_paper(title="Version of Original Only")
+        PaperVersion.objects.create(
+            paper=version_paper,
+            version=1,
+            base_doi="10.5678/test",
+            message="Version of original only",
+            original_paper=original_only,
+            publication_status=PaperVersion.PREPRINT,
+        )
+
+        result = PaperVersionService.get_all_paper_versions(original_only.id)
+
+        # Should return both papers
+        paper_ids = set(result.values_list("id", flat=True))
+        expected_ids = {original_only.id, version_paper.id}
+
+        self.assertEqual(paper_ids, expected_ids)
+        self.assertEqual(result.count(), 2)

--- a/src/researchhub_comment/serializers/rh_comment_serializer.py
+++ b/src/researchhub_comment/serializers/rh_comment_serializer.py
@@ -93,8 +93,17 @@ class DynamicRhCommentSerializer(
 
         context = self.context
         _context_fields = context.get("rhc_dcs_get_thread", {})
+
+        # Only exclude comments field if user hasn't specified custom include fields
+        # This maintains backwards compatibility
+        thread_context_fields = _context_fields.copy()
+        if "_include_fields" not in thread_context_fields:
+            # Only exclude circular field when not using custom include fields
+            exclude_fields = thread_context_fields.get("_exclude_fields", [])
+            thread_context_fields["_exclude_fields"] = exclude_fields + ["comments"]
+
         serializer = DynamicRhThreadSerializer(
-            comment.thread, context=context, **_context_fields
+            comment.thread, context=context, **thread_context_fields
         )
         return serializer.data
 

--- a/src/researchhub_comment/serializers/rh_comment_serializer.py
+++ b/src/researchhub_comment/serializers/rh_comment_serializer.py
@@ -90,20 +90,23 @@ class DynamicRhCommentSerializer(
 
     def get_thread(self, comment):
         from researchhub_comment.serializers import DynamicRhThreadSerializer
+        from researchhub_comment.serializers.utils import (
+            create_thread_reference,
+            increment_depth,
+            should_use_reference_only,
+        )
 
         context = self.context
         _context_fields = context.get("rhc_dcs_get_thread", {})
 
-        # Only exclude comments field if user hasn't specified custom include fields
-        # This maintains backwards compatibility
-        thread_context_fields = _context_fields.copy()
-        if "_include_fields" not in thread_context_fields:
-            # Only exclude circular field when not using custom include fields
-            exclude_fields = thread_context_fields.get("_exclude_fields", [])
-            thread_context_fields["_exclude_fields"] = exclude_fields + ["comments"]
+        # Use depth limiting to prevent circular dependencies
+        if should_use_reference_only(context):
+            return create_thread_reference(comment.thread)
 
+        # Full serialization for shallow depths
+        new_context = increment_depth(context)
         serializer = DynamicRhThreadSerializer(
-            comment.thread, context=context, **thread_context_fields
+            comment.thread, context=new_context, **_context_fields
         )
         return serializer.data
 

--- a/src/researchhub_comment/serializers/utils.py
+++ b/src/researchhub_comment/serializers/utils.py
@@ -1,0 +1,53 @@
+"""
+Utilities for preventing circular dependencies in comment serializers.
+"""
+
+DEFAULT_MAX_DEPTH = 2
+
+
+def get_serialization_depth(context):
+    """Get the current serialization depth from context."""
+    return context.get("serialization_depth", 0)
+
+
+def increment_depth(context):
+    """Return a new context with incremented depth."""
+    new_context = context.copy()
+    new_context["serialization_depth"] = get_serialization_depth(context) + 1
+    return new_context
+
+
+def should_use_reference_only(context, max_depth=DEFAULT_MAX_DEPTH):
+    """Check if we should use reference-only serialization due to depth limits."""
+    return get_serialization_depth(context) >= max_depth
+
+
+def create_thread_reference(thread):
+    """Create a reference-only representation of a thread."""
+    return {
+        "id": thread.id,
+        "thread_type": thread.thread_type,
+        "anchor": thread.anchor,
+        "created_date": thread.created_date,
+        "updated_date": thread.updated_date,
+    }
+
+
+def create_comment_reference(comment):
+    """Create a reference-only representation of a comment."""
+    return {
+        "id": comment.id,
+        "created_date": comment.created_date,
+        "updated_date": comment.updated_date,
+        "created_by": comment.created_by_id,
+    }
+
+
+def create_content_object_reference(content_object):
+    """Create a reference-only representation of a content object."""
+    return {
+        "id": content_object.id,
+        "name": content_object._meta.model_name,
+        "title": getattr(content_object, "title", None),
+        "created_date": getattr(content_object, "created_date", None),
+    }

--- a/src/researchhub_comment/tests/test_paper_version_comments.py
+++ b/src/researchhub_comment/tests/test_paper_version_comments.py
@@ -1,0 +1,236 @@
+from django.contrib.contenttypes.models import ContentType
+from rest_framework.test import APITestCase
+
+from paper.related_models.paper_version import PaperVersion
+from paper.tests.helpers import create_paper
+from researchhub_comment.models import RhCommentModel, RhCommentThreadModel
+from researchhub_comment.views.rh_comment_view import RhCommentViewSet
+from user.tests.helpers import create_random_default_user
+
+
+class PaperVersionCommentsTests(APITestCase):
+    def setUp(self):
+        """Set up test data for paper version comment tests."""
+        self.user = create_random_default_user("test_user")
+
+        # Create original paper
+        self.original_paper = create_paper(title="Original Paper")
+
+        # Create version 1
+        self.version_1_paper = create_paper(title="Paper Version 1")
+        self.version_1 = PaperVersion.objects.create(
+            paper=self.version_1_paper,
+            version=1,
+            base_doi="10.1234/test",
+            message="First version",
+            original_paper=self.original_paper,
+            publication_status=PaperVersion.PREPRINT,
+        )
+
+        # Create version 2
+        self.version_2_paper = create_paper(title="Paper Version 2")
+        self.version_2 = PaperVersion.objects.create(
+            paper=self.version_2_paper,
+            version=2,
+            base_doi="10.1234/test",
+            message="Second version",
+            original_paper=self.original_paper,
+            publication_status=PaperVersion.PUBLISHED,
+        )
+
+    def _create_comment_thread(self, paper, thread_type="GENERIC_COMMENT"):
+        """Helper method to create a comment thread for a paper."""
+        content_type = ContentType.objects.get_for_model(paper)
+        thread = RhCommentThreadModel.objects.create(
+            content_type=content_type,
+            object_id=paper.id,
+            thread_type=thread_type,
+            created_by=self.user,
+        )
+        return thread
+
+    def _create_comment(self, thread, text="Test comment"):
+        """Helper method to create a comment in a thread."""
+        comment = RhCommentModel.objects.create(
+            thread=thread,
+            created_by=self.user,
+            comment_content_json={"ops": [{"insert": text}]},
+        )
+        return comment
+
+    def test_get_model_object_threads_returns_all_version_threads(self):
+        """Test that _get_model_object_threads returns threads from all paper
+        versions."""
+        # Create threads for each paper version
+        original_thread = self._create_comment_thread(self.original_paper)
+        version_1_thread = self._create_comment_thread(self.version_1_paper)
+        version_2_thread = self._create_comment_thread(self.version_2_paper)
+
+        # Create comments in each thread
+        self._create_comment(original_thread, "Comment on original")
+        self._create_comment(version_1_thread, "Comment on version 1")
+        self._create_comment(version_2_thread, "Comment on version 2")
+
+        # Test with original paper
+        view = RhCommentViewSet()
+        view.kwargs = {"model": "paper", "model_object_id": self.original_paper.id}
+
+        threads = view._get_model_object_threads()
+        thread_ids = set(threads.values_list("id", flat=True))
+        expected_thread_ids = {
+            original_thread.id,
+            version_1_thread.id,
+            version_2_thread.id,
+        }
+
+        self.assertEqual(thread_ids, expected_thread_ids)
+        self.assertEqual(threads.count(), 3)
+
+    def test_get_model_object_threads_with_version_paper_id(self):
+        """Test that _get_model_object_threads works when called with a version
+        paper ID."""
+        # Create threads for each paper version
+        original_thread = self._create_comment_thread(self.original_paper)
+        version_1_thread = self._create_comment_thread(self.version_1_paper)
+        version_2_thread = self._create_comment_thread(self.version_2_paper)
+
+        # Test with version 1 paper ID
+        view = RhCommentViewSet()
+        view.kwargs = {"model": "paper", "model_object_id": self.version_1_paper.id}
+
+        threads = view._get_model_object_threads()
+        thread_ids = set(threads.values_list("id", flat=True))
+        expected_thread_ids = {
+            original_thread.id,
+            version_1_thread.id,
+            version_2_thread.id,
+        }
+
+        self.assertEqual(thread_ids, expected_thread_ids)
+        self.assertEqual(threads.count(), 3)
+
+    def test_get_model_object_threads_single_paper_no_versions(self):
+        """Test _get_model_object_threads with a standalone paper (no versions)."""
+        standalone_paper = create_paper(title="Standalone Paper")
+        standalone_thread = self._create_comment_thread(standalone_paper)
+
+        view = RhCommentViewSet()
+        view.kwargs = {"model": "paper", "model_object_id": standalone_paper.id}
+
+        threads = view._get_model_object_threads()
+        thread_ids = set(threads.values_list("id", flat=True))
+        expected_thread_ids = {standalone_thread.id}
+
+        self.assertEqual(thread_ids, expected_thread_ids)
+        self.assertEqual(threads.count(), 1)
+
+    def test_api_endpoint_returns_comments_from_all_versions(self):
+        """Test the actual API endpoint returns comments from all paper
+        versions."""
+        # Create threads and comments for each paper version
+        original_thread = self._create_comment_thread(self.original_paper)
+        version_1_thread = self._create_comment_thread(self.version_1_paper)
+        version_2_thread = self._create_comment_thread(self.version_2_paper)
+
+        original_comment = self._create_comment(original_thread, "Comment on original")
+        version_1_comment = self._create_comment(
+            version_1_thread, "Comment on version 1"
+        )
+        version_2_comment = self._create_comment(
+            version_2_thread, "Comment on version 2"
+        )
+
+        # Make API request to get comments for original paper
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"/api/paper/{self.original_paper.id}/comments/")
+
+        self.assertEqual(response.status_code, 200)
+
+        # Should return comments from all versions
+        comment_ids = {comment["id"] for comment in response.data["results"]}
+        expected_comment_ids = {
+            original_comment.id,
+            version_1_comment.id,
+            version_2_comment.id,
+        }
+
+        self.assertEqual(comment_ids, expected_comment_ids)
+        self.assertEqual(response.data["count"], 3)
+
+    def test_api_endpoint_with_version_paper_id(self):
+        """Test the API endpoint works when called with a version paper ID."""
+        # Create threads and comments for each paper version
+        original_thread = self._create_comment_thread(self.original_paper)
+        version_1_thread = self._create_comment_thread(self.version_1_paper)
+        version_2_thread = self._create_comment_thread(self.version_2_paper)
+
+        original_comment = self._create_comment(original_thread, "Comment on original")
+        version_1_comment = self._create_comment(
+            version_1_thread, "Comment on version 1"
+        )
+        version_2_comment = self._create_comment(
+            version_2_thread, "Comment on version 2"
+        )
+
+        # Make API request to get comments for version 1 paper
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"/api/paper/{self.version_1_paper.id}/comments/")
+
+        self.assertEqual(response.status_code, 200)
+
+        # Should return comments from all versions
+        comment_ids = {comment["id"] for comment in response.data["results"]}
+        expected_comment_ids = {
+            original_comment.id,
+            version_1_comment.id,
+            version_2_comment.id,
+        }
+
+        self.assertEqual(comment_ids, expected_comment_ids)
+        self.assertEqual(response.data["count"], 3)
+
+    def test_comments_from_different_paper_families_not_mixed(self):
+        """Test that comments from different paper families are not mixed."""
+        # Create a completely separate paper family
+        other_original = create_paper(title="Other Original Paper")
+        other_version_paper = create_paper(title="Other Version Paper")
+        PaperVersion.objects.create(
+            paper=other_version_paper,
+            version=1,
+            base_doi="10.9999/other",
+            message="Other version",
+            original_paper=other_original,
+            publication_status=PaperVersion.PREPRINT,
+        )
+
+        # Create threads and comments for our original paper family
+        original_thread = self._create_comment_thread(self.original_paper)
+        version_1_thread = self._create_comment_thread(self.version_1_paper)
+
+        # Create threads and comments for the other paper family
+        other_original_thread = self._create_comment_thread(other_original)
+        other_version_thread = self._create_comment_thread(other_version_paper)
+
+        our_comment = self._create_comment(original_thread, "Our comment")
+        our_version_comment = self._create_comment(
+            version_1_thread, "Our version comment"
+        )
+        other_comment = self._create_comment(other_original_thread, "Other comment")
+        other_version_comment = self._create_comment(
+            other_version_thread, "Other version comment"
+        )
+
+        # Get comments for our paper family
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"/api/paper/{self.original_paper.id}/comments/")
+
+        self.assertEqual(response.status_code, 200)
+
+        # Should only return comments from our paper family
+        comment_ids = {comment["id"] for comment in response.data["results"]}
+        expected_comment_ids = {our_comment.id, our_version_comment.id}
+        unexpected_comment_ids = {other_comment.id, other_version_comment.id}
+
+        self.assertEqual(comment_ids, expected_comment_ids)
+        self.assertTrue(comment_ids.isdisjoint(unexpected_comment_ids))
+        self.assertEqual(response.data["count"], 2)


### PR DESCRIPTION
1. Created a new service class in /src/paper/services/paper_version_service.py that contains the get_all_paper_versions method to retrieve all versions of a paper.
  2. Modified the _get_model_object_threads method in the RhCommentViewSet class to use the new service to fetch threads from all paper versions when the model is a Paper.
  3. Updated the get_discussions method in the DynamicPaperSerializer to return discussions from all paper versions.
  4. Updated the get_discussion_aggregates method in the DynamicPaperSerializer to aggregate discussion statistics from all paper versions.
  
  Linked [#206](https://github.com/ResearchHub/issues/issues/206)