### PR TITLE
chore: Create API view for Sift webhook

### DIFF
--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -48,10 +48,15 @@ from researchhub.views import asset_upload_view
 from researchhub_comment.views.rh_comment_view import RhCommentViewSet
 from review.views.peer_review_view import PeerReviewViewSet
 from review.views.review_view import ReviewViewSet
-from user.views import author_views, editor_views, moderator_view, persona_webhook_view
-from user_saved.views import UserSavedView
+from user.views import (
+    author_views,
+    editor_views,
+    moderator_view,
+    persona_webhook_view,
+    sift_webhook_view,
+)
 from user.views.custom_verify_email_view import CustomVerifyEmailView
-
+from user_saved.views import UserSavedView
 
 router = routers.DefaultRouter()
 
@@ -325,6 +330,11 @@ urlpatterns = [
         "webhooks/persona/",
         persona_webhook_view.PersonaWebhookView.as_view(),
         name="persona_webhook",
+    ),
+    path(
+        "webhooks/sift/",
+        sift_webhook_view.SiftWebhookView.as_view(),
+        name="sift_webhook",
     ),
     path(
         "webhooks/stripe/",

--- a/src/user/tests/test_sift_webhook_view.py
+++ b/src/user/tests/test_sift_webhook_view.py
@@ -40,7 +40,7 @@ class SiftWebhookViewTests(APITestCase):
         key = secret_key.encode("utf-8")
         if isinstance(body, str):
             body = body.encode("utf-8")
-        h = hmac.new(key, body, sha1)
+        h = hmac.new(key, body, sha1)  # NOSONAR: sha1 is required by Sift
         return f"sha1={h.hexdigest()}"
 
     @override_settings(SIFT_WEBHOOK_SECRET_KEY=webhook_secret)

--- a/src/user/tests/test_sift_webhook_view.py
+++ b/src/user/tests/test_sift_webhook_view.py
@@ -309,3 +309,55 @@ class SiftWebhookViewTests(APITestCase):
 
         # Assert
         self.assertEqual(response.status_code, 200)
+
+    @override_settings(SIFT_WEBHOOK_SECRET_KEY=webhook_secret)
+    def test_webhook_with_missing_decision_id_returns_400(self):
+        """
+        Test webhook with missing decision ID returns 400
+        """
+        # Arrange
+        payload = {
+            "entity": {"id": str(self.user.id)}
+            # Missing "decision" key
+        }
+
+        body = json.dumps(payload)
+        signature = self.create_signature(body, self.webhook_secret)
+
+        # Act
+        response = self.client.post(
+            "/webhooks/sift/",
+            body,
+            content_type="application/json",
+            headers={"X-Sift-Science-Signature": signature},
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"message": "Invalid payload"})
+
+    @override_settings(SIFT_WEBHOOK_SECRET_KEY=webhook_secret)
+    def test_webhook_with_missing_entity_id_returns_400(self):
+        """
+        Test webhook with missing entity ID returns 400
+        """
+        # Arrange
+        payload = {
+            "decision": {"id": "mark_as_probable_spammer_content_abuse_123"}
+            # Missing "entity" key
+        }
+
+        body = json.dumps(payload)
+        signature = self.create_signature(body, self.webhook_secret)
+
+        # Act
+        response = self.client.post(
+            "/webhooks/sift/",
+            body,
+            content_type="application/json",
+            headers={"X-Sift-Science-Signature": signature},
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"message": "Invalid payload"})

