### PR TITLE
Submit since/until parameters with ChemRxiv requests

### DIFF
--- a/src/paper/ingestion/clients/chemrxiv.py
+++ b/src/paper/ingestion/clients/chemrxiv.py
@@ -170,6 +170,8 @@ class ChemRxivClient(BaseClient):
                 "limit": current_page_size,
                 "skip": skip,
                 "sort": "PUBLISHED_DATE_DESC",
+                "searchDateFrom": since.strftime("%Y-%m-%d"),
+                "searchDateTo": until.strftime("%Y-%m-%d"),
             }
 
             logger.info(

--- a/src/paper/ingestion/clients/chemrxiv.py
+++ b/src/paper/ingestion/clients/chemrxiv.py
@@ -170,8 +170,8 @@ class ChemRxivClient(BaseClient):
                 "limit": current_page_size,
                 "skip": skip,
                 "sort": "PUBLISHED_DATE_DESC",
-                "searchDateFrom": since.strftime("%Y-%m-%d"),
-                "searchDateTo": until.strftime("%Y-%m-%d"),
+                "searchDateFrom": since.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "searchDateTo": until.strftime("%Y-%m-%dT%H:%M:%SZ"),
             }
 
             logger.info(

--- a/src/paper/ingestion/tests/clients/test_chemrxiv.py
+++ b/src/paper/ingestion/tests/clients/test_chemrxiv.py
@@ -155,6 +155,8 @@ class TestChemRxivClient(TestCase):
         self.assertIn("limit", params)
         self.assertIn("skip", params)  # Uses skip, not offset
         self.assertIn("sort", params)
+        self.assertIn("searchDateFrom", params)
+        self.assertIn("searchDateTo", params)
 
     @patch("requests.Session.get")
     def test_fetch_recent_with_dates(self, mock_get):
@@ -181,6 +183,14 @@ class TestChemRxivClient(TestCase):
 
         self.assertEqual(len(papers), 1)
         self.assertEqual(papers[0]["id"], "123")
+
+        # Verify query string parameters
+        call_args = mock_get.call_args
+        params = call_args[1]["params"]
+        self.assertIn("searchDateFrom", params)
+        self.assertEqual(params["searchDateFrom"], "2025-01-01")
+        self.assertIn("searchDateTo", params)
+        self.assertEqual(params["searchDateTo"], "2025-01-07")
 
     @patch("requests.Session.get")
     def test_fetch_recent_pagination(self, mock_get):

--- a/src/paper/ingestion/tests/clients/test_chemrxiv.py
+++ b/src/paper/ingestion/tests/clients/test_chemrxiv.py
@@ -188,9 +188,9 @@ class TestChemRxivClient(TestCase):
         call_args = mock_get.call_args
         params = call_args[1]["params"]
         self.assertIn("searchDateFrom", params)
-        self.assertEqual(params["searchDateFrom"], "2025-01-01")
+        self.assertEqual(params["searchDateFrom"], "2025-01-01T00:00:00Z")
         self.assertIn("searchDateTo", params)
-        self.assertEqual(params["searchDateTo"], "2025-01-07")
+        self.assertEqual(params["searchDateTo"], "2025-01-07T00:00:00Z")
 
     @patch("requests.Session.get")
     def test_fetch_recent_pagination(self, mock_get):


### PR DESCRIPTION
The current implementation does not restrict the requested items using the given `since` and `until` date parameters. This change passes those parameters using the respective query string parameters `searchDateFrom` and `searchDateTo`.

See: https://chemrxiv.org/engage/chemrxiv/public-api/documentation#tag/public-apiv1items/operation/getPublicapiV1Items