### PR TITLE
Add shell alias for Django manage

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -65,6 +65,10 @@
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 
+	"remoteEnv": {
+		"WORKSPACE_PATH": "${containerWorkspaceFolder}"
+	},
+
 	"mounts": [
 		"source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,readonly"
 	]

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -14,4 +14,7 @@ python manage.py migrate
 python manage.py collectstatic --no-input
 cd -
 
+# Add Django manage.py alias to .bashrc
+echo "alias dj='python ${WORKSPACE_PATH}/src/manage.py'" >> ~/.bashrc
+
 echo "Post create script complete."


### PR DESCRIPTION
Add a shell alias to execute Django's manage command more easily.

Example:

Instead of
```
cd src
python manage.py test user.tests
```

Use:
```
dj test user.tests
```