### PR TITLE
chore: Use `Vote` instead of `GrmVote` alias

### DIFF
--- a/src/feed/tests/views/test_feed_view.py
+++ b/src/feed/tests/views/test_feed_view.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from discussion.reaction_models import Vote as GrmVote
+from discussion.reaction_models import Vote
 from feed.models import FeedEntry, FeedEntryLatest, FeedEntryPopular
 from hub.models import Hub
 from paper.models import Paper
@@ -431,32 +431,32 @@ class FeedViewSetTests(TestCase):
             unified_document=self.unified_document,
         )
 
-        GrmVote.objects.create(
+        Vote.objects.create(
             content_type=self.paper_content_type,
             object_id=self.paper.id,
             created_by=self.user,
-            vote_type=GrmVote.UPVOTE,
+            vote_type=Vote.UPVOTE,
         )
 
-        GrmVote.objects.create(
+        Vote.objects.create(
             content_type=ContentType.objects.get_for_model(ResearchhubPost),
             object_id=post.id,
             created_by=self.user,
-            vote_type=GrmVote.UPVOTE,
+            vote_type=Vote.UPVOTE,
         )
 
-        GrmVote.objects.create(
+        Vote.objects.create(
             content_type=ContentType.objects.get_for_model(RhCommentModel),
             object_id=comment.id,
             created_by=self.user,
-            vote_type=GrmVote.UPVOTE,
+            vote_type=Vote.UPVOTE,
         )
 
-        GrmVote.objects.create(
+        Vote.objects.create(
             content_type=ContentType.objects.get_for_model(ResearchhubPost),
             object_id=self.post.id,
             created_by=self.user,
-            vote_type=GrmVote.UPVOTE,
+            vote_type=Vote.UPVOTE,
         )
 
         feed_entries = FeedEntry.objects.all()
@@ -514,11 +514,11 @@ class FeedViewSetTests(TestCase):
         )
 
         # Create a vote for the post by the test user
-        post_vote = GrmVote.objects.create(
+        post_vote = Vote.objects.create(
             content_type=ContentType.objects.get_for_model(ResearchhubPost),
             object_id=post.id,
             created_by=test_user,
-            vote_type=GrmVote.UPVOTE,
+            vote_type=Vote.UPVOTE,
         )
 
         # First request - no cache
@@ -544,13 +544,13 @@ class FeedViewSetTests(TestCase):
 
         # Verify the vote data is correct
         user_vote = post_item["user_vote"]
-        self.assertEqual(user_vote["vote_type"], GrmVote.UPVOTE)
+        self.assertEqual(user_vote["vote_type"], Vote.UPVOTE)
 
         # Store what was cached (should be without votes)
         cached_data = mock_cache.set.call_args[0][1]
 
         # Update the vote to verify fresh votes are fetched
-        post_vote.vote_type = GrmVote.DOWNVOTE  # Change from upvote to downvote
+        post_vote.vote_type = Vote.DOWNVOTE  # Change from upvote to downvote
         post_vote.save()
 
         # Second request - use cached response
@@ -576,7 +576,7 @@ class FeedViewSetTests(TestCase):
 
         # Verify the vote data is updated (should be a downvote now)
         user_vote = post_item["user_vote"]
-        self.assertEqual(user_vote["vote_type"], GrmVote.DOWNVOTE)
+        self.assertEqual(user_vote["vote_type"], Vote.DOWNVOTE)
 
         # Verify cache was used but not updated
         self.assertTrue(mock_cache.get.called)

--- a/src/feed/tests/views/test_funding_feed_view.py
+++ b/src/feed/tests/views/test_funding_feed_view.py
@@ -11,7 +11,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.test import APIClient, APIRequestFactory
 
-from discussion.reaction_models import Vote as GrmVote
+from discussion.reaction_models import Vote
 from hub.models import Hub
 from purchase.related_models.constants.currency import USD
 from purchase.related_models.constants.rsc_exchange_currency import MORALIS
@@ -204,11 +204,11 @@ class FundingFeedViewSetTests(TestCase):
         """Test that user votes and metrics are added to response data"""
         # Create a vote for the post
         post_content_type = ContentType.objects.get_for_model(ResearchhubPost)
-        vote = GrmVote.objects.create(
+        vote = Vote.objects.create(
             created_by=self.user,
             object_id=self.post.id,
             content_type=post_content_type,
-            vote_type=GrmVote.UPVOTE,
+            vote_type=Vote.UPVOTE,
         )
 
         url = reverse("funding_feed-list")
@@ -239,11 +239,11 @@ class FundingFeedViewSetTests(TestCase):
         """Test that user votes are added even with cached response"""
         # Create a vote for the post
         post_content_type = ContentType.objects.get_for_model(ResearchhubPost)
-        vote = GrmVote.objects.create(
+        vote = Vote.objects.create(
             created_by=self.user,
             object_id=self.post.id,
             content_type=post_content_type,
-            vote_type=GrmVote.UPVOTE,
+            vote_type=Vote.UPVOTE,
         )
 
         # Create a mock cached response without votes

--- a/src/feed/tests/views/test_journal_feed_view.py
+++ b/src/feed/tests/views/test_journal_feed_view.py
@@ -12,7 +12,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.test import APIClient, APIRequestFactory
 
-from discussion.reaction_models import Vote as GrmVote
+from discussion.reaction_models import Vote
 from feed.views.journal_feed_view import JournalFeedViewSet
 from hub.models import Hub
 from paper.related_models.paper_model import Paper
@@ -334,11 +334,11 @@ class JournalFeedViewSetTests(TestCase):
         """Test that user votes and metrics are added to response data"""
         # Create a vote for the paper
         paper_content_type = ContentType.objects.get_for_model(Paper)
-        vote = GrmVote.objects.create(
+        vote = Vote.objects.create(
             created_by=self.user,
             object_id=self.preprint_paper.id,
             content_type=paper_content_type,
-            vote_type=GrmVote.UPVOTE,
+            vote_type=Vote.UPVOTE,
         )
 
         url = reverse("journal_feed-list")
@@ -366,11 +366,11 @@ class JournalFeedViewSetTests(TestCase):
         """Test that user votes are added even with cached response"""
         # Create a vote for the paper
         paper_content_type = ContentType.objects.get_for_model(Paper)
-        vote = GrmVote.objects.create(
+        vote = Vote.objects.create(
             created_by=self.user,
             object_id=self.preprint_paper.id,
             content_type=paper_content_type,
-            vote_type=GrmVote.UPVOTE,
+            vote_type=Vote.UPVOTE,
         )
 
         # Create a mock cached response without votes

--- a/src/paper/paper_upload_tasks.py
+++ b/src/paper/paper_upload_tasks.py
@@ -596,13 +596,13 @@ def celery_create_paper(self, celery_data):
         uploaded_by = paper_submission.uploaded_by
 
         if uploaded_by:
-            from discussion.reaction_models import Vote as GrmVote
+            from discussion.reaction_models import Vote
 
-            GrmVote.objects.create(
+            Vote.objects.create(
                 content_type=get_content_type_for_model(paper),
                 created_by=uploaded_by,
                 object_id=paper.id,
-                vote_type=GrmVote.UPVOTE,
+                vote_type=Vote.UPVOTE,
             )
         paper.unified_document.update_filter(FILTER_OPEN_ACCESS)
         download_pdf.apply_async((paper_id,), priority=3, countdown=5)

--- a/src/paper/serializers/paper_serializers.py
+++ b/src/paper/serializers/paper_serializers.py
@@ -11,12 +11,11 @@ from django.http import QueryDict
 
 import utils.sentry as sentry
 from citation.constants import JOURNAL_ARTICLE
-from discussion.reaction_models import Flag as GrmFlag
-from discussion.reaction_models import Vote as GrmVote
+from discussion.reaction_models import Flag, Vote
 from discussion.reaction_serializers import (
-    DynamicVoteSerializer as DynamicGrmVoteSerializer,
+    DynamicVoteSerializer,
+    GenericReactionSerializerMixin,
 )
-from discussion.reaction_serializers import GenericReactionSerializerMixin
 from discussion.serializers import DynamicFlagSerializer
 from hub.serializers import DynamicHubSerializer, SimpleHubSerializer
 from paper.exceptions import PaperSerializerError
@@ -69,7 +68,7 @@ class BasePaperSerializer(serializers.ModelSerializer, GenericReactionSerializer
     first_preview = serializers.SerializerMethodField()
     hubs = serializers.SerializerMethodField()
     promoted = serializers.SerializerMethodField()
-    score = serializers.ReadOnlyField()  # GRM
+    score = serializers.ReadOnlyField()
     unified_document = serializers.SerializerMethodField()
     unified_document_id = serializers.SerializerMethodField()
     uploaded_by = UserSerializer(read_only=True)
@@ -201,7 +200,7 @@ class BasePaperSerializer(serializers.ModelSerializer, GenericReactionSerializer
             try:
                 flag = paper.flags.get(created_by=user.id)
                 flag = DynamicFlagSerializer(flag).data
-            except GrmFlag.DoesNotExist:
+            except Flag.DoesNotExist:
                 pass
         return flag
 
@@ -211,8 +210,8 @@ class BasePaperSerializer(serializers.ModelSerializer, GenericReactionSerializer
         if user:
             try:
                 vote = paper.votes.get(created_by=user.id)
-                vote = DynamicGrmVoteSerializer(vote).data
-            except GrmVote.DoesNotExist:
+                vote = DynamicVoteSerializer(vote).data
+            except Vote.DoesNotExist:
                 pass
         return vote
 
@@ -372,7 +371,7 @@ class ContributionPaperSerializer(BasePaperSerializer):
 
 class PaperSerializer(BasePaperSerializer):
     authors = serializers.SerializerMethodField()
-    uploaded_date = serializers.ReadOnlyField()  # GRM
+    uploaded_date = serializers.ReadOnlyField()
 
     class Meta:
         exclude = ["references"]
@@ -453,11 +452,11 @@ class PaperSerializer(BasePaperSerializer):
                 unified_doc_id = paper.unified_document.id
                 paper_id = paper.id
                 # NOTE: calvinhlee - This is an antipattern. Look into changing
-                GrmVote.objects.create(
+                Vote.objects.create(
                     content_type=get_content_type_for_model(paper),
                     created_by=user,
                     object_id=paper.id,
-                    vote_type=GrmVote.UPVOTE,
+                    vote_type=Vote.UPVOTE,
                 )
 
                 # Now add m2m values properly
@@ -864,13 +863,13 @@ class DynamicPaperSerializer(
         if user:
             try:
                 vote = paper.votes.get(created_by=user.id)
-                vote = DynamicGrmVoteSerializer(
+                vote = DynamicVoteSerializer(
                     vote,
                     context=self.context,
                     **_context_fields,
                 ).data
 
-            except GrmVote.DoesNotExist:
+            except Vote.DoesNotExist:
                 pass
 
         return vote

--- a/src/paper/utils.py
+++ b/src/paper/utils.py
@@ -16,7 +16,7 @@ from django.db.models import Count, Q
 from habanero import Crossref
 from manubot.cite.csl_item import CSL_Item
 
-from discussion.reaction_models import Vote as GrmVote
+from discussion.reaction_models import Vote
 from paper.exceptions import ManubotProcessingError
 from paper.lib import (
     journal_hosts,
@@ -30,9 +30,9 @@ from utils.http import RequestMethods as methods
 from utils.http import check_url_contains_pdf, http_request
 
 DOI_REGEX = r"10.\d{4,9}\/[-._;()\/:a-zA-Z0-9]+?(?=[\";%<>\?#&])"
-PAPER_SCORE_Q_ANNOTATION = Count(
-    "id", filter=Q(votes__vote_type=GrmVote.UPVOTE)
-) - Count("id", filter=Q(votes__vote_type=GrmVote.DOWNVOTE))
+PAPER_SCORE_Q_ANNOTATION = Count("id", filter=Q(votes__vote_type=Vote.UPVOTE)) - Count(
+    "id", filter=Q(votes__vote_type=Vote.DOWNVOTE)
+)
 
 CACHE_TOP_RATED_DATES = (
     "-score_today",

--- a/src/paper/views/paper_views.py
+++ b/src/paper/views/paper_views.py
@@ -27,8 +27,8 @@ from rest_framework.permissions import (
 from rest_framework.response import Response
 
 from analytics.amplitude import track_event
-from discussion.reaction_models import Vote as GrmVote
-from discussion.reaction_serializers import VoteSerializer as GrmVoteSerializer
+from discussion.reaction_models import Vote
+from discussion.reaction_serializers import VoteSerializer
 from discussion.reaction_views import ReactionViewActionMixin
 from hub.permissions import IsModerator
 from paper.exceptions import DOINotFoundError, PaperSerializerError
@@ -993,7 +993,7 @@ class PaperViewSet(
         paper = self.get_object()
         user = request.user
         vote = retrieve_vote(user, paper)
-        serializer = GrmVoteSerializer(vote)
+        serializer = VoteSerializer(vote)
         return Response(serializer.data, status=200)
 
     @user_vote.mapping.delete
@@ -1018,7 +1018,7 @@ class PaperViewSet(
         response = {}
 
         if user.is_authenticated:
-            votes = GrmVote.objects.filter(
+            votes = Vote.objects.filter(
                 content_type=get_content_type_for_model(Paper),
                 object_id__in=paper_ids,
                 created_by=user,
@@ -1026,7 +1026,7 @@ class PaperViewSet(
 
             for vote in votes.iterator():
                 paper_id = vote.object_id
-                data = GrmVoteSerializer(instance=vote).data
+                data = VoteSerializer(instance=vote).data
                 response[paper_id] = data
 
         return Response(response, status=status.HTTP_200_OK)
@@ -1526,12 +1526,12 @@ class FigureViewSet(viewsets.ModelViewSet):
 
 def retrieve_vote(user, paper):
     try:
-        return GrmVote.objects.get(
+        return Vote.objects.get(
             content_type=get_content_type_for_model(paper),
             created_by=user,
             object_id=paper.id,
         )
-    except GrmVote.DoesNotExist:
+    except Vote.DoesNotExist:
         return None
 
 

--- a/src/researchhub_document/signals/researchhub_unified_document_signals.py
+++ b/src/researchhub_document/signals/researchhub_unified_document_signals.py
@@ -2,7 +2,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from discussion.reaction_models import Vote as GrmVote
+from discussion.reaction_models import Vote
 from paper.models import Paper
 from reputation.related_models.bounty import Bounty
 from reputation.related_models.contribution import Contribution
@@ -11,7 +11,7 @@ from researchhub_document.tasks import recalc_hot_score_task
 from utils import sentry
 
 
-@receiver(post_save, sender=GrmVote, dispatch_uid="recalc_hot_score_on_vote")
+@receiver(post_save, sender=Vote, dispatch_uid="recalc_hot_score_on_vote")
 def recalc_hot_score(instance, sender, **kwargs):
     try:
         recalc_hot_score_task.apply_async(
@@ -60,11 +60,11 @@ def sync_is_removed_from_paper(instance, **kwargs):
 
 @receiver(
     post_save,
-    sender=GrmVote,
+    sender=Vote,
     dispatch_uid="rh_unified_doc_sync_score_vote",
 )
 def rh_unified_doc_sync_score_on_related_docs(instance, sender, **kwargs):
-    if not isinstance(instance, (GrmVote)):
+    if not isinstance(instance, (Vote)):
         return
 
     unified_document = instance.unified_document

--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -11,8 +11,8 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
-from discussion.reaction_models import Vote as GrmVote
-from discussion.reaction_serializers import VoteSerializer as GrmVoteSerializer
+from discussion.reaction_models import Vote
+from discussion.reaction_serializers import VoteSerializer
 from paper.models import Paper
 from paper.utils import get_cache_key
 from researchhub_document.filters import UnifiedDocumentFilter
@@ -522,13 +522,13 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
                 )
                 for vote in paper_votes.iterator():
                     paper_id = vote.object_id
-                    response["paper"][paper_id] = GrmVoteSerializer(instance=vote).data
+                    response["paper"][paper_id] = VoteSerializer(instance=vote).data
             if post_ids:
                 post_votes = get_user_votes(
                     user, post_ids, ContentType.objects.get_for_model(ResearchhubPost)
                 )
                 for vote in post_votes.iterator():
-                    response["posts"][vote.object_id] = GrmVoteSerializer(
+                    response["posts"][vote.object_id] = VoteSerializer(
                         instance=vote
                     ).data
         return Response(response, status=status.HTTP_200_OK)
@@ -666,6 +666,6 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
 
 
 def get_user_votes(created_by, doc_ids, reaction_content_type):
-    return GrmVote.objects.filter(
+    return Vote.objects.filter(
         content_type=reaction_content_type, object_id__in=doc_ids, created_by=created_by
     )

--- a/src/user/related_models/user_model.py
+++ b/src/user/related_models/user_model.py
@@ -283,12 +283,12 @@ class User(AbstractUser):
 
     @property
     def upvote_count(self):
-        from discussion.reaction_models import Vote as GrmVote
+        from discussion.reaction_models import Vote
 
         upvote_count = (
             Distribution.objects.filter(
                 recipient=self,
-                proof_item_content_type=ContentType.objects.get_for_model(GrmVote),
+                proof_item_content_type=ContentType.objects.get_for_model(Vote),
                 reputation_amount=1,
             ).aggregate(count=Count("id"))["count"]
             or 0

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -12,7 +12,7 @@ from rest_framework.serializers import (
     SerializerMethodField,
 )
 
-from discussion.reaction_models import Vote as GrmVote
+from discussion.reaction_models import Vote
 from hub.models import Hub
 from hub.serializers import DynamicHubSerializer, HubSerializer, SimpleHubSerializer
 from institution.serializers import DynamicInstitutionSerializer
@@ -754,7 +754,7 @@ class UserActions:
 
             if isinstance(item, Paper):
                 pass
-            elif isinstance(item, GrmVote):
+            elif isinstance(item, Vote):
                 item = item.item
                 if isinstance(item, Paper):
                     data["content_type"] += "_paper"

--- a/src/user/signals.py
+++ b/src/user/signals.py
@@ -8,7 +8,7 @@ from django.utils.crypto import get_random_string
 from django.utils.text import slugify
 
 from citation.models import CitationProject
-from discussion.reaction_models import Vote as GrmVote
+from discussion.reaction_models import Vote
 from mailing_list.tasks import build_notification_context
 from paper.models import Paper, PaperSubmission
 from purchase.models import Wallet
@@ -44,7 +44,7 @@ def doi_updated(update_fields):
 
 @receiver(post_save, sender=RhCommentModel, dispatch_uid="creation_rh_comment")
 @receiver(post_save, sender=Paper, dispatch_uid="paper_upload_action")
-@receiver(post_save, sender=GrmVote, dispatch_uid="discussion_vote_action")
+@receiver(post_save, sender=Vote, dispatch_uid="discussion_vote_action")
 @receiver(post_save, sender=ResearchhubPost, dispatch_uid="researchhubpost_action")
 @receiver(post_save, sender=PaperSubmission, dispatch_uid="create_submission_action")
 @receiver(post_save, sender=Bounty, dispatch_uid="create_bounty_action")
@@ -67,14 +67,14 @@ def create_action(sender, instance, created, **kwargs):
                     )
             user = instance.created_by
 
-        vote_types = [GrmVote]
+        vote_types = [Vote]
         display = (
             False
             if (
                 sender in vote_types
                 or sender == PaperSubmission
                 or (
-                    sender != GrmVote
+                    sender != Vote
                     and (hasattr(instance, "is_removed") and instance.is_removed)
                 )
                 or (sender == RhCommentModel and not instance.is_public)

--- a/src/user/tasks.py
+++ b/src/user/tasks.py
@@ -2,7 +2,7 @@ from django.apps import apps
 from django.core.cache import cache
 from django_elasticsearch_dsl.registries import registry
 
-from discussion.reaction_models import Vote as GrmVote
+from discussion.reaction_models import Vote
 from paper.models import Paper
 from researchhub.celery import QUEUE_ELASTIC_SEARCH, app
 from researchhub.settings import APP_ENV
@@ -78,7 +78,7 @@ def get_authored_paper_updates(author, latest_actions):
     for action in latest_actions:
         item = action.item
 
-        if isinstance(item, GrmVote):
+        if isinstance(item, Vote):
             if item.item.paper in papers:
                 updates.append(action)
         else:

--- a/src/user/tests/test_serializers.py
+++ b/src/user/tests/test_serializers.py
@@ -4,7 +4,7 @@ import time
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
-from discussion.reaction_models import Vote as GrmVote
+from discussion.reaction_models import Vote
 from hub.models import Hub
 from paper.related_models.authorship_model import Authorship
 from paper.related_models.paper_model import Paper
@@ -49,7 +49,7 @@ class UserSerializersTests(TestCase):
         for i in range(50):
             Distribution.objects.create(
                 recipient=self.user,
-                proof_item_content_type=ContentType.objects.get_for_model(GrmVote),
+                proof_item_content_type=ContentType.objects.get_for_model(Vote),
                 reputation_amount=1,
             )
             thread = RhCommentThreadModel.objects.create(

--- a/src/utils/test_helpers.py
+++ b/src/utils/test_helpers.py
@@ -12,7 +12,7 @@ from django.test import Client
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient, APITestCase, ForceAuthClientHandler
 
-from discussion.reaction_models import Vote as GrmVote
+from discussion.reaction_models import Vote
 from hub.models import Hub
 from paper.models import Paper
 from user.models import Author, University, User
@@ -152,19 +152,19 @@ class TestHelper:
         return Hub.objects.create(name=name)
 
     def create_upvote(self, user, paper):
-        return GrmVote.objects.create(
+        return Vote.objects.create(
             content_type=get_content_type_for_model(paper),
             created_by=user,
             object_id=paper.id,
-            vote_type=GrmVote.UPVOTE,
+            vote_type=Vote.UPVOTE,
         )
 
     def create_downvote(self, user, paper):
-        return GrmVote.objects.create(
+        return Vote.objects.create(
             content_type=get_content_type_for_model(paper),
             created_by=user,
             object_id=paper.id,
-            vote_type=GrmVote.DOWNVOTE,
+            vote_type=Vote.DOWNVOTE,
         )
 
 


### PR DESCRIPTION
After the deprecation of the previous vote model, there's no need to use the `GrmVote` alias anymore.