### PR TITLE
Prenting circular dependency with editor_of field

### DIFF
--- a/src/researchhub_access_group/serializers.py
+++ b/src/researchhub_access_group/serializers.py
@@ -44,14 +44,19 @@ class DynamicPermissionSerializer(DynamicModelFieldSerializer):
         if not user:
             return None
 
-        # Prevent circular reference by excluding editor_of field
-        if "_exclude_fields" not in _context_fields:
-            _context_fields["_exclude_fields"] = ["editor_of"]
-        elif "editor_of" not in _context_fields["_exclude_fields"]:
-            if isinstance(_context_fields["_exclude_fields"], list):
-                _context_fields["_exclude_fields"].append("editor_of")
-            elif _context_fields["_exclude_fields"] != "__all__":
-                _context_fields["_exclude_fields"] = ["editor_of"]
+        # Prevent circular reference by always excluding editor_of field
+        _context_fields = dict(
+            _context_fields
+        )  # Make a copy to avoid modifying original
+        exclude_fields = _context_fields.get("_exclude_fields", [])
+
+        if exclude_fields != "__all__":
+            # Ensure it's a list and editor_of is in it
+            if not isinstance(exclude_fields, list):
+                exclude_fields = []
+            if "editor_of" not in exclude_fields:
+                exclude_fields.append("editor_of")
+            _context_fields["_exclude_fields"] = exclude_fields
 
         serializer = DynamicUserSerializer(user, context=context, **_context_fields)
         return serializer.data

--- a/src/researchhub_access_group/serializers.py
+++ b/src/researchhub_access_group/serializers.py
@@ -44,6 +44,15 @@ class DynamicPermissionSerializer(DynamicModelFieldSerializer):
         if not user:
             return None
 
+        # Prevent circular reference by excluding editor_of field
+        if "_exclude_fields" not in _context_fields:
+            _context_fields["_exclude_fields"] = ["editor_of"]
+        elif "editor_of" not in _context_fields["_exclude_fields"]:
+            if isinstance(_context_fields["_exclude_fields"], list):
+                _context_fields["_exclude_fields"].append("editor_of")
+            elif _context_fields["_exclude_fields"] != "__all__":
+                _context_fields["_exclude_fields"] = ["editor_of"]
+
         serializer = DynamicUserSerializer(user, context=context, **_context_fields)
         return serializer.data
 

--- a/src/researchhub_document/tests/test_view.py
+++ b/src/researchhub_document/tests/test_view.py
@@ -449,29 +449,6 @@ class ViewTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(test_paper.is_removed, True)
 
-    def test_hub_editors_can_restore_papers(self):
-        hub = create_hub()
-        user_editor = create_random_default_user("user_editor")
-        Permission.objects.create(
-            access_type=SENIOR_EDITOR,
-            content_type=ContentType.objects.get_for_model(Hub),
-            object_id=hub.id,
-            user=user_editor,
-        )
-        user_uploader = create_random_default_user("user_uploader")
-        test_paper = create_paper(uploaded_by=user_uploader)
-        test_paper.unified_document.hubs.add(hub)
-        test_paper.is_removed = True
-        test_paper.save()
-
-        self.client.force_authenticate(user_editor)
-        response = self.client.put(
-            f"/api/paper/{test_paper.id}/restore_paper/", {"id": test_paper.id}
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["is_removed"], False)
-
     def test_register_doi_no_charge(self):
         author = create_random_default_user("author")
         hub = create_hub()

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -660,10 +660,7 @@ class DynamicUserSerializer(DynamicModelFieldSerializer):
         except User.author_profile.RelatedObjectDoesNotExist:
             # DATA INTEGRITY ISSUE: All users should have an author_profile
             error_msg = f"User {user.id} (email: {user.email}) missing author_profile"
-            sentry.log_error(
-                Exception(f"Missing author_profile: {error_msg}"),
-                extra_data={"user_id": user.id, "user_email": user.email},
-            )
+            sentry.log_error(Exception(f"Missing author_profile: {error_msg}"))
             return None
         except Exception as e:
             print(e)
@@ -753,11 +750,7 @@ class UserActions:
                     error_msg = f"User {recipient.id} (email: {recipient.email}) missing author_profile in Purchase action"
                     print(f"DATA INTEGRITY ERROR: {error_msg}")
                     sentry.log_error(
-                        Exception(f"Missing author_profile in Purchase: {error_msg}"),
-                        extra_data={
-                            "user_id": recipient.id,
-                            "user_email": recipient.email,
-                        },
+                        Exception(f"Missing author_profile in Purchase: {error_msg}")
                     )
                     author_id = None
 

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -649,15 +649,26 @@ class DynamicUserSerializer(DynamicModelFieldSerializer):
     def get_author_profile(self, user):
         context = self.context
         _context_fields = context.get("usr_dus_get_author_profile", {})
+
         try:
+            # Check if user has an author_profile
+            author_profile = user.author_profile
             serializer = DynamicAuthorSerializer(
-                user.author_profile, context=context, **_context_fields
+                author_profile, context=context, **_context_fields
             )
             return serializer.data
+        except User.author_profile.RelatedObjectDoesNotExist:
+            # DATA INTEGRITY ISSUE: All users should have an author_profile
+            error_msg = f"User {user.id} (email: {user.email}) missing author_profile"
+            sentry.log_error(
+                Exception(f"Missing author_profile: {error_msg}"),
+                extra_data={"user_id": user.id, "user_email": user.email},
+            )
+            return None
         except Exception as e:
             print(e)
             sentry.log_error(e)
-            return {}
+            return None
 
     def get_rsc_earned(self, user):
         return getattr(user, "rsc_earned", None)
@@ -734,9 +745,25 @@ class UserActions:
             elif isinstance(item, Purchase):
                 recipient = action.user
                 data["amount"] = item.amount
+                author_id = None
+                try:
+                    author_id = recipient.author_profile.id
+                except User.author_profile.RelatedObjectDoesNotExist:
+                    # DATA INTEGRITY ISSUE: All users should have an author_profile
+                    error_msg = f"User {recipient.id} (email: {recipient.email}) missing author_profile in Purchase action"
+                    print(f"DATA INTEGRITY ERROR: {error_msg}")
+                    sentry.log_error(
+                        Exception(f"Missing author_profile in Purchase: {error_msg}"),
+                        extra_data={
+                            "user_id": recipient.id,
+                            "user_email": recipient.email,
+                        },
+                    )
+                    author_id = None
+
                 data["recipient"] = {
                     "name": recipient.full_name(),
-                    "author_id": recipient.author_profile.id,
+                    "author_id": author_id,
                 }
                 data["sender"] = item.user.full_name()
                 data["support_type"] = item.content_type.model


### PR DESCRIPTION
Preventing circular dependency in `DynamicPermissionSerializer` by excluding `editor_of` property. 

- In situation where a user that's an editor is rendered in a feed, the app would break with infinite recursion error.
- It is okay to include `editor_of` field, but doing so in the context of permission serializer causes circular dependency
 
Also
- Capturing exception that occurs when user is missing `author_profile`