--- a/src/user/tests/test_sift_webhook_view.py
+++ b/src/user/tests/test_sift_webhook_view.py
@@ -1,0 +1,285 @@
+import hmac
+import json
+from hashlib import sha1
+from unittest.mock import patch
+
+from django.test import override_settings
+from rest_framework.test import APITestCase
+
+from user.models import User
+
+
+class SiftWebhookViewTests(APITestCase):
+
+    webhook_secret = "sift_test_secret_key"
+
+    def setUp(self):
+        self.user = User.objects.create(
+            email="test@researchhub.com.com", first_name="Test", last_name="User"
+        )
+
+        self.probable_spammer_payload = {
+            "decision": {"id": "mark_as_probable_spammer_content_abuse"},
+            "entity": {"id": str(self.user.id)},
+        }
+
+        self.suspend_user_payload = {
+            "decision": {"id": "suspend_user_content_abuse"},
+            "entity": {"id": str(self.user.id)},
+        }
+
+        self.unknown_decision_payload = {
+            "decision": {"id": "unknown_decision_type"},
+            "entity": {"id": str(self.user.id)},
+        }
+
+    def create_signature(self, body, secret_key):
+        """
+        Helper method to create valid Sift webhook signature
+        """
+        key = secret_key.encode("utf-8")
+        if isinstance(body, str):
+            body = body.encode("utf-8")
+        h = hmac.new(key, body, sha1)
+        return f"sha1={h.hexdigest()}"
+
+    @override_settings(SIFT_WEBHOOK_SECRET_KEY=webhook_secret)
+    def test_webhook_without_signature_returns_401(self):
+        """
+        Test that webhook without signature header returns 401
+        """
+        # Arrange
+        body = json.dumps(self.probable_spammer_payload)
+
+        # Act
+        response = self.client.post(
+            "/webhooks/sift/",
+            body,
+            content_type="application/json",
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    @override_settings(SIFT_WEBHOOK_SECRET_KEY=webhook_secret)
+    def test_webhook_with_invalid_signature_returns_401(self):
+        """
+        Test that webhook with invalid signature returns 401
+        """
+        # Arrange
+        body = json.dumps(self.probable_spammer_payload)
+
+        # Act
+        response = self.client.post(
+            "/webhooks/sift/",
+            body,
+            content_type="application/json",
+            headers={"X-Sift-Science-Signature": "sha1=invalid_signature"},
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    @patch("utils.siftscience.client")
+    @override_settings(SIFT_WEBHOOK_SECRET_KEY=webhook_secret)
+    def test_webhook_with_valid_signature_probable_spammer(self, mock_sift_client):
+        """
+        Test webhook correctly processes probable spammer decision
+        """
+        # Arrange
+        body = json.dumps(self.probable_spammer_payload)
+        signature = self.create_signature(body, self.webhook_secret)
+
+        # Verify user is not initially flagged as probable spammer
+        self.assertFalse(self.user.probable_spammer)
+
+        # Act
+        response = self.client.post(
+            "/webhooks/sift/",
+            body,
+            content_type="application/json",
+            headers={"X-Sift-Science-Signature": signature},
+        )
+
+        # Assert
+        self.user.refresh_from_db()
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(self.user.probable_spammer)
+        self.assertIsNotNone(self.user.spam_updated_date)
+
+    @patch("utils.siftscience.client")
+    @override_settings(SIFT_WEBHOOK_SECRET_KEY=webhook_secret)
+    def test_webhook_with_valid_signature_suspend_user(self, mock_sift_client):
+        """
+        Test webhook correctly processes suspend user decision
+        """
+        # Arrange
+        body = json.dumps(self.suspend_user_payload)
+        signature = self.create_signature(body, self.webhook_secret)
+
+        # Verify user is not initially suspended or inactive
+        self.assertFalse(self.user.is_suspended)
+        self.assertTrue(self.user.is_active)
+
+        # Act
+        response = self.client.post(
+            "/webhooks/sift/",
+            body,
+            content_type="application/json",
+            headers={"X-Sift-Science-Signature": signature},
+        )
+
+        # Assert
+        self.user.refresh_from_db()
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(self.user.is_suspended)
+        self.assertFalse(self.user.is_active)
+        self.assertIsNotNone(self.user.suspended_updated_date)
+
+    @patch("utils.siftscience.client")
+    @override_settings(SIFT_WEBHOOK_SECRET_KEY=webhook_secret)
+    def test_webhook_with_unknown_decision_does_nothing(self, mock_sift_client):
+        """
+        Test webhook with unknown decision type doesn't modify user
+        """
+        # Arrange
+        body = json.dumps(self.unknown_decision_payload)
+        signature = self.create_signature(body, self.webhook_secret)
+
+        initial_probable_spammer = self.user.probable_spammer
+        initial_is_suspended = self.user.is_suspended
+        initial_is_active = self.user.is_active
+
+        # Act
+        response = self.client.post(
+            "/webhooks/sift/",
+            body,
+            content_type="application/json",
+            headers={"X-Sift-Science-Signature": signature},
+        )
+
+        # Assert
+        self.user.refresh_from_db()
+        self.assertEqual(response.status_code, 200)
+        # User state should remain unchanged
+        self.assertEqual(self.user.probable_spammer, initial_probable_spammer)
+        self.assertEqual(self.user.is_suspended, initial_is_suspended)
+        self.assertEqual(self.user.is_active, initial_is_active)
+
+    @patch("utils.siftscience.client")
+    @override_settings(
+        SIFT_WEBHOOK_SECRET_KEY=webhook_secret,
+        EMAIL_WHITELIST=["moderator@researchhub.com.com"],
+    )
+    def test_webhook_skips_processing_for_moderator(self, mock_sift_client):
+        """
+        Test webhook skips processing for users who are moderators
+        """
+        # Arrange
+        moderator_user = User.objects.create(
+            email="moderator@researchhub.com.com",
+            first_name="Moderator",
+            last_name="User",
+            moderator=True,
+        )
+
+        payload = {
+            "decision": {"id": "mark_as_probable_spammer_content_abuse_123"},
+            "entity": {"id": str(moderator_user.id)},
+        }
+
+        body = json.dumps(payload)
+        signature = self.create_signature(body, self.webhook_secret)
+
+        # Act
+        response = self.client.post(
+            "/webhooks/sift/",
+            body,
+            content_type="application/json",
+            headers={"X-Sift-Science-Signature": signature},
+        )
+
+        # Assert
+        moderator_user.refresh_from_db()
+        self.assertEqual(response.status_code, 200)
+        # Moderator should not be flagged as probable spammer
+        self.assertFalse(moderator_user.probable_spammer)
+
+    @patch("utils.siftscience.client")
+    @override_settings(
+        SIFT_WEBHOOK_SECRET_KEY=webhook_secret,
+        EMAIL_WHITELIST=["whitelist@researchhub.com.com"],
+    )
+    def test_webhook_skips_processing_for_email_whitelist(self, mock_sift_client):
+        """
+        Test webhook skips processing for users in EMAIL_WHITELIST
+        """
+        # Arrange
+        whitelisted_user = User.objects.create(
+            email="whitelist@researchhub.com.com",
+            first_name="Whitelisted",
+            last_name="User",
+        )
+
+        payload = {
+            "decision": {"id": "mark_as_probable_spammer_content_abuse_123"},
+            "entity": {"id": str(whitelisted_user.id)},
+        }
+
+        body = json.dumps(payload)
+        signature = self.create_signature(body, self.webhook_secret)
+
+        # Act
+        response = self.client.post(
+            "/webhooks/sift/",
+            body,
+            content_type="application/json",
+            headers={"X-Sift-Science-Signature": signature},
+        )
+
+        # Assert
+        whitelisted_user.refresh_from_db()
+        self.assertEqual(response.status_code, 200)
+        # Whitelisted user should not be flagged as probable spammer
+        self.assertFalse(whitelisted_user.probable_spammer)
+
+    @patch("utils.siftscience.client")
+    @override_settings(
+        SIFT_WEBHOOK_SECRET_KEY=webhook_secret, SIFT_MODERATION_WHITELIST=[999]
+    )
+    def test_webhook_skips_processing_for_sift_moderation_whitelist(
+        self, mock_sift_client
+    ):
+        """
+        Test webhook skips processing for users in SIFT_MODERATION_WHITELIST
+        """
+        # Arrange
+        whitelisted_user = User.objects.create(
+            email="sift_whitelist_unique@researchhub.com.com",
+            first_name="SiftWhitelisted",
+            last_name="User",
+        )
+
+        with self.settings(SIFT_MODERATION_WHITELIST=[whitelisted_user.id]):
+            payload = {
+                "decision": {"id": "mark_as_probable_spammer_content_abuse_123"},
+                "entity": {"id": str(whitelisted_user.id)},
+            }
+
+            body = json.dumps(payload)
+            signature = self.create_signature(body, self.webhook_secret)
+
+            # Act
+            response = self.client.post(
+                "/webhooks/sift/",
+                body,
+                content_type="application/json",
+                headers={"X-Sift-Science-Signature": signature},
+            )
+
+            # Assert
+            whitelisted_user.refresh_from_db()
+            self.assertEqual(response.status_code, 200)
+            # User in SIFT_MODERATION_WHITELIST should not be flagged as probable
+            # spammer
+            self.assertFalse(whitelisted_user.probable_spammer)

--- a/src/user/views/__init__.py
+++ b/src/user/views/__init__.py
@@ -8,5 +8,6 @@ from user.views.leaderboard_views import LeaderboardViewSet
 from user.views.moderator_view import *
 from user.views.organization_view import OrganizationViewSet
 from user.views.persona_webhook_view import *
+from user.views.sift_webhook_view import *
 from user.views.user_api_token_view import UserApiTokenViewSet
 from user.views.user_views import *

--- a/src/user/views/sift_webhook_view.py
+++ b/src/user/views/sift_webhook_view.py
@@ -73,7 +73,7 @@ class SiftWebhookView(APIView):
         key = settings.SIFT_WEBHOOK_SECRET_KEY.encode("utf-8")
         postback_body = request.body
 
-        h = hmac.new(key, postback_body, sha1)
+        h = hmac.new(key, postback_body, sha1)  # NOSONAR: sha1 is required by Sift
         verification_signature = "sha1={}".format(h.hexdigest())
 
         return verification_signature == postback_signature

--- a/src/user/views/sift_webhook_view.py
+++ b/src/user/views/sift_webhook_view.py
@@ -22,6 +22,7 @@ class SiftWebhookView(APIView):
     """
 
     permission_classes = [AllowAny]
+    throttle_classes = []
 
     def post(self, request: Request, *args, **kwargs) -> Response:
         postback_signature = request.headers.get("X-Sift-Science-Signature")

--- a/src/user/views/sift_webhook_view.py
+++ b/src/user/views/sift_webhook_view.py
@@ -1,0 +1,70 @@
+import hmac
+import logging
+from hashlib import sha1
+
+from django.conf import settings
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from user.related_models.user_model import User
+
+logger = logging.getLogger(__name__)
+
+
+class SiftWebhookView(APIView):
+    """
+    View for processing Sift webhooks.
+
+    This view handles incoming POST requests from Sift.
+    Authentication is handled by validating the signature from the incoming request.
+    """
+
+    permission_classes = [AllowAny]
+
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        postback_signature = request.headers.get("X-Sift-Science-Signature")
+
+        if not postback_signature or not self._validate_signature(request):
+            return Response({"message:": "Unauthorized"}, status=401)
+
+        decision_id = request.data["decision"]["id"]
+        user_id = request.data["entity"]["id"]
+
+        user = User.objects.get(id=user_id)
+
+        if (
+            user.moderator
+            or user.email in settings.EMAIL_WHITELIST
+            or user.id in settings.SIFT_MODERATION_WHITELIST
+        ):
+            logger.info(f"Skipping moderation for whitelisted user id={user.id}")
+        else:
+            if "mark_as_probable_spammer_content_abuse" in decision_id:
+                logger.info(f"Flagging user id={user.id} as possible spammer")
+                user.set_probable_spammer()
+            elif "suspend_user_content_abuse" in decision_id:
+                logger.info(f"Suspending user id={user.id}")
+                user.set_suspended(is_manual=False)
+                user.is_active = False
+                user.save(update_fields=["is_active"])
+
+        return Response({"message:": "Webhook successfully processed"}, status=200)
+
+    def _validate_signature(self, request: Request) -> bool:
+        """
+        Validate the incoming Sift signature.
+        """
+        postback_signature = request.headers.get("X-Sift-Science-Signature")
+
+        if not postback_signature:
+            return False
+
+        key = settings.SIFT_WEBHOOK_SECRET_KEY.encode("utf-8")
+        postback_body = request.body
+
+        h = hmac.new(key, postback_body, sha1)
+        verification_signature = "sha1={}".format(h.hexdigest())
+
+        return verification_signature == postback_signature

--- a/src/user/views/sift_webhook_view.py
+++ b/src/user/views/sift_webhook_view.py
@@ -19,6 +19,8 @@ class SiftWebhookView(APIView):
 
     This view handles incoming POST requests from Sift.
     Authentication is handled by validating the signature from the incoming request.
+
+    Also see: https://developers.sift.com/docs/curl/decisions-api/decision-webhooks/
     """
 
     permission_classes = [AllowAny]

--- a/src/user/views/sift_webhook_view.py
+++ b/src/user/views/sift_webhook_view.py
@@ -32,7 +32,12 @@ class SiftWebhookView(APIView):
         decision_id = request.data["decision"]["id"]
         user_id = request.data["entity"]["id"]
 
-        user = User.objects.get(id=user_id)
+        try:
+            user = User.objects.get(id=user_id)
+        except User.DoesNotExist:
+            logger.warning(f"User id={user_id} not found for Sift webhook")
+            # Handle gracefully to avoid retries
+            return Response({"message:": "Webhook successfully processed"}, status=200)
 
         if (
             user.moderator

--- a/src/user/views/user_views.py
+++ b/src/user/views/user_views.py
@@ -508,6 +508,7 @@ class UserViewSet(FollowViewActionMixin, viewsets.ModelViewSet):
         detail=False,
         methods=[RequestMethods.POST],
         permission_classes=[AllowAny],
+        throttle_classes=[],
     )
     def sift_check_user_content(self, request):
         # https://sift.com/developers/docs/python/decisions-api/decision-webhooks/authentication


### PR DESCRIPTION
- Create a dedicated API view for processing Sift webhook (avoid mixing client-facing application logic with Sift integration).
- Handle additional error scenarios:
  - Return HTTP `400` for invalid payload.
  - Gracefully handle user-not-found cases.
-  Add unit tests

Closes https://github.com/ResearchHub/issues/issues/336