### PR TITLE
Fix error logging in Amplitude decorator

### DIFF
--- a/src/analytics/amplitude.py
+++ b/src/analytics/amplitude.py
@@ -128,7 +128,7 @@ def track_event(func):
                 amp = Amplitude()
                 amp.build_hit(res, *args, **kwargs)
         except Exception as e:
-            log_info(e, getattr(amp, "hit", None))
+            log_info(f"Failed to track amplitude event: {e}", getattr(amp, "hit", None))
         return res
 
     return inner


### PR DESCRIPTION
The `track_event` decorator uses incorrect arguments to the `log_info` function where the message is expected to be a string, not an object.