### PR TITLE
Add Payment Intent Endpoint 

### DIFF
--- a/src/purchase/serializers/payment_intent_serializer.py
+++ b/src/purchase/serializers/payment_intent_serializer.py
@@ -1,0 +1,37 @@
+from rest_framework import serializers
+
+from purchase.related_models.constants.currency import RSC, USD
+
+
+class PaymentIntentSerializer(serializers.Serializer):
+    """
+    Serializer for RSC purchase payment intent creation.
+    """
+
+    amount = serializers.IntegerField(
+        min_value=1,  # Minimum $0.01 for USD, or minimum RSC amount
+        help_text="Amount in cents (USD) or RSC units (if currency is RSC)",
+    )
+    currency = serializers.ChoiceField(
+        choices=[(USD, "USD"), (RSC, "RSC")],
+        default=USD,
+        help_text="Currency for the amount (USD or RSC)",
+    )
+
+    def validate(self, attrs):
+        amount = attrs.get("amount")
+        currency = attrs.get("currency", USD)
+
+        # Ensure amount is positive
+        if amount <= 0:
+            raise serializers.ValidationError(
+                {"amount": "Amount must be greater than zero."}
+            )
+
+        # Ensure currency is valid
+        if currency not in [USD, RSC]:
+            raise serializers.ValidationError(
+                {"currency": "Currency must be either 'USD' or 'RSC'."}
+            )
+
+        return attrs

--- a/src/purchase/tests/test_payment_intent_serializer.py
+++ b/src/purchase/tests/test_payment_intent_serializer.py
@@ -1,0 +1,90 @@
+from django.test import TestCase
+
+from purchase.related_models.constants.currency import RSC, USD
+from purchase.serializers.payment_intent_serializer import PaymentIntentSerializer
+
+
+class PaymentIntentSerializerTest(TestCase):
+    def test_valid_usd_data(self):
+        # Arrange
+        data = {
+            "amount": 1000,  # $10.00
+            "currency": USD,
+        }
+
+        # Act
+        serializer = PaymentIntentSerializer(data=data)
+
+        # Assert
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["amount"], 1000)
+        self.assertEqual(serializer.validated_data["currency"], USD)
+
+    def test_valid_rsc_data(self):
+        # Arrange
+        data = {
+            "amount": 100,  # 100 RSC
+            "currency": RSC,
+        }
+
+        # Act
+        serializer = PaymentIntentSerializer(data=data)
+
+        # Assert
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["amount"], 100)
+        self.assertEqual(serializer.validated_data["currency"], RSC)
+
+    def test_default_currency(self):
+        # Arrange
+        data = {
+            "amount": 1000,
+        }
+
+        # Act
+        serializer = PaymentIntentSerializer(data=data)
+
+        # Assert
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["currency"], USD)
+
+    def test_amount_below_minimum(self):
+        # Arrange
+        data = {
+            "amount": 0,  # Below minimum $0.01
+            "currency": USD,
+        }
+
+        # Act
+        serializer = PaymentIntentSerializer(data=data)
+
+        # Assert
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("amount", serializer.errors)
+
+    def test_invalid_currency(self):
+        # Arrange
+        data = {
+            "amount": 1000,
+            "currency": "invalid",
+        }
+
+        # Act
+        serializer = PaymentIntentSerializer(data=data)
+
+        # Assert
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("currency", serializer.errors)
+
+    def test_missing_amount(self):
+        # Arrange
+        data = {
+            "currency": USD,
+        }
+
+        # Act
+        serializer = PaymentIntentSerializer(data=data)
+
+        # Assert
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("amount", serializer.errors)

