### PR TITLE
Capture SES message ID when sending emails

### DIFF
--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -397,7 +397,12 @@ class GeneratedEmailSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
         ]
-        read_only_fields = ["id", "created_at", "updated_at"]
+        read_only_fields = [
+            "id",
+            "created_at",
+            "updated_at",
+            "ses_message_id",
+        ]
 
     def get_created_by(self, obj):
         return _get_created_by_payload(obj)

--- a/src/research_ai/services/email_sending_service.py
+++ b/src/research_ai/services/email_sending_service.py
@@ -8,13 +8,13 @@ logger = logging.getLogger(__name__)
 
 
 def send_plain_email(
-    to_email,
-    subject,
-    body,
-    reply_to=None,
-    cc=None,
-    from_email=None,
-):
+    to_email: str,
+    subject: str,
+    body: str,
+    reply_to: str | None = None,
+    cc: list[str] | None = None,
+    from_email: str | None = None,
+) -> str | None:
     """
     Send an email with optional HTML body. Normalizes subject, adds staging
     prefix when not production, and supports reply_to/cc.

--- a/src/research_ai/services/email_sending_service.py
+++ b/src/research_ai/services/email_sending_service.py
@@ -1,25 +1,10 @@
 import logging
 
 from django.conf import settings
-from django.core.mail import EmailMultiAlternatives, send_mail
+from django.core.mail import EmailMultiAlternatives
 from django.utils.html import strip_tags
 
 logger = logging.getLogger(__name__)
-
-
-def _send_to_recipient(to, subject, plain_body, from_email, html_body):
-    try:
-        send_mail(
-            subject,
-            plain_body,
-            from_email,
-            [to],
-            fail_silently=False,
-            html_message=html_body,
-        )
-    except Exception as e:
-        logger.exception("Send email failed to %s: %s", to, e)
-        raise
 
 
 def send_plain_email(
@@ -31,8 +16,10 @@ def send_plain_email(
     from_email=None,
 ):
     """
