### PR TITLE
feat: Map licenses to standardized notation

### DIFF
--- a/src/paper/ingestion/mappers/biorxiv.py
+++ b/src/paper/ingestion/mappers/biorxiv.py
@@ -96,7 +96,7 @@ class BioRxivMapper(BaseMapper):
             # Authors (JSON field)
             raw_authors=raw_authors,
             # License and access
-            pdf_license=record.get("license"),
+            pdf_license=self._parse_license(record.get("license")),
             is_open_access=True,  # BioRxiv is open access
             oa_status="gold",  # Gold open access for preprints
             # Status flags
@@ -109,6 +109,22 @@ class BioRxivMapper(BaseMapper):
             paper.url = self._compute_html_url(doi, version)
 
         return paper
+
+    def _parse_license(self, license_str: Optional[str]) -> Optional[str]:
+        """
+        Parse license string to standard format.
+
+        Args:
+            license_str: License string from BioRxiv
+
+        Returns:
+            Standardized license string or None
+        """
+        if not license_str:
+            return None
+
+        # Currently just return lowercased, hyphenated version
+        return license_str.lower().replace("_", "-").strip()
 
     def _parse_date(self, date_str: Optional[str]) -> Optional[str]:
         """

--- a/src/paper/ingestion/mappers/chemrxiv.py
+++ b/src/paper/ingestion/mappers/chemrxiv.py
@@ -369,6 +369,25 @@ class ChemRxivMapper(BaseMapper):
 
         return authorships
 
+    def _parse_license(self, license_str: Optional[str]) -> Optional[str]:
+        """
+        Parse license string to standard format.
+
+        Note: Licenses used by ChemRxiv can be queried via their API:
+        https://chemrxiv.org/engage/chemrxiv/public-api/v1/licenses
+
+        Args:
+            license_str: License string from ChemRxiv
+
+        Returns:
+            Standardized license string or None
+        """
+        if not license_str:
+            return None
+
+        # Currently just return lowercased, hyphenated version
+        return license_str.lower().replace(" ", "-").strip()
+
     def _extract_license(self, license_obj: Optional[Dict[str, Any]]) -> Optional[str]:
         """
         Extract license name.

--- a/src/paper/ingestion/tests/mappers/test_biorxiv.py
+++ b/src/paper/ingestion/tests/mappers/test_biorxiv.py
@@ -98,7 +98,7 @@ class TestBioRxivMapper(TestCase):
         self.assertEqual(paper.paper_title, paper.title)
         self.assertEqual(paper.external_source, "biorxiv")
         self.assertTrue(paper.retrieved_from_external_source)
-        self.assertEqual(paper.pdf_license, "cc_no")
+        self.assertEqual(paper.pdf_license, "cc-no")
         self.assertTrue(paper.is_open_access)
         self.assertEqual(paper.oa_status, "gold")
 
@@ -219,7 +219,7 @@ class TestBioRxivMapper(TestCase):
         self.assertEqual(hubs[0].slug, "biorxiv")
         self.assertEqual(hubs[0].namespace, Hub.Namespace.JOURNAL)
 
-    @patch.object(BioRxivMapper, 'bioarxiv_hub', new_callable=PropertyMock)
+    @patch.object(BioRxivMapper, "bioarxiv_hub", new_callable=PropertyMock)
     def test_map_to_hubs_without_existing_hub(self, mock_bioarxiv_hub):
         """
         Test map_to_hubs returns empty list when bioRxiv hub doesn't exist.
@@ -235,3 +235,29 @@ class TestBioRxivMapper(TestCase):
         # Assert
         self.assertEqual(len(hubs), 0)
         self.assertEqual(hubs, [])
+
+    def test_parse_license(self):
+        """
+        Test license parsing from BioRxiv license strings.
+        """
+        # Arrange
+        test_cases = {
+            "cc_by": "cc-by",
+            "cc_by_sa": "cc-by-sa",
+            "cc_by_nd": "cc-by-nd",
+            "cc_by_nc": "cc-by-nc",
+            "cc_by_nc_sa": "cc-by-nc-sa",
+            "cc_by_nc_nd": "cc-by-nc-nd",
+            "cc_no": "cc-no",
+            "cc0": "cc0",
+            "cc0_ng": "cc0-ng",
+            "": None,
+            None: None,
+        }
+
+        for given, expected in test_cases.items():
+            with self.subTest(given=given, expected=expected):
+                # Act
+                result = self.mapper._parse_license(given)
+                # Assert
+                self.assertEqual(result, expected)

--- a/src/paper/ingestion/tests/mappers/test_chemrxiv.py
+++ b/src/paper/ingestion/tests/mappers/test_chemrxiv.py
@@ -748,7 +748,7 @@ class TestChemRxivMapper(TestCase):
         self.assertEqual(hubs[0].slug, "biorxiv")
         self.assertEqual(hubs[0].namespace, Hub.Namespace.JOURNAL)
 
-    @patch.object(ChemRxivMapper, 'chemrxiv_hub', new_callable=PropertyMock)
+    @patch.object(ChemRxivMapper, "chemrxiv_hub", new_callable=PropertyMock)
     def test_map_to_hubs_without_existing_hub(self, mock_chemrxiv_hub):
         """
         Test map_to_hubs returns empty list when ChemRxiv hub doesn't exist.
@@ -764,3 +764,23 @@ class TestChemRxivMapper(TestCase):
         # Assert
         self.assertEqual(len(hubs), 0)
         self.assertEqual(hubs, [])
+
+    def test_parse_license(self):
+        """
+        Test license parsing from BioRxiv license strings.
+        """
+        # Arrange
+        test_cases = {
+            "CC BY 4.0": "cc-by-4.0",
+            "CC BY NC 4.0": "cc-by-nc-4.0",
+            "CC BY NC ND 4.0": "cc-by-nc-nd-4.0",
+            "": None,
+            None: None,
+        }
+
+        for given, expected in test_cases.items():
+            with self.subTest(given=given, expected=expected):
+                # Act
+                result = self.mapper._parse_license(given)
+                # Assert
+                self.assertEqual(result, expected)


### PR DESCRIPTION
Map license strings from the bioRxiv and ChemRxiv providers to a standardized notation used in the paper table.