--- a/src/purchase/tests/test_payment_intent_view.py
+++ b/src/purchase/tests/test_payment_intent_view.py
@@ -1,0 +1,187 @@
+from unittest.mock import MagicMock, patch
+
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from purchase.related_models.constants.currency import RSC, USD
+from user.tests.helpers import create_user
+
+
+class PaymentIntentViewTest(APITestCase):
+    def setUp(self):
+        self.url = reverse("payment_intent_view")
+        self.user = create_user()
+
+    @patch("purchase.views.payment_intent_view.PaymentService")
+    def test_create_payment_intent_usd_success(self, mock_payment_service_class):
+        # Arrange
+        mock_payment_service = MagicMock()
+        mock_payment_service_class.return_value = mock_payment_service
+        mock_payment_service.create_payment_intent.return_value = {
+            "client_secret": "pi_secret_123",
+            "payment_intent_id": "pi_123456",
+            "locked_rsc_amount": 100.0,
+            "stripe_amount_cents": 1000,
+        }
+
+        data = {
+            "amount": 1000,  # $10.00
+            "currency": USD,
+        }
+
+        self.client.force_authenticate(user=self.user)
+
+        # Act
+        response = self.client.post(self.url, data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {
+                "client_secret": "pi_secret_123",
+                "payment_intent_id": "pi_123456",
+                "locked_rsc_amount": 100.0,
+                "stripe_amount_cents": 1000,
+            },
+        )
+
+        # Verify the payment service was called correctly
+        mock_payment_service.create_payment_intent.assert_called_once_with(
+            user_id=self.user.id,
+            amount=1000,
+            currency=USD,
+        )
+
+    @patch("purchase.views.payment_intent_view.PaymentService")
+    def test_create_payment_intent_rsc_success(self, mock_payment_service_class):
+        # Arrange
+        mock_payment_service = MagicMock()
+        mock_payment_service_class.return_value = mock_payment_service
+        mock_payment_service.create_payment_intent.return_value = {
+            "client_secret": "pi_secret_456",
+            "payment_intent_id": "pi_789012",
+            "locked_rsc_amount": 100,
+            "stripe_amount_cents": 500,
+        }
+
+        data = {
+            "amount": 100,  # 100 RSC
+            "currency": RSC,
+        }
+
+        self.client.force_authenticate(user=self.user)
+
+        # Act
+        response = self.client.post(self.url, data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["locked_rsc_amount"], 100)
+        self.assertEqual(response.data["stripe_amount_cents"], 500)
+
+        # Verify the payment service was called correctly
+        mock_payment_service.create_payment_intent.assert_called_once_with(
+            user_id=self.user.id,
+            amount=100,
+            currency=RSC,
+        )
+
+    @patch("purchase.views.payment_intent_view.PaymentService")
+    def test_create_payment_intent_default_currency(self, mock_payment_service_class):
+        # Arrange
+        mock_payment_service = MagicMock()
+        mock_payment_service_class.return_value = mock_payment_service
+        mock_payment_service.create_payment_intent.return_value = {
+            "client_secret": "pi_secret_default",
+            "payment_intent_id": "pi_default",
+            "locked_rsc_amount": 50.0,
+            "stripe_amount_cents": 500,
+        }
+
+        data = {
+            "amount": 500,  # $5.00 (no currency specified, defaults to USD)
+        }
+
+        self.client.force_authenticate(user=self.user)
+
+        # Act
+        response = self.client.post(self.url, data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+
+        # Verify the payment service was called with default currency
+        mock_payment_service.create_payment_intent.assert_called_once_with(
+            user_id=self.user.id,
+            amount=500,
+            currency=USD,
+        )
+
+    def test_create_payment_intent_unauthenticated(self):
+        # Arrange
+        data = {
+            "amount": 1000,
+            "currency": USD,
+        }
+
+        # Act
+        response = self.client.post(self.url, data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_create_payment_intent_invalid_amount(self):
+        # Arrange
+        data = {
+            "amount": 0,
+            "currency": USD,
+        }
+
+        self.client.force_authenticate(user=self.user)
+
+        # Act
+        response = self.client.post(self.url, data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("amount", response.data)
+
+    def test_create_payment_intent_invalid_currency(self):
+        # Arrange
+        data = {
+            "amount": 1000,
+            "currency": "invalid",
+        }
+
+        self.client.force_authenticate(user=self.user)
+
+        # Act
+        response = self.client.post(self.url, data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("currency", response.data)
+
+    @patch("purchase.views.payment_intent_view.PaymentService")
+    def test_create_payment_intent_service_error(self, mock_payment_service_class):
+        # Arrange
+        mock_payment_service = MagicMock()
+        mock_payment_service_class.return_value = mock_payment_service
+        mock_payment_service.create_payment_intent.side_effect = Exception(
+            "Stripe error"
+        )
+
+        data = {
+            "amount": 1000,
+            "currency": USD,
+        }
+
+        self.client.force_authenticate(user=self.user)
+
+        # Act
+        response = self.client.post(self.url, data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.data["message"], "Failed to create payment intent")

--- a/src/purchase/views/__init__.py
+++ b/src/purchase/views/__init__.py
@@ -3,6 +3,7 @@ from .checkout_view import CheckoutView
 from .coinbase_view import CoinbaseViewSet
 from .fundraise_view import FundraiseViewSet
 from .grant_view import GrantViewSet
+from .payment_intent_view import PaymentIntentView
 from .purchase_view import PurchaseViewSet
 from .rsc_exchange_rate_view import RscExchangeRateViewSet
 from .support_view import SupportViewSet

--- a/src/purchase/views/payment_intent_view.py
+++ b/src/purchase/views/payment_intent_view.py
@@ -1,0 +1,44 @@
+import logging
+
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from purchase.serializers.payment_intent_serializer import PaymentIntentSerializer
+from purchase.services.payment_service import PaymentService
+
+logger = logging.getLogger(__name__)
+
+
+class PaymentIntentView(APIView):
+    """
+    View for creating Stripe payment intents for RSC purchase.
+    """
+
+    permission_classes = [IsAuthenticated]
+    serializer_class = PaymentIntentSerializer
+
+    def __init__(self, payment_service: PaymentService = None, **kwargs):
+        super().__init__(**kwargs)
+        self.payment_service = payment_service or PaymentService()
+
+    def post(self, request, *args, **kwargs):
+        user_id = request.user.id
+        serializer = PaymentIntentSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        data = serializer.validated_data
+        amount = data.get("amount")
+
+        try:
+            payment_intent_data = self.payment_service.create_payment_intent(
+                user_id=user_id,
+                amount=amount,
+                currency=data.get("currency", "usd"),
+            )
+
+            return Response(payment_intent_data, status=status.HTTP_200_OK)
+        except Exception as e:
+            logger.error("Error creating payment intent: %s", e)
+            return Response({"message": "Failed to create payment intent"}, status=500)

--- a/src/purchase/views/stripe_webhook_view.py
+++ b/src/purchase/views/stripe_webhook_view.py
@@ -69,7 +69,18 @@ class StripeWebhookView(APIView):
                     )
                 case "payment_intent.succeeded":
                     payment_intent = event["data"]["object"]
-                    logger.info("Payment intent ID=%s created", payment_intent["id"])
+                    logger.info("Payment intent ID=%s succeeded", payment_intent["id"])
+
+                    # Process the payment intent and create purchase record
+                    payment = self.payment_service.process_payment_intent_confirmation(
+                        payment_intent["id"]
+                    )
+                    logger.info(
+                        "Payment record created successfully: ID=%s, Amount=%s, User=%s",
+                        payment.id,
+                        payment.amount,
+                        payment.user_id,
+                    )
                 case _:
                     logger.info("Unhandled event type: %s", event_type)
         except ValueError as e:

--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -347,6 +347,11 @@ urlpatterns = [
         purchase.views.CheckoutView.as_view(),
         name="payment_view",
     ),
+    path(
+        "api/payment/payment-intent/",
+        purchase.views.PaymentIntentView.as_view(),
+        name="payment_intent_view",
+    ),
     path("user_saved/", UserSavedView.as_view(), name="user_saved"),
 ]
 


### PR DESCRIPTION
## What?
- Payment Intent Endpoint:  `/api/payment/payment-intent/` for creating Stripe payment intents
- Stores exact RSC amount in metadata for precise distribution [RSC Amount Locking 🔒 ]
  - Leverages existing RscExchangeRate service for conversions
- Returns client secret for frontend payment processing
- Webhook processes `payment_intent.succeeded` events 
- Tests