### PR TITLE
chore: Remove discussion dependencies from post model

### DIFF
--- a/src/researchhub_document/related_models/researchhub_post_model.py
+++ b/src/researchhub_document/related_models/researchhub_post_model.py
@@ -127,10 +127,6 @@ class ResearchhubPost(AbstractGenericReactionModel):
     )
 
     @property
-    def has_accepted_answer(self):
-        return self.get_accepted_answer() is not None
-
-    @property
     def is_latest_version(self):
         return self.next_version is None
 
@@ -207,11 +203,6 @@ class ResearchhubPost(AbstractGenericReactionModel):
             return "question"
 
         return "post"
-
-    def get_accepted_answer(self):
-        return self.threads.filter(
-            is_accepted_answer=True, discussion_post_type="ANSWER"
-        ).first()
 
     def get_promoted_score(self):
         purchases = self.purchases.filter(

--- a/src/researchhub_document/serializers/researchhub_post_serializer.py
+++ b/src/researchhub_document/serializers/researchhub_post_serializer.py
@@ -42,7 +42,6 @@ class ResearchhubPostSerializer(ModelSerializer, GenericReactionSerializerMixin)
             "doi",
             "editor_type",
             "full_markdown",
-            "has_accepted_answer",
             "hubs",
             "id",
             "image",
@@ -91,7 +90,6 @@ class ResearchhubPostSerializer(ModelSerializer, GenericReactionSerializerMixin)
     authors = SerializerMethodField()
     created_by = SerializerMethodField(method_name="get_created_by")
     full_markdown = SerializerMethodField(method_name="get_full_markdown")
-    has_accepted_answer = ReadOnlyField()  # @property
     hubs = SerializerMethodField(method_name="get_hubs")
     image = CharField(write_only=True, required=False, allow_null=True)
     image_url = SerializerMethodField()
@@ -223,7 +221,6 @@ class DynamicPostSerializer(DynamicModelFieldSerializer):
     created_by = SerializerMethodField()
     discussions = SerializerMethodField()
     discussion_aggregates = SerializerMethodField()
-    has_accepted_answer = ReadOnlyField()  # @property
     hubs = SerializerMethodField()
     note = SerializerMethodField()
     purchases = SerializerMethodField()


### PR DESCRIPTION
Remove accepted answer properties from the post model. The accepted answer is based on the deprecated discussion model and is not used by any client.