### PR TITLE
chore: Update Kibana version with ARM support

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - researchhub
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.10.1
+    image: docker.elastic.co/kibana/kibana:7.17.28
     environment:
       ELASTICSEARCH_HOSTS: http://elasticsearch:9200
     depends_on:


### PR DESCRIPTION
The current version of Kibana does not have an ARM image. With the updated version, an ARM-based image will be pulled on e.g. Silicon Macs.

<img width="986" alt="image" src="https://github.com/user-attachments/assets/dd1e24f2-368c-4a2b-99b1-5d61e56ac87d" />
