### PR TITLE
Update funder date to 30 days instead of 7

### DIFF
--- a/src/user/views/leaderboard_views.py
+++ b/src/user/views/leaderboard_views.py
@@ -320,19 +320,20 @@ class LeaderboardViewSet(viewsets.ModelViewSet):
     @action(detail=False, methods=[RequestMethods.GET])
     def overview(self, request):
         """Returns top 3 users for each category (reviewers and funders)"""
-        start_date = timezone.now() - timedelta(days=7)
+        reviewer_start_date = timezone.now() - timedelta(days=7)
+        funder_start_date = timezone.now() - timedelta(days=30)
 
         top_reviewers = (
             self.get_queryset()
             .annotate(
-                **self._create_reviewer_earnings_annotation(start_date=start_date)
+                **self._create_reviewer_earnings_annotation(start_date=reviewer_start_date)
             )
             .order_by("-earned_rsc")[:3]
         )
 
         top_funders = (
             self.get_queryset()
-            .annotate(**self._create_funder_earnings_annotation(start_date=start_date))
+            .annotate(**self._create_funder_earnings_annotation(start_date=funder_start_date))
             .order_by("-total_funding")[:3]
         )
 


### PR DESCRIPTION
Top funders is looking sad since our funding comes in monthly or longer batches, we should increase the overview to 30 days for funders 

<img width="322" height="557" alt="Screenshot 2025-10-08 at 8 08 58 AM" src="https://github.com/user-attachments/assets/b8dd608b-6311-4a89-a57c-0c3652719408" />
