### PR TITLE
Fix incorrect logging in paper signals

### DIFF
--- a/src/paper/signals.py
+++ b/src/paper/signals.py
@@ -10,7 +10,7 @@ from researchhub_document.related_models.constants.document_type import (
     PAPER as PAPER_DOC_TYPE,
 )
 from utils.doi import DOI
-from utils.sentry import log_error
+from utils.sentry import log_error, log_info
 
 from .models import Paper
 from .related_models.paper_version import PaperVersion
@@ -106,13 +106,12 @@ def update_paper_journal_status(sender, instance, created, **kwargs):
                     paper_version.base_doi = doi.base_doi
                     paper_version.save()
 
-                    log_error(
-                        f"Successfully created DOI {doi.doi} for paper {paper_id}"
-                    )
+                    log_info(f"Successfully created DOI {doi.doi} for paper {paper_id}")
                 else:
                     log_error(
+                        Exception(f"Failed to register DOI for paper {paper_id}"),
                         f"Failed to register DOI for paper {paper_id}: "
-                        f"Crossref returned status {crossref_response.status_code}"
+                        f"Crossref returned status {crossref_response.status_code}",
                     )
 
                 # Add paper to ResearchHub journal hub
@@ -121,9 +120,10 @@ def update_paper_journal_status(sender, instance, created, **kwargs):
 
             except PaperVersion.DoesNotExist:
                 log_error(
+                    Exception(f"No PaperVersion found for paper {paper_id}"),
                     f"No PaperVersion found for paper {paper_id}, "
-                    f"skipping journal update"
+                    f"skipping journal update",
                 )
 
     except Exception as e:
-        log_error(f"Error updating paper journal status: {e}")
+        log_error(e, message="Error updating paper journal status")

--- a/src/paper/tests/test_signals.py
+++ b/src/paper/tests/test_signals.py
@@ -105,7 +105,7 @@ class UpdatePaperJournalStatusSignalTest(TransactionTestCase):
 
             # Verify an error was logged
             mock_log_error.assert_called_once()
-            error_msg = mock_log_error.call_args[0][0]
+            error_msg = mock_log_error.call_args[0][1]
             self.assertIn(f"No PaperVersion found for paper {self.paper.id}", error_msg)
 
     def test_update_existing_paper_version(self):
@@ -223,7 +223,7 @@ class UpdatePaperJournalStatusSignalTest(TransactionTestCase):
 
         # Verify error was logged for failed DOI registration
         mock_log_error.assert_called()
-        error_calls = [call[0][0] for call in mock_log_error.call_args_list]
+        error_calls = [call[0][1] for call in mock_log_error.call_args_list]
         self.assertTrue(any("Failed to register DOI" in call for call in error_calls))
 
         # Verify the paper and paper version were NOT updated with DOI


### PR DESCRIPTION
- Informational message should be logged with `log_info` (not `log_error`).
- Provide correct arguments to `log_error` for the exception handling case.