### PR TITLE
Remove temporary, hard-coded email confirmation URL

### DIFF
--- a/src/user/custom_allauth.py
+++ b/src/user/custom_allauth.py
@@ -7,16 +7,7 @@ from django.conf import settings
 
 class CustomAccountAdapter(DefaultAccountAdapter):
     def get_email_confirmation_url(self, request, emailconfirmation):
-        # TEMPORARY:
-        # Use hard-coded URL pointing to the new web application for email confirmation.
-        # Will be replaced with `BASE_FRONTEND_URL` after moving the new web application to www.
-        base_url = settings.BASE_FRONTEND_URL
-        if settings.PRODUCTION:
-            base_url = "https://new.researchhub.com"
-        elif settings.STAGING:
-            base_url = "https://v2.staging.researchhub.com"
-
-        return f"{base_url}/verify/{emailconfirmation.key}"
+        return f"{settings.BASE_FRONTEND_URL}/verify/{emailconfirmation.key}"
 
 
 class CustomPasswordResetSerializer(PasswordResetSerializer):

--- a/src/user/tests/test_custom_allauth.py
+++ b/src/user/tests/test_custom_allauth.py
@@ -15,34 +15,6 @@ class CustomAccountAdapterTests(SimpleTestCase):
         self.adapter = CustomAccountAdapter()
 
     @override_settings(
-        PRODUCTION=True,
-        BASE_FRONTEND_URL="https://www.researchhub.com",
-    )
-    def test_get_email_confirmation_url_production(self):
-        # Arrange
-        confirm = DummyEmailConfirmation("prod")
-
-        # Act
-        url = self.adapter.get_email_confirmation_url(self.request, confirm)
-
-        # Assert
-        self.assertEqual(url, "https://new.researchhub.com/verify/prod")
-
-    @override_settings(
-        STAGING=True,
-        BASE_FRONTEND_URL="https://www.researchhub.com",
-    )
-    def test_get_email_confirmation_url_staging(self):
-        # Arrange
-        confirm = DummyEmailConfirmation("staging")
-
-        # Act
-        url = self.adapter.get_email_confirmation_url(self.request, confirm)
-
-        # Assert
-        self.assertEqual(url, "https://v2.staging.researchhub.com/verify/staging")
-
-    @override_settings(
         BASE_FRONTEND_URL="https://default.researchhub.com",
     )
     def test_get_email_confirmation_url_default(self):


### PR DESCRIPTION
Use the regular base URL from configuration instead of the hardcoded values used temporarily for the "new" domains.