### PR TITLE
chore: Preselect user verification in user views

### DIFF
--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -145,8 +145,10 @@ class AuthorSerializer(ModelSerializer):
         if obj.user is None:
             return False
 
-        user_verification = UserVerification.objects.filter(user=obj.user).last()
-        return user_verification.is_verified if user_verification else False
+        try:
+            return obj.user.userverification.is_verified
+        except UserVerification.DoesNotExist:
+            return False
 
     def get_reputation_v2(self, author):
         score = Score.objects.filter(author=author).order_by("-score").first()
@@ -1099,9 +1101,10 @@ class DynamicAuthorProfileSerializer(DynamicModelFieldSerializer):
             return None
 
         is_verified = False
-        user_verification = UserVerification.objects.filter(user=user).first()
-        if user_verification:
-            is_verified = user_verification.is_verified
+        try:
+            is_verified = user.userverification.is_verified
+        except UserVerification.DoesNotExist:
+            is_verified = False
 
         return {
             "id": user.id,

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -66,10 +66,9 @@ class ModeratorUserSerializer(ModelSerializer):
         ]
 
     def get_verification(self, user):
-
-        user_verification = UserVerification.objects.filter(user=user).last()
-
-        if user_verification is None:
+        try:
+            user_verification = user.userverification
+        except UserVerification.DoesNotExist:
             return None
 
         return {

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -579,8 +579,10 @@ class UserEditableSerializer(ModelSerializer):
 
     # FIXME: is_verified_v2 should be available on user model and not on author. This is a shim for legacy reasons.
     def get_is_verified_v2(self, user):
-        user_verification = UserVerification.objects.filter(user=user).first()
-        return user_verification.is_verified if user_verification else False
+        try:
+            return user.userverification.is_verified
+        except UserVerification.DoesNotExist:
+            return False
 
     def get_organization_slug(self, user):
         try:

--- a/src/user/views/author_views.py
+++ b/src/user/views/author_views.py
@@ -50,7 +50,10 @@ from utils.throttles import THROTTLE_CLASSES
 
 
 class AuthorViewSet(viewsets.ModelViewSet, FollowViewActionMixin):
-    queryset = Author.objects.all()
+    queryset = Author.objects.select_related(
+        "user",
+        "user__userverification",
+    )
     serializer_class = AuthorSerializer
     filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
     filterset_class = AuthorFilter

--- a/src/user/views/moderator_view.py
+++ b/src/user/views/moderator_view.py
@@ -1,21 +1,20 @@
 from rest_framework.decorators import action
-from rest_framework.permissions import AllowAny
-from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
+from user.models import User
 from user.permissions import IsModerator, UserIsEditor
 from user.serializers import ModeratorUserSerializer
 
 
 class ModeratorView(ModelViewSet):
+    queryset = User.objects.select_related(
+        "userverification",
+    )
+    serializer_class = ModeratorUserSerializer
+    permission_classes = [UserIsEditor | IsModerator]
 
     @action(
         detail=True, methods=["get"], permission_classes=[UserIsEditor | IsModerator]
     )
     def user_details(self, request, pk=None, **kwargs):
-        from user.models import User
-
-        user = User.objects.get(id=pk)
-        serializer = ModeratorUserSerializer(user)
-
-        return Response(serializer.data)
+        return super().retrieve(request, pk, **kwargs)

--- a/src/user/views/user_views.py
+++ b/src/user/views/user_views.py
@@ -55,7 +55,9 @@ from utils.sentry import log_info
 
 
 class UserViewSet(FollowViewActionMixin, viewsets.ModelViewSet):
-    queryset = User.objects.filter(is_suspended=False)
+    queryset = User.objects.select_related(
+        "userverification",
+    ).filter(is_suspended=False)
     serializer_class = UserEditableSerializer
     permission_classes = [IsAuthenticatedOrReadOnly, DeleteUserPermission]
     filter_backends = (DjangoFilterBackend,)


### PR DESCRIPTION
Use `select_related` in user/author views and use the preselected data in the corresponding serializers.