### PR TITLE
Add referral views for metrics

### DIFF
--- a/src/referral/serializers.py
+++ b/src/referral/serializers.py
@@ -1,0 +1,77 @@
+from rest_framework import serializers
+
+from referral.models import ReferralSignup
+from user.models import User
+
+
+class NetworkFundingPowerSerializer(serializers.Serializer):
+    """Serializer for network funding power metrics."""
+
+    total_deployed = serializers.FloatField()
+    total_potential_impact = serializers.FloatField()
+    breakdown = serializers.DictField()
+
+
+class ReferralActivitySerializer(serializers.Serializer):
+    """Serializer for referral activity metrics."""
+
+    funders_invited = serializers.IntegerField()
+    active_funders = serializers.IntegerField()
+
+
+class FundingCreditsSerializer(serializers.Serializer):
+    """Serializer for user's funding credits."""
+
+    available = serializers.FloatField()
+    total_earned = serializers.FloatField()
+    used = serializers.FloatField()
+
+
+class NetworkEarnedCreditsSerializer(serializers.Serializer):
+    """Serializer for network earned credits."""
+
+    total = serializers.FloatField()
+    by_referred_users = serializers.FloatField()
+
+
+class ReferralMetricsSerializer(serializers.Serializer):
+    """Main serializer for comprehensive referral metrics."""
+
+    network_funding_power = NetworkFundingPowerSerializer()
+    referral_activity = ReferralActivitySerializer()
+    your_funding_credits = FundingCreditsSerializer()
+    network_earned_credits = NetworkEarnedCreditsSerializer()
+
+
+class ReferralNetworkDetailSerializer(serializers.Serializer):
+    """Serializer for individual referred user details."""
+
+    user_id = serializers.IntegerField()
+    username = serializers.CharField()
+    signup_date = serializers.DateTimeField()
+    total_funded = serializers.FloatField()
+    referral_bonus_earned = serializers.FloatField()
+    is_active_funder = serializers.BooleanField()
+
+
+class ReferralSignupSerializer(serializers.ModelSerializer):
+    """Serializer for ReferralSignup model."""
+
+    referrer_username = serializers.CharField(
+        source="referrer.username", read_only=True
+    )
+    referred_username = serializers.CharField(
+        source="referred.username", read_only=True
+    )
+
+    class Meta:
+        model = ReferralSignup
+        fields = [
+            "id",
+            "referrer",
+            "referrer_username",
+            "referred",
+            "referred_username",
+            "signup_date",
+        ]
+        read_only_fields = ["id", "signup_date"]

--- a/src/referral/services/__init__.py
+++ b/src/referral/services/__init__.py
@@ -1,0 +1,4 @@
+from .referral_bonus_service import ReferralBonusService
+from .referral_metrics_service import ReferralMetricsService
+
+__all__ = ["ReferralBonusService", "ReferralMetricsService"]

