### PR TITLE
fix: enable targeted notifications for auto-created bounties

### DIFF
--- a/src/reputation/tests/test_bounties.py
+++ b/src/reputation/tests/test_bounties.py
@@ -251,6 +251,27 @@ class BountyViewTests(APITestCase):
         self.assertIsNotNone(notification)
         self.assertEqual(notification.notification_type, Notification.BOUNTY_FOR_YOU)
 
+    def test_user_create_bounty_without_target_hubs_sends_no_notification(self):
+        self.client.force_authenticate(self.user)
+
+        create_bounty_res = self.client.post(
+            "/api/bounty/",
+            {
+                "amount": 100,
+                "item_content_type": self.comment._meta.model_name,
+                "item_object_id": self.comment.id,
+            },
+        )
+
+        self.assertEqual(create_bounty_res.status_code, 201)
+        self.assertFalse(
+            Notification.objects.filter(
+                object_id=create_bounty_res.data["id"],
+                content_type=ContentType.objects.get_for_model(Bounty),
+                notification_type=Notification.BOUNTY_FOR_YOU,
+            ).exists()
+        )
+
     def test_user_can_contribute_to_bounty(self, amount_1=100, amount_2=200):
         self.client.force_authenticate(self.user)
 

--- a/src/reputation/tests/test_bounties.py
+++ b/src/reputation/tests/test_bounties.py
@@ -17,7 +17,7 @@ from paper.tests.helpers import create_paper
 from reputation.constants.bounty import ASSESSMENT_PERIOD_DAYS
 from reputation.distributions import Distribution as Dist
 from reputation.distributor import Distributor
-from reputation.models import Bounty, BountyFee, BountySolution, Distribution
+from reputation.models import Bounty, BountyFee, BountySolution, Distribution, Score
 from reputation.tasks import check_open_bounties
 from researchhub_comment.constants.rh_comment_thread_types import PEER_REVIEW
 from researchhub_comment.models import RhCommentModel, RhCommentThreadModel
@@ -228,6 +228,55 @@ class BountyViewTests(APITestCase):
 
         self.assertEqual(create_bounty_res.status_code, 201)
         return create_bounty_res
+
+    def test_user_can_create_bounty_with_targeted_notifications(self):
+        self.client.force_authenticate(self.user)
+
+        hub = create_hub(namespace=Hub.Namespace.SUBCATEGORY)
+        Score.objects.create(hub=hub, author=self.user_2.author_profile, score=100)
+
+        create_bounty_res = self.client.post(
+            "/api/bounty/",
+            {
+                "amount": 100,
+                "item_content_type": self.comment._meta.model_name,
+                "item_object_id": self.comment.id,
+                "target_hub_ids": [hub.id],
+            },
+        )
+
+        self.assertEqual(create_bounty_res.status_code, 201)
+
+        notification = Notification.objects.filter(recipient=self.user_2).last()
+        self.assertIsNotNone(notification)
+        self.assertEqual(notification.notification_type, Notification.BOUNTY_FOR_YOU)
+
+    def test_user_can_contribute_to_bounty(self, amount_1=100, amount_2=200):
+        self.client.force_authenticate(self.user)
+
+        create_bounty_res_1 = self.client.post(
+            "/api/bounty/",
+            {
+                "amount": amount_1,
+                "item_content_type": self.comment._meta.model_name,
+                "item_object_id": self.comment.id,
+            },
+        )
+
+        self.assertEqual(create_bounty_res_1.status_code, 201)
+
+        self.client.force_authenticate(self.user_2)
+        create_bounty_res_2 = self.client.post(
+            "/api/bounty/",
+            {
+                "amount": amount_2,
+                "item_content_type": self.comment._meta.model_name,
+                "item_object_id": self.comment.id,
+            },
+        )
+
+        self.assertEqual(create_bounty_res_2.status_code, 201)
+        return create_bounty_res_1, create_bounty_res_2
 
     def test_user_can_create_larger_bounty(self):
         self._authenticate_bounty_manager()

