### PR TITLE
Enable MFA for authentication (part 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "circle-developer-controlled-wallets>=9.2.0,<10.0.0",
     "cloudscraper>=1.2.60,<2.0.0",
     "daphne>=4.1.2,<5.0.0",
-    "dj-rest-auth[with-social]>=7.0.2,<8.0.0",
+    "dj-rest-auth[with-mfa,with-social]>=7.0.2,<8.0.0",
     "django==5.2.13",
     "django-allauth>=65.13.0,<66.0.0",
     "django-celery-results==2.6.0",

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -233,6 +233,7 @@ INSTALLED_APPS = [
     "allauth.socialaccount.providers.orcid",
     "rest_framework.authtoken",
     "dj_rest_auth",
+    "dj_rest_auth.mfa",
     "dj_rest_auth.registration",
     # Storage
     "storages",
@@ -403,6 +404,7 @@ AUTHENTICATION_BACKENDS = (
 REST_AUTH = {
     "REGISTER_SERIALIZER": "user.serializers.RegisterSerializer",
     "PASSWORD_RESET_SERIALIZER": "user.custom_allauth.CustomPasswordResetSerializer",
+    "MFA_TOTP_ISSUER": "ResearchHub",
 }
 
 

--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -310,6 +310,7 @@ urlpatterns = [
     ),
     re_path(r"api/auth/register/", include("dj_rest_auth.registration.urls")),
     re_path(r"api/auth/login/", MFALoginView.as_view(), name="rest_login"),
+    re_path(r"api/auth/", include("dj_rest_auth.mfa.urls")),
     re_path(r"api/auth/logout/", LogoutView.as_view(), name="rest_logout"),
     re_path(
         r"api/auth/password-reset/$", PasswordResetView.as_view(), name="password-reset"

--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -5,8 +5,8 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 """
 
 import debug_toolbar
+from dj_rest_auth.mfa.views import MFALoginView
 from dj_rest_auth.views import (
-    LoginView,
     LogoutView,
     PasswordChangeView,
     PasswordResetConfirmView,
@@ -309,7 +309,7 @@ urlpatterns = [
         name="rest_verify_email",
     ),
     re_path(r"api/auth/register/", include("dj_rest_auth.registration.urls")),
-    re_path(r"api/auth/login/", LoginView.as_view(), name="rest_login"),
+    re_path(r"api/auth/login/", MFALoginView.as_view(), name="rest_login"),
     re_path(r"api/auth/logout/", LogoutView.as_view(), name="rest_logout"),
     re_path(
         r"api/auth/password-reset/$", PasswordResetView.as_view(), name="password-reset"

--- a/src/user/tests/test_mfa.py
+++ b/src/user/tests/test_mfa.py
@@ -1,0 +1,113 @@
+import pyotp
+from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient, APITestCase
+
+from utils.test_helpers import generate_password
+
+User = get_user_model()
+
+
+class MFAFlowTests(APITestCase):
+    """
+    Tests for the MFA authentication flow.
+    """
+
+    def register_verified_user(self, email, password):
+        response = self.client.post(
+            "/api/auth/register/",
+            {
+                "email": email,
+                "password1": password,
+                "password2": password,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+
+        user = User.objects.get(email=email)
+        email_address = EmailAddress.objects.get(user=user, email=email)
+        email_address.verified = True
+        email_address.set_as_primary(conditional=True)
+        email_address.save()
+        return user
+
+    def login(self, email, password):
+        return self.client.post(
+            "/api/auth/login/",
+            {"email": email, "password": password},
+            format="json",
+        )
+
+    def authenticated_client(self, token):
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+        return client
+
+    def enable_mfa(self, email, password):
+        login_response = self.login(email, password)
+        self.assertEqual(login_response.status_code, 200)
+        token = login_response.data["key"]
+
+        authed_client = self.authenticated_client(token)
+        init_response = authed_client.get("/api/auth/mfa/totp/activate/", format="json")
+        self.assertEqual(init_response.status_code, 200)
+
+        secret = init_response.data["secret"]
+        activation_token = init_response.data["activation_token"]
+        activate_response = authed_client.post(
+            "/api/auth/mfa/totp/activate/",
+            {
+                "activation_token": activation_token,
+                "code": pyotp.TOTP(secret).now(),
+            },
+            format="json",
+        )
+        self.assertEqual(activate_response.status_code, 200)
+        self.assertIn("recovery_codes", activate_response.data)
+        return secret
+
+    def test_login_without_mfa_returns_standard_token_response(self):
+        # Arrange
+        email = "simple-login@researchhub.com"
+        password = generate_password()
+        self.register_verified_user(email, password)
+
+        # Act
+        response = self.login(email, password)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("key", response.data)
+        self.assertNotIn("mfa_required", response.data)
+        self.assertNotIn("ephemeral_token", response.data)
+
+    def test_login_with_mfa_returns_ephemeral_token_and_verify_returns_key(self):
+        # Arrange
+        email = "mfa-login@researchhub.com"
+        password = generate_password()
+        self.register_verified_user(email, password)
+        secret = self.enable_mfa(email, password)
+
+        # Act
+        response = self.login(email, password)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["mfa_required"])
+        self.assertIn("ephemeral_token", response.data)
+        self.assertNotIn("key", response.data)
+
+        # Act
+        verify_response = self.client.post(
+            "/api/auth/mfa/verify/",
+            {
+                "ephemeral_token": response.data["ephemeral_token"],
+                "code": pyotp.TOTP(secret).now(),
+            },
+            format="json",
+        )
+
+        # Verify
+        self.assertEqual(verify_response.status_code, 200)
+        self.assertIn("key", verify_response.data)

--- a/uv.lock
+++ b/uv.lock
@@ -862,6 +862,9 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/14/fd/c8a185a98f6860b802dc5e663c652efc01cd68f4e046c65f8cb9328c0077/dj_rest_auth-7.2.0.tar.gz", hash = "sha256:f77af37da5cf6ee28f03f283a378a2f5761860e72d1d6f2fa3d50e6286000482", size = 490126, upload-time = "2026-03-15T04:05:39.272Z" }
 
 [package.optional-dependencies]
+with-mfa = [
+    { name = "pyotp" },
+]
 with-social = [
     { name = "django-allauth", extra = ["socialaccount"] },
 ]
@@ -2434,6 +2437,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyotp"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/b2/1d5994ba2acde054a443bd5e2d384175449c7d2b6d1a0614dbca3a63abfc/pyotp-2.9.0.tar.gz", hash = "sha256:346b6642e0dbdde3b4ff5a930b664ca82abfa116356ed48cc42c7d6590d36f63", size = 17763, upload-time = "2023-07-27T23:41:03.295Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/c0/c33c8792c3e50193ef55adb95c1c3c2786fe281123291c2dbf0eaab95a6f/pyotp-2.9.0-py3-none-any.whl", hash = "sha256:81c2e5865b8ac55e825b0358e496e1d9387c811e85bb40e71a3b29b288963612", size = 13376, upload-time = "2023-07-27T23:41:01.685Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2701,7 +2713,7 @@ dependencies = [
     { name = "circle-developer-controlled-wallets" },
     { name = "cloudscraper" },
     { name = "daphne" },
-    { name = "dj-rest-auth", extra = ["with-social"] },
+    { name = "dj-rest-auth", extra = ["with-mfa", "with-social"] },
     { name = "django" },
     { name = "django-allauth" },
     { name = "django-celery-results" },
@@ -2771,7 +2783,7 @@ requires-dist = [
     { name = "circle-developer-controlled-wallets", specifier = ">=9.2.0,<10.0.0" },
     { name = "cloudscraper", specifier = ">=1.2.60,<2.0.0" },
     { name = "daphne", specifier = ">=4.1.2,<5.0.0" },
-    { name = "dj-rest-auth", extras = ["with-social"], specifier = ">=7.0.2,<8.0.0" },
+    { name = "dj-rest-auth", extras = ["with-mfa", "with-social"], specifier = ">=7.0.2,<8.0.0" },
     { name = "django", specifier = "==5.2.13" },
     { name = "django-allauth", specifier = ">=65.13.0,<66.0.0" },
     { name = "django-celery-results", specifier = "==2.6.0" },


### PR DESCRIPTION
- Enable dj-rest-auth's MFA extra packages.
- Enable MFA app in Django application.
- Replace the regular login with the MFA variant.
- Register MFA endpoints.