### PR TITLE
fix: DRF logs warnings about use of floats in serializers

### DIFF
--- a/src/purchase/serializers/coinbase_serializer.py
+++ b/src/purchase/serializers/coinbase_serializer.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from rest_framework import serializers
 
 
@@ -24,7 +26,7 @@ class CoinbaseSerializer(serializers.Serializer):
 
     preset_crypto_amount = serializers.FloatField(
         required=False,
-        min_value=0.00001,
+        min_value=Decimal("0.00001"),
         help_text="Preset crypto amount",
     )
 

--- a/src/purchase/serializers/payment_intent_serializer.py
+++ b/src/purchase/serializers/payment_intent_serializer.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from rest_framework import serializers
 
 from purchase.related_models.fundraise_model import Fundraise
@@ -14,7 +16,7 @@ class PaymentIntentSerializer(serializers.Serializer):
     amount = serializers.DecimalField(
         max_digits=19,
         decimal_places=10,
-        min_value=0.01,
+        min_value=Decimal("0.01"),
         help_text="Amount of RSC to purchase",
     )
     fundraise_id = serializers.IntegerField(


### PR DESCRIPTION
DRF will log warning if regular floats are used for min_value parameters:

```
/lib/python3.13/site-packages/rest_framework/fields.py:992: UserWarning: min_value should be an integer or Decimal instance.
  warnings.warn("min_value should be an integer or Decimal instance.")
```