### PR TITLE
fix: Test `test_filter_by_author_update` currently fails.

### DIFF
--- a/src/researchhub_comment/tests/test_comments.py
+++ b/src/researchhub_comment/tests/test_comments.py
@@ -903,11 +903,11 @@ class CommentViewTests(APITestCase):
         self.assertEqual(_discussion_count(), baseline_discussion_ct)
 
     def test_filter_by_author_update(self):
-        author_update_creator = self.user_1
+        author_update_creator = self.paper.created_by
         regular_creator = self.user_2
         self._create_paper_comment(
             self.paper.id,
-            author_update_creator,
+            created_by=author_update_creator,
             thread_type="AUTHOR_UPDATE",
             comment_type="AUTHOR_UPDATE",
         )


### PR DESCRIPTION
The author update comment creator should be the paper creator.