### PR TITLE
Fix Missing Author Field in Feed View

### DIFF
--- a/src/feed/signals/document_signals.py
+++ b/src/feed/signals/document_signals.py
@@ -48,12 +48,20 @@ def _create_document_feed_entries(instance, pk_set):
         hub_ids = list(pk_set)
         item = instance.get_document()
 
+        # Get the user from the document
+        user_id = None
+        if hasattr(item, "created_by"):
+            user_id = item.created_by.id
+        elif hasattr(item, "uploaded_by"):
+            user_id = item.uploaded_by.id
+
         create_feed_entry.apply_async(
             args=(
                 item.id,
                 ContentType.objects.get_for_model(item).id,
                 "PUBLISH",
                 hub_ids,
+                user_id,
             ),
             priority=1,
         )
@@ -63,12 +71,21 @@ def _create_document_feed_entries(instance, pk_set):
             unified_document = hub.related_documents.get(id=document_id)
             item = unified_document.get_document()
             hub_ids = list(item.hubs.values_list("id", flat=True))
+
+            # Get the user from the document
+            user_id = None
+            if hasattr(item, "created_by"):
+                user_id = item.created_by.id
+            elif hasattr(item, "uploaded_by"):
+                user_id = item.uploaded_by.id
+
             create_feed_entry.apply_async(
                 args=(
                     item.id,
                     ContentType.objects.get_for_model(item).id,
                     "PUBLISH",
                     hub_ids,
+                    user_id,
                 ),
                 priority=1,
             )

--- a/src/feed/tests/signals/test_document_signals.py
+++ b/src/feed/tests/signals/test_document_signals.py
@@ -32,6 +32,7 @@ class DocumentSignalsTests(TestCase):
         )
         self.assertEqual(len(feed_entries), 1)
         self.assertEqual(feed_entries[0].hubs.count(), 2)
+        self.assertEqual(feed_entries[0].user, paper.uploaded_by)
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True, CELERY_TASK_EAGER_PROPAGATES=True)
     def test_feed_entries_are_deleted_when_all_hubs_are_removed_from_paper(self):
@@ -129,6 +130,7 @@ class DocumentSignalsTests(TestCase):
         )
         self.assertEqual(len(feed_entries), 1)
         self.assertEqual(feed_entries[0].hubs.count(), 2)
+        self.assertEqual(feed_entries[0].user, post.created_by)
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True, CELERY_TASK_EAGER_PROPAGATES=True)
     def test_feed_entries_are_deleted_when_all_hubs_are_removed_from_post(self):


### PR DESCRIPTION
What?
====
- This PR fixes a bug where the author field was missing from the main feed API (`/api/feed/`) while working correctly in the funding feed. 
- The issue is in `src/feed/signals/document_signals.py` where `create_feed_entry` calls are missing the `user_id` parameter

How?
====
- Updated the document signals to pass the `user_id` parameter