--- a/src/referral/services/referral_metrics_service.py
+++ b/src/referral/services/referral_metrics_service.py
@@ -1,0 +1,328 @@
+from decimal import Decimal
+
+from django.db.models import DecimalField, Sum
+from django.db.models.functions import Cast
+
+from purchase.models import Purchase
+from purchase.related_models.balance_model import Balance
+from referral.models import ReferralSignup
+from reputation.related_models.distribution import Distribution
+
+
+class ReferralMetricsService:
+    """Service for calculating referral network metrics and funding impact."""
+
+    def __init__(self, user):
+        self.user = user
+        self.bonus_percentage = Decimal("10.00")
+
+    def get_comprehensive_metrics(self):
+        """
+        Get comprehensive referral metrics for a user including:
+        - Network funding power
+        - Referral activity
+        - Funding credits
+        - Network earned credits
+        """
+        metrics = {
+            "network_funding_power": self._calculate_network_funding_power(),
+            "referral_activity": self._calculate_referral_activity(),
+            "your_funding_credits": self._calculate_user_funding_credits(),
+            "network_earned_credits": self._calculate_network_earned_credits(),
+        }
+        return metrics
+
+    def _calculate_network_funding_power(self):
+        """
+        Calculate the total funding power of the user's referral network.
+
+        Returns:
+            dict: Contains total_deployed, total_potential_impact, and breakdown
+        """
+        # Direct funding by the user (fundraise contributions)
+        direct_funding = self._get_user_direct_funding()
+
+        # Funding by referred users
+        network_funding = self._get_network_funding()
+
+        # Credits used from referral bonuses
+        credits_used = self._get_used_referral_credits()
+
+        # Total deployed = direct + network + used credits
+        total_deployed = direct_funding + network_funding + credits_used
+
+        # Available credits that could still be deployed
+        available_credits = self._get_available_referral_credits()
+        network_available_credits = self._get_network_available_credits()
+
+        # Total potential = deployed + available credits
+        total_potential_impact = (
+            total_deployed + available_credits + network_available_credits
+        )
+
+        return {
+            "total_deployed": float(total_deployed),
+            "total_potential_impact": float(total_potential_impact),
+            "breakdown": {
+                "direct_funding": float(direct_funding),
+                "network_funding": float(network_funding),
+                "credits_used": float(credits_used),
+                "available_credits": float(available_credits),
+                "network_available_credits": float(network_available_credits),
+            },
+        }
+
+    def _calculate_referral_activity(self):
+        """
+        Calculate referral activity metrics.
+
+        Returns:
+            dict: Contains funders_invited and active_funders count
+        """
+        # Get all users referred by this user
+        referred_users = ReferralSignup.objects.filter(
+            referrer=self.user
+        ).select_related("referred")
+
+        total_invited = referred_users.count()
+
+        # Active funders are those who have made at least one contribution
+        active_funders = (
+            referred_users.filter(
+                referred__purchases__purchase_type=Purchase.FUNDRAISE_CONTRIBUTION,
+                referred__purchases__paid_status=Purchase.PAID,
+            )
+            .distinct()
+            .count()
+        )
+
+        return {
+            "funders_invited": total_invited,
+            "active_funders": active_funders,
+        }
+
+    def _calculate_user_funding_credits(self):
+        """
+        Calculate the user's own funding credits from referral bonuses.
+
+        Returns:
+            dict: Contains available, total_earned, and used amounts
+        """
+        # Get all referral bonus distributions for this user
+        referral_distributions = Distribution.objects.filter(
+            recipient=self.user,
+            distribution_type="REFERRAL_BONUS",
+            distributed_status=Distribution.DISTRIBUTED,
+        )
+
+        total_earned = referral_distributions.aggregate(
+            total=Sum(Cast("amount", DecimalField(max_digits=19, decimal_places=8)))
+        )["total"] or Decimal("0")
+
+        # Get available balance (locked referral bonus balance)
+        available = Balance.objects.filter(
+            user=self.user, is_locked=True, lock_type="REFERRAL_BONUS"
+        ).aggregate(
+            total=Sum(Cast("amount", DecimalField(max_digits=19, decimal_places=8)))
+        )[
+            "total"
+        ] or Decimal(
+            "0"
+        )
+
+        # Used = total earned - available
+        used = total_earned - available
+
+        return {
+            "available": float(available),
+            "total_earned": float(total_earned),
+            "used": float(used),
+        }
+
+    def _calculate_network_earned_credits(self):
+        """
+        Calculate total credits earned by users referred by this user.
+
+        Returns:
+            dict: Contains total credits earned by referred users
+        """
+        # Get all users referred by this user
+        referred_user_ids = ReferralSignup.objects.filter(
+            referrer=self.user
+        ).values_list("referred_id", flat=True)
+
+        # Get total referral bonuses earned by these users
+        network_earned = Distribution.objects.filter(
+            recipient_id__in=referred_user_ids,
+            distribution_type="REFERRAL_BONUS",
+            distributed_status=Distribution.DISTRIBUTED,
+        ).aggregate(
+            total=Sum(Cast("amount", DecimalField(max_digits=19, decimal_places=8)))
+        )[
+            "total"
+        ] or Decimal(
+            "0"
+        )
+
+        return {
+            "total": float(network_earned),
+            "by_referred_users": float(network_earned),
+        }
+
+    def _get_user_direct_funding(self):
+        """Get total direct funding contributions by the user."""
+        return Purchase.objects.filter(
+            user=self.user,
+            purchase_type=Purchase.FUNDRAISE_CONTRIBUTION,
+            paid_status=Purchase.PAID,
+        ).aggregate(
+            total=Sum(Cast("amount", DecimalField(max_digits=19, decimal_places=8)))
+        )[
+            "total"
+        ] or Decimal(
+            "0"
+        )
+
+    def _get_network_funding(self):
+        """Get total funding by users referred by this user."""
+        referred_user_ids = ReferralSignup.objects.filter(
+            referrer=self.user
+        ).values_list("referred_id", flat=True)
+
+        return Purchase.objects.filter(
+            user_id__in=referred_user_ids,
+            purchase_type=Purchase.FUNDRAISE_CONTRIBUTION,
+            paid_status=Purchase.PAID,
+        ).aggregate(
+            total=Sum(Cast("amount", DecimalField(max_digits=19, decimal_places=8)))
+        )[
+            "total"
+        ] or Decimal(
+            "0"
+        )
+
+    def _get_used_referral_credits(self):
+        """
+        Get the amount of referral credits that have been used (unlocked and spent).
+        This represents referral bonus funds that were used for funding.
+        """
+        # First, get total earned referral bonuses
+        total_earned = Distribution.objects.filter(
+            recipient=self.user,
+            distribution_type="REFERRAL_BONUS",
+            distributed_status=Distribution.DISTRIBUTED,
+        ).aggregate(
+            total=Sum(Cast("amount", DecimalField(max_digits=19, decimal_places=8)))
+        )[
+            "total"
+        ] or Decimal(
+            "0"
+        )
+
+        # Then get current locked balance
+        locked_balance = Balance.objects.filter(
+            user=self.user, is_locked=True, lock_type="REFERRAL_BONUS"
+        ).aggregate(
+            total=Sum(Cast("amount", DecimalField(max_digits=19, decimal_places=8)))
+        )[
+            "total"
+        ] or Decimal(
+            "0"
+        )
+
+        # Used = earned - still locked
+        # Assuming unlocked funds were used for funding
+        return total_earned - locked_balance
+
+    def _get_available_referral_credits(self):
+        """Get available (locked) referral bonus credits for the user."""
+        return Balance.objects.filter(
+            user=self.user, is_locked=True, lock_type="REFERRAL_BONUS"
+        ).aggregate(
+            total=Sum(Cast("amount", DecimalField(max_digits=19, decimal_places=8)))
+        )[
+            "total"
+        ] or Decimal(
+            "0"
+        )
+
+    def _get_network_available_credits(self):
+        """Get total available credits for all referred users."""
+        referred_user_ids = ReferralSignup.objects.filter(
+            referrer=self.user
+        ).values_list("referred_id", flat=True)
+
+        return Balance.objects.filter(
+            user_id__in=referred_user_ids, is_locked=True, lock_type="REFERRAL_BONUS"
+        ).aggregate(
+            total=Sum(Cast("amount", DecimalField(max_digits=19, decimal_places=8)))
+        )[
+            "total"
+        ] or Decimal(
+            "0"
+        )
+
+    def get_referral_network_details(self):
+        """
+        Get detailed information about each referred user and their activity.
+
+        Returns:
+            list: List of referred users with their funding activity
+        """
+        referred_signups = (
+            ReferralSignup.objects.filter(referrer=self.user)
+            .select_related("referred")
+            .order_by("-signup_date")
+        )
+
+        network_details = []
+        for signup in referred_signups:
+            user_data = {
+                "user_id": signup.referred.id,
+                "username": signup.referred.username,
+                "signup_date": signup.signup_date,
+                "total_funded": self._get_user_total_funded(signup.referred),
+                "referral_bonus_earned": self._get_user_referral_bonus(signup.referred),
+                "is_active_funder": self._is_active_funder(signup.referred),
+            }
+            network_details.append(user_data)
+
+        return network_details
+
+    def _get_user_total_funded(self, user):
+        """Get total amount funded by a specific user."""
+        total = Purchase.objects.filter(
+            user=user,
+            purchase_type=Purchase.FUNDRAISE_CONTRIBUTION,
+            paid_status=Purchase.PAID,
+        ).aggregate(
+            total=Sum(Cast("amount", DecimalField(max_digits=19, decimal_places=8)))
+        )[
+            "total"
+        ] or Decimal(
+            "0"
+        )
+        return float(total)
+
+    def _get_user_referral_bonus(self, user):
+        """Get total referral bonus earned by a specific user."""
+        total = Distribution.objects.filter(
+            recipient=user,
+            distribution_type="REFERRAL_BONUS",
+            distributed_status=Distribution.DISTRIBUTED,
+        ).aggregate(
+            total=Sum(Cast("amount", DecimalField(max_digits=19, decimal_places=8)))
+        )[
+            "total"
+        ] or Decimal(
+            "0"
+        )
+        return float(total)
+
+    def _is_active_funder(self, user):
+        """Check if a user has made any funding contributions."""
+        return Purchase.objects.filter(
+            user=user,
+            purchase_type=Purchase.FUNDRAISE_CONTRIBUTION,
+            paid_status=Purchase.PAID,
+        ).exists()

