### PR TITLE
Configure uv link mode to avoid warning in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -71,6 +71,7 @@
 	// "remoteUser": "root"
 
 	"remoteEnv": {
+		"UV_LINK_MODE": "copy",
 		"WORKSPACE_PATH": "${containerWorkspaceFolder}"
 	},
 


### PR DESCRIPTION
By default, uv tries to create hard links, which will fail in dev containers. The following warning is logged in such cases:

```
Uninstalled 1 package in 25ms
░░░░░░░░░░░░░░░░░░░░ [0/1] Installing wheels...                                                                                                                            warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If the cache and target directories are on different filesystems, hardlinking may not be supported.
         If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.
Installed 1 package in 22ms
```