### PR TITLE
Add foundation award badge feature

### DIFF
--- a/src/reputation/migrations/0103_add_awarded_by_to_bounty_solution.py
+++ b/src/reputation/migrations/0103_add_awarded_by_to_bounty_solution.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('reputation', '0102_remove_locked_balance_distribution_type'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='bountysolution',
+            name='awarded_by',
+            field=models.ForeignKey(
+                blank=True,
+                help_text='User who awarded this bounty solution',
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='awarded_solutions',
+                to=settings.AUTH_USER_MODEL
+            ),
+        ),
+    ]

--- a/src/reputation/related_models/bounty.py
+++ b/src/reputation/related_models/bounty.py
@@ -291,6 +291,14 @@ class BountySolution(DefaultModel):
     created_by = models.ForeignKey(
         "user.User", on_delete=models.CASCADE, related_name="solutions"
     )
+    awarded_by = models.ForeignKey(
+        "user.User", 
+        on_delete=models.SET_NULL, 
+        null=True,
+        blank=True,
+        related_name="awarded_solutions",
+        help_text="User who awarded this bounty solution"
+    )
     content_type = models.ForeignKey(
         ContentType, on_delete=models.CASCADE, related_name="bounty_solution"
     )

--- a/src/reputation/serializers/bounty_serializer.py
+++ b/src/reputation/serializers/bounty_serializer.py
@@ -8,6 +8,7 @@ from reputation.serializers.escrow_serializer import DynamicEscrowSerializer
 from researchhub.serializers import DynamicModelFieldSerializer
 from researchhub_document.serializers import DynamicUnifiedDocumentSerializer
 from user.serializers import DynamicUserSerializer
+from user.related_models.user_model import FOUNDATION_EMAIL
 from utils import sentry
 from utils.http import get_user_from_request
 
@@ -181,6 +182,8 @@ class DynamicBountySolutionSerializer(DynamicModelFieldSerializer):
     content_type = serializers.SerializerMethodField()
     item = serializers.SerializerMethodField()
     created_by = serializers.SerializerMethodField()
+    awarded_by = serializers.SerializerMethodField()
+    is_foundation_awarded = serializers.SerializerMethodField()
 
     class Meta:
         model = BountySolution
@@ -226,3 +229,16 @@ class DynamicBountySolutionSerializer(DynamicModelFieldSerializer):
         if serializer is not None:
             return serializer.data
         return None
+
+    def get_awarded_by(self, solution):
+        if not solution.awarded_by:
+            return None
+        context = self.context
+        _context_fields = context.get("rep_dbss_get_awarded_by", {})
+        serializer = DynamicUserSerializer(
+            solution.awarded_by, context=context, **_context_fields
+        )
+        return serializer.data
+
+    def get_is_foundation_awarded(self, solution):
+        return solution.awarded_by and solution.awarded_by.is_official_account


### PR DESCRIPTION
  ### What's Changed
  - Add `awarded_by` field to `BountySolution` model to track who awards bounties
  - Add `is_foundation_awarded` flag to API responses when awarder has `is_official_account=True`
  - Update serializers to include foundation award status in comment and feed endpoints
  - Include migration `0103_add_awarded_by_to_bounty_solution`

  ### Technical Details
  - Uses existing `is_official_account` user field for identification (no new constants)
  - Maintains audit trail of who awards each bounty
  - Backward compatible - nullable field with proper defaults
  - No hardcoded values or emails
