### PR TITLE
Stop auto-assigning "researchhub reviews" to external papers

### DIFF
--- a/src/paper/paper_upload_tasks.py
+++ b/src/paper/paper_upload_tasks.py
@@ -698,12 +698,6 @@ def create_paper_related_tags(paper, openalex_concepts=[], openalex_topics=[]):
         journal = _get_or_create_journal_hub(paper.external_source)
         paper.unified_document.hubs.add(journal)
 
-        # Add to bioRxiv hub if applicable
-        if "bioRxiv" in paper.external_source:
-            biorxiv_hub_id = 436
-            if Hub.objects.filter(id=biorxiv_hub_id).exists():
-                paper.unified_document.hubs.add(biorxiv_hub_id)
-
 
 def _get_or_create_journal_hub(external_source: str) -> Hub:
     """


### PR DESCRIPTION
### Issue: 
Externally sourced papers (e.g. search bar uploads) are automatically assigned the "ResearchHub Reviews" hub upon upload. This enables upvote-based bounties via the "ResearchHub Reviews" tag, leading to peer reviews on papers outside the editorial team's scope and expertise.
To give editors full control over bounty assignments, this automatic assignment should be removed. Editors will manually add the "ResearchHub Reviews" hub to papers they have specifically selected for review.

### Expected Behavior:
Editors will manually assign the "ResearchHub Reviews" tag to preprints that they plan to solicit peer reviews for.