### PR TITLE
chore: Avoid Sift connection attempts when running tests

### DIFF
--- a/src/user/tests/test_persona_webhook_view.py
+++ b/src/user/tests/test_persona_webhook_view.py
@@ -80,11 +80,17 @@ class PersonaWebhookViewTests(TestCase):
             digest, "0fd4586aa5cb67c098a920ed55906fb2669a2bb21c6ed2de58e4f5cfb79814c7"
         )
 
+    @mock.patch("utils.siftscience.update_user_risk_score")
+    @mock.patch("utils.siftscience.events_api.track_account")
     @mock.patch("notification.models.Notification.send_notification")
     @override_settings(PERSONA_WEBHOOK_SECRET=webhook_secret)
-    def test_post_webhook(self, send_notification_mock):
+    def test_post_webhook(
+        self, send_notification_mock, track_account_mock, update_risk_score_mock
+    ):
         # arrange
         user = User.objects.create(first_name="firstName1", last_name="lastName1")
+
+        track_account_mock.return_value = {"score": 0.5}  # Mock Sift response
 
         # replace the reference-id placeholder in the body with the Id of the
         # created user and recomputes the digest:
@@ -124,11 +130,17 @@ class PersonaWebhookViewTests(TestCase):
         self.assertEqual(notification.item, user_verification)
         send_notification_mock.assert_called_once()
 
+    @mock.patch("utils.siftscience.update_user_risk_score")
+    @mock.patch("utils.siftscience.events_api.track_account")
     @mock.patch("notification.models.Notification.send_notification")
     @override_settings(PERSONA_WEBHOOK_SECRET=webhook_secret)
-    def test_post_webhook_declined_status(self, send_notification_mock):
+    def test_post_webhook_declined_status(
+        self, send_notification_mock, track_account_mock, update_risk_score_mock
+    ):
         # arrange
         user = User.objects.create(first_name="firstName1", last_name="lastName1")
+
+        track_account_mock.return_value = {"score": 0.5}  # Mock Sift response
 
         # replace the reference-id placeholder in the body with the Id of the
         # created user and recomputes the digest:
@@ -168,11 +180,17 @@ class PersonaWebhookViewTests(TestCase):
         self.assertEqual(notification.item, user_verification)
         send_notification_mock.assert_called_once()
 
+    @mock.patch("utils.siftscience.update_user_risk_score")
+    @mock.patch("utils.siftscience.events_api.track_account")
     @mock.patch("notification.models.Notification.send_notification")
     @override_settings(PERSONA_WEBHOOK_SECRET=webhook_secret)
-    def test_post_webhook_failed_status(self, send_notification_mock):
+    def test_post_webhook_failed_status(
+        self, send_notification_mock, track_account_mock, update_risk_score_mock
+    ):
         # arrange
         user = User.objects.create(first_name="firstName1", last_name="lastName1")
+
+        track_account_mock.return_value = {"score": 0.5}  # Mock Sift response
 
         # replace the reference-id placeholder in the body with the Id of the
         # created user and recomputes the digest:
@@ -212,11 +230,17 @@ class PersonaWebhookViewTests(TestCase):
         self.assertEqual(notification.item, user_verification)
         send_notification_mock.assert_called_once()
 
+    @mock.patch("utils.siftscience.update_user_risk_score")
+    @mock.patch("utils.siftscience.events_api.track_account")
     @mock.patch("notification.models.Notification.send_notification")
     @override_settings(PERSONA_WEBHOOK_SECRET=webhook_secret)
-    def test_post_webhook_marked_for_review_status(self, send_notification_mock):
+    def test_post_webhook_marked_for_review_status(
+        self, send_notification_mock, track_account_mock, update_risk_score_mock
+    ):
         # arrange
         user = User.objects.create(first_name="firstName1", last_name="lastName1")
+
+        track_account_mock.return_value = {"score": 0.5}  # Mock Sift response
 
         # replace the reference-id placeholder in the body with the Id of the
         # created user and recomputes the digest:


### PR DESCRIPTION
Running tests for the Persona webhook will cause Sift connection attempts. These makes it harder to reason about the test results:

```
test_post_webhook (user.tests.test_persona_webhook_view.PersonaWebhookViewTests.test_post_webhook) ... Traceback (most recent call last):
  File "/home/runner/work/researchhub-backend/researchhub-backend/src/utils/siftscience.py", line 170, in celery_track_account
    response = client.track(track_type, properties, return_score=False)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pypoetry/virtualenvs/researchhub-uwcL_9NP-py3.12/lib/python3.12/site-packages/sift/client.py", line 200, in track
    return Response(response)
           ^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pypoetry/virtualenvs/researchhub-uwcL_9NP-py3.12/lib/python3.12/site-packages/sift/client.py", line 1182, in __init__
    raise ApiException(
sift.client.ApiException: https://api.siftscience.com/v205/events returned non-2XX http status code 400
[...]
```