### PR TITLE
feat: Add OpenAlex ingest client

### DIFF
--- a/src/paper/ingestion/clients/openalex.py
+++ b/src/paper/ingestion/clients/openalex.py
@@ -1,0 +1,286 @@
+"""
+OpenAlex API client for fetching academic papers.
+
+Handles communication with OpenAlex API endpoints.
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Union
+
+import requests
+
+from ..exceptions import FetchError, TimeoutError
+from .base import BaseClient, ClientConfig
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAlexConfig(ClientConfig):
+    """OpenAlex-specific configuration."""
+
+    def __init__(self, **kwargs):
+        # Extract OpenAlex-specific config
+        self.max_results_per_query = kwargs.pop("max_results_per_query", 200)
+        self.email = kwargs.pop("email", None)  # Polite pool access
+
+        defaults = {
+            "source_name": "openalex",
+            "base_url": "https://api.openalex.org",
+            "rate_limit": 10.0,  # OpenAlex allows 10 requests per second (100k per day)
+            "page_size": 200,  # OpenAlex max per_page is 200
+            "request_timeout": 30.0,
+        }
+        defaults.update(kwargs)
+        super().__init__(**defaults)
+
+
+class OpenAlexClient(BaseClient):
+    """Client for fetching papers from OpenAlex API."""
+
+    def __init__(self, config: Optional[OpenAlexConfig] = None):
+        """Initialize OpenAlex client."""
+        if config is None:
+            config = OpenAlexConfig()
+        super().__init__(config)
+        self.session = requests.Session()
+
+        self.headers = {"Accept": "application/json"}
+        if config.email:
+            # See: https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication#the-polite-pool
+            self.headers["User-Agent"] = f"mailto:{config.email}"
+
+    def fetch(
+        self, endpoint: str, params: Optional[Dict[str, Any]] = None, **kwargs
+    ) -> Union[str, bytes, Dict[str, Any]]:
+        """
+        Fetch data from OpenAlex API.
+
+        Args:
+            endpoint: API endpoint (e.g., "/works")
+            params: Query parameters
+            **kwargs: Additional arguments
+
+        Returns:
+            JSON response as dict
+
+        Raises:
+            FetchError: If request fails
+            TimeoutError: If request times out
+        """
+        url = f"{self.config.base_url}{endpoint}"
+
+        try:
+            response = self.session.get(
+                url,
+                params=params,
+                timeout=self.config.request_timeout,
+                headers=self.headers,
+            )
+            response.raise_for_status()
+
+            # OpenAlex returns JSON
+            return response.json()
+
+        except requests.Timeout:
+            raise TimeoutError(
+                f"Request timed out after {self.config.request_timeout}s"
+            )
+        except requests.RequestException as e:
+            raise FetchError(f"Failed to fetch from {url}: {str(e)}")
+
+    def parse(
+        self, raw_data: Union[str, bytes, Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """
+        Parse OpenAlex JSON response and return raw entry data.
+
+        This minimal parsing just extracts the results list,
+        leaving detailed mapping to a separate mapper component.
+
+        Args:
+            raw_data: JSON response from API
+
+        Returns:
+            List of raw paper records
+        """
+        if not isinstance(raw_data, dict):
+            logger.error("Expected dict response from OpenAlex API")
+            return []
+
+        results = raw_data.get("results", [])
+
+        papers = []
+        for result in results:
+            papers.append({"raw_data": result, "source": "openalex"})
+
+        return papers
+
+    def fetch_recent(
+        self,
+        since: Optional[datetime] = None,
+        until: Optional[datetime] = None,
+        max_results: Optional[int] = None,
+        filters: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> List[Dict[str, Any]]:
+        """
+        Fetch recent papers from OpenAlex within date range.
+
+        Args:
+            since: Start date (defaults to 7 days ago)
+            until: End date (defaults to today)
+            max_results: Maximum number of results to return
+            filters: Additional OpenAlex filters
+            **kwargs: Additional parameters
+
+        Returns:
+            List of raw paper records
+        """
+        # Default date range: last 7 days
+        if until is None:
+            until = datetime.now()
+        if since is None:
+            since = until - timedelta(days=7)
+
+        # Format dates for OpenAlex (YYYY-MM-DD format)
+        since_str = since.strftime("%Y-%m-%d")
+        until_str = until.strftime("%Y-%m-%d")
+
+        filter_parts = []
+
+        # Add date range filter using publication_date
+        filter_parts.append(f"from_publication_date:{since_str}")
+        filter_parts.append(f"to_publication_date:{until_str}")
+
+        # Add any additional filters
+        if filters:
+            for key, value in filters.items():
+                filter_parts.append(f"{key}:{value}")
+
+        filter_str = ",".join(filter_parts)
+
+        all_papers = []
+        cursor = "*"  # cursor-based pagination
+        page_size = min(self.config.page_size, self.config.max_results_per_query)
+
+        # Determine total results to fetch
+        if max_results:
+            total_to_fetch = max_results
+        else:
+            total_to_fetch = float("inf")
+
+        while len(all_papers) < total_to_fetch:
+            # Calculate how many to fetch in this request
+            remaining = total_to_fetch - len(all_papers)
+            current_page_size = min(page_size, remaining)
+
+            params = {
+                "filter": filter_str,
+                "per-page": current_page_size,
+                "cursor": cursor,
+                "sort": "publication_date:desc",
+            }
+
+            logger.info(
+                f"Fetching papers from OpenAlex "
+                f"(cursor={cursor}, per_page={current_page_size})"
+            )
+
+            try:
+                response = self.fetch_with_retry("/works", params)
+                papers = self.process_page(response)
+
+                if not papers:
+                    break  # no more results
+
+                all_papers.extend(papers)
+
+                # Check for next page cursor
+                meta = response.get("meta", {})
+                next_cursor = meta.get("next_cursor")
+
+                if not next_cursor or len(papers) < current_page_size:
+                    break  # no more pages
+
+                cursor = next_cursor
+
+            except Exception as e:
+                logger.error(f"Failed to fetch page with cursor={cursor}: {e}")
+                break  # continue with the next page
+
+        logger.info(
+            f"Fetched {len(all_papers)} papers from OpenAlex "
+            f"between {since_str} and {until_str}"
+        )
+        return all_papers
+
+    def fetch_by_doi(self, doi: str) -> Optional[Dict[str, Any]]:
+        """
+        Fetch a specific paper by DOI.
+
+        Args:
+            doi: The DOI to fetch
+
+        Returns:
+            Raw paper record or None if not found
+        """
+        # Clean DOI - remove any URL prefix to get just the DOI
+        doi = doi.replace("https://doi.org/", "").replace("http://doi.org/", "")
+
+        # OpenAlex uses https://doi.org/ format in URLs
+        encoded_doi = f"https://doi.org/{doi}"
+
+        try:
+            response = self.fetch_with_retry(f"/works/{encoded_doi}")
+            if response:
+                return {"raw_data": response, "source": "openalex"}
+        except FetchError as e:
+            logger.warning(f"Paper with DOI {doi} not found: {e}")
+
+        return None
+
+    def fetch_by_ids(
+        self, ids: List[str], id_type: str = "doi"
+    ) -> List[Dict[str, Any]]:
+        """
+        Fetch papers by a list of IDs.
+
+        Args:
+            ids: List of IDs to fetch
+            id_type: Type of ID (doi, openalex, pmid, etc.)
+
+        Returns:
+            List of raw paper records
+        """
+        if not ids:
+            return []
+
+        # Build filter based on ID type
+        if id_type == "doi":
+            # Clean and format DOIs for OpenAlex
+            cleaned_ids = [
+                id.replace("https://doi.org/", "").replace("http://doi.org/", "")
+                for id in ids
+            ]
+            formatted_ids = [f"https://doi.org/{id}" for id in cleaned_ids]
+            filter_str = f"doi:{'|'.join(formatted_ids)}"
+        elif id_type == "openalex":
+            filter_str = f"openalex:{'|'.join(ids)}"
+        elif id_type == "pmid":
+            filter_str = f"pmid:{'|'.join(ids)}"
+        else:
+            logger.error(f"Unsupported ID type: {id_type}")
+            return []
+
+        params = {
+            "filter": filter_str,
+            "per-page": min(len(ids), self.config.page_size),
+        }
+
+        try:
+            response = self.fetch_with_retry("/works", params)
+            return self.process_page(response)
+        except Exception as e:
+            logger.error(f"Failed to fetch papers by IDs: {e}")
+            return []

--- a/src/paper/ingestion/clients/openalex.py
+++ b/src/paper/ingestion/clients/openalex.py
@@ -44,6 +44,7 @@ class OpenAlexClient(BaseClient):
             config = OpenAlexConfig()
         super().__init__(config)
         self.session = requests.Session()
+        self.api_key = config.api_key
 
         self.headers = {"Accept": "application/json"}
         if config.email:
@@ -69,6 +70,12 @@ class OpenAlexClient(BaseClient):
             TimeoutError: If request times out
         """
         url = f"{self.config.base_url}{endpoint}"
