### PR TITLE
Add `renderable_text` to bounty

### DIFF
--- a/src/reputation/views/bounty_view.py
+++ b/src/reputation/views/bounty_view.py
@@ -213,6 +213,7 @@ class BountyViewSet(viewsets.ModelViewSet):
                 "title",
                 "abstract",
                 "authors",
+                "renderable_text",
             )
         }
         context["rep_dbs_get_hubs"] = {


### PR DESCRIPTION
- Adding property so it can be viewed on the web app when we render bounty cards