### PR TITLE
Reduced upvotes from 5 to 3 to trigger create_automated_bounty(item)

### DIFF
--- a/src/discussion/reaction_views.py
+++ b/src/discussion/reaction_views.py
@@ -378,7 +378,7 @@ def create_vote(user, item, vote_type):
 def create_automated_bounty(item):
     if (
         isinstance(item, Paper)
-        and item.score >= 5
+        and item.score >= 3
         and item.hubs.filter(id=436).exists()  # Hardcoded Biorxiv Hub
         and not item.automated_bounty_created
     ):


### PR DESCRIPTION
Editors requested we reduce the upvote to trigger a bounty from 5 to 3 in order to ensure we are not missing any bounties due to not enough upvotes.  