### PR TITLE
Add new endpoint for flagging user as probable spammer

### DIFF
--- a/src/user/tests/test_views.py
+++ b/src/user/tests/test_views.py
@@ -25,6 +25,7 @@ from utils.openalex import OpenAlex
 from utils.test_helpers import (
     get_authenticated_get_response,
     get_authenticated_patch_response,
+    get_authenticated_post_response,
 )
 
 
@@ -531,18 +532,10 @@ class UserPopoverTests(APITestCase):
 
 class UserModerationTests(APITestCase):
     def setUp(self):
-        from user.tests.helpers import (
-            create_random_authenticated_user,
-            create_random_default_user,
-        )
-
         self.moderator = create_random_authenticated_user("mod", moderator=True)
         self.target_user = create_random_authenticated_user("target_user")
-        self.create_random_default_user = create_random_default_user
 
     def test_mark_probable_spammer_success(self):
-        from utils.test_helpers import get_authenticated_post_response
-
         url = "/api/user/mark_probable_spammer/"
         data = {"authorId": self.target_user.author_profile.id}
         response = get_authenticated_post_response(self.moderator, url, data)
@@ -554,10 +547,8 @@ class UserModerationTests(APITestCase):
         self.assertTrue(self.target_user.is_active)
 
     def test_mark_probable_spammer_requires_moderator(self):
-        from utils.test_helpers import get_authenticated_post_response
-
         non_mod = self.target_user
-        another_user = self.create_random_default_user("another_user")
+        another_user = create_random_default_user("another_user")
         url = "/api/user/mark_probable_spammer/"
         data = {"authorId": another_user.author_profile.id}
         response = get_authenticated_post_response(non_mod, url, data)
@@ -565,8 +556,6 @@ class UserModerationTests(APITestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_mark_probable_spammer_missing_author_id(self):
-        from utils.test_helpers import get_authenticated_post_response
-
         url = "/api/user/mark_probable_spammer/"
         data = {}
         response = get_authenticated_post_response(self.moderator, url, data)
@@ -574,8 +563,6 @@ class UserModerationTests(APITestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_mark_probable_spammer_user_not_found(self):
-        from utils.test_helpers import get_authenticated_post_response
-
         url = "/api/user/mark_probable_spammer/"
         data = {"authorId": -1}
         response = get_authenticated_post_response(self.moderator, url, data)


### PR DESCRIPTION
**Context**: Moderators were missing the ability to flag users, which was previously done on SIFT. With SIFT paused, they have been missing this option and could only Ban or Reinstate.