### PR TITLE
fix: Pull papers always uses default since date

### DIFF
--- a/src/paper/ingestion/pipeline.py
+++ b/src/paper/ingestion/pipeline.py
@@ -75,9 +75,6 @@ class PaperIngestionPipeline:
         if sources is None:
             sources = list(self.clients.keys())
 
-        if since is None:
-            since = timezone.now() - timedelta(days=1)
-
         if until is None:
             until = timezone.now()
 


### PR DESCRIPTION
With the current implementation, the pull paper job always uses the default since date (1 day ago) instead of the date from the last successful job execution from the corresponding paper fetch log entry.