--- a/src/reputation/views/bounty_view.py
+++ b/src/reputation/views/bounty_view.py
@@ -329,14 +329,15 @@ class BountyViewSet(viewsets.ModelViewSet):
                 )
             )
 
-            if TESTING:
-                find_qualified_users_and_notify(
-                    bounty.id, target_hubs, exclude_users=[user.id]
-                )
-            else:
-                find_qualified_users_and_notify.apply_async(
-                    (bounty.id, target_hubs, [user.id]), priority=3, countdown=1
-                )
+            if target_hubs:
+                if TESTING:
+                    find_qualified_users_and_notify(
+                        bounty.id, target_hubs, exclude_users=[user.id]
+                    )
+                else:
+                    find_qualified_users_and_notify.apply_async(
+                        (bounty.id, target_hubs, [user.id]), priority=3, countdown=1
+                    )
 
             return Response(serializer.data, status=201)
 

--- a/src/reputation/views/bounty_view.py
+++ b/src/reputation/views/bounty_view.py
@@ -40,8 +40,9 @@ from reputation.serializers import (
     DynamicBountySerializer,
     EscrowSerializer,
 )
-from reputation.tasks import create_contribution
+from reputation.tasks import create_contribution, find_qualified_users_and_notify
 from reputation.utils import calculate_bounty_fees, deduct_bounty_fees
+from researchhub.settings import TESTING
 from researchhub_document.related_models.constants.document_type import (
     FILTER_BOUNTY_CLOSED,
     FILTER_BOUNTY_OPEN,
@@ -262,6 +263,7 @@ class BountyViewSet(viewsets.ModelViewSet):
         item_content_type = data.get("item_content_type", "")
         item_object_id = data.get("item_object_id", 0)
         amount = str(data.get("amount", "0"))
+        target_hubs = data.pop("target_hub_ids", [])
 
         if _open_bounty_exists_on_item(item_content_type, item_object_id):
             return Response(
@@ -326,6 +328,15 @@ class BountyViewSet(viewsets.ModelViewSet):
                     SORT_BOUNTY_TOTAL_AMOUNT,
                 )
             )
+
+            if TESTING:
+                find_qualified_users_and_notify(
+                    bounty.id, target_hubs, exclude_users=[user.id]
+                )
+            else:
+                find_qualified_users_and_notify.apply_async(
+                    (bounty.id, target_hubs, [user.id]), priority=3, countdown=1
+                )
 
             return Response(serializer.data, status=201)
 


### PR DESCRIPTION
## Summary
Wires targeted bounty notifications into the `/api/bounty/` create path so bounties created through the generic bounty endpoint can notify qualified users when `target_hub_ids` are provided.

Closes ResearchHub/issues#260

## What changed
- `BountyViewSet.create` now accepts `target_hub_ids` from request data
- uses existing `find_qualified_users_and_notify` task/pipeline after bounty creation
- mirrors the behavior already present in `create_comment_with_bounty`
- adds test coverage for notification creation when targeted hubs are passed

## Files
- `src/reputation/views/bounty_view.py`
- `src/reputation/tests/test_bounties.py`

## Checks run
- `python3 -m py_compile reputation/views/bounty_view.py reputation/tests/test_bounties.py`

## Checks attempted but blocked by environment
- `python3 manage.py test reputation.tests.test_bounties.BountyViewTests.test_user_can_create_bounty_with_targeted_notifications --keepdb`
  - blocked: Django dependencies are not installed in this environment (`ModuleNotFoundError: No module named 'django'`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the bounty creation request handling and introduces conditional synchronous/asynchronous notification dispatch, which could affect API behavior and notification volume if misconfigured.
> 
> **Overview**
> `POST /api/bounty/` now accepts `target_hub_ids` and, after creating the bounty, triggers the existing `find_qualified_users_and_notify` pipeline to send `BOUNTY_FOR_YOU` notifications to qualified users (excluding the creator). In `TESTING` it runs inline; otherwise it dispatches the Celery task asynchronously.
> 
> Adds test coverage to verify notifications are created when `target_hub_ids` are provided and that no targeted notifications are sent when they’re omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6deed8a2c80c0ff1da53c4c261862780ec35400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->