### PR TITLE
Assign attributes for Amplitude tracking

### DIFF
--- a/src/purchase/views/stripe_webhook_view.py
+++ b/src/purchase/views/stripe_webhook_view.py
@@ -26,6 +26,12 @@ class StripeWebhookView(APIView):
 
     permission_classes = [AllowAny]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Set attributes for Amplitude tracking
+        self.basename = "stripe_webhook"
+        self.action = "process"
+
     @track_event
     def post(self, request, *args, **kwargs):
         """


### PR DESCRIPTION
The `track_event` decorator requires the two attributes `basename` and `action` to work correctly. These are present in model views, but not in API views. This change adds these two attributes to the Stripe webhook view, allowing the use of the decorator.