### PR TITLE
Add old production website to CORS allow list

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -180,6 +180,8 @@ CORS_ORIGIN_WHITELIST = [
     "https://localhost:3000",
     "https://dev.researchhub.com",
     "https://new.researchhub.com",
+    "https://old.researchhub.com",
+    "https://www.old.researchhub.com",
     "https://researchnow.researchhub.com",
     "https://www.researchhub.com",
     "https://researchhub.com",


### PR DESCRIPTION
This adds the "old" website DNS names [old.research.com](https://old.research.com/) and [www.old.research.com](https://www.old.research.com/) to the CORS allow list.