### PR TITLE
Add review object to contributions endpoint

### DIFF
--- a/src/researchhub_comment/tests/test_comments.py
+++ b/src/researchhub_comment/tests/test_comments.py
@@ -902,6 +902,7 @@ class CommentViewTests(APITestCase):
         # Count should revert to baseline
         self.assertEqual(_discussion_count(), baseline_discussion_ct)
 
+    def test_filter_by_author_update(self):
         author_update_creator = self.paper.created_by
         regular_creator = self.user_2
         self._create_paper_comment(

--- a/src/researchhub_comment/tests/test_comments.py
+++ b/src/researchhub_comment/tests/test_comments.py
@@ -903,7 +903,7 @@ class CommentViewTests(APITestCase):
         self.assertEqual(_discussion_count(), baseline_discussion_ct)
 
     def test_filter_by_author_update(self):
-        author_update_creator = self.user_1
+        author_update_creator = self.paper_uploader
         regular_creator = self.user_2
         self._create_paper_comment(
             self.paper.id,

--- a/src/user/tests/test_contribution_views.py
+++ b/src/user/tests/test_contribution_views.py
@@ -1,0 +1,88 @@
+from django.contrib.contenttypes.models import ContentType
+from rest_framework.test import APITestCase
+
+from researchhub_comment.models import RhCommentModel
+from researchhub_comment.related_models.rh_comment_thread_model import (
+    RhCommentThreadModel,
+)
+from researchhub_document.models import ResearchhubUnifiedDocument
+from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
+from review.models import Review
+from user.models import Action
+from user.tests.helpers import create_random_default_user
+
+
+class ContributionViewSetTests(APITestCase):
+    def setUp(self):
+        self.user = create_random_default_user("test_user")
+        self.client.force_authenticate(self.user)
+
+    def test_latest_contributions_with_review(self):
+        # Create a unified document and post
+        unified_doc = ResearchhubUnifiedDocument.objects.create(
+            document_type="DISCUSSION"
+        )
+        post = ResearchhubPost.objects.create(
+            title="Test Post", created_by=self.user, unified_document=unified_doc
+        )
+
+        # Create a comment thread
+        thread = RhCommentThreadModel.objects.create(
+            content_type=ContentType.objects.get_for_model(ResearchhubPost),
+            object_id=post.id,
+            created_by=self.user,
+        )
+
+        # Create a comment
+        comment = RhCommentModel.objects.create(
+            created_by=self.user,
+            thread=thread,
+            comment_content_json={
+                "type": "doc",
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": "Test comment"}],
+                    }
+                ],
+            },
+        )
+
+        # Create a review for the comment
+        Review.objects.create(
+            created_by=self.user,
+            score=4.5,
+            content_type=ContentType.objects.get_for_model(RhCommentModel),
+            object_id=comment.id,
+        )
+
+        # Create an action for the comment
+        Action.objects.create(
+            user=self.user,
+            content_type=ContentType.objects.get_for_model(RhCommentModel),
+            object_id=comment.id,
+            item=comment,
+        )
+
+        # Make request to latest_contributions endpoint
+        response = self.client.get("/api/contribution/latest_contributions/")
+
+        # Verify response
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.data["results"]) > 0)
+
+        # Find the comment in the results
+        comment_result = None
+        for result in response.data["results"]:
+            if result["content_type"]["name"] == "rhcommentmodel":
+                comment_result = result
+                break
+
+        self.assertIsNotNone(comment_result)
+        self.assertIn("item", comment_result)
+        self.assertIn("review", comment_result["item"])
+
+        # Verify review score is included
+        review_data = comment_result["item"]["review"]
+        self.assertIsNotNone(review_data)
+        self.assertEqual(review_data["score"], 4.5)

--- a/src/user/views/contribution_views.py
+++ b/src/user/views/contribution_views.py
@@ -226,6 +226,12 @@ class ContributionViewSet(viewsets.ReadOnlyModelViewSet):
             "rhc_dcs_get_thread": {
                 "_include_fields": ["content_object", "thread_type", "anchor"]
             },
+            "rhc_dcs_get_review": {
+                "_include_fields": [
+                    "id",
+                    "score",
+                ]
+            },
             "rhc_dts_get_content_object": {
                 "_include_fields": [
                     "id",

--- a/src/user/views/contribution_views.py
+++ b/src/user/views/contribution_views.py
@@ -226,14 +226,6 @@ class ContributionViewSet(viewsets.ReadOnlyModelViewSet):
             "rhc_dcs_get_thread": {
                 "_include_fields": ["content_object", "thread_type", "anchor"]
             },
-            "rhc_dcs_get_review": {
-                "_include_fields": [
-                    "id",
-                    "score",
-                    "created_by",
-                    "unified_document",
-                ]
-            },
             "rhc_dts_get_content_object": {
                 "_include_fields": [
                     "id",

--- a/src/user/views/contribution_views.py
+++ b/src/user/views/contribution_views.py
@@ -94,6 +94,7 @@ class ContributionViewSet(viewsets.ReadOnlyModelViewSet):
                     "item",
                     "paper_title",
                     "renderable_text",
+                    "review",
                     "slug",
                     "title",
                     "thread",
@@ -224,6 +225,14 @@ class ContributionViewSet(viewsets.ReadOnlyModelViewSet):
             },
             "rhc_dcs_get_thread": {
                 "_include_fields": ["content_object", "thread_type", "anchor"]
+            },
+            "rhc_dcs_get_review": {
+                "_include_fields": [
+                    "id",
+                    "score",
+                    "created_by",
+                    "unified_document",
+                ]
             },
             "rhc_dts_get_content_object": {
                 "_include_fields": [


### PR DESCRIPTION
## What?
- The `/api/contribution/latest_contributions/` endpoint returns peer review comments but not their associated review scores.
- Issue: https://github.com/ResearchHub/issues/issues/200

## How?
- Added `review` field to the `usr_das_get_item` serializer context in `ContributionViewSet`
- Added test to verify review scores are included in the response
