### PR TITLE
chore: Remove unused paper endpoints

### DIFF
--- a/src/paper/tests/test_views.py
+++ b/src/paper/tests/test_views.py
@@ -848,12 +848,6 @@ class PaperViewsTests(TestCase):
         result = response.data
         self.assertEqual(result["base_rewards"], 100)
 
-    def test_search_by_url_bad(self):
-        url = self.base_url + "search_by_url/"
-        data = {"url": "org/this-is-a-bad-url"}
-        response = get_authenticated_post_response(self.user, url, data)
-        self.assertContains(response, "Double check that URL", status_code=400)
-
 
 class PaperDOITests(APITestCase):
     def setUp(self):

--- a/src/paper/views/paper_views.py
+++ b/src/paper/views/paper_views.py
@@ -1060,22 +1060,6 @@ class PaperViewSet(
         }
         return Response(summary, status=200)
 
-    @staticmethod
-    def search_by_csl_item(csl_item):
-        """
-        Perform an elasticsearch query for papers matching
-        the input CSL_Item.
-        """
-        from elasticsearch_dsl import Q, Search
-
-        search = Search(index="paper")
-        title = csl_item.get("title", "")
-        query = Q("match", title=title) | Q("match", paper_title=title)
-        if csl_item.get("DOI"):
-            query |= Q("match", doi=csl_item["DOI"])
-        search.query(query)
-        return search
-
     @action(detail=False, methods=["get"], permission_classes=[AllowAny])
     def doi_search_via_openalex(self, request):
         doi_string = request.query_params.get("doi", None)

--- a/src/paper/views/paper_views.py
+++ b/src/paper/views/paper_views.py
@@ -891,40 +891,6 @@ class PaperViewSet(
         return Response("Paper was deleted.", status=200)
 
     @action(
-        detail=False,
-        methods=["get"],
-    )
-    def pdf_coverage(self, request, pk=None):
-        date = request.GET.get("date", None)
-        paper_query = Paper.objects.all()
-        if date:
-            paper_query = paper_query.filter(created_date__gte=date)
-
-        paper_count = paper_query.count()
-        papers_with_pdfs = paper_query.filter(Q(file="") | Q(file__isnull=True)).count()
-
-        open_access_count = paper_query.filter(is_open_access=True).count()
-        open_access_papers_with_pdf = paper_query.filter(
-            Q(file="") | Q(file__isnull=True), is_open_access=True
-        ).count()
-
-        return Response(
-            {
-                "paper_count": paper_count,
-                "internal_pdf_count": papers_with_pdfs,
-                "internal_coverage_percentage": "{}%".format(
-                    round(papers_with_pdfs / paper_count, 2) * 100
-                ),
-                "open_access_count": open_access_count,
-                "open_access_pdf_count": open_access_papers_with_pdf,
-                "open_access_pdf_percentage": "{}%".format(
-                    round(open_access_papers_with_pdf / open_access_count, 2) * 100
-                ),
-            },
-            status=200,
-        )
-
-    @action(
         detail=True,
         methods=["put", "patch", "delete"],
         permission_classes=[HasDocumentCensorPermission],


### PR DESCRIPTION
Remove the following unused paper endpoints:
- `search_by_url`
- `search_by_csl_item`
- `pdf_coverage`