### PR TITLE
Make password reset URL clickable in email template

### DIFF
--- a/src/templates/account/registration/reset_message.html
+++ b/src/templates/account/registration/reset_message.html
@@ -9,8 +9,7 @@
       <br/>
       Click on the link below to complete your password reset.
       <br/>
-      {{ reset_url }}
-      {{ uid}}
+      <a href="{{ reset_url }}">{{ reset_url }}</a>
       <br/>
       <br/>
       Best,


### PR DESCRIPTION
## What?
- Currently, the password reset URL in the email template is displayed as plain text, requiring users to copy and paste it into their browser. 
- This change makes the URL clickable for better user experience.

## How?
- Wrapped `{{ reset_url }}` in an `<a>` tag to make it clickable