-    Send an email with optional HTML body. Normalizes subject, adds staging prefix
-    when not production, and supports reply_to/cc via EmailMultiAlternatives.
+    Send an email with optional HTML body. Normalizes subject, adds staging
+    prefix when not production, and supports reply_to/cc.
+
+    Returns the SES Message ID when the email was sent via SES, or None otherwise.
     """
     subject = (subject or "").replace("\n", "").replace("\r", "")
     if not settings.PRODUCTION:
@@ -43,17 +30,17 @@ def send_plain_email(
     html_body = body or ""
     plain_body = strip_tags(html_body).strip() or "(No content)"
 
-    if reply_to or cc:
+    ses_message_id = None
+    for to in to_list:
         msg = EmailMultiAlternatives(
             subject=subject,
             body=plain_body,
             from_email=from_email,
-            to=to_list,
+            to=[to],
             reply_to=[reply_to] if reply_to else None,
             cc=cc or None,
         )
         msg.attach_alternative(html_body, "text/html")
         msg.send(fail_silently=False)
-    else:
-        for to in to_list:
-            _send_to_recipient(to, subject, plain_body, from_email, html_body)
+        ses_message_id = msg.extra_headers.get("message_id")
+    return ses_message_id

--- a/src/research_ai/services/email_sending_service.py
+++ b/src/research_ai/services/email_sending_service.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 def send_plain_email(
-    to_emails,
+    to_email,
     subject,
     body,
     reply_to=None,
@@ -26,21 +26,19 @@ def send_plain_email(
         subject = "[Staging] " + subject
     if from_email is None:
         from_email = f"ResearchHub <{settings.DEFAULT_FROM_EMAIL}>"
-    to_list = to_emails if isinstance(to_emails, list) else [to_emails]
     html_body = body or ""
     plain_body = strip_tags(html_body).strip() or "(No content)"
 
     ses_message_id = None
-    for to in to_list:
-        msg = EmailMultiAlternatives(
-            subject=subject,
-            body=plain_body,
-            from_email=from_email,
-            to=[to],
-            reply_to=[reply_to] if reply_to else None,
-            cc=cc or None,
-        )
-        msg.attach_alternative(html_body, "text/html")
-        msg.send(fail_silently=False)
-        ses_message_id = msg.extra_headers.get("message_id")
+    msg = EmailMultiAlternatives(
+        subject=subject,
+        body=plain_body,
+        from_email=from_email,
+        to=[to_email],
+        reply_to=[reply_to] if reply_to else None,
+        cc=cc or None,
+    )
+    msg.attach_alternative(html_body, "text/html")
+    msg.send(fail_silently=False)
+    ses_message_id = msg.extra_headers.get("message_id")
     return ses_message_id

--- a/src/research_ai/tasks.py
+++ b/src/research_ai/tasks.py
@@ -372,7 +372,7 @@ def send_queued_emails_task(
             failed += 1
             continue
         try:
-            send_plain_email(
+            ses_message_id = send_plain_email(
                 [rec.expert_email],
                 rec.email_subject,
                 rec.email_body,
@@ -382,6 +382,7 @@ def send_queued_emails_task(
             )
             GeneratedEmail.objects.filter(id=rec.id).update(
                 status=GeneratedEmail.Status.SENT,
+                ses_message_id=ses_message_id or "",
                 updated_date=timezone.now(),
             )
             sent += 1

--- a/src/research_ai/tasks.py
+++ b/src/research_ai/tasks.py
@@ -373,7 +373,7 @@ def send_queued_emails_task(
             continue
         try:
             ses_message_id = send_plain_email(
-                [rec.expert_email],
+                rec.expert_email,
                 rec.email_subject,
                 rec.email_body,
                 reply_to=reply_to_stripped,

--- a/src/research_ai/tests/test_email_views.py
+++ b/src/research_ai/tests/test_email_views.py
@@ -444,25 +444,19 @@ class GeneratedEmailDetailViewTests(APITestCase):
 
     def test_get_requires_authentication(self):
         email = self._create_email()
-        response = self.client.get(
-            f"/api/research_ai/expert-finder/emails/{email.id}/"
-        )
+        response = self.client.get(f"/api/research_ai/expert-finder/emails/{email.id}/")
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_get_requires_moderator(self):
         self.client.force_authenticate(self.user)
         email = self._create_email()
-        response = self.client.get(
-            f"/api/research_ai/expert-finder/emails/{email.id}/"
-        )
+        response = self.client.get(f"/api/research_ai/expert-finder/emails/{email.id}/")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_get_returns_200_for_own_email(self):
         email = self._create_email()
         self.client.force_authenticate(self.moderator)
-        response = self.client.get(
-            f"/api/research_ai/expert-finder/emails/{email.id}/"
-        )
+        response = self.client.get(f"/api/research_ai/expert-finder/emails/{email.id}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["id"], email.id)
         self.assertEqual(response.json()["expert_name"], "Dr. Test")
@@ -477,9 +471,7 @@ class GeneratedEmailDetailViewTests(APITestCase):
             email_body="",
         )
         self.client.force_authenticate(self.moderator)
-        response = self.client.get(
-            f"/api/research_ai/expert-finder/emails/{email.id}/"
-        )
+        response = self.client.get(f"/api/research_ai/expert-finder/emails/{email.id}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         nav = response.json()["list_navigation"]
         self.assertEqual(nav["total"], 1)
@@ -570,18 +562,14 @@ class GeneratedEmailDetailViewTests(APITestCase):
 
     def test_get_returns_404_for_nonexistent(self):
         self.client.force_authenticate(self.moderator)
-        response = self.client.get(
-            "/api/research_ai/expert-finder/emails/999999/"
-        )
+        response = self.client.get("/api/research_ai/expert-finder/emails/999999/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_returns_200_for_other_users_email(self):
         """Generated emails are shared: any editor can retrieve any email."""
         email = self._create_email(created_by=self.user)
         self.client.force_authenticate(self.moderator)
-        response = self.client.get(
-            f"/api/research_ai/expert-finder/emails/{email.id}/"
-        )
+        response = self.client.get(f"/api/research_ai/expert-finder/emails/{email.id}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["id"], email.id)
 

--- a/src/research_ai/tests/test_email_views.py
+++ b/src/research_ai/tests/test_email_views.py
@@ -782,9 +782,11 @@ class BulkGenerateEmailViewTests(APITestCase):
 class SendPlainEmailTests(APITestCase):
     """Unit tests for send_plain_email service."""
 
-    @patch("research_ai.services.email_sending_service.send_mail")
-    def test_send_plain_email_calls_send_mail_with_plain_and_html(self, mock_send_mail):
-        send_plain_email(
+    @patch("research_ai.services.email_sending_service.EmailMultiAlternatives")
+    def test_send_plain_email_calls_send_mail_with_plain_and_html(self, mock_email_alt):
+        mock_instance = mock_email_alt.return_value
+        mock_instance.extra_headers = {"message_id": "messageId1"}
+        ses_message_id = send_plain_email(
             ["to@example.com"],
             "Subject",
             "<p>Hello</p>",
@@ -792,13 +794,16 @@ class SendPlainEmailTests(APITestCase):
             cc=None,
             from_email=None,
         )
-        mock_send_mail.assert_called_once()
-        # send_mail(subject, message, from_email, recipient_list, ...)
-        call_args = mock_send_mail.call_args[0]
-        self.assertIn("Subject", call_args[0])
-        self.assertIn("Hello", call_args[1])
-        self.assertEqual(call_args[3], ["to@example.com"])
-        self.assertEqual(mock_send_mail.call_args[1]["html_message"], "<p>Hello</p>")
+        mock_email_alt.assert_called_once()
+        call_kwargs = mock_email_alt.call_args[1]
+        self.assertIn("Subject", call_kwargs["subject"])
+        self.assertIn("Hello", call_kwargs["body"])
+        self.assertEqual(call_kwargs["to"], ["to@example.com"])
+        mock_instance.attach_alternative.assert_called_once_with(
+            "<p>Hello</p>", "text/html"
+        )
+        mock_instance.send.assert_called_once()
+        self.assertEqual(ses_message_id, "messageId1")
 
     @patch("research_ai.services.email_sending_service.EmailMultiAlternatives")
     def test_send_plain_email_with_reply_to_uses_email_multi_alternatives(
@@ -946,6 +951,7 @@ class SendEmailViewTests(APITestCase):
     def test_send_queued_emails_task_sends_and_updates_status(self, mock_send):
         from research_ai.tasks import send_queued_emails_task
 
+        mock_send.return_value = "ses-msg-id-123"
         email_rec = GeneratedEmail.objects.create(
             created_by=self.moderator,
             expert_name="Dr. Y",
@@ -966,4 +972,5 @@ class SendEmailViewTests(APITestCase):
         self.assertEqual(result["failed"], 0)
         email_rec.refresh_from_db()
         self.assertEqual(email_rec.status, "sent")
+        self.assertEqual(email_rec.ses_message_id, "ses-msg-id-123")
         mock_send.assert_called_once()

--- a/src/research_ai/tests/test_email_views.py
+++ b/src/research_ai/tests/test_email_views.py
@@ -787,7 +787,7 @@ class SendPlainEmailTests(APITestCase):
         mock_instance = mock_email_alt.return_value
         mock_instance.extra_headers = {"message_id": "messageId1"}
         ses_message_id = send_plain_email(
-            ["to@example.com"],
+            "to@example.com",
             "Subject",
             "<p>Hello</p>",
             reply_to=None,
@@ -810,7 +810,7 @@ class SendPlainEmailTests(APITestCase):
         self, mock_email_alt
     ):
         send_plain_email(
-            ["to@example.com"],
+            "to@example.com",
             "Subject",
             "Body",
             reply_to="reply@example.com",

--- a/src/research_ai/views/email_views.py
+++ b/src/research_ai/views/email_views.py
@@ -221,7 +221,9 @@ class BulkGenerateEmailView(APIView):
                     email_record = GeneratedEmail.objects.create(
                         created_by=request.user,
                         expert_search=expert_search,
-                        expert_name=format_expert_name_from_raw(resolved.get("name") or ""),
+                        expert_name=format_expert_name_from_raw(
+                            resolved.get("name") or ""
+                        ),
                         expert_title=resolved.get("title") or "",
                         expert_affiliation=resolved.get("affiliation") or "",
                         expert_email=(resolved.get("email") or "").strip(),

--- a/src/research_ai/views/email_views.py
+++ b/src/research_ai/views/email_views.py
@@ -291,7 +291,7 @@ class PreviewEmailView(APIView):
         for rec in qs:
             try:
                 send_plain_email(
-                    [recipient],
+                    recipient,
                     rec.email_subject,
                     rec.email_body,
                     reply_to=reply_to,


### PR DESCRIPTION
Capture the SES message ID when sending Expert Finder emails.