### PR TITLE
Bug: Prevent empty pagination requests in feed API

### DIFF
--- a/src/feed/tests/views/test_common.py
+++ b/src/feed/tests/views/test_common.py
@@ -1,30 +1,100 @@
-import unittest
 from unittest.mock import Mock
 
-from django.test import RequestFactory, TestCase
+from django.test import TestCase
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
 
 from feed.views.common import FeedPagination
 
 
 class FeedPaginationTests(TestCase):
     def setUp(self):
-        self.factory = RequestFactory()
+        self.factory = APIRequestFactory()
         self.pagination = FeedPagination()
 
-    @unittest.skip("Skipping pagination test")
     def test_pagination_no_next_link_when_results_less_than_page_size(self):
         """
         Test that no next link is included when results are less than page size.
         This prevents repeated requests for empty pages.
         """
-        # TODO: Implement this test when pagination logic is updated
-        pass
+        # Set up pagination with DRF Request
+        django_request = self.factory.get("/api/feed/?page=1&page_size=20")
+        request = Request(django_request)
+        self.pagination.request = request
+        self.pagination.page = Mock()
+        self.pagination.page.has_next = Mock(return_value=True)
 
-    @unittest.skip("Skipping pagination test")
+        # Create mock data with fewer items than page size
+        data = [{"id": i} for i in range(5)]  # 5 items, page_size is 20
+
+        response = self.pagination.get_paginated_response(data)
+
+        # Should not have next link when results < page_size
+        self.assertIsNone(response.data["next"])
+
     def test_pagination_includes_next_link_when_results_equal_page_size(self):
         """
         Test that next link is included when results equal page size.
         This indicates there may be more pages available.
         """
-        # TODO: Implement this test when pagination logic is updated
-        pass
+        # Set up pagination with DRF Request
+        django_request = self.factory.get("/api/feed/?page=1&page_size=20")
+        request = Request(django_request)
+        self.pagination.request = request
+        self.pagination.page = Mock()
+        self.pagination.page.has_next = Mock(return_value=True)
+
+        # Create mock data with exactly page_size items
+        data = [{"id": i} for i in range(20)]  # 20 items, page_size is 20
+
+        response = self.pagination.get_paginated_response(data)
+
+        # Should have next link when results == page_size
+        self.assertIsNotNone(response.data["next"])
+
+    def test_pagination_includes_next_link_when_results_greater_than_page_size(self):
+        """
+        Test that next link is included when results exceed page size.
+        This should not happen in practice, but tests edge case.
+        """
+        # Set up pagination with DRF Request
+        django_request = self.factory.get("/api/feed/?page=1&page_size=20")
+        request = Request(django_request)
+        self.pagination.request = request
+        self.pagination.page = Mock()
+        self.pagination.page.has_next = Mock(return_value=True)
+
+        # Create mock data with more items than page size
+        data = [{"id": i} for i in range(25)]  # 25 items, page_size is 20
+
+        response = self.pagination.get_paginated_response(data)
+
+        # Should have next link when results > page_size
+        self.assertIsNotNone(response.data["next"])
+
+    def test_pagination_respects_custom_page_size(self):
+        """
+        Test that pagination respects custom page_size query parameter.
+        """
+        # Set up pagination with custom page_size
+        django_request = self.factory.get("/api/feed/?page=1&page_size=10")
+        request = Request(django_request)
+        self.pagination.request = request
+        self.pagination.page = Mock()
+        self.pagination.page.has_next = Mock(return_value=True)
+
+        # Create mock data with exactly custom page_size items
+        data = [{"id": i} for i in range(10)]  # 10 items, custom page_size is 10
+
+        response = self.pagination.get_paginated_response(data)
+
+        # Should have next link when results == custom page_size
+        self.assertIsNotNone(response.data["next"])
+
+        # Create mock data with fewer than custom page_size items
+        data = [{"id": i} for i in range(5)]  # 5 items, custom page_size is 10
+
+        response = self.pagination.get_paginated_response(data)
+
+        # Should not have next link when results < custom page_size
+        self.assertIsNone(response.data["next"])

--- a/src/feed/views/common.py
+++ b/src/feed/views/common.py
@@ -26,10 +26,11 @@ class FeedPagination(PageNumberPagination):
         Return paginated response without total count.
         Uses has_next to determine if there are more pages.
         """
-        # FIXME: Only include next link if there are results equal to page size
+        # Only include next link if there are results equal to page size
         # to avoid repeated requests for empty pages
         next_link = None
-        if data and len(data) > 0:
+        page_size = self.get_page_size(self.request)
+        if data and len(data) >= page_size:
             next_link = self.get_next_link()
 
         return Response(


### PR DESCRIPTION
https://github.com/ResearchHub/issues/issues/684


### What?
The feed API endpoint (`/api/feed/`) was returning a `next` pagination link even when there were no more items to fetch. This caused the frontend to make unnecessary API requests to empty pages.

**Example:**
- Request: `api/feed/?page=1&page_size=20&feed_view=popular&hub_slug=biology`
- Response: Returns 5 items but includes `next` pointing to `page=2`
- Frontend makes another request to `page=2` which returns empty results

### Solution
Updated `FeedPagination.get_paginated_response()` to only include the `next` link when the number of results equals the requested page size. This ensures:
- If you get a full page (e.g., 20 items when requesting 20), include `next` (more pages may exist)
- If you get fewer items than requested (e.g., 5 items when requesting 20), omit `next` (no more pages)