--- a/src/referral/tests/test_referral_metrics_api.py
+++ b/src/referral/tests/test_referral_metrics_api.py
@@ -1,3 +1,4 @@
+import uuid
 from decimal import Decimal
 
 from django.contrib.contenttypes.models import ContentType
@@ -24,19 +25,19 @@ class ReferralMetricsAPITest(TestCase):
 
         # Create test users
         self.referrer = User.objects.create_user(
-            username="referrer", email="referrer@test.com", password="testpass123"
+            username="referrer", email="referrer@test.com", password=uuid.uuid4().hex
         )
 
         self.referred_user1 = User.objects.create_user(
-            username="referred1", email="referred1@test.com", password="testpass123"
+            username="referred1", email="referred1@test.com", password=uuid.uuid4().hex
         )
 
         self.referred_user2 = User.objects.create_user(
-            username="referred2", email="referred2@test.com", password="testpass123"
+            username="referred2", email="referred2@test.com", password=uuid.uuid4().hex
         )
 
         self.admin_user = User.objects.create_superuser(
-            username="admin", email="admin@test.com", password="adminpass123"
+            username="admin", email="admin@test.com", password=uuid.uuid4().hex
         )
 
         # Create referral signups

--- a/src/referral/tests/test_referral_metrics_api.py
+++ b/src/referral/tests/test_referral_metrics_api.py
@@ -1,0 +1,228 @@
+from decimal import Decimal
+
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from hub.models import Hub
+from purchase.models import Purchase
+from purchase.related_models.balance_model import Balance
+from purchase.related_models.fundraise_model import Fundraise
+from referral.models import ReferralSignup
+from reputation.related_models.distribution import Distribution
+from researchhub_document.models import ResearchhubUnifiedDocument
+from user.models import User
+
+
+class ReferralMetricsAPITest(TestCase):
+    """Test cases for referral metrics API endpoints."""
+
+    def setUp(self):
+        self.client = APIClient()
+
+        # Create test users
+        self.referrer = User.objects.create_user(
+            username="referrer", email="referrer@test.com", password="testpass123"
+        )
+
+        self.referred_user1 = User.objects.create_user(
+            username="referred1", email="referred1@test.com", password="testpass123"
+        )
+
+        self.referred_user2 = User.objects.create_user(
+            username="referred2", email="referred2@test.com", password="testpass123"
+        )
+
+        self.admin_user = User.objects.create_superuser(
+            username="admin", email="admin@test.com", password="adminpass123"
+        )
+
+        # Create referral signups
+        self.referral1 = ReferralSignup.objects.create(
+            referrer=self.referrer, referred=self.referred_user1
+        )
+
+        self.referral2 = ReferralSignup.objects.create(
+            referrer=self.referrer, referred=self.referred_user2
+        )
+
+        # Create test hub and unified document for fundraise
+        self.hub = Hub.objects.create(name="Test Hub")
+
+        # Create unified document
+        self.unified_document = ResearchhubUnifiedDocument.objects.create(
+            document_type="PAPER"
+        )
+        self.unified_document.hubs.add(self.hub)
+
+        # Create a fundraise
+        self.fundraise = Fundraise.objects.create(
+            created_by=self.referrer,
+            unified_document=self.unified_document,
+            goal_amount=10000,
+            goal_currency="USD",
+            status="OPEN",
+        )
+
+        # Create purchases (contributions)
+        fundraise_content_type = ContentType.objects.get_for_model(Fundraise)
+
+        self.purchase1 = Purchase.objects.create(
+            user=self.referred_user1,
+            content_type=fundraise_content_type,
+            object_id=self.fundraise.id,
+            purchase_type=Purchase.FUNDRAISE_CONTRIBUTION,
+            purchase_method=Purchase.OFF_CHAIN,
+            paid_status=Purchase.PAID,
+            amount="1000",
+        )
+
+        self.purchase2 = Purchase.objects.create(
+            user=self.referrer,
+            content_type=fundraise_content_type,
+            object_id=self.fundraise.id,
+            purchase_type=Purchase.FUNDRAISE_CONTRIBUTION,
+            purchase_method=Purchase.OFF_CHAIN,
+            paid_status=Purchase.PAID,
+            amount="5000",
+        )
+
+        # Create referral bonus distributions
+        self.distribution1 = Distribution.objects.create(
+            recipient=self.referrer,
+            distribution_type="REFERRAL_BONUS",
+            amount=Decimal("100"),  # 10% of referred user's contribution
+            distributed_status=Distribution.DISTRIBUTED,
+        )
+
+        self.distribution2 = Distribution.objects.create(
+            recipient=self.referred_user1,
+            distribution_type="REFERRAL_BONUS",
+            amount=Decimal("100"),
+            distributed_status=Distribution.DISTRIBUTED,
+        )
+
+        # Create locked balances linked to distributions
+        distribution_content_type = ContentType.objects.get_for_model(Distribution)
+
+        self.balance1 = Balance.objects.create(
+            user=self.referrer,
+            content_type=distribution_content_type,
+            object_id=self.distribution1.id,
+            amount="100",
+            is_locked=True,
+            lock_type="REFERRAL_BONUS",
+        )
+
+        self.balance2 = Balance.objects.create(
+            user=self.referred_user1,
+            content_type=distribution_content_type,
+            object_id=self.distribution2.id,
+            amount="100",
+            is_locked=True,
+            lock_type="REFERRAL_BONUS",
+        )
+
+    def test_get_my_referral_metrics(self):
+        """Test getting current user's referral metrics."""
+        self.client.force_authenticate(user=self.referrer)
+
+        url = reverse("referral:referral-metrics-my-metrics")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        # Check structure
+        self.assertIn("network_funding_power", data)
+        self.assertIn("referral_activity", data)
+        self.assertIn("your_funding_credits", data)
+        self.assertIn("network_earned_credits", data)
+
+        # Check network funding power
+        self.assertEqual(
+            data["network_funding_power"]["breakdown"]["direct_funding"], 5000.0
+        )
+        self.assertEqual(
+            data["network_funding_power"]["breakdown"]["network_funding"], 1000.0
+        )
+
+        # Check referral activity
+        self.assertEqual(data["referral_activity"]["funders_invited"], 2)
+        self.assertEqual(data["referral_activity"]["active_funders"], 1)
+
+        # Check funding credits
+        self.assertEqual(data["your_funding_credits"]["available"], 100.0)
+        self.assertEqual(data["your_funding_credits"]["total_earned"], 100.0)
+
+    def test_get_network_details(self):
+        """Test getting detailed network information."""
+        self.client.force_authenticate(user=self.referrer)
+
+        url = reverse("referral:referral-metrics-network-details")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(len(data), 2)
+
+        # Find referred_user1 in the response
+        user1_data = next(d for d in data if d["user_id"] == self.referred_user1.id)
+        self.assertEqual(user1_data["total_funded"], 1000.0)
+        self.assertEqual(user1_data["referral_bonus_earned"], 100.0)
+        self.assertTrue(user1_data["is_active_funder"])
+
+    def test_admin_can_view_other_user_metrics(self):
+        """Test that admin can view any user's referral metrics."""
+        self.client.force_authenticate(user=self.admin_user)
+
+        url = reverse(
+            "referral:referral-metrics-user-metrics", kwargs={"pk": self.referrer.id}
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data["user_id"], self.referrer.id)
+        self.assertEqual(data["username"], self.referrer.username)
+        self.assertIn("metrics", data)
+
+    def test_non_admin_cannot_view_other_user_metrics(self):
+        """Test that non-admin users cannot view other users' metrics."""
+        self.client.force_authenticate(user=self.referred_user1)
+
+        url = reverse(
+            "referral:referral-metrics-user-metrics", kwargs={"pk": self.referrer.id}
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_aggregate_metrics_admin_only(self):
+        """Test that aggregate metrics are only accessible to admins."""
+        # Test as regular user
+        self.client.force_authenticate(user=self.referrer)
+        url = reverse("referral:aggregate-referral-metrics-list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Test as admin
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertIn("total_referrals", data)
+        self.assertIn("active_referrals", data)
+        self.assertIn("total_bonuses_distributed", data)
+        self.assertIn("top_referrers", data)
+
+    def test_unauthenticated_access_denied(self):
+        """Test that unauthenticated users cannot access referral metrics."""
+        url = reverse("referral:referral-metrics-my-metrics")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/src/referral/urls.py
+++ b/src/referral/urls.py
@@ -1,0 +1,18 @@
+from django.urls import include, path
+from rest_framework.routers import DefaultRouter
+
+from referral.views import AggregateReferralMetricsViewSet, ReferralMetricsViewSet
+
+router = DefaultRouter()
+router.register(r"metrics", ReferralMetricsViewSet, basename="referral-metrics")
+router.register(
+    r"aggregate-metrics",
+    AggregateReferralMetricsViewSet,
+    basename="aggregate-referral-metrics",
+)
+
+app_name = "referral"
+
+urlpatterns = [
+    path("", include(router.urls)),
+]

--- a/src/referral/views.py
+++ b/src/referral/views.py
@@ -1,0 +1,162 @@
+from django.db.models import Count, Q, Sum
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAdminUser, IsAuthenticated
+from rest_framework.response import Response
+
+from purchase.models import Purchase
+from referral.models import ReferralSignup
+from referral.serializers import (
+    ReferralMetricsSerializer,
+    ReferralNetworkDetailSerializer,
+)
+from referral.services.referral_metrics_service import ReferralMetricsService
+from reputation.related_models.distribution import Distribution
+from user.models import User
+
+
+class ReferralMetricsViewSet(viewsets.ViewSet):
+    """
+    ViewSet for referral metrics endpoints.
+
+    Provides metrics about referral network funding power and activity.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def retrieve(self, request, pk=None):
+        """
+        Get comprehensive referral metrics for the authenticated user.
+
+        Returns:
+            - Network funding power (deployed and potential)
+            - Referral activity statistics
+            - User's funding credits
+            - Network earned credits
+        """
+        user = request.user
+        service = ReferralMetricsService(user)
+        metrics = service.get_comprehensive_metrics()
+
+        serializer = ReferralMetricsSerializer(metrics)
+        return Response(serializer.data)
+
+    @action(detail=False, methods=["get"])
+    def my_metrics(self, request):
+        """
+        Convenience endpoint to get current user's metrics without needing user ID.
+        """
+        user = request.user
+        service = ReferralMetricsService(user)
+        metrics = service.get_comprehensive_metrics()
+
+        serializer = ReferralMetricsSerializer(metrics)
+        return Response(serializer.data)
+
+    @action(detail=False, methods=["get"])
+    def network_details(self, request):
+        """
+        Get detailed information about each referred user in the network.
+
+        Returns list of referred users with:
+            - User information
+            - Total funded amount
+            - Referral bonuses earned
+            - Activity status
+        """
+        user = request.user
+        service = ReferralMetricsService(user)
+        network_details = service.get_referral_network_details()
+
+        serializer = ReferralNetworkDetailSerializer(network_details, many=True)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=["get"], permission_classes=[IsAdminUser])
+    def user_metrics(self, request, pk=None):
+        """
+        Admin endpoint to view any user's referral metrics.
+
+        Args:
+            pk: User ID to get metrics for
+        """
+        try:
+
+            user = User.objects.get(pk=pk)
+        except User.DoesNotExist:
+            return Response(
+                {"detail": "User not found."}, status=status.HTTP_404_NOT_FOUND
+            )
+
+        service = ReferralMetricsService(user)
+        metrics = service.get_comprehensive_metrics()
+
+        serializer = ReferralMetricsSerializer(metrics)
+        return Response(
+            {"user_id": user.id, "username": user.username, "metrics": serializer.data}
+        )
+
+
+class AggregateReferralMetricsViewSet(viewsets.ViewSet):
+    """
+    ViewSet for platform-wide aggregate referral metrics.
+    Admin only.
+    """
+
+    permission_classes = [IsAdminUser]
+
+    def list(self, request):
+        """
+        Get platform-wide referral metrics.
+
+        Returns aggregate statistics about:
+            - Total referrals made
+            - Total referral bonuses distributed
+            - Active referral networks
+            - Top referrers
+        """
+        # Total referrals
+        total_referrals = ReferralSignup.objects.count()
+
+        # Active referrals (those who have made contributions)
+        active_referrals = (
+            ReferralSignup.objects.filter(
+                referred__purchases__purchase_type=Purchase.FUNDRAISE_CONTRIBUTION,
+                referred__purchases__paid_status=Purchase.PAID,
+            )
+            .distinct()
+            .count()
+        )
+
+        # Total referral bonuses distributed
+        total_bonuses = (
+            Distribution.objects.filter(
+                distribution_type="REFERRAL_BONUS",
+                distributed_status=Distribution.DISTRIBUTED,
+            ).aggregate(total=Sum("amount"))["total"]
+            or 0
+        )
+
+        # Top referrers by number of successful referrals
+        top_referrers = (
+            ReferralSignup.objects.values("referrer__id", "referrer__username")
+            .annotate(
+                referral_count=Count("id"),
+                active_referral_count=Count(
+                    "id",
+                    filter=Q(
+                        referred__purchases__purchase_type=Purchase.FUNDRAISE_CONTRIBUTION,
+                        referred__purchases__paid_status=Purchase.PAID,
+                    ),
+                ),
+            )
+            .order_by("-referral_count")[:10]
+        )
+
+        return Response(
+            {
+                "total_referrals": total_referrals,
+                "active_referrals": active_referrals,
+                "total_bonuses_distributed": float(total_bonuses),
+                "top_referrers": list(top_referrers),
+            }
+        )

--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -238,6 +238,8 @@ urlpatterns = [
     ),
     path("api/permissions/", researchhub.views.permissions, name="permissions"),
     path("api/search/", include(search.urls)),
+    # Referral endpoints
+    path("api/referral/", include("referral.urls")),
     # Organization endpoints
     path(
         "api/organizations/non-profit/search/",


### PR DESCRIPTION
  - /api/referral/metrics/my_metrics/ - Current user's referral metrics
  - /api/referral/metrics/network_details/ - Detailed network information
  - /api/referral/metrics/{user_id}/user_metrics/ - Admin can view any user's metrics
  - /api/referral/aggregate-metrics/ - Admin can view platform-wide aggregate metrics