+
+        if params is None:
+            params = {}
+        # Add API key, if available
+        if self.api_key:
+            params["api_key"] = self.api_key
 
         try:
             response = self.session.get(

--- a/src/paper/ingestion/tests/clients/fixtures/openalex_empty_response.json
+++ b/src/paper/ingestion/tests/clients/fixtures/openalex_empty_response.json
@@ -1,0 +1,12 @@
+{
+    "meta": {
+        "count": 0,
+        "db_response_time_ms": 27,
+        "page": null,
+        "per_page": 3,
+        "next_cursor": null,
+        "groups_count": null
+    },
+    "results": [],
+    "group_by": []
+}

--- a/src/paper/ingestion/tests/clients/fixtures/openalex_sample_get_by_doi_response.json
+++ b/src/paper/ingestion/tests/clients/fixtures/openalex_sample_get_by_doi_response.json
@@ -1,0 +1,1681 @@
+{
+    "id": "https://openalex.org/W2741809807",
+    "doi": "https://doi.org/10.7717/peerj.4375",
+    "title": "The state of OA: a large-scale analysis of the prevalence and impact of Open Access articles",
+    "display_name": "The state of OA: a large-scale analysis of the prevalence and impact of Open Access articles",
+    "publication_year": 2018,
+    "publication_date": "2018-02-13",
+    "ids": {
+        "openalex": "https://openalex.org/W2741809807",
+        "doi": "https://doi.org/10.7717/peerj.4375",
+        "mag": "2741809807",
+        "pmid": "https://pubmed.ncbi.nlm.nih.gov/29456894",
+        "pmcid": "https://www.ncbi.nlm.nih.gov/pmc/articles/5815332"
+    },
+    "language": "en",
+    "primary_location": {
+        "is_oa": true,
+        "landing_page_url": "https://doi.org/10.7717/peerj.4375",
+        "pdf_url": "https://peerj.com/articles/4375.pdf",
+        "source": {
+            "id": "https://openalex.org/S1983995261",
+            "display_name": "PeerJ",
+            "issn_l": "2167-8359",
+            "issn": [
+                "2167-8359"
+            ],
+            "is_oa": true,
+            "is_in_doaj": true,
+            "is_indexed_in_scopus": true,
+            "is_core": true,
+            "host_organization": "https://openalex.org/P4310320104",
+            "host_organization_name": "PeerJ, Inc.",
+            "host_organization_lineage": [
+                "https://openalex.org/P4310320104"
+            ],
+            "host_organization_lineage_names": [
+                "PeerJ, Inc."
+            ],
+            "type": "journal"
+        },
+        "license": "cc-by",
+        "license_id": "https://openalex.org/licenses/cc-by",
+        "version": "publishedVersion",
+        "is_accepted": true,
+        "is_published": true
+    },
+    "type": "article",
+    "type_crossref": "journal-article",
+    "indexed_in": [
+        "crossref",
+        "doaj",
+        "pubmed"
+    ],
+    "open_access": {
+        "is_oa": true,
+        "oa_status": "gold",
+        "oa_url": "https://peerj.com/articles/4375.pdf",
+        "any_repository_has_fulltext": true
+    },
+    "authorships": [
+        {
+            "author_position": "first",
+            "author": {
+                "id": "https://openalex.org/A5048491430",
+                "display_name": "Heather Piwowar",
+                "orcid": "https://orcid.org/0000-0003-1613-5981"
+            },
+            "institutions": [
+                {
+                    "id": "https://openalex.org/I4210166736",
+                    "display_name": "Impact Technology Development (United States)",
+                    "ror": "https://ror.org/05ppvf150",
+                    "country_code": "US",
+                    "type": "company",
+                    "lineage": [
+                        "https://openalex.org/I4210166736"
+                    ]
+                }
+            ],
+            "countries": [
+                "US"
+            ],
+            "is_corresponding": false,
+            "raw_author_name": "Heather Piwowar",
+            "raw_affiliation_strings": [
+                "Impactstory, Sanford, NC, USA"
+            ],
+            "affiliations": [
+                {
+                    "raw_affiliation_string": "Impactstory, Sanford, NC, USA",
+                    "institution_ids": [
+                        "https://openalex.org/I4210166736"
+                    ]
+                }
+            ]
+        },
+        {
+            "author_position": "middle",
+            "author": {
+                "id": "https://openalex.org/A5023888391",
+                "display_name": "Jason Priem",
+                "orcid": "https://orcid.org/0000-0001-6187-6610"
+            },
+            "institutions": [
+                {
+                    "id": "https://openalex.org/I4210166736",
+                    "display_name": "Impact Technology Development (United States)",
+                    "ror": "https://ror.org/05ppvf150",
+                    "country_code": "US",
+                    "type": "company",
+                    "lineage": [
+                        "https://openalex.org/I4210166736"
+                    ]
+                }
+            ],
+            "countries": [
+                "US"
+            ],
+            "is_corresponding": false,
+            "raw_author_name": "Jason Priem",
+            "raw_affiliation_strings": [
+                "Impactstory, Sanford, NC, USA"
+            ],
+            "affiliations": [
+                {
+                    "raw_affiliation_string": "Impactstory, Sanford, NC, USA",
+                    "institution_ids": [
+                        "https://openalex.org/I4210166736"
+                    ]
+                }
+            ]
+        },
+        {
+            "author_position": "middle",
+            "author": {
+                "id": "https://openalex.org/A5068542997",
+                "display_name": "Vincent Larivière",
+                "orcid": "https://orcid.org/0000-0002-2733-0689"
+            },
+            "institutions": [
+                {
+                    "id": "https://openalex.org/I70931966",
+                    "display_name": "Université de Montréal",
+                    "ror": "https://ror.org/0161xgx34",
+                    "country_code": "CA",
+                    "type": "funder",
+                    "lineage": [
+                        "https://openalex.org/I70931966"
+                    ]
+                },
+                {
+                    "id": "https://openalex.org/I159129438",
+                    "display_name": "Université du Québec à Montréal",
+                    "ror": "https://ror.org/002rjbv21",
+                    "country_code": "CA",
+                    "type": "funder",
+                    "lineage": [
+                        "https://openalex.org/I159129438",
+                        "https://openalex.org/I49663120"
+                    ]
+                }
+            ],
+            "countries": [
+                "CA"
+            ],
+            "is_corresponding": false,
+            "raw_author_name": "Vincent Larivière",
+            "raw_affiliation_strings": [
+                "Observatoire des Sciences et des Technologies (OST), Centre Interuniversitaire de Recherche sur la Science et la Technologie (CIRST), Université du Québec à Montréal, Montréal, QC, Canada",
+                "École de bibliothéconomie et des sciences de l’information, Université de Montréal, Montréal, QC, Canada"
+            ],
+            "affiliations": [
+                {
+                    "raw_affiliation_string": "École de bibliothéconomie et des sciences de l’information, Université de Montréal, Montréal, QC, Canada",
+                    "institution_ids": [
+                        "https://openalex.org/I70931966"
+                    ]
+                },
+                {
+                    "raw_affiliation_string": "Observatoire des Sciences et des Technologies (OST), Centre Interuniversitaire de Recherche sur la Science et la Technologie (CIRST), Université du Québec à Montréal, Montréal, QC, Canada",
+                    "institution_ids": [
+                        "https://openalex.org/I159129438"
+                    ]
+                }
+            ]
+        },
+        {
+            "author_position": "middle",
+            "author": {
+                "id": "https://openalex.org/A5085171399",
+                "display_name": "Juan Pablo Alperín",
+                "orcid": "https://orcid.org/0000-0002-9344-7439"
+            },
+            "institutions": [
+                {
+                    "id": "https://openalex.org/I18014758",
+                    "display_name": "Simon Fraser University",
+                    "ror": "https://ror.org/0213rcc28",
+                    "country_code": "CA",
+                    "type": "funder",
+                    "lineage": [
+                        "https://openalex.org/I18014758"
+                    ]
+                },
+                {
+                    "id": "https://openalex.org/I4387153203",
+                    "display_name": "Public Knowledge Project",
+                    "ror": "https://ror.org/05ek4tb53",
+                    "country_code": null,
+                    "type": "other",
+                    "lineage": [
+                        "https://openalex.org/I18014758",
+                        "https://openalex.org/I4387153203"
+                    ]
+                }
+            ],
+            "countries": [
+                "CA"
+            ],
+            "is_corresponding": false,
+            "raw_author_name": "Juan Pablo Alperin",
+            "raw_affiliation_strings": [
+                "Canadian Institute for Studies in Publishing, Simon Fraser University, Vancouver, BC, Canada",
+                "Public Knowledge Project, Canada"
+            ],
+            "affiliations": [
+                {
+                    "raw_affiliation_string": "Canadian Institute for Studies in Publishing, Simon Fraser University, Vancouver, BC, Canada",
+                    "institution_ids": [
+                        "https://openalex.org/I18014758"
+                    ]
+                },
+                {
+                    "raw_affiliation_string": "Public Knowledge Project, Canada",
+                    "institution_ids": [
+                        "https://openalex.org/I4387153203"
+                    ]
+                }
+            ]
+        },
+        {
+            "author_position": "middle",
+            "author": {
+                "id": "https://openalex.org/A5066880338",
+                "display_name": "Lisa Matthias",
+                "orcid": "https://orcid.org/0000-0002-2612-2132"
+            },
+            "institutions": [
+                {
+                    "id": "https://openalex.org/I18014758",
+                    "display_name": "Simon Fraser University",
+                    "ror": "https://ror.org/0213rcc28",
+                    "country_code": "CA",
+                    "type": "funder",
+                    "lineage": [
+                        "https://openalex.org/I18014758"
+                    ]
+                }
+            ],
+            "countries": [
+                "CA"
+            ],
+            "is_corresponding": false,
+            "raw_author_name": "Lisa Matthias",
+            "raw_affiliation_strings": [
+                "Scholarly Communications Lab, Simon Fraser University, Vancouver, Canada"
+            ],
+            "affiliations": [
+                {
+                    "raw_affiliation_string": "Scholarly Communications Lab, Simon Fraser University, Vancouver, Canada",
+                    "institution_ids": [
+                        "https://openalex.org/I18014758"
+                    ]
+                }
+            ]
+        },
+        {
+            "author_position": "middle",
+            "author": {
+                "id": "https://openalex.org/A5015414792",
+                "display_name": "Bree Norlander",
+                "orcid": "https://orcid.org/0000-0002-0431-4221"
+            },
+            "institutions": [
+                {
+                    "id": "https://openalex.org/I201448701",
+                    "display_name": "University of Washington",
+                    "ror": "https://ror.org/00cvxb145",
+                    "country_code": "US",
+                    "type": "funder",
+                    "lineage": [
+                        "https://openalex.org/I201448701"
+                    ]
+                },
+                {
+                    "id": "https://openalex.org/I58610484",
+                    "display_name": "Seattle University",
+                    "ror": "https://ror.org/02jqc0m91",
+                    "country_code": "US",
+                    "type": "education",
+                    "lineage": [
+                        "https://openalex.org/I58610484"
+                    ]
+                }
+            ],
+            "countries": [
+                "US"
+            ],
+            "is_corresponding": false,
+            "raw_author_name": "Bree Norlander",
+            "raw_affiliation_strings": [
+                "FlourishOA, USA",
+                "Information School, University of Washington, Seattle, USA"
+            ],
+            "affiliations": [
+                {
+                    "raw_affiliation_string": "Information School, University of Washington, Seattle, USA",
+                    "institution_ids": [
+                        "https://openalex.org/I201448701",
+                        "https://openalex.org/I58610484"
+                    ]
+                },
+                {
+                    "raw_affiliation_string": "FlourishOA, USA",
+                    "institution_ids": []
+                }
+            ]
+        },
+        {
+            "author_position": "middle",
+            "author": {
+                "id": "https://openalex.org/A5062989025",
+                "display_name": "Ashley Farley",
+                "orcid": "https://orcid.org/0000-0001-9310-6944"
+            },
+            "institutions": [
+                {
+                    "id": "https://openalex.org/I201448701",
+                    "display_name": "University of Washington",
+                    "ror": "https://ror.org/00cvxb145",
+                    "country_code": "US",
+                    "type": "funder",
+                    "lineage": [
+                        "https://openalex.org/I201448701"
+                    ]
+                },
+                {
+                    "id": "https://openalex.org/I58610484",
+                    "display_name": "Seattle University",
+                    "ror": "https://ror.org/02jqc0m91",
+                    "country_code": "US",
+                    "type": "education",
+                    "lineage": [
+                        "https://openalex.org/I58610484"
+                    ]
+                }
+            ],
+            "countries": [
+                "US"
+            ],
+            "is_corresponding": false,
+            "raw_author_name": "Ashley Farley",
+            "raw_affiliation_strings": [
+                "FlourishOA, USA",
+                "Information School, University of Washington, Seattle, USA"
+            ],
+            "affiliations": [
+                {
+                    "raw_affiliation_string": "Information School, University of Washington, Seattle, USA",
+                    "institution_ids": [
+                        "https://openalex.org/I201448701",
+                        "https://openalex.org/I58610484"
+                    ]
+                },
+                {
+                    "raw_affiliation_string": "FlourishOA, USA",
+                    "institution_ids": []
+                }
+            ]
+        },
+        {
+            "author_position": "middle",
+            "author": {
+                "id": "https://openalex.org/A5046879461",
+                "display_name": "Jevin D. West",
+                "orcid": "https://orcid.org/0000-0002-4118-0322"
+            },
+            "institutions": [
+                {
+                    "id": "https://openalex.org/I201448701",
+                    "display_name": "University of Washington",
+                    "ror": "https://ror.org/00cvxb145",
+                    "country_code": "US",
+                    "type": "funder",
+                    "lineage": [
+                        "https://openalex.org/I201448701"
+                    ]
+                },
+                {
+                    "id": "https://openalex.org/I58610484",
+                    "display_name": "Seattle University",
+                    "ror": "https://ror.org/02jqc0m91",
+                    "country_code": "US",
+                    "type": "education",
+                    "lineage": [
+                        "https://openalex.org/I58610484"
+                    ]
+                }
+            ],
+            "countries": [
+                "US"
+            ],
+            "is_corresponding": false,
+            "raw_author_name": "Jevin West",
+            "raw_affiliation_strings": [
+                "Information School, University of Washington, Seattle, USA"
+            ],
+            "affiliations": [
+                {
+                    "raw_affiliation_string": "Information School, University of Washington, Seattle, USA",
+                    "institution_ids": [
+                        "https://openalex.org/I201448701",
+                        "https://openalex.org/I58610484"
+                    ]
+                }
+            ]
+        },
+        {
+            "author_position": "last",
+            "author": {
+                "id": "https://openalex.org/A5014077037",
+                "display_name": "Stefanie Haustein",
+                "orcid": "https://orcid.org/0000-0003-0157-1430"
+            },
+            "institutions": [
+                {
+                    "id": "https://openalex.org/I159129438",
+                    "display_name": "Université du Québec à Montréal",
+                    "ror": "https://ror.org/002rjbv21",
+                    "country_code": "CA",
+                    "type": "funder",
+                    "lineage": [
+                        "https://openalex.org/I159129438",
+                        "https://openalex.org/I49663120"
+                    ]
+                },
+                {
+                    "id": "https://openalex.org/I153718931",
+                    "display_name": "University of Ottawa",
+                    "ror": "https://ror.org/03c4mmv16",
+                    "country_code": "CA",
+                    "type": "funder",
+                    "lineage": [
+                        "https://openalex.org/I153718931"
+                    ]
+                }
+            ],
+            "countries": [
+                "CA"
+            ],
+            "is_corresponding": false,
+            "raw_author_name": "Stefanie Haustein",
+            "raw_affiliation_strings": [
+                "Observatoire des Sciences et des Technologies (OST), Centre Interuniversitaire de Recherche sur la Science et la Technologie (CIRST), Université du Québec à Montréal, Montréal, QC, Canada",
+                "School of Information Studies, University of Ottawa, Ottawa, ON, Canada"
+            ],
+            "affiliations": [
+                {
+                    "raw_affiliation_string": "Observatoire des Sciences et des Technologies (OST), Centre Interuniversitaire de Recherche sur la Science et la Technologie (CIRST), Université du Québec à Montréal, Montréal, QC, Canada",
+                    "institution_ids": [
+                        "https://openalex.org/I159129438"
+                    ]
+                },
+                {
+                    "raw_affiliation_string": "School of Information Studies, University of Ottawa, Ottawa, ON, Canada",
+                    "institution_ids": [
+                        "https://openalex.org/I153718931"
+                    ]
+                }
+            ]
+        }
+    ],
+    "institution_assertions": [],
+    "countries_distinct_count": 2,
+    "institutions_distinct_count": 8,
+    "corresponding_author_ids": [],
+    "corresponding_institution_ids": [],
+    "apc_list": {
+        "value": 1395,
+        "currency": "USD",
+        "value_usd": 1395
+    },
+    "apc_paid": {
+        "value": 1395,
+        "currency": "USD",
+        "value_usd": 1395
+    },
+    "fwci": 76.52,
+    "has_fulltext": true,
+    "fulltext_origin": "pdf",
+    "cited_by_count": 1004,
+    "citation_normalized_percentile": {
+        "value": 0.999764,
+        "is_in_top_1_percent": true,
+        "is_in_top_10_percent": true
+    },
+    "cited_by_percentile_year": {
+        "min": 99,
+        "max": 100
+    },
+    "biblio": {
+        "volume": "6",
+        "issue": null,
+        "first_page": "e4375",
+        "last_page": "e4375"
+    },
+    "is_retracted": false,
+    "is_paratext": false,
+    "primary_topic": {
+        "id": "https://openalex.org/T10102",
+        "display_name": "scientometrics and bibliometrics research",
+        "score": 0.9969,
+        "subfield": {
+            "id": "https://openalex.org/subfields/1804",
+            "display_name": "Statistics, Probability and Uncertainty"
+        },
+        "field": {
+            "id": "https://openalex.org/fields/18",
+            "display_name": "Decision Sciences"
+        },
+        "domain": {
+            "id": "https://openalex.org/domains/2",
+            "display_name": "Social Sciences"
+        }
+    },
+    "topics": [
+        {
+            "id": "https://openalex.org/T10102",
+            "display_name": "scientometrics and bibliometrics research",
+            "score": 0.9969,
+            "subfield": {
+                "id": "https://openalex.org/subfields/1804",
+                "display_name": "Statistics, Probability and Uncertainty"
+            },
+            "field": {
+                "id": "https://openalex.org/fields/18",
+                "display_name": "Decision Sciences"
+            },
+            "domain": {
+                "id": "https://openalex.org/domains/2",
+                "display_name": "Social Sciences"
+            }
+        },
+        {
+            "id": "https://openalex.org/T13607",
+            "display_name": "Academic Publishing and Open Access",
+            "score": 0.9807,
+            "subfield": {
+                "id": "https://openalex.org/subfields/1802",
+                "display_name": "Information Systems and Management"
+            },
+            "field": {
+                "id": "https://openalex.org/fields/18",
+                "display_name": "Decision Sciences"
+            },
+            "domain": {
+                "id": "https://openalex.org/domains/2",
+                "display_name": "Social Sciences"
+            }
+        },
+        {
+            "id": "https://openalex.org/T11937",
+            "display_name": "Research Data Management Practices",
+            "score": 0.9185,
+            "subfield": {
+                "id": "https://openalex.org/subfields/1710",
+                "display_name": "Information Systems"
+            },
+            "field": {
+                "id": "https://openalex.org/fields/17",
+                "display_name": "Computer Science"
+            },
+            "domain": {
+                "id": "https://openalex.org/domains/3",
+                "display_name": "Physical Sciences"
+            }
+        }
+    ],
+    "keywords": [
+        {
+            "id": "https://openalex.org/keywords/scholarly-communication",
+            "display_name": "Scholarly Communication",
+            "score": 0.5683152
+        },
+        {
+            "id": "https://openalex.org/keywords/web-of-science",
+            "display_name": "Web of science",
+            "score": 0.5055373
+        },
+        {
+            "id": "https://openalex.org/keywords/open-science",
+            "display_name": "Open Science",
+            "score": 0.48734793
+        },
+        {
+            "id": "https://openalex.org/keywords/citation-analysis",
+            "display_name": "Citation analysis",
+            "score": 0.43920913
+        }
+    ],
+    "concepts": [
+        {
+            "id": "https://openalex.org/C2778805511",
+            "wikidata": "https://www.wikidata.org/wiki/Q1713",
+            "display_name": "Citation",
+            "level": 2,
+            "score": 0.68818974
+        },
+        {
+            "id": "https://openalex.org/C2780560020",
+            "wikidata": "https://www.wikidata.org/wiki/Q79719",
+            "display_name": "License",
+            "level": 2,
+            "score": 0.5919564
+        },
+        {
+            "id": "https://openalex.org/C2777462167",
+            "wikidata": "https://www.wikidata.org/wiki/Q7432048",
+            "display_name": "Scholarly communication",
+            "level": 3,
+            "score": 0.5683152
+        },
+        {
+            "id": "https://openalex.org/C3020774429",
+            "wikidata": "https://www.wikidata.org/wiki/Q1201886",
+            "display_name": "Web of science",
+            "level": 3,
+            "score": 0.5055373
+        },
+        {
+            "id": "https://openalex.org/C178315738",
+            "wikidata": "https://www.wikidata.org/wiki/Q603441",
+            "display_name": "Bibliometrics",
+            "level": 2,
+            "score": 0.4962271
+        },
+        {
+            "id": "https://openalex.org/C2778149293",
+            "wikidata": "https://www.wikidata.org/wiki/Q309823",
+            "display_name": "Open science",
+            "level": 2,
+            "score": 0.48734793
+        },
+        {
+            "id": "https://openalex.org/C41008148",
+            "wikidata": "https://www.wikidata.org/wiki/Q21198",
+            "display_name": "Computer science",
+            "level": 0,
+            "score": 0.45299834
+        },
+        {
+            "id": "https://openalex.org/C136764020",
+            "wikidata": "https://www.wikidata.org/wiki/Q466",
+            "display_name": "World Wide Web",
+            "level": 1,
+            "score": 0.45292723
+        },
+        {
+            "id": "https://openalex.org/C105345328",
+            "wikidata": "https://www.wikidata.org/wiki/Q206276",
+            "display_name": "Citation analysis",
+            "level": 3,
+            "score": 0.43920913
+        },
+        {
+            "id": "https://openalex.org/C71924100",
+            "wikidata": "https://www.wikidata.org/wiki/Q11190",
+            "display_name": "Medicine",
+            "level": 0,
+            "score": 0.38992488
+        },
+        {
+            "id": "https://openalex.org/C161191863",
+            "wikidata": "https://www.wikidata.org/wiki/Q199655",
+            "display_name": "Library science",
+            "level": 1,
+            "score": 0.37244928
+        },
+        {
+            "id": "https://openalex.org/C17744445",
+            "wikidata": "https://www.wikidata.org/wiki/Q36442",
+            "display_name": "Political science",
+            "level": 0,
+            "score": 0.24154112
+        },
+        {
+            "id": "https://openalex.org/C95190672",
+            "wikidata": "https://www.wikidata.org/wiki/Q815382",
+            "display_name": "Meta-analysis",
+            "level": 2,
+            "score": 0.15993848
+        },
+        {
+            "id": "https://openalex.org/C126322002",
+            "wikidata": "https://www.wikidata.org/wiki/Q11180",
+            "display_name": "Internal medicine",
+            "level": 1,
+            "score": 0.1485905
+        },
+        {
+            "id": "https://openalex.org/C105795698",
+            "wikidata": "https://www.wikidata.org/wiki/Q12483",
+            "display_name": "Statistics",
+            "level": 1,
+            "score": 0.13449502
+        },
+        {
+            "id": "https://openalex.org/C33923547",
+            "wikidata": "https://www.wikidata.org/wiki/Q395",
+            "display_name": "Mathematics",
+            "level": 0,
+            "score": 0.11654329
+        },
+        {
+            "id": "https://openalex.org/C151719136",
+            "wikidata": "https://www.wikidata.org/wiki/Q3972943",
+            "display_name": "Publishing",
+            "level": 2,
+            "score": 0
+        },
+        {
+            "id": "https://openalex.org/C199539241",
+            "wikidata": "https://www.wikidata.org/wiki/Q7748",
+            "display_name": "Law",
+            "level": 1,
+            "score": 0
+        },
+        {
+            "id": "https://openalex.org/C111919701",
+            "wikidata": "https://www.wikidata.org/wiki/Q9135",
+            "display_name": "Operating system",
+            "level": 1,
+            "score": 0
+        }
+    ],
+    "mesh": [],
+    "locations_count": 7,
+    "locations": [
+        {
+            "is_oa": true,
+            "landing_page_url": "https://doi.org/10.7717/peerj.4375",
+            "pdf_url": "https://peerj.com/articles/4375.pdf",
+            "source": {
+                "id": "https://openalex.org/S1983995261",
+                "display_name": "PeerJ",
+                "issn_l": "2167-8359",
+                "issn": [
+                    "2167-8359"
+                ],
+                "is_oa": true,
+                "is_in_doaj": true,
+                "is_indexed_in_scopus": true,
+                "is_core": true,
+                "host_organization": "https://openalex.org/P4310320104",
+                "host_organization_name": "PeerJ, Inc.",
+                "host_organization_lineage": [
+                    "https://openalex.org/P4310320104"
+                ],
+                "host_organization_lineage_names": [
+                    "PeerJ, Inc."
+                ],
+                "type": "journal"
+            },
+            "license": "cc-by",
+            "license_id": "https://openalex.org/licenses/cc-by",
+            "version": "publishedVersion",
+            "is_accepted": true,
+            "is_published": true
+        },
+        {
+            "is_oa": false,
+            "landing_page_url": "https://doaj.org/article/13b0006802e745a6973c19b2ecb9b97a",
+            "pdf_url": null,
+            "source": {
+                "id": "https://openalex.org/S4306401280",
+                "display_name": "DOAJ (DOAJ: Directory of Open Access Journals)",
+                "issn_l": null,
+                "issn": null,
+                "is_oa": true,
+                "is_in_doaj": false,
+                "is_indexed_in_scopus": false,
+                "is_core": false,
+                "host_organization": null,
+                "host_organization_name": null,
+                "host_organization_lineage": [],
+                "host_organization_lineage_names": [],
+                "type": "repository"
+            },
+            "license": null,
+            "license_id": null,
+            "version": null,
+            "is_accepted": false,
+            "is_published": false
+        },
+        {
+            "is_oa": true,
+            "landing_page_url": "https://europepmc.org/articles/pmc5815332",
+            "pdf_url": "https://europepmc.org/articles/pmc5815332?pdf=render",
+            "source": {
+                "id": "https://openalex.org/S4306400806",
+                "display_name": "Europe PMC (PubMed Central)",
+                "issn_l": null,
+                "issn": null,
+                "is_oa": true,
+                "is_in_doaj": false,
+                "is_indexed_in_scopus": false,
+                "is_core": false,
+                "host_organization": "https://openalex.org/I1303153112",
+                "host_organization_name": "European Bioinformatics Institute",
+                "host_organization_lineage": [
+                    "https://openalex.org/I1303153112"
+                ],
+                "host_organization_lineage_names": [
+                    "European Bioinformatics Institute"
+                ],
+                "type": "repository"
+            },
+            "license": "cc-by",
+            "license_id": "https://openalex.org/licenses/cc-by",
+            "version": "publishedVersion",
+            "is_accepted": true,
+            "is_published": true
+        },
+        {
+            "is_oa": true,
+            "landing_page_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5815332",
+            "pdf_url": null,
+            "source": {
+                "id": "https://openalex.org/S2764455111",
+                "display_name": "PubMed Central",
+                "issn_l": null,
+                "issn": null,
+                "is_oa": true,
+                "is_in_doaj": false,
+                "is_indexed_in_scopus": false,
+                "is_core": false,
+                "host_organization": "https://openalex.org/I1299303238",
+                "host_organization_name": "National Institutes of Health",
+                "host_organization_lineage": [
+                    "https://openalex.org/I1299303238"
+                ],
+                "host_organization_lineage_names": [
+                    "National Institutes of Health"
+                ],
+                "type": "repository"
+            },
+            "license": null,
+            "license_id": null,
+            "version": "publishedVersion",
+            "is_accepted": true,
+            "is_published": true
+        },
+        {
+            "is_oa": true,
+            "landing_page_url": "https://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1143&context=scholcom",
+            "pdf_url": "https://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1143&context=scholcom",
+            "source": {
+                "id": "https://openalex.org/S4377196105",
+                "display_name": "Digital Commons - University of Nebraska Lincoln (University of Nebraska–Lincoln)",
+                "issn_l": null,
+                "issn": null,
+                "is_oa": false,
+                "is_in_doaj": false,
+                "is_indexed_in_scopus": false,
+                "is_core": false,
+                "host_organization": "https://openalex.org/I114395901",
+                "host_organization_name": "University of Nebraska–Lincoln",
+                "host_organization_lineage": [
+                    "https://openalex.org/I114395901"
+                ],
+                "host_organization_lineage_names": [
+                    "University of Nebraska–Lincoln"
+                ],
+                "type": "repository"
+            },
+            "license": "cc-by",
+            "license_id": "https://openalex.org/licenses/cc-by",
+            "version": "submittedVersion",
+            "is_accepted": false,
+            "is_published": false
+        },
+        {
+            "is_oa": true,
+            "landing_page_url": "http://hdl.handle.net/1866/23242",
+            "pdf_url": "https://papyrus.bib.umontreal.ca/xmlui/bitstream/1866/23242/1/peerj-06-4375.pdf",
+            "source": {
+                "id": "https://openalex.org/S4306402422",
+                "display_name": "Papyrus : Institutional Repository (Université de Montréal)",
+                "issn_l": null,
+                "issn": null,
+                "is_oa": true,
+                "is_in_doaj": false,
+                "is_indexed_in_scopus": false,
+                "is_core": false,
+                "host_organization": "https://openalex.org/I70931966",
+                "host_organization_name": "Université de Montréal",
+                "host_organization_lineage": [
+                    "https://openalex.org/I70931966"
+                ],
+                "host_organization_lineage_names": [
+                    "Université de Montréal"
+                ],
+                "type": "repository"
+            },
+            "license": "cc-by",
+            "license_id": "https://openalex.org/licenses/cc-by",
+            "version": "submittedVersion",
+            "is_accepted": false,
+            "is_published": false
+        },
+        {
+            "is_oa": false,
+            "landing_page_url": "https://pubmed.ncbi.nlm.nih.gov/29456894",
+            "pdf_url": null,
+            "source": {
+                "id": "https://openalex.org/S4306525036",
+                "display_name": "PubMed",
+                "issn_l": null,
+                "issn": null,
+                "is_oa": false,
+                "is_in_doaj": false,
+                "is_indexed_in_scopus": false,
+                "is_core": false,
+                "host_organization": "https://openalex.org/I1299303238",
+                "host_organization_name": "National Institutes of Health",
+                "host_organization_lineage": [
+                    "https://openalex.org/I1299303238"
+                ],
+                "host_organization_lineage_names": [
+                    "National Institutes of Health"
+                ],
+                "type": "repository"
+            },
+            "license": null,
+            "license_id": null,
+            "version": null,
+            "is_accepted": false,
+            "is_published": false
+        }
+    ],
+    "best_oa_location": {
+        "is_oa": true,
+        "landing_page_url": "https://doi.org/10.7717/peerj.4375",
+        "pdf_url": "https://peerj.com/articles/4375.pdf",
+        "source": {
+            "id": "https://openalex.org/S1983995261",
+            "display_name": "PeerJ",
+            "issn_l": "2167-8359",
+            "issn": [
+                "2167-8359"
+            ],
+            "is_oa": true,
+            "is_in_doaj": true,
+            "is_indexed_in_scopus": true,
+            "is_core": true,
+            "host_organization": "https://openalex.org/P4310320104",
+            "host_organization_name": "PeerJ, Inc.",
+            "host_organization_lineage": [
+                "https://openalex.org/P4310320104"
+            ],
+            "host_organization_lineage_names": [
+                "PeerJ, Inc."
+            ],
+            "type": "journal"
+        },
+        "license": "cc-by",
+        "license_id": "https://openalex.org/licenses/cc-by",
+        "version": "publishedVersion",
+        "is_accepted": true,
+        "is_published": true
+    },
+    "sustainable_development_goals": [],
+    "grants": [],
+    "datasets": [],
+    "versions": [],
+    "referenced_works_count": 45,
+    "referenced_works": [
+        "https://openalex.org/W1560783210",
+        "https://openalex.org/W1724212071",
+        "https://openalex.org/W1767272795",
+        "https://openalex.org/W1917633107",
+        "https://openalex.org/W1931854307",
+        "https://openalex.org/W1944943415",
+        "https://openalex.org/W1957687230",
+        "https://openalex.org/W1989318653",
+        "https://openalex.org/W2003844967",
+        "https://openalex.org/W2016860460",
+        "https://openalex.org/W2020807482",
+        "https://openalex.org/W2029057325",
+        "https://openalex.org/W2031754690",
+        "https://openalex.org/W2048185449",
+        "https://openalex.org/W2078310052",
+        "https://openalex.org/W2089123513",
+        "https://openalex.org/W2115339903",
+        "https://openalex.org/W2140880926",
+        "https://openalex.org/W2160597895",
+        "https://openalex.org/W2231201268",
+        "https://openalex.org/W2299516731",
+        "https://openalex.org/W2306268324",
+        "https://openalex.org/W2322381034",
+        "https://openalex.org/W2343014812",
+        "https://openalex.org/W2345375849",
+        "https://openalex.org/W2463568293",
+        "https://openalex.org/W2511661767",
+        "https://openalex.org/W2511663072",
+        "https://openalex.org/W2520991028",
+        "https://openalex.org/W2563251083",
+        "https://openalex.org/W2566143661",
+        "https://openalex.org/W2587705861",
+        "https://openalex.org/W2588027260",
+        "https://openalex.org/W2611818942",
+        "https://openalex.org/W2737712680",
+        "https://openalex.org/W2753353163",
+        "https://openalex.org/W2762597540",
+        "https://openalex.org/W2785823074",
+        "https://openalex.org/W2953072907",
+        "https://openalex.org/W2997143876",
+        "https://openalex.org/W3012252063",
+        "https://openalex.org/W3121567788",
+        "https://openalex.org/W4254015553",
+        "https://openalex.org/W4298108315",
+        "https://openalex.org/W4301734034"
+    ],
+    "related_works": [
+        "https://openalex.org/W3203790917",
+        "https://openalex.org/W3201736257",
+        "https://openalex.org/W2904800587",
+        "https://openalex.org/W2608652318",
+        "https://openalex.org/W2294604317",
+        "https://openalex.org/W2285613965",
+        "https://openalex.org/W2162430746",
+        "https://openalex.org/W2086473138",
+        "https://openalex.org/W2060904856",
+        "https://openalex.org/W203102807"
+    ],
+    "abstract_inverted_index": {
+        "67": [
+            43
+        ],
+        "Despite": [
+            0
+        ],
+        "growing": [
+            1
+        ],
+        "interest": [
+            2
+        ],
+        "in": [
+            3,
+            57,
+            73,
+            110,
+            122
+        ],
+        "Open": [
+            4,
+            201
+        ],
+        "Access": [
+            5
+        ],
+        "(OA)": [
+            6
+        ],
+        "to": [
+            7,
+            54,
+            252
+        ],
+        "scholarly": [
+            8,
+            105
+        ],
+        "literature,": [
+            9
+        ],
+        "there": [
+            10
+        ],
+        "is": [
+            11,
+            107,
+            116,
+            176
+        ],
+        "an": [
+            12,
+            34,
+            85,
+            185,
+            199,
+            231
+        ],
+        "unmet": [
+            13
+        ],
+        "need": [
+            14,
+            31
+        ],
+        "for": [
+            15,
+            42,
+            174,
+            219
+        ],
+        "large-scale,": [
+            16
+        ],
+        "up-to-date,": [
+            17
+        ],
+        "and": [
+            18,
+            24,
+            77,
+            112,
+            124,
+            144,
+            221,
+            237,
+            256
+        ],
+        "reproducible": [
+            19
+        ],
+        "studies": [
+            20
+        ],
+        "assessing": [
+            21
+        ],
+        "the": [
+            22,
+            104,
+            134,
+            145,
+            170,
+            195,
+            206,
+            213,
+            245
+        ],
+        "prevalence": [
+            23
+        ],
+        "characteristics": [
+            25
+        ],
+        "of": [
+            26,
+            51,
+            75,
+            83,
+            103,
+            137,
+            141,
+            163,
+            209
+        ],
+        "OA.": [
+            27,
+            168,
+            239
+        ],
+        "We": [
+            28,
+            46,
+            97,
+            203,
+            240
+        ],
+        "address": [
+            29
+        ],
+        "this": [
+            30,
+            114,
+            142
+        ],
+        "using": [
+            32,
+            95,
+            244
+        ],
+        "oaDOI,": [
+            33
+        ],
+        "open": [
+            35
+        ],
+        "online": [
+            36
+        ],
+        "service": [
+            37
+        ],
+        "that": [
+            38,
+            89,
+            99,
+            113,
+            147,
+            155
+        ],
+        "determines": [
+            39
+        ],
+        "OA": [
+            40,
+            56,
+            93,
+            108,
+            138,
+            159,
+            175,
+            210,
+            223,
+            254
+        ],
+        "status": [
+            41
+        ],
+        "million": [
+            44
+        ],
+        "articles.": [
+            45
+        ],
+        "use": [
+            47
+        ],
+        "three": [
+            48,
+            58
+        ],
+        "samples,": [
+            49
+        ],
+        "each": [
+            50
+        ],
+        "100,000": [
+            52
+        ],
+        "articles,": [
+            53,
+            152,
+            211
+        ],
+        "investigate": [
+            55
+        ],
+        "populations:": [
+            59
+        ],
+        "(1)": [
+            60
+        ],
+        "all": [
+            61
+        ],
+        "journal": [
+            62,
+            70
+        ],
+        "articles": [
+            63,
+            71,
+            79,
+            94,
+            164,
+            191,
+            224
+        ],
+        "assigned": [
+            64
+        ],
+        "a": [
+            65,
+            250
+        ],
+        "Crossref": [
+            66
+        ],
+        "DOI,": [
+            67
+        ],
+        "(2)": [
+            68
+        ],
+        "recent": [
+            69,
+            128
+        ],
+        "indexed": [
+            72
+        ],
+        "Web": [
+            74
+        ],
+        "Science,": [
+            76
+        ],
+        "(3)": [
+            78
+        ],
+        "viewed": [
+            80
+        ],
+        "by": [
+            81,
+            120,
+            235
+        ],
+        "users": [
+            82,
+            91,
+            157
+        ],
+        "Unpaywall,": [
+            84
+        ],
+        "open-source": [
+            86
+        ],
+        "browser": [
+            87
+        ],
+        "extension": [
+            88
+        ],
+        "lets": [
+            90
+        ],
+        "find": [
+            92,
+            154
+        ],
+        "oaDOI.": [
+            96
+        ],
+        "estimate": [
+            98
+        ],
+        "at": [
+            100
+        ],
+        "least": [
+            101
+        ],
+        "28%": [
+            102
+        ],
+        "literature": [
+            106
+        ],
+        "(19M": [
+            109
+        ],
+        "total)": [
+            111
+        ],
+        "proportion": [
+            115
+        ],
+        "growing,": [
+            117
+        ],
+        "driven": [
+            118,
+            233
+        ],
+        "particularly": [
+            119
+        ],
+        "growth": [
+            121
+        ],
+        "Gold": [
+            123
+        ],
+        "Hybrid.": [
+            125
+        ],
+        "The": [
+            126
+        ],
+        "most": [
+            127,
+            171
+        ],
+        "year": [
+            129
+        ],
+        "analyzed": [
+            130
+        ],
+        "(2015)": [
+            131
+        ],
+        "also": [
+            132,
+            204
+        ],
+        "has": [
+            133
+        ],
+        "highest": [
+            135
+        ],
+        "percentage": [
+            136
+        ],
+        "(45%).": [
+            139
+        ],
+        "Because": [
+            140
+        ],
+        "growth,": [
+            143
+        ],
+        "fact": [
+            146
+        ],
+        "readers": [
+            148
+        ],
+        "disproportionately": [
+            149
+        ],
+        "access": [
+            150
+        ],
+        "newer": [
+            151
+        ],
+        "we": [
+            153,
+            188
+        ],
+        "Unpaywall": [
+            156
+        ],
+        "encounter": [
+            158
+        ],
+        "quite": [
+            160
+        ],
+        "frequently:": [
+            161
+        ],
+        "47%": [
+            162
+        ],
+        "they": [
+            165
+        ],
+        "view": [
+            166
+        ],
+        "are": [
+            167
+        ],
+        "Notably,": [
+            169
+        ],
+        "common": [
+            172
+        ],
+        "mechanism": [
+            173
+        ],
+        "not": [
+            177
+        ],
+        "Gold,": [
+            178
+        ],
+        "Green,": [
+            179
+        ],
+        "or": [
+            180
+        ],
+        "Hybrid": [
+            181,
+            238
+        ],
+        "OA,": [
+            182
+        ],
+        "but": [
+            183
+        ],
+        "rather": [
+            184
+        ],
+        "under-discussed": [
+            186
+        ],
+        "category": [
+            187
+        ],
+        "dub": [
+            189
+        ],
+        "Bronze:": [
+            190
+        ],
+        "made": [
+            192
+        ],
+        "free-to-read": [
+            193
+        ],
+        "on": [
+            194
+        ],
+        "publisher": [
+            196
+        ],
+        "website,": [
+            197
+        ],
+        "without": [
+            198
+        ],
+        "explicit": [
+            200
+        ],
+        "license.": [
+            202
+        ],
+        "examine": [
+            205
+        ],
+        "citation": [
+            207,
+            216
+        ],
+        "impact": [
+            208
+        ],
+        "corroborating": [
+            212
+        ],
+        "so-called": [
+            214
+        ],
+        "open-access": [
+            215
+        ],
+        "advantage:": [
+            217
+        ],
+        "accounting": [
+            218
+        ],
+        "age": [
+            220
+        ],
+        "discipline,": [
+            222
+        ],
+        "receive": [
+            225
+        ],
+        "18%": [
+            226
+        ],
+        "more": [
+            227
+        ],
+        "citations": [
+            228
+        ],
+        "than": [
+            229
+        ],
+        "average,": [
+            230
+        ],
+        "effect": [
+            232
+        ],
+        "primarily": [
+            234
+        ],
+        "Green": [
+            236
+        ],
+        "encourage": [
+            241
+        ],
+        "further": [
+            242
+        ],
+        "research": [
+            243
+        ],
+        "free": [
+            246
+        ],
+        "oaDOI": [
+            247
+        ],
+        "service,": [
+            248
+        ],
+        "as": [
+            249
+        ],
+        "way": [
+            251
+        ],
+        "inform": [
+            253
+        ],
+        "policy": [
+            255
+        ],
+        "practice.": [
+            257
+        ]
+    },
+    "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W2741809807",
+    "counts_by_year": [
+        {
+            "year": 2025,
+            "cited_by_count": 67
+        },
+        {
+            "year": 2024,
+            "cited_by_count": 118
+        },
+        {
+            "year": 2023,
+            "cited_by_count": 142
+        },
+        {
+            "year": 2022,
+            "cited_by_count": 148
+        },
+        {
+            "year": 2021,
+            "cited_by_count": 146
+        },
+        {
+            "year": 2020,
+            "cited_by_count": 179
+        },
+        {
+            "year": 2019,
+            "cited_by_count": 131
+        },
+        {
+            "year": 2018,
+            "cited_by_count": 59
+        },
+        {
+            "year": 2017,
+            "cited_by_count": 9
+        }
+    ],
+    "updated_date": "2025-09-17T09:32:54.582208",
+    "created_date": "2017-08-08"
+}

--- a/src/paper/ingestion/tests/clients/fixtures/openalex_sample_response.json
+++ b/src/paper/ingestion/tests/clients/fixtures/openalex_sample_response.json
@@ -1,0 +1,10768 @@
+{
+    "meta": {
+        "count": 11111537,
+        "db_response_time_ms": 113,
+        "page": null,
+        "per_page": 3,
+        "next_cursor": "IlsxMDAuMCwgMjkyMTAsICdodHRwczovL29wZW5hbGV4Lm9yZy9XMzAwMTg5NzA1NSddIg==",
+        "groups_count": null
+    },
+    "results": [
+        {
+            "id": "https://openalex.org/W3001118548",
+            "doi": "https://doi.org/10.1016/s0140-6736(20)30183-5",
+            "title": "Clinical features of patients infected with 2019 novel coronavirus in Wuhan, China",
+            "display_name": "Clinical features of patients infected with 2019 novel coronavirus in Wuhan, China",
+            "publication_year": 2020,
+            "publication_date": "2020-01-24",
+            "ids": {
+                "openalex": "https://openalex.org/W3001118548",
+                "doi": "https://doi.org/10.1016/s0140-6736(20)30183-5",
+                "mag": "3001118548",
+                "pmid": "https://pubmed.ncbi.nlm.nih.gov/31986264",
+                "pmcid": "https://www.ncbi.nlm.nih.gov/pmc/articles/7159299"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1016/s0140-6736(20)30183-5",
+                "pdf_url": "http://www.thelancet.com/article/S0140673620301835/pdf",
+                "source": {
+                    "id": "https://openalex.org/S49861241",
+                    "display_name": "The Lancet",
+                    "issn_l": "0140-6736",
+                    "issn": [
+                        "0140-6736",
+                        "1474-547X"
+                    ],
+                    "is_oa": false,
+                    "is_in_doaj": false,
+                    "is_indexed_in_scopus": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310320990",
+                    "host_organization_name": "Elsevier BV",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310320990"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Elsevier BV"
+                    ],
+                    "type": "journal"
+                },
+                "license": "other-oa",
+                "license_id": "https://openalex.org/licenses/other-oa",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "type": "article",
+            "type_crossref": "journal-article",
+            "indexed_in": [
+                "crossref",
+                "pubmed"
+            ],
+            "open_access": {
+                "is_oa": true,
+                "oa_status": "green",
+                "oa_url": "http://www.thelancet.com/article/S0140673620301835/pdf",
+                "any_repository_has_fulltext": true
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5101545030",
+                        "display_name": "Chaolin Huang",
+                        "orcid": "https://orcid.org/0000-0001-6240-7963"
+                    },
+                    "institutions": [],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Chaolin Huang",
+                    "raw_affiliation_strings": [
+                        "Jin Yin-tan Hospital, Wuhan, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Jin Yin-tan Hospital, Wuhan, China",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5101454711",
+                        "display_name": "Yeming Wang",
+                        "orcid": "https://orcid.org/0000-0003-4343-9606"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I2801051648",
+                            "display_name": "China-Japan Friendship Hospital",
+                            "ror": "https://ror.org/037cjxp13",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Yeming Wang",
+                    "raw_affiliation_strings": [
+                        "Department of Pulmonary and Critical Care Medicine, Center of Respiratory Medicine, National Clinical Research Center for Respiratory Diseases, China-Japan Friendship Hospital, Beijing, China",
+                        "Department of Respiratory Medicine, Capital Medical University, Beijing, China",
+                        "Institute of Respiratory Medicine, Chinese Academy of Medical Sciences, Peking Union Medical College, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Department of Pulmonary and Critical Care Medicine, Center of Respiratory Medicine, National Clinical Research Center for Respiratory Diseases, China-Japan Friendship Hospital, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Institute of Respiratory Medicine, Chinese Academy of Medical Sciences, Peking Union Medical College, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Department of Respiratory Medicine, Capital Medical University, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5101925685",
+                        "display_name": "Xingwang Li",
+                        "orcid": "https://orcid.org/0009-0001-5424-6722"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Xingwang Li",
+                    "raw_affiliation_strings": [
+                        "Clinical and Research Center of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Clinical and Research Center of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I183519381"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5005176337",
+                        "display_name": "Lili Ren",
+                        "orcid": "https://orcid.org/0000-0002-6645-8183"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Lili Ren",
+                    "raw_affiliation_strings": [
+                        "NHC Key Laboratory of Systems Biology of Pathogens and Christophe Merieux Laboratory, Institute of Pathogen Biology, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "NHC Key Laboratory of Systems Biology of Pathogens and Christophe Merieux Laboratory, Institute of Pathogen Biology, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5052152159",
+                        "display_name": "Jianping Zhao",
+                        "orcid": "https://orcid.org/0000-0003-3057-5617"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210160344",
+                            "display_name": "Tongji Hospital",
+                            "ror": "https://ror.org/04xy45965",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210160344"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I47720641",
+                            "display_name": "Huazhong University of Science and Technology",
+                            "ror": "https://ror.org/00p991c53",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I47720641"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jianping Zhao",
+                    "raw_affiliation_strings": [
+                        "Tongji Hospital, Tongji Medical College, Huazhong University of Science and Technology, Wuhan, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Tongji Hospital, Tongji Medical College, Huazhong University of Science and Technology, Wuhan, China",
+                            "institution_ids": [
+                                "https://openalex.org/I4210160344",
+                                "https://openalex.org/I47720641"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5031491320",
+                        "display_name": "Yi Hu",
+                        "orcid": "https://orcid.org/0000-0002-2882-5210"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I47720641",
+                            "display_name": "Huazhong University of Science and Technology",
+                            "ror": "https://ror.org/00p991c53",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I47720641"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Yi Hu",
+                    "raw_affiliation_strings": [
+                        "Department of Pulmonary and Critical Care Medicine, The Central Hospital of Wuhan, Tongji Medical College, Huazhong University of Science and Technology, Wuhan, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Department of Pulmonary and Critical Care Medicine, The Central Hospital of Wuhan, Tongji Medical College, Huazhong University of Science and Technology, Wuhan, China",
+                            "institution_ids": [
+                                "https://openalex.org/I47720641",
+                                "https://openalex.org/I4210143568"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100425676",
+                        "display_name": "Li Zhang",
+                        "orcid": "https://orcid.org/0000-0002-9687-8293"
+                    },
+                    "institutions": [],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Li Zhang",
+                    "raw_affiliation_strings": [
+                        "Jin Yin-tan Hospital, Wuhan, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Jin Yin-tan Hospital, Wuhan, China",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5082759663",
+                        "display_name": "Guohui Fan",
+                        "orcid": "https://orcid.org/0000-0003-2299-3560"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I2801051648",
+                            "display_name": "China-Japan Friendship Hospital",
+                            "ror": "https://ror.org/037cjxp13",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Guohui Fan",
+                    "raw_affiliation_strings": [
+                        "Department of Pulmonary and Critical Care Medicine, Center of Respiratory Medicine, National Clinical Research Center for Respiratory Diseases, China-Japan Friendship Hospital, Beijing, China",
+                        "Institute of Clinical Medical Sciences, China-Japan Friendship Hospital, Beijing, China",
+                        "Institute of Respiratory Medicine, Chinese Academy of Medical Sciences, Peking Union Medical College, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Institute of Clinical Medical Sciences, China-Japan Friendship Hospital, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Department of Pulmonary and Critical Care Medicine, Center of Respiratory Medicine, National Clinical Research Center for Respiratory Diseases, China-Japan Friendship Hospital, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Institute of Respiratory Medicine, Chinese Academy of Medical Sciences, Peking Union Medical College, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5062226704",
+                        "display_name": "Jiuyang Xu",
+                        "orcid": "https://orcid.org/0000-0002-1906-5918"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I99065089",
+                            "display_name": "Tsinghua University",
+                            "ror": "https://ror.org/03cve4549",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I99065089"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jiuyang Xu",
+                    "raw_affiliation_strings": [
+                        "Tsinghua University School of Medicine, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Tsinghua University School of Medicine, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I99065089"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5101081875",
+                        "display_name": "Xiaoying Gu",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I2801051648",
+                            "display_name": "China-Japan Friendship Hospital",
+                            "ror": "https://ror.org/037cjxp13",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Xiaoying Gu",
+                    "raw_affiliation_strings": [
+                        "Department of Pulmonary and Critical Care Medicine, Center of Respiratory Medicine, National Clinical Research Center for Respiratory Diseases, China-Japan Friendship Hospital, Beijing, China",
+                        "Institute of Clinical Medical Sciences, China-Japan Friendship Hospital, Beijing, China",
+                        "Institute of Respiratory Medicine, Chinese Academy of Medical Sciences, Peking Union Medical College, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Institute of Respiratory Medicine, Chinese Academy of Medical Sciences, Peking Union Medical College, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Institute of Clinical Medical Sciences, China-Japan Friendship Hospital, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Department of Pulmonary and Critical Care Medicine, Center of Respiratory Medicine, National Clinical Research Center for Respiratory Diseases, China-Japan Friendship Hospital, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5101711490",
+                        "display_name": "Zhenshun Cheng",
+                        "orcid": "https://orcid.org/0000-0002-7387-496X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210120234",
+                            "display_name": "Zhongnan Hospital of Wuhan University",
+                            "ror": "https://ror.org/01v5mqw79",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210120234"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I37461747",
+                            "display_name": "Wuhan University",
+                            "ror": "https://ror.org/033vjfk17",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I37461747"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Zhenshun Cheng",
+                    "raw_affiliation_strings": [
+                        "Department of Respiratory medicine, Zhongnan Hospital of Wuhan University, Wuhan, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Department of Respiratory medicine, Zhongnan Hospital of Wuhan University, Wuhan, China",
+                            "institution_ids": [
+                                "https://openalex.org/I4210120234",
+                                "https://openalex.org/I37461747"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100655339",
+                        "display_name": "Ting Yu",
+                        "orcid": "https://orcid.org/0000-0003-4096-8975"
+                    },
+                    "institutions": [],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Ting Yu",
+                    "raw_affiliation_strings": [
+                        "Jin Yin-tan Hospital, Wuhan, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Jin Yin-tan Hospital, Wuhan, China",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5024929222",
+                        "display_name": "Jiaan Xia",
+                        "orcid": null
+                    },
+                    "institutions": [],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jiaan Xia",
+                    "raw_affiliation_strings": [
+                        "Jin Yin-tan Hospital, Wuhan, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Jin Yin-tan Hospital, Wuhan, China",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100344847",
+                        "display_name": "Yuan Wei",
+                        "orcid": "https://orcid.org/0000-0002-4025-6567"
+                    },
+                    "institutions": [],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Yuan Wei",
+                    "raw_affiliation_strings": [
+                        "Jin Yin-tan Hospital, Wuhan, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Jin Yin-tan Hospital, Wuhan, China",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5103981505",
+                        "display_name": "Wenjuan Wu",
+                        "orcid": null
+                    },
+                    "institutions": [],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Wenjuan Wu",
+                    "raw_affiliation_strings": [
+                        "Jin Yin-tan Hospital, Wuhan, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Jin Yin-tan Hospital, Wuhan, China",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5037416293",
+                        "display_name": "Xuelei Xie",
+                        "orcid": null
+                    },
+                    "institutions": [],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Xuelei Xie",
+                    "raw_affiliation_strings": [
+                        "Jin Yin-tan Hospital, Wuhan, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Jin Yin-tan Hospital, Wuhan, China",
+                            "institution_ids": []
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5014572115",
+                        "display_name": "Wen Yin",
+                        "orcid": "https://orcid.org/0000-0002-1393-7682"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I47720641",
+                            "display_name": "Huazhong University of Science and Technology",
+                            "ror": "https://ror.org/00p991c53",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I47720641"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Wen Yin",
+                    "raw_affiliation_strings": [
+                        "Department of Pulmonary and Critical Care Medicine, The Central Hospital of Wuhan, Tongji Medical College, Huazhong University of Science and Technology, Wuhan, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Department of Pulmonary and Critical Care Medicine, The Central Hospital of Wuhan, Tongji Medical College, Huazhong University of Science and Technology, Wuhan, China",
+                            "institution_ids": [
+                                "https://openalex.org/I47720641",
+                                "https://openalex.org/I4210143568"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5057824494",
+                        "display_name": "Hui Li",
+                        "orcid": "https://orcid.org/0000-0002-8751-3065"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I2801051648",
+                            "display_name": "China-Japan Friendship Hospital",
+                            "ror": "https://ror.org/037cjxp13",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Hui Li",
+                    "raw_affiliation_strings": [
+                        "Department of Pulmonary and Critical Care Medicine, Center of Respiratory Medicine, National Clinical Research Center for Respiratory Diseases, China-Japan Friendship Hospital, Beijing, China",
+                        "Department of Respiratory Medicine, Capital Medical University, Beijing, China",
+                        "Institute of Respiratory Medicine, Chinese Academy of Medical Sciences, Peking Union Medical College, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Department of Pulmonary and Critical Care Medicine, Center of Respiratory Medicine, National Clinical Research Center for Respiratory Diseases, China-Japan Friendship Hospital, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Institute of Respiratory Medicine, Chinese Academy of Medical Sciences, Peking Union Medical College, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Department of Respiratory Medicine, Capital Medical University, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5045493285",
+                        "display_name": "Min Liu",
+                        "orcid": "https://orcid.org/0000-0003-1298-4441"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I2801051648",
+                            "display_name": "China-Japan Friendship Hospital",
+                            "ror": "https://ror.org/037cjxp13",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Min Liu",
+                    "raw_affiliation_strings": [
+                        "Department of Radiology, China-Japan Friendship Hospital, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Department of Radiology, China-Japan Friendship Hospital, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100606060",
+                        "display_name": "Xiao Yan",
+                        "orcid": "https://orcid.org/0000-0001-7626-2128"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Yan Xiao",
+                    "raw_affiliation_strings": [
+                        "NHC Key Laboratory of Systems Biology of Pathogens and Christophe Merieux Laboratory, Institute of Pathogen Biology, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "NHC Key Laboratory of Systems Biology of Pathogens and Christophe Merieux Laboratory, Institute of Pathogen Biology, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5101633148",
+                        "display_name": "Hong Gao",
+                        "orcid": "https://orcid.org/0000-0002-2488-8695"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210131085",
+                            "display_name": "Institute of Laboratory Animal Science",
+                            "ror": "https://ror.org/038z7hb11",
+                            "country_code": "CN",
+                            "type": "facility",
+                            "lineage": [
+                                "https://openalex.org/I4210131085",
+                                "https://openalex.org/I4210141683"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Hong Gao",
+                    "raw_affiliation_strings": [
+                        "Institute of Laboratory Animal Science, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Institute of Laboratory Animal Science, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I4210131085",
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5070771101",
+                        "display_name": "Li Guo",
+                        "orcid": "https://orcid.org/0000-0002-0184-6847"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Li Guo",
+                    "raw_affiliation_strings": [
+                        "NHC Key Laboratory of Systems Biology of Pathogens and Christophe Merieux Laboratory, Institute of Pathogen Biology, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "NHC Key Laboratory of Systems Biology of Pathogens and Christophe Merieux Laboratory, Institute of Pathogen Biology, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5058709579",
+                        "display_name": "Jungang Xie",
+                        "orcid": "https://orcid.org/0000-0001-9037-3027"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210160344",
+                            "display_name": "Tongji Hospital",
+                            "ror": "https://ror.org/04xy45965",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210160344"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I47720641",
+                            "display_name": "Huazhong University of Science and Technology",
+                            "ror": "https://ror.org/00p991c53",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I47720641"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jungang Xie",
+                    "raw_affiliation_strings": [
+                        "Tongji Hospital, Tongji Medical College, Huazhong University of Science and Technology, Wuhan, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Tongji Hospital, Tongji Medical College, Huazhong University of Science and Technology, Wuhan, China",
+                            "institution_ids": [
+                                "https://openalex.org/I4210160344",
+                                "https://openalex.org/I47720641"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5013568062",
+                        "display_name": "Guangfa Wang",
+                        "orcid": "https://orcid.org/0000-0001-5949-2124"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210130930",
+                            "display_name": "Peking University First Hospital",
+                            "ror": "https://ror.org/02z1vqm45",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210130930"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I20231570",
+                            "display_name": "Peking University",
+                            "ror": "https://ror.org/02v51f717",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I20231570"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Guangfa Wang",
+                    "raw_affiliation_strings": [
+                        "Department of Pulmonary and Critical Care Medicine, Peking University First Hospital, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Department of Pulmonary and Critical Care Medicine, Peking University First Hospital, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I4210130930",
+                                "https://openalex.org/I20231570"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5112776266",
+                        "display_name": "Rongmeng Jiang",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Rongmeng Jiang",
+                    "raw_affiliation_strings": [
+                        "Clinical and Research Center of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Clinical and Research Center of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I183519381"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5026007726",
+                        "display_name": "Zhancheng Gao",
+                        "orcid": "https://orcid.org/0000-0002-8495-9221"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210124809",
+                            "display_name": "Peking University People's Hospital",
+                            "ror": "https://ror.org/035adwg89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210124809"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I20231570",
+                            "display_name": "Peking University",
+                            "ror": "https://ror.org/02v51f717",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I20231570"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Zhancheng Gao",
+                    "raw_affiliation_strings": [
+                        "Department of Pulmonary and Critical Care Medicine, Peking University People's Hospital, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Department of Pulmonary and Critical Care Medicine, Peking University People's Hospital, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I4210124809",
+                                "https://openalex.org/I20231570"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100637146",
+                        "display_name": "Qi Jin",
+                        "orcid": "https://orcid.org/0000-0002-3586-6344"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Qi Jin",
+                    "raw_affiliation_strings": [
+                        "NHC Key Laboratory of Systems Biology of Pathogens and Christophe Merieux Laboratory, Institute of Pathogen Biology, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "NHC Key Laboratory of Systems Biology of Pathogens and Christophe Merieux Laboratory, Institute of Pathogen Biology, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100424784",
+                        "display_name": "Jianwei Wang",
+                        "orcid": "https://orcid.org/0000-0002-1116-4559"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Jianwei Wang",
+                    "raw_affiliation_strings": [
+                        "NHC Key Laboratory of Systems Biology of Pathogens and Christophe Merieux Laboratory, Institute of Pathogen Biology, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "NHC Key Laboratory of Systems Biology of Pathogens and Christophe Merieux Laboratory, Institute of Pathogen Biology, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "last",
+                    "author": {
+                        "id": "https://openalex.org/A5100613209",
+                        "display_name": "Bin Cao",
+                        "orcid": "https://orcid.org/0000-0001-6991-0350"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I99065089",
+                            "display_name": "Tsinghua University",
+                            "ror": "https://ror.org/03cve4549",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I99065089"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I20231570",
+                            "display_name": "Peking University",
+                            "ror": "https://ror.org/02v51f717",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I20231570"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I2801051648",
+                            "display_name": "China-Japan Friendship Hospital",
+                            "ror": "https://ror.org/037cjxp13",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210160507",
+                            "display_name": "Center for Life Sciences",
+                            "ror": "https://ror.org/05kje8j93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I20231570",
+                                "https://openalex.org/I4210160507",
+                                "https://openalex.org/I99065089"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": true,
+                    "raw_author_name": "Bin Cao",
+                    "raw_affiliation_strings": [
+                        "Department of Pulmonary and Critical Care Medicine, Center of Respiratory Medicine, National Clinical Research Center for Respiratory Diseases, China-Japan Friendship Hospital, Beijing, China",
+                        "Department of Respiratory Medicine, Capital Medical University, Beijing, China",
+                        "Institute of Respiratory Medicine, Chinese Academy of Medical Sciences, Peking Union Medical College, Beijing, China",
+                        "Tsinghua University-Peking University Joint Center for Life Sciences, Beijing, China"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "Tsinghua University-Peking University Joint Center for Life Sciences, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I99065089",
+                                "https://openalex.org/I20231570",
+                                "https://openalex.org/I4210160507"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Department of Pulmonary and Critical Care Medicine, Center of Respiratory Medicine, National Clinical Research Center for Respiratory Diseases, China-Japan Friendship Hospital, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I2801051648"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Institute of Respiratory Medicine, Chinese Academy of Medical Sciences, Peking Union Medical College, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "raw_affiliation_string": "Department of Respiratory Medicine, Capital Medical University, Beijing, China",
+                            "institution_ids": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "institution_assertions": [],
+            "countries_distinct_count": 1,
+            "institutions_distinct_count": 15,
+            "corresponding_author_ids": [
+                "https://openalex.org/A5100424784",
+                "https://openalex.org/A5100613209"
+            ],
+            "corresponding_institution_ids": [
+                "https://openalex.org/I200296433",
+                "https://openalex.org/I99065089",
+                "https://openalex.org/I20231570",
+                "https://openalex.org/I2801051648",
+                "https://openalex.org/I200296433",
+                "https://openalex.org/I183519381",
+                "https://openalex.org/I4210160507"
+            ],
+            "apc_list": {
+                "value": 6830,
+                "currency": "USD",
+                "value_usd": 6830
+            },
+            "apc_paid": null,
+            "fwci": 1204.335,
+            "has_fulltext": true,
+            "fulltext_origin": "pdf",
+            "cited_by_count": 50056,
+            "citation_normalized_percentile": {
+                "value": 0.999954,
+                "is_in_top_1_percent": true,
+                "is_in_top_10_percent": true
+            },
+            "cited_by_percentile_year": {
+                "min": 99,
+                "max": 100
+            },
+            "biblio": {
+                "volume": "395",
+                "issue": "10223",
+                "first_page": "497",
+                "last_page": "506"
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T10118",
+                "display_name": "SARS-CoV-2 and COVID-19 Research",
+                "score": 1,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/2725",
+                    "display_name": "Infectious Diseases"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/27",
+                    "display_name": "Medicine"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/4",
+                    "display_name": "Health Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T10118",
+                    "display_name": "SARS-CoV-2 and COVID-19 Research",
+                    "score": 1,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2725",
+                        "display_name": "Infectious Diseases"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T10041",
+                    "display_name": "COVID-19 Clinical Research Studies",
+                    "score": 0.9986,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2725",
+                        "display_name": "Infectious Diseases"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T10976",
+                    "display_name": "Viral gastroenteritis research and epidemiology",
+                    "score": 0.9984,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2725",
+                        "display_name": "Infectious Diseases"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/myalgia",
+                    "display_name": "myalgia",
+                    "score": 0.75457096
+                },
+                {
+                    "id": "https://openalex.org/keywords/medical-record",
+                    "display_name": "Medical record",
+                    "score": 0.48094743
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C71924100",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11190",
+                    "display_name": "Medicine",
+                    "level": 0,
+                    "score": 0.84961367
+                },
+                {
+                    "id": "https://openalex.org/C2778616394",
+                    "wikidata": "https://www.wikidata.org/wiki/Q474959",
+                    "display_name": "myalgia",
+                    "level": 2,
+                    "score": 0.75457096
+                },
+                {
+                    "id": "https://openalex.org/C107130276",
+                    "wikidata": "https://www.wikidata.org/wiki/Q133805",
+                    "display_name": "Epidemiology",
+                    "level": 2,
+                    "score": 0.729414
+                },
+                {
+                    "id": "https://openalex.org/C2777914695",
+                    "wikidata": "https://www.wikidata.org/wiki/Q12192",
+                    "display_name": "Pneumonia",
+                    "level": 2,
+                    "score": 0.6362847
+                },
+                {
+                    "id": "https://openalex.org/C2776301714",
+                    "wikidata": "https://www.wikidata.org/wiki/Q259346",
+                    "display_name": "Sputum",
+                    "level": 3,
+                    "score": 0.5497839
+                },
+                {
+                    "id": "https://openalex.org/C2776376669",
+                    "wikidata": "https://www.wikidata.org/wiki/Q5094647",
+                    "display_name": "Intensive care unit",
+                    "level": 2,
+                    "score": 0.54216385
+                },
+                {
+                    "id": "https://openalex.org/C126322002",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11180",
+                    "display_name": "Internal medicine",
+                    "level": 1,
+                    "score": 0.519866
+                },
+                {
+                    "id": "https://openalex.org/C195910791",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1324077",
+                    "display_name": "Medical record",
+                    "level": 2,
+                    "score": 0.48094743
+                },
+                {
+                    "id": "https://openalex.org/C555293320",
+                    "wikidata": "https://www.wikidata.org/wiki/Q12206",
+                    "display_name": "Diabetes mellitus",
+                    "level": 2,
+                    "score": 0.4671974
+                },
+                {
+                    "id": "https://openalex.org/C187212893",
+                    "wikidata": "https://www.wikidata.org/wiki/Q123028",
+                    "display_name": "Pediatrics",
+                    "level": 1,
+                    "score": 0.4072899
+                },
+                {
+                    "id": "https://openalex.org/C2781069245",
+                    "wikidata": "https://www.wikidata.org/wiki/Q12204",
+                    "display_name": "Tuberculosis",
+                    "level": 2,
+                    "score": 0.23705223
+                },
+                {
+                    "id": "https://openalex.org/C142724271",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7208",
+                    "display_name": "Pathology",
+                    "level": 1,
+                    "score": 0.099972725
+                },
+                {
+                    "id": "https://openalex.org/C134018914",
+                    "wikidata": "https://www.wikidata.org/wiki/Q162606",
+                    "display_name": "Endocrinology",
+                    "level": 1,
+                    "score": 0
+                }
+            ],
+            "mesh": [
+                {
+                    "descriptor_ui": "D000328",
+                    "descriptor_name": "Adult",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D017677",
+                    "descriptor_name": "Age Distribution",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000368",
+                    "descriptor_name": "Aged",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000086382",
+                    "descriptor_name": "COVID-19",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D002681",
+                    "descriptor_name": "China",
+                    "qualifier_ui": "Q000453",
+                    "qualifier_name": "epidemiology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D015897",
+                    "descriptor_name": "Comorbidity",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D018352",
+                    "descriptor_name": "Coronavirus Infections",
+                    "qualifier_ui": "Q000150",
+                    "qualifier_name": "complications",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D003371",
+                    "descriptor_name": "Cough",
+                    "qualifier_ui": "Q000453",
+                    "qualifier_name": "epidemiology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D005260",
+                    "descriptor_name": "Female",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D005334",
+                    "descriptor_name": "Fever",
+                    "qualifier_ui": "Q000453",
+                    "qualifier_name": "epidemiology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D006760",
+                    "descriptor_name": "Hospitalization",
+                    "qualifier_ui": "Q000706",
+                    "qualifier_name": "statistics & numerical data",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D006801",
+                    "descriptor_name": "Humans",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D007362",
+                    "descriptor_name": "Intensive Care Units",
+                    "qualifier_ui": "Q000706",
+                    "qualifier_name": "statistics & numerical data",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D008297",
+                    "descriptor_name": "Male",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D008875",
+                    "descriptor_name": "Middle Aged",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D063806",
+                    "descriptor_name": "Myalgia",
+                    "qualifier_ui": "Q000453",
+                    "qualifier_name": "epidemiology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D011024",
+                    "descriptor_name": "Pneumonia, Viral",
+                    "qualifier_ui": "Q000150",
+                    "qualifier_name": "complications",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D011379",
+                    "descriptor_name": "Prognosis",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D013902",
+                    "descriptor_name": "Radiography, Thoracic",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D012128",
+                    "descriptor_name": "Respiratory Distress Syndrome",
+                    "qualifier_ui": "Q000453",
+                    "qualifier_name": "epidemiology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D013997",
+                    "descriptor_name": "Time Factors",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D014057",
+                    "descriptor_name": "Tomography, X-Ray Computed",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D055815",
+                    "descriptor_name": "Young Adult",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                }
+            ],
+            "locations_count": 4,
+            "locations": [
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://doi.org/10.1016/s0140-6736(20)30183-5",
+                    "pdf_url": "http://www.thelancet.com/article/S0140673620301835/pdf",
+                    "source": {
+                        "id": "https://openalex.org/S49861241",
+                        "display_name": "The Lancet",
+                        "issn_l": "0140-6736",
+                        "issn": [
+                            "0140-6736",
+                            "1474-547X"
+                        ],
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": true,
+                        "is_core": true,
+                        "host_organization": "https://openalex.org/P4310320990",
+                        "host_organization_name": "Elsevier BV",
+                        "host_organization_lineage": [
+                            "https://openalex.org/P4310320990"
+                        ],
+                        "host_organization_lineage_names": [
+                            "Elsevier BV"
+                        ],
+                        "type": "journal"
+                    },
+                    "license": "other-oa",
+                    "license_id": "https://openalex.org/licenses/other-oa",
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7159299",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S2764455111",
+                        "display_name": "PubMed Central",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://europepmc.org/articles/pmc7159299",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306400806",
+                        "display_name": "Europe PMC (PubMed Central)",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1303153112",
+                        "host_organization_name": "European Bioinformatics Institute",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1303153112"
+                        ],
+                        "host_organization_lineage_names": [
+                            "European Bioinformatics Institute"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "acceptedVersion",
+                    "is_accepted": true,
+                    "is_published": false
+                },
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://pubmed.ncbi.nlm.nih.gov/31986264",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306525036",
+                        "display_name": "PubMed",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1016/s0140-6736(20)30183-5",
+                "pdf_url": "http://www.thelancet.com/article/S0140673620301835/pdf",
+                "source": {
+                    "id": "https://openalex.org/S49861241",
+                    "display_name": "The Lancet",
+                    "issn_l": "0140-6736",
+                    "issn": [
+                        "0140-6736",
+                        "1474-547X"
+                    ],
+                    "is_oa": false,
+                    "is_in_doaj": false,
+                    "is_indexed_in_scopus": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310320990",
+                    "host_organization_name": "Elsevier BV",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310320990"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Elsevier BV"
+                    ],
+                    "type": "journal"
+                },
+                "license": "other-oa",
+                "license_id": "https://openalex.org/licenses/other-oa",
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "sustainable_development_goals": [
+                {
+                    "id": "https://metadata.un.org/sdg/3",
+                    "score": 0.79,
+                    "display_name": "Good health and well-being"
+                }
+            ],
+            "grants": [],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 35,
+            "referenced_works": [
+                "https://openalex.org/W1761204585",
+                "https://openalex.org/W1977050884",
+                "https://openalex.org/W1993577573",
+                "https://openalex.org/W2006434809",
+                "https://openalex.org/W2026274122",
+                "https://openalex.org/W2034462612",
+                "https://openalex.org/W2046153984",
+                "https://openalex.org/W2054076340",
+                "https://openalex.org/W2062817591",
+                "https://openalex.org/W2070463916",
+                "https://openalex.org/W2073060575",
+                "https://openalex.org/W2104548316",
+                "https://openalex.org/W2112147913",
+                "https://openalex.org/W2114699265",
+                "https://openalex.org/W2131262274",
+                "https://openalex.org/W2132260239",
+                "https://openalex.org/W2150120685",
+                "https://openalex.org/W2166867592",
+                "https://openalex.org/W2168446943",
+                "https://openalex.org/W2397221660",
+                "https://openalex.org/W2565805236",
+                "https://openalex.org/W2725497285",
+                "https://openalex.org/W2769689735",
+                "https://openalex.org/W2790127336",
+                "https://openalex.org/W2791599184",
+                "https://openalex.org/W2903899730",
+                "https://openalex.org/W3000139095",
+                "https://openalex.org/W3000413850",
+                "https://openalex.org/W3017468735",
+                "https://openalex.org/W3032912912",
+                "https://openalex.org/W3033599099",
+                "https://openalex.org/W3034453825",
+                "https://openalex.org/W3125942575",
+                "https://openalex.org/W3158868742",
+                "https://openalex.org/W3216146939"
+            ],
+            "related_works": [
+                "https://openalex.org/W4280625170",
+                "https://openalex.org/W3108472106",
+                "https://openalex.org/W2510552373",
+                "https://openalex.org/W2336896728",
+                "https://openalex.org/W2335083976",
+                "https://openalex.org/W2259358466",
+                "https://openalex.org/W2137905551",
+                "https://openalex.org/W2102858081",
+                "https://openalex.org/W2087488583",
+                "https://openalex.org/W2012032058"
+            ],
+            "abstract_inverted_index": null,
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W3001118548",
+            "counts_by_year": [
+                {
+                    "year": 2025,
+                    "cited_by_count": 828
+                },
+                {
+                    "year": 2024,
+                    "cited_by_count": 2537
+                },
+                {
+                    "year": 2023,
+                    "cited_by_count": 4997
+                },
+                {
+                    "year": 2022,
+                    "cited_by_count": 8321
+                },
+                {
+                    "year": 2021,
+                    "cited_by_count": 13927
+                },
+                {
+                    "year": 2020,
+                    "cited_by_count": 19323
+                },
+                {
+                    "year": 2019,
+                    "cited_by_count": 38
+                },
+                {
+                    "year": 2018,
+                    "cited_by_count": 4
+                },
+                {
+                    "year": 2017,
+                    "cited_by_count": 2
+                },
+                {
+                    "year": 2016,
+                    "cited_by_count": 1
+                },
+                {
+                    "year": 2015,
+                    "cited_by_count": 3
+                },
+                {
+                    "year": 2013,
+                    "cited_by_count": 1
+                }
+            ],
+            "updated_date": "2025-09-26T01:33:11.823080",
+            "created_date": "2020-01-30"
+        },
+        {
+            "id": "https://openalex.org/W3008827533",
+            "doi": "https://doi.org/10.1056/nejmoa2002032",
+            "title": "Clinical Characteristics of Coronavirus Disease 2019 in China",
+            "display_name": "Clinical Characteristics of Coronavirus Disease 2019 in China",
+            "publication_year": 2020,
+            "publication_date": "2020-02-28",
+            "ids": {
+                "openalex": "https://openalex.org/W3008827533",
+                "doi": "https://doi.org/10.1056/nejmoa2002032",
+                "mag": "3008827533",
+                "pmid": "https://pubmed.ncbi.nlm.nih.gov/32109013",
+                "pmcid": "https://www.ncbi.nlm.nih.gov/pmc/articles/7092819"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1056/nejmoa2002032",
+                "pdf_url": null,
+                "source": {
+                    "id": "https://openalex.org/S62468778",
+                    "display_name": "New England Journal of Medicine",
+                    "issn_l": "0028-4793",
+                    "issn": [
+                        "0028-4793",
+                        "1533-4406"
+                    ],
+                    "is_oa": false,
+                    "is_in_doaj": false,
+                    "is_indexed_in_scopus": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310320239",
+                    "host_organization_name": "Massachusetts Medical Society",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310320239"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Massachusetts Medical Society"
+                    ],
+                    "type": "journal"
+                },
+                "license": null,
+                "license_id": null,
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "type": "article",
+            "type_crossref": "journal-article",
+            "indexed_in": [
+                "crossref",
+                "pubmed"
+            ],
+            "open_access": {
+                "is_oa": true,
+                "oa_status": "green",
+                "oa_url": "https://doi.org/10.1056/nejmoa2002032",
+                "any_repository_has_fulltext": true
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5101633572",
+                        "display_name": "Wei‐jie Guan",
+                        "orcid": "https://orcid.org/0000-0001-5463-391X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Wei-Jie Guan",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5034117843",
+                        "display_name": "Zhengyi Ni",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Zheng-Yi Ni",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100523570",
+                        "display_name": "Yu Hu",
+                        "orcid": "https://orcid.org/0009-0009-1746-0402"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Yu Hu",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5031255136",
+                        "display_name": "Wenhua Liang",
+                        "orcid": "https://orcid.org/0000-0002-1391-8238"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Wen-Hua Liang",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5101506716",
+                        "display_name": "Chun‐Quan Ou",
+                        "orcid": "https://orcid.org/0000-0001-6866-7213"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Chun-Quan Ou",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100751322",
+                        "display_name": "Jianxing He",
+                        "orcid": "https://orcid.org/0000-0003-1737-8192"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jian-Xing He",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100349482",
+                        "display_name": "Lei Liu",
+                        "orcid": "https://orcid.org/0000-0001-6764-3260"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Lei Liu",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5022408293",
+                        "display_name": "Hong Shan",
+                        "orcid": "https://orcid.org/0000-0001-6640-1390"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Hong Shan",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5110843713",
+                        "display_name": "Chunliang Lei",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Chun-Liang Lei",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5089024033",
+                        "display_name": "David S.C. Hui",
+                        "orcid": "https://orcid.org/0000-0003-4382-2445"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "David S C Hui",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998",
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5012294390",
+                        "display_name": "Bin Du",
+                        "orcid": "https://orcid.org/0000-0001-6237-2895"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Bin Du",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5057422995",
+                        "display_name": "Lanjuan Li",
+                        "orcid": "https://orcid.org/0000-0001-6945-0593"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Lan-Juan Li",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5065458315",
+                        "display_name": "Guang Zeng",
+                        "orcid": "https://orcid.org/0000-0002-5201-9796"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Guang Zeng",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998",
+                                "https://openalex.org/I58200834"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5074675036",
+                        "display_name": "Kwok‐Yung Yuen",
+                        "orcid": "https://orcid.org/0000-0002-2083-1552"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Kwok-Yung Yuen",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5061008437",
+                        "display_name": "Ruchong Chen",
+                        "orcid": "https://orcid.org/0000-0001-5376-8230"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Ru-Chong Chen",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5103136145",
+                        "display_name": "Chunli Tang",
+                        "orcid": "https://orcid.org/0009-0004-7902-2620"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Chun-Li Tang",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100453619",
+                        "display_name": "Tao Wang",
+                        "orcid": "https://orcid.org/0000-0002-8943-7916"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Tao Wang",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998",
+                                "https://openalex.org/I4210109004"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5012491543",
+                        "display_name": "Pingyan Chen",
+                        "orcid": "https://orcid.org/0000-0002-3747-8003"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Ping-Yan Chen",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5101520726",
+                        "display_name": "Jie Xiang",
+                        "orcid": "https://orcid.org/0000-0001-6601-5481"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jie Xiang",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5101728447",
+                        "display_name": "Shiyue Li",
+                        "orcid": "https://orcid.org/0000-0001-8213-6566"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Shi-Yue Li",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998",
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5112505276",
+                        "display_name": "Jinlin Wang",
+                        "orcid": "https://orcid.org/0000-0003-0525-6649"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jin-Lin Wang",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210111998",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5087858925",
+                        "display_name": "Zijing Liang",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Zi-Jing Liang",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5109466473",
+                        "display_name": "Yixiang Peng",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Yi-Xiang Peng",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100751018",
+                        "display_name": "Wei Li",
+                        "orcid": "https://orcid.org/0000-0002-5257-7130"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Li Wei",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998",
+                                "https://openalex.org/I58200834"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5008676917",
+                        "display_name": "Yong Liu",
+                        "orcid": "https://orcid.org/0000-0002-5208-888X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Yong Liu",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998",
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5102707681",
+                        "display_name": "Yahua Hu",
+                        "orcid": "https://orcid.org/0000-0003-3115-5956"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Ya-Hua Hu",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100416329",
+                        "display_name": "Peng Peng",
+                        "orcid": "https://orcid.org/0000-0002-8170-8961"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Peng Peng",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100707507",
+                        "display_name": "Jianming Wang",
+                        "orcid": "https://orcid.org/0000-0002-9151-284X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jian-Ming Wang",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5101887888",
+                        "display_name": "Jiyang Liu",
+                        "orcid": "https://orcid.org/0000-0002-9858-0060"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Ji-Yang Liu",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998",
+                                "https://openalex.org/I4210143568"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5113360709",
+                        "display_name": "Zhong Chen",
+                        "orcid": "https://orcid.org/0009-0007-6692-2648"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Zhong Chen",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5100438769",
+                        "display_name": "Gang Li",
+                        "orcid": "https://orcid.org/0000-0003-1583-641X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Gang Li",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5110448998",
+                        "display_name": "Zhijian Zheng",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Zhi-Jian Zheng",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998",
+                                "https://openalex.org/I58200834"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5032532898",
+                        "display_name": "Shaoqin Qiu",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Shao-Qin Qiu",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5067095480",
+                        "display_name": "Jie Luo",
+                        "orcid": "https://orcid.org/0000-0002-3276-115X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jie Luo",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5018142228",
+                        "display_name": "Chang-jiang Ye",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Chang-Jiang Ye",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5110669068",
+                        "display_name": "Shaoyong Zhu",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Shao-Yong Zhu",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "last",
+                    "author": {
+                        "id": "https://openalex.org/A5101475024",
+                        "display_name": "Nanshan Zhong",
+                        "orcid": "https://orcid.org/0000-0003-2274-1427"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I58200834",
+                            "display_name": "Southern Medical University",
+                            "ror": "https://ror.org/01vjw4z39",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I58200834"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I157773358",
+                            "display_name": "Sun Yat-sen University",
+                            "ror": "https://ror.org/0064kty71",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I157773358"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210156462",
+                            "display_name": "Guangzhou Eighth People's Hospital",
+                            "ror": "https://ror.org/0534awx66",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210156462"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210098361",
+                            "display_name": "First Affiliated Hospital of Guangzhou Medical University",
+                            "ror": "https://ror.org/00z0j0d77",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210098361"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210154954",
+                            "display_name": "State Key Laboratory of Respiratory Disease",
+                            "ror": "https://ror.org/04hja5e04",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210154954"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210109004",
+                            "display_name": "Wuhan Pulmonary Hospital",
+                            "ror": "https://ror.org/01kqcdh89",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210109004"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210143568",
+                            "display_name": "Central Hospital of Wuhan",
+                            "ror": "https://ror.org/04qs2sz84",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210143568"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I43922553",
+                            "display_name": "Wuhan University of Science and Technology",
+                            "ror": "https://ror.org/00e4hrk88",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I43922553"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210111998",
+                            "display_name": "Wuhan No.1 Hospital",
+                            "ror": "https://ror.org/021ty3131",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Nan-Shan Zhong",
+                    "raw_affiliation_strings": [
+                        "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit"
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the State Key Laboratory of Respiratory Disease, National Clinical Research Center for Respiratory Disease, Guangzhou Institute of Respiratory Health, First Affiliated Hospital of Guangzhou Medical University (W.G., W.L., J.H., R.C., C.T., T.W., S.L., Jin-lin Wang, N.Z., J.H., W.L.), the Departments of Thoracic Oncology (W.L.), Thoracic Surgery and Oncology (J.H.), and Emergency Medicine (Z.L.), First Affiliated Hospital of Guangzhou Medical University, and Guangzhou Eighth People's Hospital, Guangzhou Medical University (C.L.), and the State Key Laboratory of Organ Failure Research, Department of Biostatistics, Guangdong Provincial Key Laboratory of Tropical Disease Research, School of Public Health, Southern Medical University (C.O., P.C.), Guangzhou, Wuhan Jinyintan Hospital (Z.N., J.X.), Union Hospital, Tongji Medical College, Huazhong University of Science and Technology (Yu Hu), the Central Hospital of Wuhan (Y.P.), Wuhan No. 1 Hospital, Wuhan Hospital of Traditional Chinese and Western Medicine (L.W.), Wuhan Pulmonary Hospital (P.P.), Tianyou Hospital Affiliated to Wuhan University of Science and Technology (Jian-ming Wang), and the People's Hospital of Huangpi District (S.Z.), Wuhan, Shenzhen Third People's Hospital and the Second Affiliated Hospital of Southern University of Science and Technology, National Clinical Research Center for Infectious Diseases (L. Liu), and the Department of Clinical Microbiology and Infection Control, University of Hong Kong-Shenzhen Hospital (K.-Y.Y.), Shenzhen, the Fifth Affiliated Hospital of Sun Yat-sen University, Zhuhai (H.S.), the Department of Medicine and Therapeutics, Chinese University of Hong Kong, Shatin (D.S.C.H.), and the Department of Microbiology and the Carol Yu Center for Infection, Li Ka Shing Faculty of Medicine, University of Hong Kong, Pok Fu Lam (K.-Y.Y.), Hong Kong, Medical ICU, Peking Union Medical College Hospital, Peking Union Medical College and Chinese Academy of Medical Sciences (B.D.), and the Chinese Center for Disease Control and Prevention (G.Z.), Beijing, the State Key Laboratory for Diagnosis and Treatment of Infectious Diseases, National Clinical Research Center for Infectious Diseases, First Affiliated Hospital, College of Medicine, Zhejiang University, Hangzhou (L. Li), Chengdu Public Health Clinical Medical Center, Chengdu (Y.L.), Huangshi Central Hospital of Edong Healthcare Group, Affiliated Hospital of Hubei Polytechnic University, Huangshi (Ya-hua Hu), the First Hospit",
+                            "institution_ids": [
+                                "https://openalex.org/I58200834",
+                                "https://openalex.org/I157773358",
+                                "https://openalex.org/I4210156462",
+                                "https://openalex.org/I4210098361",
+                                "https://openalex.org/I4210154954",
+                                "https://openalex.org/I4210109004",
+                                "https://openalex.org/I4210143568",
+                                "https://openalex.org/I43922553",
+                                "https://openalex.org/I4210111998"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "institution_assertions": [],
+            "countries_distinct_count": 1,
+            "institutions_distinct_count": 9,
+            "corresponding_author_ids": [],
+            "corresponding_institution_ids": [],
+            "apc_list": null,
+            "apc_paid": null,
+            "fwci": 714.246,
+            "has_fulltext": true,
+            "fulltext_origin": "pdf",
+            "cited_by_count": 29323,
+            "citation_normalized_percentile": {
+                "value": 0.999954,
+                "is_in_top_1_percent": true,
+                "is_in_top_10_percent": true
+            },
+            "cited_by_percentile_year": {
+                "min": 99,
+                "max": 100
+            },
+            "biblio": {
+                "volume": "382",
+                "issue": "18",
+                "first_page": "1708",
+                "last_page": "1720"
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T10041",
+                "display_name": "COVID-19 Clinical Research Studies",
+                "score": 0.9999,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/2725",
+                    "display_name": "Infectious Diseases"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/27",
+                    "display_name": "Medicine"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/4",
+                    "display_name": "Health Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T10041",
+                    "display_name": "COVID-19 Clinical Research Studies",
+                    "score": 0.9999,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2725",
+                        "display_name": "Infectious Diseases"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T10118",
+                    "display_name": "SARS-CoV-2 and COVID-19 Research",
+                    "score": 0.9996,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2725",
+                        "display_name": "Infectious Diseases"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T11296",
+                    "display_name": "COVID-19 and healthcare impacts",
+                    "score": 0.9989,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2730",
+                        "display_name": "Oncology"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/interquartile-range",
+                    "display_name": "Interquartile range",
+                    "score": 0.80703413
+                },
+                {
+                    "id": "https://openalex.org/keywords/lymphocytopenia",
+                    "display_name": "Lymphocytopenia",
+                    "score": 0.6866892
+                },
+                {
+                    "id": "https://openalex.org/keywords/contact-tracing",
+                    "display_name": "Contact tracing",
+                    "score": 0.42761332
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C71924100",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11190",
+                    "display_name": "Medicine",
+                    "level": 0,
+                    "score": 0.8485516
+                },
+                {
+                    "id": "https://openalex.org/C119060515",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1916617",
+                    "display_name": "Interquartile range",
+                    "level": 2,
+                    "score": 0.80703413
+                },
+                {
+                    "id": "https://openalex.org/C2777990475",
+                    "wikidata": "https://www.wikidata.org/wiki/Q485831",
+                    "display_name": "Lymphocytopenia",
+                    "level": 3,
+                    "score": 0.6866892
+                },
+                {
+                    "id": "https://openalex.org/C2776376669",
+                    "wikidata": "https://www.wikidata.org/wiki/Q5094647",
+                    "display_name": "Intensive care unit",
+                    "level": 2,
+                    "score": 0.6684219
+                },
+                {
+                    "id": "https://openalex.org/C2777080012",
+                    "wikidata": "https://www.wikidata.org/wiki/Q3766250",
+                    "display_name": "Mechanical ventilation",
+                    "level": 2,
+                    "score": 0.6509378
+                },
+                {
+                    "id": "https://openalex.org/C2777914695",
+                    "wikidata": "https://www.wikidata.org/wiki/Q12192",
+                    "display_name": "Pneumonia",
+                    "level": 2,
+                    "score": 0.52577806
+                },
+                {
+                    "id": "https://openalex.org/C113162765",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1128437",
+                    "display_name": "Contact tracing",
+                    "level": 5,
+                    "score": 0.42761332
+                },
+                {
+                    "id": "https://openalex.org/C2779134260",
+                    "wikidata": "https://www.wikidata.org/wiki/Q12136",
+                    "display_name": "Disease",
+                    "level": 2,
+                    "score": 0.4109407
+                },
+                {
+                    "id": "https://openalex.org/C126322002",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11180",
+                    "display_name": "Internal medicine",
+                    "level": 1,
+                    "score": 0.40266782
+                },
+                {
+                    "id": "https://openalex.org/C3008058167",
+                    "wikidata": "https://www.wikidata.org/wiki/Q84263196",
+                    "display_name": "Coronavirus disease 2019 (COVID-19)",
+                    "level": 4,
+                    "score": 0.38312167
+                },
+                {
+                    "id": "https://openalex.org/C187212893",
+                    "wikidata": "https://www.wikidata.org/wiki/Q123028",
+                    "display_name": "Pediatrics",
+                    "level": 1,
+                    "score": 0.34172451
+                },
+                {
+                    "id": "https://openalex.org/C194828623",
+                    "wikidata": "https://www.wikidata.org/wiki/Q2861470",
+                    "display_name": "Emergency medicine",
+                    "level": 1,
+                    "score": 0.3281744
+                },
+                {
+                    "id": "https://openalex.org/C524204448",
+                    "wikidata": "https://www.wikidata.org/wiki/Q788926",
+                    "display_name": "Infectious disease (medical specialty)",
+                    "level": 3,
+                    "score": 0.10835719
+                },
+                {
+                    "id": "https://openalex.org/C2777761686",
+                    "wikidata": "https://www.wikidata.org/wiki/Q715347",
+                    "display_name": "Lymphocyte",
+                    "level": 2,
+                    "score": 0
+                }
+            ],
+            "mesh": [
+                {
+                    "descriptor_ui": "D000073640",
+                    "descriptor_name": "Betacoronavirus",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D018352",
+                    "descriptor_name": "Coronavirus Infections",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D004196",
+                    "descriptor_name": "Disease Outbreaks",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D058873",
+                    "descriptor_name": "Pandemics",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D011024",
+                    "descriptor_name": "Pneumonia, Viral",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D000293",
+                    "descriptor_name": "Adolescent",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000328",
+                    "descriptor_name": "Adult",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000368",
+                    "descriptor_name": "Aged",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000086382",
+                    "descriptor_name": "COVID-19",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D002648",
+                    "descriptor_name": "Child",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D002681",
+                    "descriptor_name": "China",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D002681",
+                    "descriptor_name": "China",
+                    "qualifier_ui": "Q000453",
+                    "qualifier_name": "epidemiology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D018352",
+                    "descriptor_name": "Coronavirus Infections",
+                    "qualifier_ui": "Q000453",
+                    "qualifier_name": "epidemiology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D018352",
+                    "descriptor_name": "Coronavirus Infections",
+                    "qualifier_ui": "Q000628",
+                    "qualifier_name": "therapy",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D018352",
+                    "descriptor_name": "Coronavirus Infections",
+                    "qualifier_ui": "Q000150",
+                    "qualifier_name": "complications",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D018352",
+                    "descriptor_name": "Coronavirus Infections",
+                    "qualifier_ui": "Q000175",
+                    "qualifier_name": "diagnosis",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D005260",
+                    "descriptor_name": "Female",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D005334",
+                    "descriptor_name": "Fever",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D005334",
+                    "descriptor_name": "Fever",
+                    "qualifier_ui": "Q000209",
+                    "qualifier_name": "etiology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D006801",
+                    "descriptor_name": "Humans",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D008297",
+                    "descriptor_name": "Male",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D008875",
+                    "descriptor_name": "Middle Aged",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D062072",
+                    "descriptor_name": "Patient Acuity",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D011024",
+                    "descriptor_name": "Pneumonia, Viral",
+                    "qualifier_ui": "Q000150",
+                    "qualifier_name": "complications",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D011024",
+                    "descriptor_name": "Pneumonia, Viral",
+                    "qualifier_ui": "Q000175",
+                    "qualifier_name": "diagnosis",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D011024",
+                    "descriptor_name": "Pneumonia, Viral",
+                    "qualifier_ui": "Q000453",
+                    "qualifier_name": "epidemiology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D011024",
+                    "descriptor_name": "Pneumonia, Viral",
+                    "qualifier_ui": "Q000628",
+                    "qualifier_name": "therapy",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000086402",
+                    "descriptor_name": "SARS-CoV-2",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D055815",
+                    "descriptor_name": "Young Adult",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                }
+            ],
+            "locations_count": 5,
+            "locations": [
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://doi.org/10.1056/nejmoa2002032",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S62468778",
+                        "display_name": "New England Journal of Medicine",
+                        "issn_l": "0028-4793",
+                        "issn": [
+                            "0028-4793",
+                            "1533-4406"
+                        ],
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": true,
+                        "is_core": true,
+                        "host_organization": "https://openalex.org/P4310320239",
+                        "host_organization_name": "Massachusetts Medical Society",
+                        "host_organization_lineage": [
+                            "https://openalex.org/P4310320239"
+                        ],
+                        "host_organization_lineage_names": [
+                            "Massachusetts Medical Society"
+                        ],
+                        "type": "journal"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://europepmc.org/articles/pmc7092819",
+                    "pdf_url": "https://europepmc.org/articles/pmc7092819?pdf=render",
+                    "source": {
+                        "id": "https://openalex.org/S4306400806",
+                        "display_name": "Europe PMC (PubMed Central)",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1303153112",
+                        "host_organization_name": "European Bioinformatics Institute",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1303153112"
+                        ],
+                        "host_organization_lineage_names": [
+                            "European Bioinformatics Institute"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": "other-oa",
+                    "license_id": "https://openalex.org/licenses/other-oa",
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7092819",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S2764455111",
+                        "display_name": "PubMed Central",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://doi.org/10.1101/2020.02.06.20020974",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306400573",
+                        "display_name": "medRxiv (Cold Spring Harbor Laboratory)",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I2750212522",
+                        "host_organization_name": "Cold Spring Harbor Laboratory",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I2750212522"
+                        ],
+                        "host_organization_lineage_names": [
+                            "Cold Spring Harbor Laboratory"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "submittedVersion",
+                    "is_accepted": false,
+                    "is_published": false
+                },
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://pubmed.ncbi.nlm.nih.gov/32109013",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306525036",
+                        "display_name": "PubMed",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1056/nejmoa2002032",
+                "pdf_url": null,
+                "source": {
+                    "id": "https://openalex.org/S62468778",
+                    "display_name": "New England Journal of Medicine",
+                    "issn_l": "0028-4793",
+                    "issn": [
+                        "0028-4793",
+                        "1533-4406"
+                    ],
+                    "is_oa": false,
+                    "is_in_doaj": false,
+                    "is_indexed_in_scopus": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310320239",
+                    "host_organization_name": "Massachusetts Medical Society",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310320239"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Massachusetts Medical Society"
+                    ],
+                    "type": "journal"
+                },
+                "license": null,
+                "license_id": null,
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "sustainable_development_goals": [
+                {
+                    "id": "https://metadata.un.org/sdg/3",
+                    "score": 0.44,
+                    "display_name": "Good health and well-being"
+                }
+            ],
+            "grants": [],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 21,
+            "referenced_works": [
+                "https://openalex.org/W1757215199",
+                "https://openalex.org/W1843578997",
+                "https://openalex.org/W2107053896",
+                "https://openalex.org/W2138324310",
+                "https://openalex.org/W2159340685",
+                "https://openalex.org/W2192340715",
+                "https://openalex.org/W2772576710",
+                "https://openalex.org/W2977322360",
+                "https://openalex.org/W3001118548",
+                "https://openalex.org/W3001897055",
+                "https://openalex.org/W3002108456",
+                "https://openalex.org/W3002539152",
+                "https://openalex.org/W3003465021",
+                "https://openalex.org/W3003573988",
+                "https://openalex.org/W3003668884",
+                "https://openalex.org/W3003951199",
+                "https://openalex.org/W3004239190",
+                "https://openalex.org/W3004318991",
+                "https://openalex.org/W3005079553",
+                "https://openalex.org/W3036980653",
+                "https://openalex.org/W3165656738"
+            ],
+            "related_works": [
+                "https://openalex.org/W4403170676",
+                "https://openalex.org/W4285299813",
+                "https://openalex.org/W4237099237",
+                "https://openalex.org/W3186334452",
+                "https://openalex.org/W3171701736",
+                "https://openalex.org/W3005048046",
+                "https://openalex.org/W2607917841",
+                "https://openalex.org/W2066816338",
+                "https://openalex.org/W1998701987",
+                "https://openalex.org/W1985448535"
+            ],
+            "abstract_inverted_index": {
+                "2": [
+                    176,
+                    233
+                ],
+                "4": [
+                    172
+                ],
+                "5": [
+                    213
+                ],
+                "30": [
+                    41
+                ],
+                "47": [
+                    80
+                ],
+                "67": [
+                    95
+                ],
+                "157": [
+                    203
+                ],
+                "173": [
+                    215
+                ],
+                "552": [
+                    38
+                ],
+                "877": [
+                    205
+                ],
+                "1099": [
+                    32
+                ],
+                "2019": [
+                    6
+                ],
+                "BackgroundSince": [
+                    0
+                ],
+                "December": [
+                    1
+                ],
+                "2019,": [
+                    2
+                ],
+                "when": [
+                    3
+                ],
+                "coronavirus": [
+                    4
+                ],
+                "disease": [
+                    5,
+                    210
+                ],
+                "(Covid-19)": [
+                    7
+                ],
+                "emerged": [
+                    8
+                ],
+                "in": [
+                    9,
+                    40,
+                    47,
+                    94,
+                    202,
+                    212,
+                    224
+                ],
+                "Wuhan": [
+                    10
+                ],
+                "city": [
+                    11
+                ],
+                "and": [
+                    12,
+                    45,
+                    112,
+                    156,
+                    160,
+                    211,
+                    244,
+                    255,
+                    271
+                ],
+                "rapidly": [
+                    13,
+                    241
+                ],
+                "spread": [
+                    14,
+                    240
+                ],
+                "throughout": [
+                    15,
+                    242
+                ],
+                "China,": [
+                    16
+                ],
+                "data": [
+                    17,
+                    30
+                ],
+                "have": [
+                    18,
+                    259
+                ],
+                "been": [
+                    19
+                ],
+                "needed": [
+                    20
+                ],
+                "on": [
+                    21,
+                    154,
+                    189,
+                    229
+                ],
+                "the": [
+                    22,
+                    26,
+                    67,
+                    77,
+                    84,
+                    104,
+                    119,
+                    145,
+                    184,
+                    227,
+                    231,
+                    236,
+                    265
+                ],
+                "clinical": [
+                    23
+                ],
+                "characteristics": [
+                    24
+                ],
+                "of": [
+                    25,
+                    69,
+                    76,
+                    83,
+                    118,
+                    124,
+                    131,
+                    138,
+                    204,
+                    214,
+                    226,
+                    235,
+                    248,
+                    269,
+                    277
+                ],
+                "affected": [
+                    27
+                ],
+                "patients.MethodsWe": [
+                    28
+                ],
+                "extracted": [
+                    29
+                ],
+                "regarding": [
+                    31
+                ],
+                "patients": [
+                    33,
+                    78,
+                    85,
+                    96,
+                    120,
+                    206,
+                    216,
+                    228
+                ],
+                "with": [
+                    34,
+                    127,
+                    136,
+                    208,
+                    218
+                ],
+                "laboratory-confirmed": [
+                    35
+                ],
+                "Covid-19": [
+                    36,
+                    239,
+                    278
+                ],
+                "from": [
+                    37
+                ],
+                "hospitals": [
+                    39
+                ],
+                "provinces,": [
+                    42
+                ],
+                "autonomous": [
+                    43
+                ],
+                "regions,": [
+                    44
+                ],
+                "municipalities": [
+                    46
+                ],
+                "mainland": [
+                    48
+                ],
+                "China": [
+                    49,
+                    243,
+                    270
+                ],
+                "through": [
+                    50
+                ],
+                "January": [
+                    51
+                ],
+                "29,": [
+                    52
+                ],
+                "2020.": [
+                    53
+                ],
+                "The": [
+                    54,
+                    88,
+                    147,
+                    167
+                ],
+                "primary": [
+                    55,
+                    89
+                ],
+                "composite": [
+                    56,
+                    90
+                ],
+                "end": [
+                    57,
+                    91
+                ],
+                "point": [
+                    58,
+                    92
+                ],
+                "was": [
+                    59,
+                    79,
+                    164,
+                    171,
+                    183,
+                    200,
+                    222
+                ],
+                "admission": [
+                    60,
+                    155
+                ],
+                "to": [
+                    61,
+                    103,
+                    177
+                ],
+                "an": [
+                    62
+                ],
+                "intensive": [
+                    63
+                ],
+                "care": [
+                    64
+                ],
+                "unit": [
+                    65
+                ],
+                "(ICU),": [
+                    66
+                ],
+                "use": [
+                    68
+                ],
+                "mechanical": [
+                    70,
+                    110
+                ],
+                "ventilation,": [
+                    71,
+                    111
+                ],
+                "or": [
+                    72,
+                    197
+                ],
+                "death.ResultsThe": [
+                    73
+                ],
+                "median": [
+                    74,
+                    168
+                ],
+                "age": [
+                    75
+                ],
+                "years;": [
+                    81
+                ],
+                "41.9%": [
+                    82
+                ],
+                "were": [
+                    86,
+                    101,
+                    151
+                ],
+                "female.": [
+                    87
+                ],
+                "occurred": [
+                    93
+                ],
+                "(6.1%),": [
+                    97
+                ],
+                "including": [
+                    98,
+                    140
+                ],
+                "5.0%": [
+                    99
+                ],
+                "who": [
+                    100,
+                    107,
+                    114,
+                    142
+                ],
+                "admitted": [
+                    102
+                ],
+                "ICU,": [
+                    105
+                ],
+                "2.3%": [
+                    106
+                ],
+                "underwent": [
+                    108
+                ],
+                "invasive": [
+                    109
+                ],
+                "1.4%": [
+                    113
+                ],
+                "died.": [
+                    115
+                ],
+                "Only": [
+                    116
+                ],
+                "1.9%": [
+                    117
+                ],
+                "had": [
+                    121,
+                    134,
+                    143
+                ],
+                "a": [
+                    122
+                ],
+                "history": [
+                    123
+                ],
+                "direct": [
+                    125
+                ],
+                "contact": [
+                    126,
+                    135
+                ],
+                "wildlife.": [
+                    128
+                ],
+                "Among": [
+                    129
+                ],
+                "nonresidents": [
+                    130
+                ],
+                "Wuhan,": [
+                    132,
+                    139
+                ],
+                "72.3%": [
+                    133
+                ],
+                "residents": [
+                    137
+                ],
+                "31.3%": [
+                    141
+                ],
+                "visited": [
+                    144
+                ],
+                "city.": [
+                    146
+                ],
+                "most": [
+                    148,
+                    185
+                ],
+                "common": [
+                    149,
+                    186
+                ],
+                "symptoms": [
+                    150
+                ],
+                "fever": [
+                    152
+                ],
+                "(43.8%": [
+                    153
+                ],
+                "88.7%": [
+                    157
+                ],
+                "during": [
+                    158
+                ],
+                "hospitalization)": [
+                    159
+                ],
+                "cough": [
+                    161
+                ],
+                "(67.8%).": [
+                    162
+                ],
+                "Diarrhea": [
+                    163
+                ],
+                "uncommon": [
+                    165
+                ],
+                "(3.8%).": [
+                    166
+                ],
+                "incubation": [
+                    169
+                ],
+                "period": [
+                    170
+                ],
+                "days": [
+                    173
+                ],
+                "(interquartile": [
+                    174
+                ],
+                "range,": [
+                    175
+                ],
+                "7).": [
+                    178
+                ],
+                "On": [
+                    179
+                ],
+                "admission,": [
+                    180
+                ],
+                "ground-glass": [
+                    181
+                ],
+                "opacity": [
+                    182
+                ],
+                "radiologic": [
+                    187,
+                    261
+                ],
+                "finding": [
+                    188
+                ],
+                "chest": [
+                    190
+                ],
+                "computed": [
+                    191
+                ],
+                "tomography": [
+                    192
+                ],
+                "(CT)": [
+                    193
+                ],
+                "(56.4%).": [
+                    194
+                ],
+                "No": [
+                    195
+                ],
+                "radiographic": [
+                    196
+                ],
+                "CT": [
+                    198
+                ],
+                "abnormality": [
+                    199
+                ],
+                "found": [
+                    201
+                ],
+                "(17.9%)": [
+                    207
+                ],
+                "nonsevere": [
+                    209
+                ],
+                "(2.9%)": [
+                    217
+                ],
+                "severe": [
+                    219
+                ],
+                "disease.": [
+                    220
+                ],
+                "Lymphocytopenia": [
+                    221
+                ],
+                "present": [
+                    223
+                ],
+                "83.2%": [
+                    225
+                ],
+                "admission.ConclusionsDuring": [
+                    230
+                ],
+                "first": [
+                    232
+                ],
+                "months": [
+                    234
+                ],
+                "current": [
+                    237
+                ],
+                "outbreak,": [
+                    238
+                ],
+                "caused": [
+                    245
+                ],
+                "varying": [
+                    246
+                ],
+                "degrees": [
+                    247
+                ],
+                "illness.": [
+                    249
+                ],
+                "Patients": [
+                    250
+                ],
+                "often": [
+                    251
+                ],
+                "presented": [
+                    252
+                ],
+                "without": [
+                    253
+                ],
+                "fever,": [
+                    254
+                ],
+                "many": [
+                    256
+                ],
+                "did": [
+                    257
+                ],
+                "not": [
+                    258
+                ],
+                "abnormal": [
+                    260
+                ],
+                "findings.": [
+                    262
+                ],
+                "(Funded": [
+                    263
+                ],
+                "by": [
+                    264
+                ],
+                "National": [
+                    266
+                ],
+                "Health": [
+                    267
+                ],
+                "Commission": [
+                    268
+                ],
+                "others.)": [
+                    272
+                ],
+                "Quick": [
+                    273
+                ],
+                "Take": [
+                    274
+                ],
+                "Clinical": [
+                    275
+                ],
+                "Characteristics": [
+                    276
+                ],
+                "2m": [
+                    279
+                ],
+                "8s": [
+                    280
+                ]
+            },
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W3008827533",
+            "counts_by_year": [
+                {
+                    "year": 2025,
+                    "cited_by_count": 381
+                },
+                {
+                    "year": 2024,
+                    "cited_by_count": 1279
+                },
+                {
+                    "year": 2023,
+                    "cited_by_count": 2533
+                },
+                {
+                    "year": 2022,
+                    "cited_by_count": 4508
+                },
+                {
+                    "year": 2021,
+                    "cited_by_count": 8306
+                },
+                {
+                    "year": 2020,
+                    "cited_by_count": 12253
+                },
+                {
+                    "year": 2019,
+                    "cited_by_count": 28
+                },
+                {
+                    "year": 2018,
+                    "cited_by_count": 1
+                },
+                {
+                    "year": 2015,
+                    "cited_by_count": 1
+                },
+                {
+                    "year": 2013,
+                    "cited_by_count": 1
+                },
+                {
+                    "year": 2012,
+                    "cited_by_count": 2
+                }
+            ],
+            "updated_date": "2025-09-22T22:07:46.122808",
+            "created_date": "2020-03-06"
+        },
+        {
+            "id": "https://openalex.org/W3001897055",
+            "doi": "https://doi.org/10.1056/nejmoa2001017",
+            "title": "A Novel Coronavirus from Patients with Pneumonia in China, 2019",
+            "display_name": "A Novel Coronavirus from Patients with Pneumonia in China, 2019",
+            "publication_year": 2020,
+            "publication_date": "2020-01-24",
+            "ids": {
+                "openalex": "https://openalex.org/W3001897055",
+                "doi": "https://doi.org/10.1056/nejmoa2001017",
+                "mag": "3001897055",
+                "pmid": "https://pubmed.ncbi.nlm.nih.gov/31978945",
+                "pmcid": "https://www.ncbi.nlm.nih.gov/pmc/articles/7092803"
+            },
+            "language": "en",
+            "primary_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1056/nejmoa2001017",
+                "pdf_url": null,
+                "source": {
+                    "id": "https://openalex.org/S62468778",
+                    "display_name": "New England Journal of Medicine",
+                    "issn_l": "0028-4793",
+                    "issn": [
+                        "0028-4793",
+                        "1533-4406"
+                    ],
+                    "is_oa": false,
+                    "is_in_doaj": false,
+                    "is_indexed_in_scopus": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310320239",
+                    "host_organization_name": "Massachusetts Medical Society",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310320239"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Massachusetts Medical Society"
+                    ],
+                    "type": "journal"
+                },
+                "license": null,
+                "license_id": null,
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "type": "article",
+            "type_crossref": "journal-article",
+            "indexed_in": [
+                "crossref",
+                "pubmed"
+            ],
+            "open_access": {
+                "is_oa": true,
+                "oa_status": "green",
+                "oa_url": "https://doi.org/10.1056/nejmoa2001017",
+                "any_repository_has_fulltext": true
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A5112999757",
+                        "display_name": "Na Zhu",
+                        "orcid": "https://orcid.org/0009-0001-5499-8756"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Na Zhu",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5043631759",
+                        "display_name": "Dingyu Zhang",
+                        "orcid": "https://orcid.org/0000-0002-9277-5705"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Dingyu Zhang",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5057178901",
+                        "display_name": "Wen‐Ching Wang",
+                        "orcid": "https://orcid.org/0000-0002-7422-3667"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Wenling Wang",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210150338"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5101925685",
+                        "display_name": "Xingwang Li",
+                        "orcid": "https://orcid.org/0009-0001-5424-6722"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Xingwang Li",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5072820962",
+                        "display_name": "Bo Yang",
+                        "orcid": "https://orcid.org/0000-0002-3183-5567"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Bo Yang",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210150338"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5031203283",
+                        "display_name": "Jingdong Song",
+                        "orcid": "https://orcid.org/0000-0001-8808-1981"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Jingdong Song",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5079882302",
+                        "display_name": "Xiang Zhao",
+                        "orcid": "https://orcid.org/0000-0002-1168-3439"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Xiang Zhao",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5063481153",
+                        "display_name": "Baoying Huang",
+                        "orcid": "https://orcid.org/0000-0001-9516-1146"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Baoying Huang",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5079289072",
+                        "display_name": "Weifeng Shi",
+                        "orcid": "https://orcid.org/0000-0002-8717-2942"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Weifeng Shi",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5112492347",
+                        "display_name": "Roujian Lu",
+                        "orcid": "https://orcid.org/0000-0002-3362-662X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Roujian Lu",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5045195522",
+                        "display_name": "Peihua Niu",
+                        "orcid": "https://orcid.org/0000-0001-5930-4234"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Peihua Niu",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5109113291",
+                        "display_name": "Faxian Zhan",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Faxian Zhan",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5078433604",
+                        "display_name": "Xuejun Ma",
+                        "orcid": "https://orcid.org/0000-0001-5891-5260"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Xuejun Ma",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5101759768",
+                        "display_name": "Dayan Wang",
+                        "orcid": "https://orcid.org/0000-0002-4990-1016"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Dayan Wang",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5102005952",
+                        "display_name": "Wenbo Xu",
+                        "orcid": "https://orcid.org/0000-0001-5911-8837"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Wenbo Xu",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5042900498",
+                        "display_name": "Guizhen Wu",
+                        "orcid": "https://orcid.org/0000-0003-2778-4290"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Guizhen Wu",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "middle",
+                    "author": {
+                        "id": "https://openalex.org/A5015873777",
+                        "display_name": "George F. Gao",
+                        "orcid": "https://orcid.org/0000-0002-3869-615X"
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "George F Gao",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210150338"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "author_position": "last",
+                    "author": {
+                        "id": "https://openalex.org/A5053933911",
+                        "display_name": "Wenjie Tan",
+                        "orcid": null
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I200296433",
+                            "display_name": "Chinese Academy of Medical Sciences & Peking Union Medical College",
+                            "ror": "https://ror.org/02drdmm93",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I200296433"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210150338",
+                            "display_name": "Beijing Ditan Hospital",
+                            "ror": "https://ror.org/05kkkes98",
+                            "country_code": "CN",
+                            "type": "healthcare",
+                            "lineage": [
+                                "https://openalex.org/I4210150338"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210103686",
+                            "display_name": "Hubei Provincial Center for Disease Control and Prevention",
+                            "ror": "https://ror.org/0197nmp73",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I4210103686"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210163399",
+                            "display_name": "Shandong First Medical University",
+                            "ror": "https://ror.org/05jb9pq57",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I4210163399"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I183519381",
+                            "display_name": "Capital Medical University",
+                            "ror": "https://ror.org/013xs5b60",
+                            "country_code": "CN",
+                            "type": "funder",
+                            "lineage": [
+                                "https://openalex.org/I183519381"
+                            ]
+                        },
+                        {
+                            "id": "https://openalex.org/I4210140986",
+                            "display_name": "National Institute for Viral Disease Control and Prevention",
+                            "ror": "https://ror.org/04b1sh213",
+                            "country_code": "CN",
+                            "type": "government",
+                            "lineage": [
+                                "https://openalex.org/I184490438",
+                                "https://openalex.org/I4210127390",
+                                "https://openalex.org/I4210140986",
+                                "https://openalex.org/I4210151987"
+                            ]
+                        }
+                    ],
+                    "countries": [
+                        "CN"
+                    ],
+                    "is_corresponding": false,
+                    "raw_author_name": "Wenjie Tan",
+                    "raw_affiliation_strings": [
+                        "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.)."
+                    ],
+                    "affiliations": [
+                        {
+                            "raw_affiliation_string": "From the NHC Key Laboratory of Biosafety, National Institute for Viral Disease Control and Prevention, Chinese Center for Disease Control and Prevention (N.Z., W.W., J.S., X.Z., B.H., R.L., P.N., X.M., D.W., W.X., G.W., G.F.G., W.T.), and the Department of Infectious Diseases, Beijing Ditan Hospital, Capital Medical University (X.L.) - both in Beijing; Wuhan Jinyintan Hospital (D.Z.), the Division for Viral Disease Detection, Hubei Provincial Center for Disease Control and Prevention (B.Y., F.Z.), and the Center for Biosafety Mega-Science, Chinese Academy of Sciences (W.T.) - all in Wuhan; and the Shandong First Medical University and Shandong Academy of Medical Sciences, Jinan, China (W.S.).",
+                            "institution_ids": [
+                                "https://openalex.org/I200296433",
+                                "https://openalex.org/I4210150338",
+                                "https://openalex.org/I4210103686",
+                                "https://openalex.org/I4210163399",
+                                "https://openalex.org/I183519381",
+                                "https://openalex.org/I4210140986"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "institution_assertions": [],
+            "countries_distinct_count": 1,
+            "institutions_distinct_count": 6,
+            "corresponding_author_ids": [],
+            "corresponding_institution_ids": [],
+            "apc_list": null,
+            "apc_paid": null,
+            "fwci": 698.551,
+            "has_fulltext": true,
+            "fulltext_origin": "pdf",
+            "cited_by_count": 29210,
+            "citation_normalized_percentile": {
+                "value": 0.999954,
+                "is_in_top_1_percent": true,
+                "is_in_top_10_percent": true
+            },
+            "cited_by_percentile_year": {
+                "min": 99,
+                "max": 100
+            },
+            "biblio": {
+                "volume": "382",
+                "issue": "8",
+                "first_page": "727",
+                "last_page": "733"
+            },
+            "is_retracted": false,
+            "is_paratext": false,
+            "primary_topic": {
+                "id": "https://openalex.org/T10118",
+                "display_name": "SARS-CoV-2 and COVID-19 Research",
+                "score": 0.9999,
+                "subfield": {
+                    "id": "https://openalex.org/subfields/2725",
+                    "display_name": "Infectious Diseases"
+                },
+                "field": {
+                    "id": "https://openalex.org/fields/27",
+                    "display_name": "Medicine"
+                },
+                "domain": {
+                    "id": "https://openalex.org/domains/4",
+                    "display_name": "Health Sciences"
+                }
+            },
+            "topics": [
+                {
+                    "id": "https://openalex.org/T10118",
+                    "display_name": "SARS-CoV-2 and COVID-19 Research",
+                    "score": 0.9999,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2725",
+                        "display_name": "Infectious Diseases"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T10976",
+                    "display_name": "Viral gastroenteritis research and epidemiology",
+                    "score": 0.9942,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2725",
+                        "display_name": "Infectious Diseases"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                },
+                {
+                    "id": "https://openalex.org/T10041",
+                    "display_name": "COVID-19 Clinical Research Studies",
+                    "score": 0.994,
+                    "subfield": {
+                        "id": "https://openalex.org/subfields/2725",
+                        "display_name": "Infectious Diseases"
+                    },
+                    "field": {
+                        "id": "https://openalex.org/fields/27",
+                        "display_name": "Medicine"
+                    },
+                    "domain": {
+                        "id": "https://openalex.org/domains/4",
+                        "display_name": "Health Sciences"
+                    }
+                }
+            ],
+            "keywords": [
+                {
+                    "id": "https://openalex.org/keywords/coronavirus",
+                    "display_name": "Coronavirus",
+                    "score": 0.7485354
+                },
+                {
+                    "id": "https://openalex.org/keywords/2019-20-coronavirus-outbreak",
+                    "display_name": "2019-20 coronavirus outbreak",
+                    "score": 0.64657855
+                },
+                {
+                    "id": "https://openalex.org/keywords/betacoronavirus",
+                    "display_name": "Betacoronavirus",
+                    "score": 0.4843334
+                }
+            ],
+            "concepts": [
+                {
+                    "id": "https://openalex.org/C2777914695",
+                    "wikidata": "https://www.wikidata.org/wiki/Q12192",
+                    "display_name": "Pneumonia",
+                    "level": 2,
+                    "score": 0.7995335
+                },
+                {
+                    "id": "https://openalex.org/C3008058167",
+                    "wikidata": "https://www.wikidata.org/wiki/Q84263196",
+                    "display_name": "Coronavirus disease 2019 (COVID-19)",
+                    "level": 4,
+                    "score": 0.76756346
+                },
+                {
+                    "id": "https://openalex.org/C2777648638",
+                    "wikidata": "https://www.wikidata.org/wiki/Q57751738",
+                    "display_name": "Coronavirus",
+                    "level": 5,
+                    "score": 0.7485354
+                },
+                {
+                    "id": "https://openalex.org/C3007834351",
+                    "wikidata": "https://www.wikidata.org/wiki/Q82069695",
+                    "display_name": "Severe acute respiratory syndrome coronavirus 2 (SARS-CoV-2)",
+                    "level": 5,
+                    "score": 0.65132844
+                },
+                {
+                    "id": "https://openalex.org/C3006700255",
+                    "wikidata": "https://www.wikidata.org/wiki/Q81068910",
+                    "display_name": "2019-20 coronavirus outbreak",
+                    "level": 3,
+                    "score": 0.64657855
+                },
+                {
+                    "id": "https://openalex.org/C159047783",
+                    "wikidata": "https://www.wikidata.org/wiki/Q7215",
+                    "display_name": "Virology",
+                    "level": 1,
+                    "score": 0.572797
+                },
+                {
+                    "id": "https://openalex.org/C191935318",
+                    "wikidata": "https://www.wikidata.org/wiki/Q148",
+                    "display_name": "China",
+                    "level": 2,
+                    "score": 0.5474737
+                },
+                {
+                    "id": "https://openalex.org/C71924100",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11190",
+                    "display_name": "Medicine",
+                    "level": 0,
+                    "score": 0.5086606
+                },
+                {
+                    "id": "https://openalex.org/C2778137277",
+                    "wikidata": "https://www.wikidata.org/wiki/Q16532287",
+                    "display_name": "Betacoronavirus",
+                    "level": 5,
+                    "score": 0.4843334
+                },
+                {
+                    "id": "https://openalex.org/C205649164",
+                    "wikidata": "https://www.wikidata.org/wiki/Q1071",
+                    "display_name": "Geography",
+                    "level": 0,
+                    "score": 0.2749225
+                },
+                {
+                    "id": "https://openalex.org/C126322002",
+                    "wikidata": "https://www.wikidata.org/wiki/Q11180",
+                    "display_name": "Internal medicine",
+                    "level": 1,
+                    "score": 0.20134768
+                },
+                {
+                    "id": "https://openalex.org/C116675565",
+                    "wikidata": "https://www.wikidata.org/wiki/Q3241045",
+                    "display_name": "Outbreak",
+                    "level": 2,
+                    "score": 0.14580399
+                },
+                {
+                    "id": "https://openalex.org/C524204448",
+                    "wikidata": "https://www.wikidata.org/wiki/Q788926",
+                    "display_name": "Infectious disease (medical specialty)",
+                    "level": 3,
+                    "score": 0.07421616
+                },
+                {
+                    "id": "https://openalex.org/C166957645",
+                    "wikidata": "https://www.wikidata.org/wiki/Q23498",
+                    "display_name": "Archaeology",
+                    "level": 1,
+                    "score": 0.063531965
+                },
+                {
+                    "id": "https://openalex.org/C2779134260",
+                    "wikidata": "https://www.wikidata.org/wiki/Q12136",
+                    "display_name": "Disease",
+                    "level": 2,
+                    "score": 0.053421736
+                }
+            ],
+            "mesh": [
+                {
+                    "descriptor_ui": "D000073640",
+                    "descriptor_name": "Betacoronavirus",
+                    "qualifier_ui": "Q000302",
+                    "qualifier_name": "isolation & purification",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D018352",
+                    "descriptor_name": "Coronavirus Infections",
+                    "qualifier_ui": "Q000821",
+                    "qualifier_name": "virology",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D008168",
+                    "descriptor_name": "Lung",
+                    "qualifier_ui": "Q000000981",
+                    "qualifier_name": "diagnostic imaging",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D011024",
+                    "descriptor_name": "Pneumonia, Viral",
+                    "qualifier_ui": "Q000821",
+                    "qualifier_name": "virology",
+                    "is_major_topic": true
+                },
+                {
+                    "descriptor_ui": "D000328",
+                    "descriptor_name": "Adult",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000073640",
+                    "descriptor_name": "Betacoronavirus",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000073640",
+                    "descriptor_name": "Betacoronavirus",
+                    "qualifier_ui": "Q000235",
+                    "qualifier_name": "genetics",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000073640",
+                    "descriptor_name": "Betacoronavirus",
+                    "qualifier_ui": "Q000648",
+                    "qualifier_name": "ultrastructure",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D001992",
+                    "descriptor_name": "Bronchoalveolar Lavage Fluid",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D001992",
+                    "descriptor_name": "Bronchoalveolar Lavage Fluid",
+                    "qualifier_ui": "Q000821",
+                    "qualifier_name": "virology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000086382",
+                    "descriptor_name": "COVID-19",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D002478",
+                    "descriptor_name": "Cells, Cultured",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D002681",
+                    "descriptor_name": "China",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D018352",
+                    "descriptor_name": "Coronavirus Infections",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D018352",
+                    "descriptor_name": "Coronavirus Infections",
+                    "qualifier_ui": "Q000000981",
+                    "qualifier_name": "diagnostic imaging",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D018352",
+                    "descriptor_name": "Coronavirus Infections",
+                    "qualifier_ui": "Q000473",
+                    "qualifier_name": "pathology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D004847",
+                    "descriptor_name": "Epithelial Cells",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D004847",
+                    "descriptor_name": "Epithelial Cells",
+                    "qualifier_ui": "Q000473",
+                    "qualifier_name": "pathology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D004847",
+                    "descriptor_name": "Epithelial Cells",
+                    "qualifier_ui": "Q000821",
+                    "qualifier_name": "virology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D005260",
+                    "descriptor_name": "Female",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D016679",
+                    "descriptor_name": "Genome, Viral",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D006801",
+                    "descriptor_name": "Humans",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D008168",
+                    "descriptor_name": "Lung",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D008168",
+                    "descriptor_name": "Lung",
+                    "qualifier_ui": "Q000473",
+                    "qualifier_name": "pathology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D008168",
+                    "descriptor_name": "Lung",
+                    "qualifier_ui": "Q000821",
+                    "qualifier_name": "virology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D008297",
+                    "descriptor_name": "Male",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D046529",
+                    "descriptor_name": "Microscopy, Electron, Transmission",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D008875",
+                    "descriptor_name": "Middle Aged",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D010802",
+                    "descriptor_name": "Phylogeny",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D011024",
+                    "descriptor_name": "Pneumonia, Viral",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D011024",
+                    "descriptor_name": "Pneumonia, Viral",
+                    "qualifier_ui": "Q000000981",
+                    "qualifier_name": "diagnostic imaging",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D011024",
+                    "descriptor_name": "Pneumonia, Viral",
+                    "qualifier_ui": "Q000473",
+                    "qualifier_name": "pathology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D013902",
+                    "descriptor_name": "Radiography, Thoracic",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D012137",
+                    "descriptor_name": "Respiratory System",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D012137",
+                    "descriptor_name": "Respiratory System",
+                    "qualifier_ui": "Q000821",
+                    "qualifier_name": "virology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D012137",
+                    "descriptor_name": "Respiratory System",
+                    "qualifier_ui": "Q000473",
+                    "qualifier_name": "pathology",
+                    "is_major_topic": false
+                },
+                {
+                    "descriptor_ui": "D000086402",
+                    "descriptor_name": "SARS-CoV-2",
+                    "qualifier_ui": "",
+                    "qualifier_name": null,
+                    "is_major_topic": false
+                }
+            ],
+            "locations_count": 5,
+            "locations": [
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://doi.org/10.1056/nejmoa2001017",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S62468778",
+                        "display_name": "New England Journal of Medicine",
+                        "issn_l": "0028-4793",
+                        "issn": [
+                            "0028-4793",
+                            "1533-4406"
+                        ],
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": true,
+                        "is_core": true,
+                        "host_organization": "https://openalex.org/P4310320239",
+                        "host_organization_name": "Massachusetts Medical Society",
+                        "host_organization_lineage": [
+                            "https://openalex.org/P4310320239"
+                        ],
+                        "host_organization_lineage_names": [
+                            "Massachusetts Medical Society"
+                        ],
+                        "type": "journal"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://europepmc.org/articles/pmc7092803",
+                    "pdf_url": "https://europepmc.org/articles/pmc7092803?pdf=render",
+                    "source": {
+                        "id": "https://openalex.org/S4306400806",
+                        "display_name": "Europe PMC (PubMed Central)",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1303153112",
+                        "host_organization_name": "European Bioinformatics Institute",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1303153112"
+                        ],
+                        "host_organization_lineage_names": [
+                            "European Bioinformatics Institute"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": "other-oa",
+                    "license_id": "https://openalex.org/licenses/other-oa",
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7092803",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S2764455111",
+                        "display_name": "PubMed Central",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": "publishedVersion",
+                    "is_accepted": true,
+                    "is_published": true
+                },
+                {
+                    "is_oa": true,
+                    "landing_page_url": "https://repositorio.unal.edu.co/handle/unal/81004",
+                    "pdf_url": "https://repositorio.unal.edu.co/bitstream/unal/81004/1/1088314019.2022.pdf",
+                    "source": {
+                        "id": "https://openalex.org/S4306402641",
+                        "display_name": "LA Referencia (Red Federada de Repositorios Institucionales de Publicaciones Científicas)",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": true,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I4383465926",
+                        "host_organization_name": "LA Referencia",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I4383465926"
+                        ],
+                        "host_organization_lineage_names": [
+                            "LA Referencia"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": "cc-by-nc-nd",
+                    "license_id": "https://openalex.org/licenses/cc-by-nc-nd",
+                    "version": "acceptedVersion",
+                    "is_accepted": true,
+                    "is_published": false
+                },
+                {
+                    "is_oa": false,
+                    "landing_page_url": "https://pubmed.ncbi.nlm.nih.gov/31978945",
+                    "pdf_url": null,
+                    "source": {
+                        "id": "https://openalex.org/S4306525036",
+                        "display_name": "PubMed",
+                        "issn_l": null,
+                        "issn": null,
+                        "is_oa": false,
+                        "is_in_doaj": false,
+                        "is_indexed_in_scopus": false,
+                        "is_core": false,
+                        "host_organization": "https://openalex.org/I1299303238",
+                        "host_organization_name": "National Institutes of Health",
+                        "host_organization_lineage": [
+                            "https://openalex.org/I1299303238"
+                        ],
+                        "host_organization_lineage_names": [
+                            "National Institutes of Health"
+                        ],
+                        "type": "repository"
+                    },
+                    "license": null,
+                    "license_id": null,
+                    "version": null,
+                    "is_accepted": false,
+                    "is_published": false
+                }
+            ],
+            "best_oa_location": {
+                "is_oa": true,
+                "landing_page_url": "https://doi.org/10.1056/nejmoa2001017",
+                "pdf_url": null,
+                "source": {
+                    "id": "https://openalex.org/S62468778",
+                    "display_name": "New England Journal of Medicine",
+                    "issn_l": "0028-4793",
+                    "issn": [
+                        "0028-4793",
+                        "1533-4406"
+                    ],
+                    "is_oa": false,
+                    "is_in_doaj": false,
+                    "is_indexed_in_scopus": true,
+                    "is_core": true,
+                    "host_organization": "https://openalex.org/P4310320239",
+                    "host_organization_name": "Massachusetts Medical Society",
+                    "host_organization_lineage": [
+                        "https://openalex.org/P4310320239"
+                    ],
+                    "host_organization_lineage_names": [
+                        "Massachusetts Medical Society"
+                    ],
+                    "type": "journal"
+                },
+                "license": null,
+                "license_id": null,
+                "version": "publishedVersion",
+                "is_accepted": true,
+                "is_published": true
+            },
+            "sustainable_development_goals": [
+                {
+                    "id": "https://metadata.un.org/sdg/14",
+                    "score": 0.56,
+                    "display_name": "Life below water"
+                }
+            ],
+            "grants": [],
+            "datasets": [],
+            "versions": [],
+            "referenced_works_count": 16,
+            "referenced_works": [
+                "https://openalex.org/W10914455",
+                "https://openalex.org/W1909499787",
+                "https://openalex.org/W2104548316",
+                "https://openalex.org/W2132260239",
+                "https://openalex.org/W2141877163",
+                "https://openalex.org/W2166867592",
+                "https://openalex.org/W2167391272",
+                "https://openalex.org/W2257005270",
+                "https://openalex.org/W2306794997",
+                "https://openalex.org/W2792024998",
+                "https://openalex.org/W2903899730",
+                "https://openalex.org/W2955025503",
+                "https://openalex.org/W2997069256",
+                "https://openalex.org/W3017468735",
+                "https://openalex.org/W3027518954",
+                "https://openalex.org/W4211029266"
+            ],
+            "related_works": [
+                "https://openalex.org/W4290085574",
+                "https://openalex.org/W4280491013",
+                "https://openalex.org/W4220712676",
+                "https://openalex.org/W3127156785",
+                "https://openalex.org/W3124487864",
+                "https://openalex.org/W3043486364",
+                "https://openalex.org/W3031607536",
+                "https://openalex.org/W3009669391",
+                "https://openalex.org/W3006642361",
+                "https://openalex.org/W3005417802"
+            ],
+            "abstract_inverted_index": {
+                "In": [
+                    0
+                ],
+                "December": [
+                    1
+                ],
+                "2019,": [
+                    2
+                ],
+                "a": [
+                    3,
+                    15,
+                    48,
+                    55
+                ],
+                "cluster": [
+                    4
+                ],
+                "of": [
+                    5,
+                    9,
+                    31,
+                    74,
+                    77,
+                    98,
+                    109
+                ],
+                "patients": [
+                    6,
+                    37
+                ],
+                "with": [
+                    7,
+                    38
+                ],
+                "pneumonia": [
+                    8
+                ],
+                "unknown": [
+                    10,
+                    24
+                ],
+                "cause": [
+                    11
+                ],
+                "was": [
+                    12,
+                    26
+                ],
+                "linked": [
+                    13
+                ],
+                "to": [
+                    14,
+                    46
+                ],
+                "seafood": [
+                    16
+                ],
+                "wholesale": [
+                    17
+                ],
+                "market": [
+                    18
+                ],
+                "in": [
+                    19,
+                    34,
+                    112
+                ],
+                "Wuhan,": [
+                    20
+                ],
+                "China.": [
+                    21
+                ],
+                "A": [
+                    22
+                ],
+                "previously": [
+                    23
+                ],
+                "betacoronavirus": [
+                    25
+                ],
+                "discovered": [
+                    27
+                ],
+                "through": [
+                    28
+                ],
+                "the": [
+                    29,
+                    58,
+                    71,
+                    75,
+                    91,
+                    101
+                ],
+                "use": [
+                    30
+                ],
+                "unbiased": [
+                    32
+                ],
+                "sequencing": [
+                    33
+                ],
+                "samples": [
+                    35
+                ],
+                "from": [
+                    36,
+                    64
+                ],
+                "pneumonia.": [
+                    39
+                ],
+                "Human": [
+                    40
+                ],
+                "airway": [
+                    41
+                ],
+                "epithelial": [
+                    42
+                ],
+                "cells": [
+                    43
+                ],
+                "were": [
+                    44
+                ],
+                "used": [
+                    45
+                ],
+                "isolate": [
+                    47
+                ],
+                "novel": [
+                    49
+                ],
+                "coronavirus,": [
+                    50
+                ],
+                "named": [
+                    51
+                ],
+                "2019-nCoV,": [
+                    52
+                ],
+                "which": [
+                    53
+                ],
+                "formed": [
+                    54
+                ],
+                "clade": [
+                    56
+                ],
+                "within": [
+                    57
+                ],
+                "subgenus": [
+                    59
+                ],
+                "sarbecovirus,": [
+                    60
+                ],
+                "Orthocoronavirinae": [
+                    61
+                ],
+                "subfamily.": [
+                    62
+                ],
+                "Different": [
+                    63
+                ],
+                "both": [
+                    65
+                ],
+                "MERS-CoV": [
+                    66
+                ],
+                "and": [
+                    67,
+                    84,
+                    95,
+                    100,
+                    107
+                ],
+                "SARS-CoV,": [
+                    68
+                ],
+                "2019-nCoV": [
+                    69
+                ],
+                "is": [
+                    70
+                ],
+                "seventh": [
+                    72
+                ],
+                "member": [
+                    73
+                ],
+                "family": [
+                    76
+                ],
+                "coronaviruses": [
+                    78
+                ],
+                "that": [
+                    79
+                ],
+                "infect": [
+                    80
+                ],
+                "humans.": [
+                    81
+                ],
+                "Enhanced": [
+                    82
+                ],
+                "surveillance": [
+                    83
+                ],
+                "further": [
+                    85
+                ],
+                "investigation": [
+                    86
+                ],
+                "are": [
+                    87
+                ],
+                "ongoing.": [
+                    88
+                ],
+                "(Funded": [
+                    89
+                ],
+                "by": [
+                    90
+                ],
+                "National": [
+                    92,
+                    102
+                ],
+                "Key": [
+                    93
+                ],
+                "Research": [
+                    94
+                ],
+                "Development": [
+                    96
+                ],
+                "Program": [
+                    97
+                ],
+                "China": [
+                    99
+                ],
+                "Major": [
+                    103
+                ],
+                "Project": [
+                    104
+                ],
+                "for": [
+                    105
+                ],
+                "Control": [
+                    106
+                ],
+                "Prevention": [
+                    108
+                ],
+                "Infectious": [
+                    110
+                ],
+                "Disease": [
+                    111
+                ],
+                "China.).": [
+                    113
+                ]
+            },
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W3001897055",
+            "counts_by_year": [
+                {
+                    "year": 2025,
+                    "cited_by_count": 532
+                },
+                {
+                    "year": 2024,
+                    "cited_by_count": 1601
+                },
+                {
+                    "year": 2023,
+                    "cited_by_count": 2876
+                },
+                {
+                    "year": 2022,
+                    "cited_by_count": 5019
+                },
+                {
+                    "year": 2021,
+                    "cited_by_count": 8134
+                },
+                {
+                    "year": 2020,
+                    "cited_by_count": 10979
+                },
+                {
+                    "year": 2019,
+                    "cited_by_count": 35
+                },
+                {
+                    "year": 2018,
+                    "cited_by_count": 5
+                },
+                {
+                    "year": 2012,
+                    "cited_by_count": 1
+                }
+            ],
+            "updated_date": "2025-09-20T16:51:00.928324",
+            "created_date": "2020-01-30"
+        }
+    ],
+    "group_by": []
+}

--- a/src/paper/ingestion/tests/clients/test_openalex.py
+++ b/src/paper/ingestion/tests/clients/test_openalex.py
@@ -1,0 +1,504 @@
+import json
+import os
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import requests
+from django.test import TestCase
+
+from paper.ingestion.clients.openalex import OpenAlexClient, OpenAlexConfig
+from paper.ingestion.exceptions import FetchError, TimeoutError
+
+
+class TestOpenAlexClient(TestCase):
+    """
+    Test cases for the OpenAlex client.
+    """
+
+    def setUp(self):
+        self.config = OpenAlexConfig(email="test@example.com")
+        self.client = OpenAlexClient(self.config)
+
+        # Load fixture files
+        fixtures_dir = os.path.join(os.path.dirname(__file__), "fixtures")
+
+        with open(
+            os.path.join(fixtures_dir, "openalex_sample_response.json"), "r"
+        ) as f:
+            self.sample_list_response = json.load(f)
+
+        with open(
+            os.path.join(fixtures_dir, "openalex_sample_get_by_doi_response.json"),
+            "r",
+        ) as f:
+            self.sample_single_response = json.load(f)
+
+        with open(os.path.join(fixtures_dir, "openalex_empty_response.json"), "r") as f:
+            self.empty_list_response = json.load(f)
+
+    def test_config_defaults(self):
+        """
+        Test OpenAlex config has correct defaults.
+        """
+        # Arrange & Act
+        config = OpenAlexConfig()
+
+        # Assert
+        self.assertEqual(config.source_name, "openalex")
+        self.assertEqual(config.base_url, "https://api.openalex.org")
+        self.assertEqual(config.rate_limit, 10.0)  # 10 requests per second
+        self.assertEqual(config.page_size, 200)  # OpenAlex max
+        self.assertEqual(config.request_timeout, 30.0)
+        self.assertEqual(config.max_results_per_query, 200)
+
+    def test_config_with_email(self):
+        """
+        Test OpenAlex config with email for polite pool.
+        """
+        # Arrange
+        config = OpenAlexConfig(email="test@example.com")
+
+        # Act
+        client = OpenAlexClient(config)
+        self.assertEqual(client.headers["User-Agent"], "mailto:test@example.com")
+
+    def test_parse_list_response(self):
+        """
+        Test parsing of OpenAlex list response.
+        """
+        # Act
+        papers = self.client.parse(self.sample_list_response)
+
+        # Assert
+        # Should have 3 papers from the fixture
+        self.assertEqual(len(papers), 3)
+
+        # Check first paper structure
+        paper1 = papers[0]
+        self.assertIn("raw_data", paper1)
+        self.assertEqual(paper1["source"], "openalex")
+
+        # Verify the raw data contains expected fields
+        raw = paper1["raw_data"]
+        self.assertEqual(raw["id"], "https://openalex.org/W3001118548")
+        self.assertEqual(raw["doi"], "https://doi.org/10.1016/s0140-6736(20)30183-5")
+        self.assertIn("Clinical features", raw["title"])
+        self.assertEqual(raw["publication_year"], 2020)
+
+    def test_parse_empty_response(self):
+        """
+        Test parsing empty response.
+        """
+        # Act
+        papers = self.client.parse(self.empty_list_response)
+
+        # Assert
+        self.assertEqual(papers, [])
+
+    def test_parse_missing_results_key(self):
+        """
+        Test parsing response without results key.
+        """
+        # Arrange
+        invalid_response = {"meta": {"count": 0}}
+
+        # Act
+        papers = self.client.parse(invalid_response)
+
+        # Assert
+        self.assertEqual(papers, [])
+
+    def test_parse_non_dict_response(self):
+        """
+        Test parsing non-dict response returns empty list.
+        """
+        # Act & Assert
+        papers = self.client.parse("Invalid response")
+        self.assertEqual(papers, [])
+
+        papers = self.client.parse(None)
+        self.assertEqual(papers, [])
+
+        papers = self.client.parse([])
+        self.assertEqual(papers, [])
+
+    @patch("requests.Session.get")
+    def test_fetch(self, mock_get):
+        """
+        Test basic fetch method.
+        """
+        # Arrange
+        mock_response = MagicMock()
+        mock_response.json.return_value = self.sample_list_response
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        # Act
+        result = self.client.fetch("/works", {"filter": "is_oa:true"})
+
+        # Assert
+        self.assertEqual(result, self.sample_list_response)
+        mock_get.assert_called_once_with(
+            "https://api.openalex.org/works",
+            params={"filter": "is_oa:true"},
+            timeout=30.0,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "mailto:test@example.com",
+            },
+        )
+
+    @patch("requests.Session.get")
+    def test_fetch_timeout(self, mock_get):
+        """
+        Test fetch with timeout.
+        """
+        # Arrange
+        mock_get.side_effect = requests.Timeout("Request timed out")
+
+        # Act & Assert
+        with self.assertRaises(TimeoutError) as context:
+            self.client.fetch("/works")
+
+        self.assertIn("Request timed out after 30.0s", str(context.exception))
+
+    @patch("requests.Session.get")
+    def test_fetch_request_error(self, mock_get):
+        """
+        Test fetch with request error.
+        """
+        # Arrange
+        mock_get.side_effect = requests.RequestException("Connection error")
+
+        # Act & Assert
+        with self.assertRaises(FetchError) as context:
+            self.client.fetch("/works")
+
+        self.assertIn("Failed to fetch from", str(context.exception))
+        self.assertIn("Connection error", str(context.exception))
+
+    @patch.object(OpenAlexClient, "fetch_with_retry")
+    @patch.object(OpenAlexClient, "process_page")
+    def test_fetch_recent_basic(self, mock_process, mock_fetch):
+        """
+        Test fetching recent papers.
+        """
+        # Arrange
+        mock_fetch.return_value = self.sample_list_response
+        mock_process.return_value = self.client.parse(self.sample_list_response)
+
+        # Act
+        papers = self.client.fetch_recent(
+            since=datetime(2025, 1, 1),
+            until=datetime(2025, 1, 7),
+            max_results=10,
+        )
+
+        # Assert
+        self.assertEqual(len(papers), 3)
+        self.assertIn("raw_data", papers[0])
+
+        # Verify query was constructed correctly
+        call_args = mock_fetch.call_args
+        params = call_args[0][1]  # Get params from call
+        self.assertIn("from_publication_date:2025-01-01", params["filter"])
+        self.assertIn("to_publication_date:2025-01-07", params["filter"])
+        self.assertEqual(params["sort"], "publication_date:desc")
+
+    @patch.object(OpenAlexClient, "fetch_with_retry")
+    @patch.object(OpenAlexClient, "process_page")
+    def test_fetch_recent_default_dates(self, mock_process, mock_fetch):
+        """
+        Test fetch_recent with default date range.
+        """
+        # Arrange
+        mock_fetch.return_value = self.empty_list_response
+        mock_process.return_value = []
+
+        # Act
+        self.client.fetch_recent()
+
+        # Assert
+        # Should use default 7 day range
+        call_args = mock_fetch.call_args
+        params = call_args[0][1]
+        filter_str = params["filter"]
+
+        # Check that date filter is present
+        self.assertIn("from_publication_date:", filter_str)
+        self.assertIn("to_publication_date:", filter_str)
+
+    @patch.object(OpenAlexClient, "fetch_with_retry")
+    @patch.object(OpenAlexClient, "process_page")
+    def test_fetch_recent_pagination(self, mock_process, mock_fetch):
+        """
+        Test pagination handling in fetch_recent.
+        """
+        # Arrange
+        first_page = {
+            "meta": {"next_cursor": "cursor_page2", "count": 250},
+            "results": [{"id": f"W{i}"} for i in range(200)],
+        }
+        second_page = {
+            "meta": {"next_cursor": None, "count": 250},
+            "results": [{"id": f"W{i}"} for i in range(200, 250)],
+        }
+
+        mock_fetch.side_effect = [first_page, second_page]
+        mock_process.side_effect = [
+            self.client.parse(first_page),
+            self.client.parse(second_page),
+        ]
+
+        # Act
+        papers = self.client.fetch_recent(
+            since=datetime(2025, 1, 1), until=datetime(2025, 1, 2)
+        )
+
+        # Assert
+        # Should have fetched all papers
+        self.assertEqual(len(papers), 250)
+        self.assertEqual(mock_fetch.call_count, 2)
+
+        # Check cursor progression
+        first_call_params = mock_fetch.call_args_list[0][0][1]
+        second_call_params = mock_fetch.call_args_list[1][0][1]
+        self.assertEqual(first_call_params["cursor"], "*")
+        self.assertEqual(second_call_params["cursor"], "cursor_page2")
+
+    @patch.object(OpenAlexClient, "fetch_with_retry")
+    def test_fetch_by_doi(self, mock_fetch):
+        """
+        Test fetching a single paper by DOI.
+        """
+        # Arrange
+        mock_fetch.return_value = self.sample_single_response
+
+        # Act
+        paper = self.client.fetch_by_doi("10.7717/peerj.4375")
+        # Assert
+        self.assertIsNotNone(paper)
+        self.assertEqual(paper["source"], "openalex")
+        self.assertEqual(paper["raw_data"]["id"], "https://openalex.org/W2741809807")
+
+        # Verify correct URL was called
+        mock_fetch.assert_called_with("/works/https://doi.org/10.7717/peerj.4375")
+
+    @patch.object(OpenAlexClient, "fetch_with_retry")
+    def test_fetch_by_doi_with_url_prefix(self, mock_fetch):
+        """
+        Test fetching by DOI with URL prefix.
+        """
+        # Arrange
+        mock_fetch.return_value = self.sample_single_response
+
+        # Act - Test with https prefix
+        paper = self.client.fetch_by_doi("https://doi.org/10.7717/peerj.4375")
+        # Assert
+        self.assertIsNotNone(paper)
+
+        # Should have cleaned the DOI
+        mock_fetch.assert_called_with("/works/https://doi.org/10.7717/peerj.4375")
+
+        # Act - Test with http prefix
+        mock_fetch.reset_mock()
+        paper = self.client.fetch_by_doi("http://doi.org/10.7717/peerj.4375")
+        # Assert
+        self.assertIsNotNone(paper)
+
+        mock_fetch.assert_called_with("/works/https://doi.org/10.7717/peerj.4375")
+
+    @patch.object(OpenAlexClient, "fetch_with_retry")
+    def test_fetch_by_doi_not_found(self, mock_fetch):
+        """
+        Test fetching by DOI when paper not found.
+        """
+        # Arrange
+        mock_fetch.side_effect = FetchError("404 Not Found")
+
+        # Act
+        paper = self.client.fetch_by_doi("10.1234/nonexistent")
+
+        # Assert
+        self.assertIsNone(paper)
+
+    @patch.object(OpenAlexClient, "fetch_with_retry")
+    @patch.object(OpenAlexClient, "process_page")
+    def test_fetch_by_ids_dois(self, mock_process, mock_fetch):
+        """
+        Test fetching papers by multiple DOIs.
+        """
+        # Arrange
+        mock_fetch.return_value = self.sample_list_response
+        mock_process.return_value = self.client.parse(self.sample_list_response)
+        dois = ["10.1234/test1", "10.5678/test2"]
+
+        # Act
+        papers = self.client.fetch_by_ids(dois, id_type="doi")
+
+        # Assert
+        self.assertEqual(len(papers), 3)  # Based on sample response
+
+        # Verify filter was constructed correctly
+        call_args = mock_fetch.call_args
+        params = call_args[0][1]
+        expected_filter = (
+            "doi:https://doi.org/10.1234/test1|https://doi.org/10.5678/test2"
+        )
+        self.assertEqual(params["filter"], expected_filter)
+
+    @patch.object(OpenAlexClient, "fetch_with_retry")
+    @patch.object(OpenAlexClient, "process_page")
+    def test_fetch_by_ids_dois_with_prefixes(self, mock_process, mock_fetch):
+        """
+        Test fetching by DOIs that already have URL prefixes.
+        """
+        # Arrange
+        mock_fetch.return_value = self.sample_list_response
+        mock_process.return_value = self.client.parse(self.sample_list_response)
+        dois = [
+            "https://doi.org/10.1234/test1",
+            "http://doi.org/10.5678/test2",
+            "10.9999/test3",  # Mix of prefixed and non-prefixed
+        ]
+
+        # Act
+        self.client.fetch_by_ids(dois, id_type="doi")
+
+        # Assert
+        # Verify DOIs were cleaned before constructing filter
+        call_args = mock_fetch.call_args
+        params = call_args[0][1]
+        expected_filter = (
+            "doi:https://doi.org/10.1234/test1|"
+            "https://doi.org/10.5678/test2|"
+            "https://doi.org/10.9999/test3"
+        )
+        self.assertEqual(params["filter"], expected_filter)
+
+    @patch.object(OpenAlexClient, "fetch_with_retry")
+    @patch.object(OpenAlexClient, "process_page")
+    def test_fetch_by_ids_openalex(self, mock_process, mock_fetch):
+        """
+        Test fetching by OpenAlex IDs.
+        """
+        # Arrange
+        mock_fetch.return_value = self.sample_list_response
+        mock_process.return_value = self.client.parse(self.sample_list_response)
+        ids = ["W2741809807", "W3001118548"]
+
+        # Act
+        self.client.fetch_by_ids(ids, id_type="openalex")
+
+        # Assert
+        call_args = mock_fetch.call_args
+        params = call_args[0][1]
+        self.assertEqual(params["filter"], "openalex:W2741809807|W3001118548")
+
+    def test_fetch_by_ids_empty_list(self):
+        """
+        Test fetch_by_ids with empty list.
+        """
+        # Act
+        papers = self.client.fetch_by_ids([])
+
+        # Assert
+        self.assertEqual(papers, [])
+
+    def test_fetch_by_ids_unsupported_type(self):
+        """
+        Test fetch_by_ids with unsupported ID type.
+        """
+        # Act
+        papers = self.client.fetch_by_ids(["123"], id_type="unsupported")
+
+        # Assert
+        self.assertEqual(papers, [])
+
+    @patch.object(OpenAlexClient, "fetch_with_retry")
+    def test_fetch_by_ids_error_handling(self, mock_fetch):
+        """
+        Test error handling in fetch_by_ids.
+        """
+        # Arrange
+        mock_fetch.side_effect = Exception("API error")
+
+        # Act
+        papers = self.client.fetch_by_ids(["10.1234/test"], id_type="doi")
+
+        # Assert
+        self.assertEqual(papers, [])
+
+    @patch.object(OpenAlexClient, "fetch_with_retry")
+    def test_fetch_recent_with_additional_filters(self, mock_fetch):
+        """
+        Test fetch_recent with additional filters.
+        """
+        # Arrange
+        mock_fetch.return_value = self.empty_list_response
+        filters = {
+            "is_oa": "true",
+            "has_doi": "true",
+            "type": "article",
+        }
+
+        # Act
+        self.client.fetch_recent(
+            since=datetime(2025, 1, 1),
+            until=datetime(2025, 1, 7),
+            filters=filters,
+        )
+
+        # Assert
+        call_args = mock_fetch.call_args
+        params = call_args[0][1]
+        filter_str = params["filter"]
+
+        self.assertIn("from_publication_date:2025-01-01", filter_str)
+        self.assertIn("to_publication_date:2025-01-07", filter_str)
+        self.assertIn("is_oa:true", filter_str)
+        self.assertIn("has_doi:true", filter_str)
+        self.assertIn("type:article", filter_str)
+
+    @patch.object(OpenAlexClient, "fetch_with_retry")
+    def test_fetch_recent_max_results_limit(self, mock_fetch):
+        """
+        Test that fetch_recent respects max_results limit.
+        """
+        # Arrange
+        large_response = {
+            "meta": {"next_cursor": "next", "count": 500},
+            "results": [{"id": f"W{i}"} for i in range(200)],
+        }
+        mock_fetch.return_value = large_response
+
+        # Act
+        self.client.fetch_recent(
+            since=datetime(2025, 1, 1),
+            until=datetime(2025, 1, 7),
+            max_results=50,
+        )
+
+        # Assert
+        # Should stop at max_results even if more are available
+        call_args = mock_fetch.call_args
+        params = call_args[0][1]
+        self.assertEqual(params["per-page"], 50)  # Should request only what's needed
+
+    def test_rate_limiter(self):
+        """
+        Test that rate limiter enforces delays between requests.
+        """
+        # Arrange
+        with patch("time.sleep") as mock_sleep:
+            with patch.object(self.client, "fetch") as mock_fetch:
+                mock_fetch.return_value = self.sample_list_response
+
+                # Act
+                self.client.fetch_with_rate_limit("/works")
+                self.client.fetch_with_rate_limit("/works")
+
+                # Assert
+                # Should have slept to respect rate limit
+                # (10 requests/second = 0.1s delay)
+                mock_sleep.assert_called()


### PR DESCRIPTION
Add an OpenAlex client for paper ingestion processes, including operations for fetching multiple papers and single papers (by DOI or other identifiers).