### PR TITLE
Adding Leaderboard Sorting Option for Funding Opportunities

### DIFF
--- a/src/feed/filters.py
+++ b/src/feed/filters.py
@@ -85,8 +85,8 @@ class FundOrderingFilter(OrderingFilter):
             return self._apply_most_applicants_sorting(queryset, model_config['model_class'])
         elif ordering == 'amount_raised':
             return self._apply_amount_raised_sorting(queryset, model_config['model_class'])
-        elif ordering == 'leaderboard':
-            return self._apply_leaderboard_sorting(queryset)
+        elif ordering == 'funding_opportunities':
+            return self._apply_funding_opportunities_sorting(queryset)
         else:
             # For any other ordering field, fall back to DRF's standard ordering
             return super().filter_queryset(request, queryset, view)
@@ -104,7 +104,7 @@ class FundOrderingFilter(OrderingFilter):
             if fields:
                 field = fields[0]
                 field_name = field.lstrip('-') 
-                custom_fields = ['newest', 'best', 'upvotes', 'most_applicants', 'amount_raised', 'leaderboard']
+                custom_fields = ['newest', 'best', 'upvotes', 'most_applicants', 'amount_raised', 'funding_opportunities']
                 if field_name in custom_fields:
                     return [field] 
                 ordering_fields = getattr(view, 'ordering_fields', None)
@@ -232,7 +232,7 @@ class FundOrderingFilter(OrderingFilter):
                 )
             ).order_by("-contributor_count", "-created_date")
     
-    def _apply_leaderboard_sorting(self, queryset: QuerySet) -> QuerySet:
+    def _apply_funding_opportunities_sorting(self, queryset: QuerySet) -> QuerySet:
         """Return top OPEN grants sorted by total contributions to their proposals."""
         leaderboard_size = 5
         now = timezone.now()

--- a/src/feed/filters.py
+++ b/src/feed/filters.py
@@ -243,12 +243,15 @@ class FundOrderingFilter(OrderingFilter):
             | Q(unified_document__grants__end_date__gt=now),
         )
 
+        # Build the ORM path: grant post → grant → applications → proposal → fundraise → escrow
+        grant = "unified_document__grants"
+        proposals = f"{grant}__applications__preregistration_post"
+        fundraises = f"{proposals}__unified_document__fundraises"
+        escrow = f"{fundraises}__escrow"
+
         queryset = queryset.annotate(
             total_funded=Coalesce(
-                Sum(
-                    F("unified_document__grants__applications__preregistration_post__unified_document__fundraises__escrow__amount_holding")
-                    + F("unified_document__grants__applications__preregistration_post__unified_document__fundraises__escrow__amount_paid"),
-                ),
+                Sum(F(f"{escrow}__amount_holding") + F(f"{escrow}__amount_paid")),
                 Value(0),
                 output_field=DecimalField(max_digits=19, decimal_places=10),
             ),

--- a/src/feed/filters.py
+++ b/src/feed/filters.py
@@ -232,10 +232,9 @@ class FundOrderingFilter(OrderingFilter):
                 )
             ).order_by("-contributor_count", "-created_date")
     
-    LEADERBOARD_SIZE = 5
-
     def _apply_leaderboard_sorting(self, queryset: QuerySet) -> QuerySet:
         """Return top OPEN grants sorted by total contributions to their proposals."""
+        leaderboard_size = 5
         now = timezone.now()
 
         queryset = queryset.filter(
@@ -263,7 +262,7 @@ class FundOrderingFilter(OrderingFilter):
             ),
         )
 
-        return queryset.order_by("-total_funded", "-grant_amount")[:self.LEADERBOARD_SIZE]
+        return queryset.order_by("-total_funded", "-grant_amount")[:leaderboard_size]
 
     def _apply_amount_raised_sorting(self, queryset: QuerySet, model_class: Union[Type[Grant], Type[Fundraise]]) -> QuerySet:
         if model_class == Grant:

--- a/src/feed/tests/views/test_grant_feed_view.py
+++ b/src/feed/tests/views/test_grant_feed_view.py
@@ -550,7 +550,7 @@ class GrantFeedViewTests(APITestCase):
         # Assert
         self.assertEqual(len(response.data["results"]), 0)
 
-    def test_leaderboard_ordering(self):
+    def test_funding_opportunities_ordering(self):
         """Top 5 OPEN grants: funded first, then by budget; closed excluded."""
         # Arrange — 6 open grants (+ 1 from setUp = 7 open, 2 closed/completed)
         grants = []
@@ -580,7 +580,7 @@ class GrantFeedViewTests(APITestCase):
 
         # Act
         self.client.force_authenticate(self.user)
-        response = self.client.get("/api/grant_feed/?ordering=leaderboard")
+        response = self.client.get("/api/grant_feed/?ordering=funding_opportunities")
         titles = [r["content_object"]["title"] for r in response.data["results"]]
 
         # Assert — capped at 5, funded grant first, closed/completed excluded

--- a/src/feed/views/grant_feed_view.py
+++ b/src/feed/views/grant_feed_view.py
@@ -29,7 +29,7 @@ class GrantFeedViewSet(FeedViewMixin, ModelViewSet):
     pagination_class = FeedPagination
     filter_backends = [DjangoFilterBackend, FundOrderingFilter]
     is_grant_view = True
-    ordering_fields = ['newest', 'upvotes', 'most_applicants', 'amount_raised', 'leaderboard']
+    ordering_fields = ['newest', 'upvotes', 'most_applicants', 'amount_raised', 'funding_opportunities']
     ordering = 'newest'  # Default ordering
 
     def get_serializer_context(self):

--- a/src/feed/views/grant_feed_view.py
+++ b/src/feed/views/grant_feed_view.py
@@ -29,7 +29,7 @@ class GrantFeedViewSet(FeedViewMixin, ModelViewSet):
     pagination_class = FeedPagination
     filter_backends = [DjangoFilterBackend, FundOrderingFilter]
     is_grant_view = True
-    ordering_fields = ['newest', 'upvotes', 'most_applicants', 'amount_raised']
+    ordering_fields = ['newest', 'upvotes', 'most_applicants', 'amount_raised', 'leaderboard']
     ordering = 'newest'  # Default ordering
 
     def get_serializer_context(self):


### PR DESCRIPTION
## Overview ##

This PR adds the "leaderboard" filter for grants to be utilized for the Funding Opportunities leaderboard display.  It grabs 5 OPEN RFPs sorted by the amount of funding.