### PR TITLE
chore: Upgrade pkginto during bootstrapping

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,7 +3,7 @@ set -e
 
 # Install dependencies
 poetry install --directory=src
-pip install --upgrade pip
+pip install --upgrade pip pkginfo
 pip install -r src/requirements.txt --no-deps
 
 cd src


### PR DESCRIPTION
This prevents the following error when managing
dependencies with Poetry:
```
Unknown metadata version: 2.4
```