### PR TITLE
Access purchases more defensively

### DIFF
--- a/src/purchase/related_models/purchase_model.py
+++ b/src/purchase/related_models/purchase_model.py
@@ -96,13 +96,17 @@ class Purchase(PaidStatusModelMixin):
     def get_boost_time(self, amount=None):
         day_multiplier = 60 * 60 * 24
         previous_boost_time = 0
-        if self.item.purchases:
-            previous_boosts = self.item.purchases.exclude(id=self.id)
-            if previous_boosts.exists():
-                previous_boost_amounts = previous_boosts.values_list(
-                    "amount", flat=True
-                )
-                previous_boost_time += sum(map(float, previous_boost_amounts))
+        try:
+            if self.item and hasattr(self.item, "purchases"):
+                previous_boosts = self.item.purchases.exclude(id=self.id)
+                if previous_boosts.exists():
+                    previous_boost_amounts = previous_boosts.values_list(
+                        "amount", flat=True
+                    )
+                    previous_boost_time += sum(map(float, previous_boost_amounts))
+        except (AttributeError, ContentType.DoesNotExist):
+            # continue with previous_boost_time = 0
+            pass
 
         if amount:
             boost_time = float(amount) + previous_boost_time


### PR DESCRIPTION
Access an item's purchases more defensively when calculating boost. This is to avoid the following error:
```
[2025-09-19 01:00:00,299: ERROR/ForkPoolWorker-2] Task purchase.tasks.update_purchases[1425366a-bbf9-4af0-b46e-011390d54612] raised unexpected: AttributeError("'NoneType' object has no a
ttribute '_base_manager'")
Traceback (most recent call last):
  File "/var/app/venv/staging-LQM1lest/lib64/python3.13/site-packages/celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
                 ~~~^^^^^^^^^^^^^^^^^
  File "/var/app/venv/staging-LQM1lest/lib64/python3.13/site-packages/sentry_sdk/integrations/celery.py", line 325, in _inner
    reraise(*exc_info)
    ~~~~~~~^^^^^^^^^^^
  File "/var/app/venv/staging-LQM1lest/lib64/python3.13/site-packages/sentry_sdk/_compat.py", line 127, in reraise
    raise value
  File "/var/app/venv/staging-LQM1lest/lib64/python3.13/site-packages/sentry_sdk/integrations/celery.py", line 320, in _inner
    return f(*args, **kwargs)
  File "/var/app/venv/staging-LQM1lest/lib64/python3.13/site-packages/celery/app/trace.py", line 736, in __protected_call__
    return self.run(*args, **kwargs)
           ~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/var/app/current/purchase/tasks.py", line 24, in update_purchases
    purchase.boost_time = purchase.get_boost_time()
                          ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/var/app/current/purchase/related_models/purchase_model.py", line 99, in get_boost_time
    if self.item.purchases:
       ^^^^^^^^^
  File "/var/app/venv/staging-LQM1lest/lib64/python3.13/site-packages/django/contrib/contenttypes/fields.py", line 262, in __get__
    rel_obj = ct.get_object_for_this_type(
        using=instance._state.db, pk=pk_val
    )
  File "/var/app/venv/staging-LQM1lest/lib64/python3.13/site-packages/django/contrib/contenttypes/models.py", line 179, in get_object_for_this_type
    return self.model_class()._base_manager.using(using).get(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute '_base_manager'
```