### PR TITLE
Fix timezone warnings

### DIFF
--- a/src/paper/tests/helpers.py
+++ b/src/paper/tests/helpers.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from paper.models import Paper
@@ -16,7 +18,7 @@ class TestData:
         " Aids to Magical Mischief-Makers are proud to present THE"
         " MARAUDER'S MAP"
     )
-    paper_publish_date = "1990-10-01"
+    paper_publish_date = datetime(1990, 10, 1, tzinfo=timezone.utc)
 
 
 def create_paper(

--- a/src/utils/test_helpers.py
+++ b/src/utils/test_helpers.py
@@ -1,6 +1,7 @@
 import json
 import random
 import secrets
+from datetime import datetime, timezone
 import string
 import threading
 import time
@@ -70,7 +71,7 @@ class TestData:
         "Improving Elevator Performance Using Reinforcement Learning",
         "Softassign versus Softmax: Benchmarks in Combinatorial Optimization",
     ]
-    paper_publish_date = "1990-10-01"
+    paper_publish_date = datetime(1990, 10, 1, tzinfo=timezone.utc)
 
 
 # REFACTOR: Instead of having to inherit this class, test cases should import


### PR DESCRIPTION
```
RuntimeWarning: DateTimeField Paper.paper_publish_date received a naive datetime (1990-10-01 00:00:00) while time zone support is active.
```