### PR TITLE
Add option for permanent deletion of contacts from Mailchimp

### DIFF
--- a/src/user/management/commands/remove_spammers_from_mailchimp.py
+++ b/src/user/management/commands/remove_spammers_from_mailchimp.py
@@ -17,9 +17,15 @@ class Command(BaseCommand):
             action="store_true",
             help="Perform a dry run without actually removing users from Mailchimp",
         )
+        parser.add_argument(
+            "--permanent-delete",
+            action="store_true",
+            help="Permanently delete contacts (instead of archiving)",
+        )
 
     def handle(self, *args, **options):
         dry_run = options.get("dry_run", False)
+        permanent_delete = options.get("permanent_delete", False)
 
         mailchimp = Client()
         mailchimp.set_config(
@@ -40,10 +46,16 @@ class Command(BaseCommand):
         removed_count = 0
         error_count = 0
 
-        self.stdout.write(f"Found {total_count} users for removal from Mailchimp")
+        action_type = "permanent deletion" if permanent_delete else "archival"
+        self.stdout.write(f"Found {total_count} users for {action_type} from Mailchimp")
 
         if dry_run:
             self.stdout.write("DRY RUN - No actual changes are made")
+
+        if permanent_delete:
+            self.stdout.write(
+                self.style.WARNING("\nWARNING: Permanent deletion active!")
+            )
 
         for i, user in enumerate(users_to_remove):
             email = user.email.lower()
@@ -53,12 +65,26 @@ class Command(BaseCommand):
 
             if not dry_run:
                 try:
-                    # Remove user from Mailchimp list
-                    mailchimp.lists.delete_list_member(MAILCHIMP_LIST_ID, email_hash)
-                    removed_count += 1
-                    self.stdout.write(
-                        self.style.SUCCESS(f"  ✓ Removed {email} from Mailchimp")
-                    )
+                    if permanent_delete:
+                        # Permanently delete contact
+                        mailchimp.lists.delete_list_member_permanent(
+                            MAILCHIMP_LIST_ID, email_hash
+                        )
+                        removed_count += 1
+                        self.stdout.write(
+                            self.style.SUCCESS(
+                                f"  ✓ Permanently deleted {email} from Mailchimp"
+                            )
+                        )
+                    else:
+                        # Archive user from Mailchimp list (can be unarchived)
+                        mailchimp.lists.delete_list_member(
+                            MAILCHIMP_LIST_ID, email_hash
+                        )
+                        removed_count += 1
+                        self.stdout.write(
+                            self.style.SUCCESS(f"  ✓ Archived {email} from Mailchimp")
+                        )
                 except ApiClientError as error:
                     error_count += 1
                     error_detail = error.text if hasattr(error, "text") else str(error)
@@ -84,14 +110,16 @@ class Command(BaseCommand):
                         )
                     )
             else:
-                self.stdout.write(f"  → Would remove {email} from Mailchimp")
+                action = "permanently delete" if permanent_delete else "archive"
+                self.stdout.write(f"  → Would {action} {email} from Mailchimp")
 
         # Create summary
         self.stdout.write("\n" + "=" * 50)
         self.stdout.write(f"Total users processed: {total_count}")
 
         if not dry_run:
-            self.stdout.write(self.style.SUCCESS(f"Removed: {removed_count}"))
+            action_past = "Permanently deleted" if permanent_delete else "Archived"
+            self.stdout.write(self.style.SUCCESS(f"{action_past}: {removed_count}"))
             self.stdout.write(self.style.ERROR(f"Errors: {error_count}"))
         else:
             self.stdout.write("DRY RUN completed - no changes were made")


### PR DESCRIPTION
Add a `--permanent-delete` option to the management command for removing spammers from Mailchimp. This will remove users from Mailchimp, rather than just archiving them.

Also see: https://mailchimp.com/developer/marketing/api/list-members/delete-list-member/