### PR TITLE
by_category endpoint

### DIFF
--- a/src/hub/serializers.py
+++ b/src/hub/serializers.py
@@ -52,6 +52,7 @@ class SimpleHubSerializer(ModelSerializer):
 
 class HubSerializer(ModelSerializer):
     editor_permission_groups = SerializerMethodField()
+    category = SerializerMethodField()
 
     class Meta:
         fields = [
@@ -70,8 +71,20 @@ class HubSerializer(ModelSerializer):
             "namespace",
             "is_used_for_rep",
         ]
-        read_only_fields = ["editor_permission_groups"]
+        read_only_fields = ["editor_permission_groups", "category"]
         model = Hub
+
+    def get_category(self, obj):
+        # Check if we have category mapping in context
+        hub_category_mapping = self.context.get("hub_category_mapping", {})
+        if hub_category_mapping and obj.slug in hub_category_mapping:
+            return hub_category_mapping[obj.slug]
+        # Otherwise return the DB category if it exists
+        return (
+            obj.category.category_name
+            if hasattr(obj, "category") and obj.category
+            else None
+        )
 
     def get_editor_permission_groups(self, hub_instance):
         context = self.context

--- a/src/hub/views.py
+++ b/src/hub/views.py
@@ -475,7 +475,7 @@ class HubViewSet(viewsets.ModelViewSet, FollowViewActionMixin):
     @action(detail=False, methods=[GET], permission_classes=[AllowAny])
     def by_category(self, request):
         """
-        Returns all subcategory hubs with their parent category.
+        Returns all subcategory hubs with their parent category from mappings.
         Example: "neuroscience" hub will have category="Biology"
         """
 
@@ -514,7 +514,6 @@ class HubViewSet(viewsets.ModelViewSet, FollowViewActionMixin):
         serializer = self.get_serializer(hubs, many=True, context=context)
         data = serializer.data
 
-        # Cache for 24 hours
         cache.set(cache_key, data, timeout=60 * 60 * 24)
 
         return Response(data, status=200)


### PR DESCRIPTION
- Added `hub/by_category` endpoint which returns a list of subcategories along with category property based on mappings file defined in https://github.com/ResearchHub/researchhub-backend/pull/2590

Example response (uses `HubSerializer`):
```
    {
        "category": "physics",
        "description": "Strongly Correlated - research hub",
        "discussion_count": 0,
        "editor_permission_groups": [],
        "hub_image": null,
        "id": 14915,
        "is_locked": false,
        "is_removed": false,
        "name": "Strongly Correlated",
        "paper_count": 0,
        "slug": "strongly-correlated",
        "subscriber_count": 0,
        "namespace": null,
        "is_used_for_rep": false
    },
    {
        "category": "Nonlinear Sciences",
        "description": "Adaptation And Self Organization - research hub",
        "discussion_count": 0,
        "editor_permission_groups": [],
        "hub_image": null,
        "id": 14917,
        "is_locked": false,
        "is_removed": false,
        "name": "Adaptation And Self Organization",
        "paper_count": 0,
        "slug": "adaptation-and-self-organization",
        "subscriber_count": 0,
        "namespace": null,
        "is_used_for_rep": false
    },
```