### PR TITLE
Use HTTPS for the arXiv API

### DIFF
--- a/src/paper/ingestion/clients/arxiv.py
+++ b/src/paper/ingestion/clients/arxiv.py
@@ -26,7 +26,7 @@ class ArXivConfig(ClientConfig):
 
         defaults = {
             "source_name": "arxiv",
-            "base_url": "http://export.arxiv.org/api",  # NOSONAR - ArXiv API uses HTTP
+            "base_url": "https://export.arxiv.org/api",
             "rate_limit": 0.33,  # Recommended 3 second delay between requests
             "page_size": 100,  # ArXiv recommends smaller batches for better performance
             "request_timeout": 30.0,

--- a/src/paper/ingestion/tests/clients/test_arxiv.py
+++ b/src/paper/ingestion/tests/clients/test_arxiv.py
@@ -34,7 +34,7 @@ class TestArXivClient(TestCase):
         self.assertEqual(config.source_name, "arxiv")
         self.assertEqual(
             config.base_url,
-            "http://export.arxiv.org/api",  # NOSONAR - ArXiv API uses HTTP
+            "https://export.arxiv.org/api",
         )
         self.assertEqual(config.rate_limit, 0.33)  # 3 second delay
         self.assertEqual(config.page_size, 100)


### PR DESCRIPTION
Use HTTPS for accessing the arXiv API. This avoids HTTP 307 redirects on every API request.

Note: The returned payload from arXiv still contains HTTP URLs.