### PR TITLE
Metrics average field must be defined float

### DIFF
--- a/src/feed/documents/feed_document.py
+++ b/src/feed/documents/feed_document.py
@@ -21,7 +21,15 @@ class FeedEntryDocument(Document):
         }
     )
     hot_score = fields.IntegerField()
-    metrics = fields.ObjectField(properties={})
+    metrics = fields.ObjectField(
+        properties={
+            "review_metrics": fields.ObjectField(
+                properties={
+                    "avg": fields.FloatField(),
+                }
+            ),
+        }
+    )
     action = fields.KeywordField()
     action_date = fields.DateField()
     created_date = fields.DateField()


### PR DESCRIPTION
Avoid this error:
```
elasticsearch.helpers.errors.BulkIndexError: ('2 document(s) failed to index.', [{'index': {'_index': 'feed_entries', '_type': '_doc', '_id': '337615', 'status': 400, 'error': {'type': 'illegal_argument_exception', 'reason': 'mapper [metrics.review_metrics.avg] cannot be changed from type [float] to [long]'}, 'data': {'id': 337615, 'content_type': {'id': 19, 'model': 'paper'}, 'object_id': 3236051, 'content': {'comment_content_json': {}}, 'hot_score': 0, 'metrics': {'votes': 0, 'replies': 0, 'citations': 0, 'review_metrics': {'avg': 0, 'count': 0}}, 'action': 'PUBLISH', 'action_date': datetime.datetime(2025, 5, 22, 0, 0, tzinfo=datetime.timezone.utc), 'created_date': datetime.datetime(2025, 5, 22, 21, 32, 29, 713008, tzinfo=datetime.timezone.utc), 'updated_date': datetime.datetime(2025, 5, 22, 21, 32, 29, 713030, tzinfo=datetime.timezone.utc), 'author': None, 'unified_document': {'id': 2400665, 'document_type': 'PAPER'}, 'hubs': [{'id': 22352, 'name': 'ResearchHub Journal', 'slug': 'researchhub-journal'}]}}}, {'index': {'_index': 'feed_entries', '_type': '_doc', '_id': '25587', 'status': 400, 'error': {'type': 'illegal_argument_exception', 'reason': 'mapper [metrics.review_metrics.avg] cannot be changed from type [float] to [long]'}, 'data': {'id': 25587, 'content_type': {'id': 19, 'model': 'paper'}, 'object_id': 3214374, 'content': {'comment_content_json': {}}, 'hot_score': 1, 'metrics': {'votes': 0, 'replies': 0, 'citations': 0, 'review_metrics': {'avg': 0, 'count': 0}}, 'action': 'PUBLISH', 'action_date': datetime.datetime(2025, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'created_date': datetime.datetime(2025, 2, 11, 0, 23, 11, 847258, tzinfo=datetime.timezone.utc), 'updated_date': datetime.datetime(2025, 2, 11, 0, 23, 11, 847275, tzinfo=datetime.timezone.utc), 'author': None, 'unified_document': {'id': 2378879, 'document_type': 'PAPER'}, 'hubs': [{'id': 17150, 'name': 'Synaptic pruning', 'slug': 'synaptic-pruning'}]}}}])
```