### PR TITLE
Log exception details when fetch fails

### DIFF
--- a/src/paper/ingestion/clients/base.py
+++ b/src/paper/ingestion/clients/base.py
@@ -117,7 +117,8 @@ class BaseClient(ABC):
                     )
 
                 logger.warning(
-                    f"Attempt {attempt + 1}/{self.config.max_retries + 1} failed. "
+                    f"Attempt {attempt + 1}/{self.config.max_retries + 1} failed: "
+                    f"{str(e)}. "
                     f"Retrying in {backoff:.1f}s..."
                 )
                 time.sleep(backoff)


### PR DESCRIPTION
Log exception details when fetching from a preprint server fails.

Current log message:
```
2025-09-30 11:39:57,405 WARNING paper.ingestion.clients.base [base.py:119] Attempt 1/4 failed.
Retrying in 1.0s...
```

New log message:
```
2025-09-30 11:41:23,988 WARNING paper.ingestion.clients.base [base.py:119] Attempt 1/4 failed:
Failed to fetch from https://chemrxiv.org/engage/chemrxiv/public-api/v1/items: 500 Server Error: Internal Server Error for url: https://chemrxiv.org/engage/chemrxiv/public-api/v1/items?limit=50&skip=400&sort=PUBLISHED_DATE_DESC&searchDateFrom=2024-01-01T00%3A00%3A00Z&searchDateTo=2025-09-30T11%3A41%3A02Z.
Retrying in 1.0s...
```