### PR TITLE
Refactor proposal review scoring to use category-based evaluation, up…

### DIFF
--- a/src/ai_peer_review/constants.py
+++ b/src/ai_peer_review/constants.py
@@ -2,46 +2,77 @@
 PROPOSAL_REVIEW_MAX_OUTPUT_TOKENS = 16384
 
 
-DIMENSION_KEYS = [
-    "fundability",
-    "feasibility",
-    "novelty",
-    "impact",
-    "reproducibility",
+CATEGORY_KEYS = [
+    "funding_opportunity_fit",
+    "methods_rigor",
+    "statistical_analysis_plan",
+    "feasibility_and_execution",
+    "scientific_impact",
+    "clinical_or_translational_impact",
+    "societal_and_broader_impact",
 ]
 
-DIMENSION_SUB_AREAS = {
-    "fundability": ["scope_alignment", "budget_adequacy", "timeline_realism"],
-    "feasibility": [
-        "investigator_expertise",
-        "institutional_capacity",
-        "track_record",
+CATEGORY_ITEMS = {
+    "funding_opportunity_fit": [
+        "fit_modality",
+        "fit_aims",
+        "fit_deliverables",
+        "fit_scope",
     ],
-    "novelty": [
-        "conceptual_novelty",
-        "methodological_novelty",
-        "literature_positioning",
+    "methods_rigor": [
+        "methods_detail",
+        "parameters_specified",
+        "controls_defined",
+        "model_choice_justified",
+        "outcomes_linked_to_aims",
     ],
-    "impact": [
-        "scientific_impact",
-        "clinical_translational_impact",
-        "societal_broader_impact",
-        "community_ecosystem_impact",
+    "statistical_analysis_plan": [
+        "analysis_present",
+        "power_analysis",
+        "multiple_comparisons",
+        "metrics_defined",
+        "analysis_matches_design",
     ],
-    "reproducibility": [
-        "methods_rigor",
-        "statistical_analysis_plan",
-        "data_code_transparency",
-        "gold_standard_methodology",
-        "validation_robustness",
+    "feasibility_and_execution": [
+        "recruitment_feasible",
+        "procedures_feasible",
+        "timeline_milestones",
+        "team_environment",
+        "ethics_data_quality",
+    ],
+    "scientific_impact": [
+        "advances_understanding",
+        "generalizability",
+        "opens_new_directions",
+    ],
+    "clinical_or_translational_impact": [
+        "clinical_pathway",
+        "unmet_need",
+        "milestones_defined",
+    ],
+    "societal_and_broader_impact": [
+        "societal_challenge",
+        "public_communication",
+        "commercial_potential",
     ],
 }
 
-OPTIONAL_SUB_AREAS = frozenset(
+# Only these categories may resolve to "N/A" (entire category inapplicable).
+OPTIONAL_CATEGORIES = frozenset(
     {
-        ("feasibility", "track_record"),
-        ("impact", "clinical_translational_impact"),
-        ("impact", "community_ecosystem_impact"),
-        ("reproducibility", "gold_standard_methodology"),
+        "statistical_analysis_plan",
+        "clinical_or_translational_impact",
+        "societal_and_broader_impact",
+    }
+)
+
+# If any listed item decision is "No", cap the owning category at "Medium".
+CRITICAL_FAIL_ITEMS = frozenset(
+    {
+        ("methods_rigor", "methods_detail"),
+        ("methods_rigor", "controls_defined"),
+        ("statistical_analysis_plan", "analysis_present"),
+        ("statistical_analysis_plan", "power_analysis"),
+        ("feasibility_and_execution", "timeline_milestones"),
     }
 )

--- a/src/ai_peer_review/models.py
+++ b/src/ai_peer_review/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.db.models import Q
 
+from ai_peer_review.constants import CATEGORY_KEYS
 from researchhub_document.related_models.researchhub_unified_document_model import (
     ResearchhubUnifiedDocument,
 )
@@ -17,11 +18,19 @@ class ReviewStatus(models.TextChoices):
 
 
 class OverallRating(models.TextChoices):
-    """Aggregate proposal quality from five dimension scores (5-15 scale)."""
+    """Aggregate proposal quality from recomputed category scores."""
 
     EXCELLENT = "excellent", "excellent"
     GOOD = "good", "good"
     POOR = "poor", "poor"
+
+
+class OverallConfidence(models.TextChoices):
+    """Reviewer-reported confidence in the overall judgment."""
+
+    HIGH = "High", "High"
+    MEDIUM = "Medium", "Medium"
+    LOW = "Low", "Low"
 
 
 class ExpertDimensionScore(models.TextChoices):
@@ -33,9 +42,7 @@ class ExpertDimensionScore(models.TextChoices):
 
 
 class ProposalReview(DefaultModel):
-    """
-    AI 5-dimension review for a proposal
-    """
+    """AI structured review for a proposal (flat categories + overall fields)."""
 
     created_by = models.ForeignKey(
         "user.User",
@@ -69,6 +76,13 @@ class ProposalReview(DefaultModel):
         choices=OverallRating.choices,
         blank=True,
         null=True,
+    )
+    overall_rationale = models.TextField(blank=True, default="")
+    overall_confidence = models.CharField(
+        max_length=16,
+        blank=True,
+        null=True,
+        choices=OverallConfidence.choices,
     )
     overall_score_numeric = models.IntegerField(null=True, blank=True)
     result_data = models.JSONField(default=dict, blank=True)
@@ -171,26 +185,6 @@ class EditorialFeedback(DefaultModel):
         related_name="ai_peer_review_editorial_feedbacks_updated",
         db_comment="Editor who last saved changes.",
     )
-    fundability_expert = models.CharField(
-        max_length=16,
-        choices=ExpertDimensionScore.choices,
-    )
-    feasibility_expert = models.CharField(
-        max_length=16,
-        choices=ExpertDimensionScore.choices,
-    )
-    novelty_expert = models.CharField(
-        max_length=16,
-        choices=ExpertDimensionScore.choices,
-    )
-    impact_expert = models.CharField(
-        max_length=16,
-        choices=ExpertDimensionScore.choices,
-    )
-    reproducibility_expert = models.CharField(
-        max_length=16,
-        choices=ExpertDimensionScore.choices,
-    )
     expert_insights = models.TextField(blank=True)
 
     class Meta:
@@ -198,3 +192,25 @@ class EditorialFeedback(DefaultModel):
 
     def __str__(self):
         return f"EditorialFeedback ud={self.unified_document_id}"
+
+
+class EditorialFeedbackCategory(DefaultModel):
+    """Per-category human editorial score for a proposal."""
+
+    feedback = models.ForeignKey(
+        EditorialFeedback,
+        on_delete=models.CASCADE,
+        related_name="categories",
+    )
+    category_code = models.CharField(
+        max_length=64,
+        choices=[(k, k) for k in CATEGORY_KEYS],
+    )
+    score = models.CharField(max_length=16, choices=ExpertDimensionScore.choices)
+
+    class Meta:
+        db_table = "ai_peer_review_editorial_feedback_category"
+        unique_together = [("feedback", "category_code")]
+
+    def __str__(self):
+        return f"EditorialFeedbackCategory {self.category_code}={self.score}"

--- a/src/ai_peer_review/prompts/proposal_review_prompts.py
+++ b/src/ai_peer_review/prompts/proposal_review_prompts.py
@@ -45,8 +45,8 @@ def build_proposal_review_user_prompt(
     if external_researcher_context and external_researcher_context.strip():
         external = (
             "\n\nEXTERNAL RESEARCHER CONTEXT (from ORCID public record and OpenAlex; "
-            "factual only—use for feasibility.track_record and to ground expertise; "
-            "do not invent facts beyond this block):\n"
+            "factual only—use for feasibility_and_execution.team_environment and to "
+            "ground expertise; do not invent facts beyond this block):\n"
             f"{external_researcher_context.strip()}\n"
         )
     web_ctx = ""
@@ -62,8 +62,10 @@ def build_proposal_review_user_prompt(
         text = text[:120000] + "\n\n[TRUNCATED FOR LENGTH]"
     return (
         "Evaluate the following research proposal and return the structured JSON assessment "
-        "with all five dimensions and narrative sections "
-        "(editorial_summary, issue_table, feasibility_timeline_notes, budget_notes).\n\n"
+        "with the seven top-level categories (under \"categories\"), overall_summary, "
+        "overall_rationale, overall_confidence, major_strengths, major_weaknesses, and "
+        "fatal_flaws. Provide overall_rating and overall_score_numeric when you can; "
+        "the server canonicalizes them and may fill numeric from categories if missing.\n\n"
         "PROPOSAL TEXT:\n"
         f"{text}"
         f"{author}"

--- a/src/ai_peer_review/prompts/proposal_review_system.txt
+++ b/src/ai_peer_review/prompts/proposal_review_system.txt
@@ -1,364 +1,205 @@
+You are an expert scientific grant reviewer and evaluation specialist acting in an NIH-style peer review posture. You will receive the full text of a research proposal or grant application (plain text or markdown from our platform), and when present, RFP or funding-opportunity context.
 
-You are an expert scientific grant reviewer and evaluation specialist. You will receive the full text of a research proposal or grant application (plain text or markdown from our platform). Your task is to evaluate it across five
-dimensions AND produce narrative sections for a structured report, then return a SINGLE valid
-JSON object. Do NOT include any text, explanation, preamble, or markdown outside the JSON object.
+Core rules:
+- Base every judgment only on text you were given (proposal, RFP context, and the labeled context blocks below when present). Do not invent citations, results, or institutional facts that are not supported by that text.
+- Distinguish pilot or exploratory work from confirmatory claims. Penalize over-claims relative to evidence.
+- Prefer precise, conservative language. When uncertain, say so in the rationale and reflect that in Partial decisions rather than guessing.
+- Support judgments with brief paraphrase or short quoted fragments from the proposal when useful (still keep JSON valid and ASCII-only in free-text fields).
 
----
+When AUTHOR CONTEXT, EXTERNAL RESEARCHER CONTEXT, or WEB SEARCH NOTES appear in the user message, you may treat them as factual inputs for feasibility_and_execution (especially team_environment), fit, and related items, and they supersede any generic "no outside knowledge" instruction for those fields only. Do not treat web notes as verified truth; reconcile with the proposal when they conflict.
 
-### SCORING SCALE
-
-**Mandatory sub-area scores:** "High" | "Medium" | "Low"
-**Optional sub-area scores:** "High" | "Medium" | "Low" | "N/A"
-  - Use "N/A" ONLY for optional sub-areas that are entirely inapplicable.
-
-**Mandatory question answers:** "Yes" | "No" | "Partial"
-  - N/A is NOT permitted for mandatory sub-areas. Commit to a real assessment.
-
-**Optional question answers:** "Yes" | "No" | "Partial" | "N/A"
-  - Use "N/A" when the question genuinely does not apply.
+Your task is to evaluate the proposal using the seven category schema below, then return a SINGLE valid JSON object. Do NOT include any text, explanation, preamble, or markdown outside the JSON object.
 
 ---
 
-### DETERMINISTIC SCORING RUBRIC (MUST FOLLOW)
+### Category scores (stored as "score" in JSON)
 
-Use this exact numeric mapping internally:
+For each category (except optional categories that are wholly inapplicable), the category-level label is "score": "High" | "Medium" | "Low".
+
+Per-item decisions are "Yes" | "No" | "Partial". Optional categories may use "N/A" per policy below.
+
+---
+
+### N/A policy (strict)
+
+Only these three categories may have category-level score "N/A", and only when every item in that category is "N/A":
+- statistical_analysis_plan (non-quantitative / no inferential statistics)
+- clinical_or_translational_impact (no plausible clinical or translational path)
+- societal_and_broader_impact (no meaningful broader or societal angle)
+
+For all other categories, every item must be Yes / No / Partial (never N/A), and the category score must be High / Medium / Low.
+
+For optional categories that are applicable, do not use N/A on individual items.
+
+---
+
+### Deterministic scoring rubric (must follow)
+
+Use this exact numeric mapping internally for each item decision:
 - Yes = 1.0
 - Partial = 0.5
 - No = 0.0
 
-For each sub-area, compute the mean of its question values.
+For each category (except an all-N/A optional category), compute the mean of its item decisions (excluding optional-category items marked N/A from the mean). Map the mean to the category score:
 - High: mean >= 0.75
 - Medium: 0.40 <= mean < 0.75
 - Low: mean < 0.40
 
-For optional sub-areas:
-- If the sub-area is truly inapplicable, set score="N/A" and set ALL its questions to "N/A".
-- If applicable, do NOT use "N/A" for individual questions.
+Recompute each category score from item decisions before emitting JSON so your category ``score`` matches the rubric. The server trusts your category scores and only canonicalizes labels (for example casing) for storage.
 
-For each dimension overall_score:
-- Compute from the mean of sub-area means.
-- Exclude optional sub-areas with score="N/A" from the dimension mean.
-- Apply the same thresholds (High >= 0.75, Medium 0.40-0.74, Low < 0.40).
-
-Critical fail cap rule:
-- If any of these are "No", the related sub-area cannot be High:
-  - fundability.timeline_realism.go_no_go_gates
-  - reproducibility.statistical_analysis_plan.stats_plan
-  - reproducibility.statistical_analysis_plan.power_analysis
-  - reproducibility.methods_rigor.methods_detail
-  - reproducibility.methods_rigor.controls_defined
+Critical fail cap rule (must enforce before emitting):
+If any of the following item decisions is "No", the owning category score cannot be "High" (cap at "Medium" even if the mean is high):
+- methods_rigor.methods_detail
+- methods_rigor.controls_defined
+- statistical_analysis_plan.analysis_present
+- statistical_analysis_plan.power_analysis
+- feasibility_and_execution.timeline_milestones
 
 ---
 
-### OPTIONAL SUB-AREAS
+### Evaluation categories and items
 
-The following sub-areas may not be applicable to all proposals. If the entire sub-area
-is inapplicable (e.g., a basic-science proposal has no clinical path), set the sub-area
-score to "N/A", explain why in the rationale, and set ALL individual questions to "N/A".
+1) funding_opportunity_fit
+Items: fit_modality, fit_aims, fit_deliverables, fit_scope
+Assess alignment between aims, methods, deliverables, and scope versus the stated opportunity or, when no RFP block is present, internal coherence of the plan.
 
-Do NOT include optional sub-areas with score "N/A" when computing the dimension's overall_score.
-The dimension overall_score must be the consensus of APPLICABLE (non-N/A) sub-areas only.
+2) methods_rigor
+Items: methods_detail, parameters_specified, controls_defined, model_choice_justified, outcomes_linked_to_aims
 
-Optional sub-areas:
-1. feasibility.track_record — If the user prompt includes "EXTERNAL RESEARCHER CONTEXT" and/or
-   "WEB SEARCH NOTES", you MUST assess this sub-area from those sources plus the proposal.
-   Score each question Yes/No/Partial (not all N/A) when the external block contains enough
-   evidence (e.g. publication volume, h-index, ORCID works list for prior_grants/open_science
-   signals where inferable). Cite specific numbers or work examples from the external block
-   in the track_record rationale. Use N/A only for individual questions that remain truly
-   unknowable from the provided material (e.g. formal endorsement letters not in ORCID).
-   If neither external block is present, treat track_record as before: the sub-area lacks
-   verifiable external bibliometric/ORCID data, so set score to N/A and all questions to N/A.
-2. impact.clinical_translational_impact — not applicable to basic/computational/theoretical science
-3. impact.community_ecosystem_impact — not always applicable
-4. reproducibility.gold_standard_methodology — not applicable to theoretical or review proposals
+3) statistical_analysis_plan
+Items: analysis_present, power_analysis, multiple_comparisons, metrics_defined, analysis_matches_design
 
-For all other sub-areas (mandatory), you MUST provide a real score (High/Medium/Low) with
-a specific rationale drawn from the proposal text. Never use N/A for mandatory sub-areas.
+4) feasibility_and_execution
+Items: recruitment_feasible, procedures_feasible, timeline_milestones, team_environment, ethics_data_quality
 
-When "WEB SEARCH NOTES" is present, you may use it to inform novelty.literature_positioning
-and impact sub-areas where grounded; prefer proposal text + external blocks over speculation.
+5) scientific_impact
+Items: advances_understanding, generalizability, opens_new_directions
+
+6) clinical_or_translational_impact
+Items: clinical_pathway, unmet_need, milestones_defined
+
+7) societal_and_broader_impact
+Items: societal_challenge, public_communication, commercial_potential
 
 ---
 
-### JSON STRUCTURE
+### Overall fields (flattened; no separate verdict object)
 
-Return exactly this JSON structure. All keys are required.
+Provide:
+- overall_summary: narrative overview
+- overall_rationale: short rationale for the overall judgment
+- overall_confidence: "High" | "Medium" | "Low"
+- overall_rating: "excellent" | "good" | "poor" (lowercase preferred; server canonicalizes)
+- overall_score_numeric: number from 1 to 3 (server clamps or infers from categories only if missing or invalid)
+
+Also provide:
+- major_strengths: array of strings
+- major_weaknesses: array of strings
+- fatal_flaws: array of strings (use [] if none). If present, your overall_rating should usually be "poor".
+
+---
+
+### OUTPUT JSON SHAPE (required keys)
 
 {
-  "fundability": {
-    "overall_score": "High" | "Medium" | "Low",
-    "overall_rationale": "<2-4 sentences citing specific evidence>",
-    "scope_alignment": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence from proposal>",
-      "flags": ["<issue>"],
-      "rfp_goals": "Yes" | "No" | "Partial",
-      "aims_boundaries": "Yes" | "No" | "Partial",
-      "target_population": "Yes" | "No" | "Partial"
+  "overall_summary": "<narrative>",
+  "overall_rating": "excellent|good|poor",
+  "overall_rationale": "<short rationale>",
+  "overall_confidence": "High|Medium|Low",
+  "overall_score_numeric": 0,
+  "major_strengths": ["...", "..."],
+  "major_weaknesses": ["...", "..."],
+  "fatal_flaws": [],
+  "categories": {
+    "funding_opportunity_fit": {
+      "score": "High|Medium|Low",
+      "rationale": "...",
+      "items": {
+        "fit_modality": { "decision": "Yes|No|Partial", "justification": "..." },
+        "fit_aims": { "decision": "Yes|No|Partial", "justification": "..." },
+        "fit_deliverables": { "decision": "Yes|No|Partial", "justification": "..." },
+        "fit_scope": { "decision": "Yes|No|Partial", "justification": "..." }
+      }
     },
-    "budget_adequacy": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence>",
-      "flags": ["<issue>"],
-      "total_scope_alignment": "Yes" | "No" | "Partial",
-      "line_items_justified": "Yes" | "No" | "Partial",
-      "personnel_proportional": "Yes" | "No" | "Partial",
-      "compute_realistic": "Yes" | "No" | "Partial",
-      "contingency_adequate": "Yes" | "No" | "Partial",
-      "over_under_allocation": "Yes" | "No" | "Partial"
-    },
-    "timeline_realism": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence>",
-      "flags": ["<issue>"],
-      "timeline_realistic": "Yes" | "No" | "Partial",
-      "milestones_sequenced": "Yes" | "No" | "Partial",
-      "buffers_adequate": "Yes" | "No" | "Partial",
-      "go_no_go_gates": "Yes" | "No" | "Partial"
-    }
-  },
-
-  "feasibility": {
-    "overall_score": "High" | "Medium" | "Low",
-    "overall_rationale": "<2-4 sentences>",
-    "investigator_expertise": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence>",
-      "flags": ["<issue>"],
-      "publication_record": "Yes" | "No" | "Partial",
-      "methods_expertise": "Yes" | "No" | "Partial",
-      "comparable_projects": "Yes" | "No" | "Partial",
-      "recent_activity": "Yes" | "No" | "Partial",
-      "team_composition": "Yes" | "No" | "Partial"
-    },
-    "institutional_capacity": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence>",
-      "flags": ["<issue>"],
-      "core_facilities": "Yes" | "No" | "Partial",
-      "specialized_resources": "Yes" | "No" | "Partial",
-      "institutional_support": "Yes" | "No" | "Partial"
-    },
-    "track_record": {
-      "score": "High" | "Medium" | "Low" | "N/A",
-      "rationale": "<specific evidence or reason for N/A>",
-      "flags": ["<issue>"],
-      "prior_grants": "Yes" | "No" | "Partial" | "N/A",
-      "h_index_profile": "Yes" | "No" | "Partial" | "N/A",
-      "open_science": "Yes" | "No" | "Partial" | "N/A",
-      "community_engagement": "Yes" | "No" | "Partial" | "N/A",
-      "endorsements": "Yes" | "No" | "Partial" | "N/A"
-    }
-  },
-
-  "novelty": {
-    "overall_score": "High" | "Medium" | "Low",
-    "overall_rationale": "<2-4 sentences>",
-    "conceptual_novelty": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence>",
-      "flags": ["<issue>"],
-      "new_hypothesis": "Yes" | "No" | "Partial",
-      "challenges_models": "Yes" | "No" | "Partial",
-      "distinct_framing": "Yes" | "No" | "Partial"
-    },
-    "methodological_novelty": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence>",
-      "flags": ["<issue>"],
-      "new_methods": "Yes" | "No" | "Partial",
-      "combined_methods": "Yes" | "No" | "Partial",
-      "new_tools_datasets": "Yes" | "No" | "Partial"
-    },
-    "literature_positioning": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence>",
-      "flags": ["<issue>"],
-      "prior_work_cited": "Yes" | "No" | "Partial",
-      "pi_overlap": "Yes" | "No" | "Partial",
-      "recent_overlap": "Yes" | "No" | "Partial",
-      "concurrent_work": "Yes" | "No" | "Partial"
-    }
-  },
-
-  "impact": {
-    "overall_score": "High" | "Medium" | "Low",
-    "overall_rationale": "<2-4 sentences>",
-    "scientific_impact": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence>",
-      "flags": ["<issue>"],
-      "fundamental_understanding": "Yes" | "No" | "Partial",
-      "generalizability": "Yes" | "No" | "Partial",
-      "new_directions": "Yes" | "No" | "Partial"
-    },
-    "clinical_translational_impact": {
-      "score": "High" | "Medium" | "Low" | "N/A",
-      "rationale": "<specific evidence or reason for N/A>",
-      "flags": ["<issue>"],
-      "clinical_path": "Yes" | "No" | "Partial" | "N/A",
-      "unmet_need": "Yes" | "No" | "Partial" | "N/A",
-      "translational_milestones": "Yes" | "No" | "Partial" | "N/A"
-    },
-    "societal_broader_impact": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence>",
-      "flags": ["<issue>"],
-      "societal_challenge": "Yes" | "No" | "Partial",
-      "public_communication": "Yes" | "No" | "Partial",
-      "commercial_application": "Yes" | "No" | "Partial"
-    },
-    "community_ecosystem_impact": {
-      "score": "High" | "Medium" | "Low" | "N/A",
-      "rationale": "<specific evidence or reason for N/A>",
-      "flags": ["<issue>"],
-      "public_outputs": "Yes" | "No" | "Partial" | "N/A",
-      "pi_reusable_outputs": "Yes" | "No" | "Partial" | "N/A",
-      "community_demand": "Yes" | "No" | "Partial" | "N/A"
-    }
-  },
-
-  "reproducibility": {
-    "overall_score": "High" | "Medium" | "Low",
-    "overall_rationale": "<2-4 sentences>",
     "methods_rigor": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence>",
-      "flags": ["<issue>"],
-      "methods_detail": "Yes" | "No" | "Partial",
-      "parameters_specified": "Yes" | "No" | "Partial",
-      "controls_defined": "Yes" | "No" | "Partial",
-      "model_justified": "Yes" | "No" | "Partial"
+      "score": "High|Medium|Low",
+      "rationale": "...",
+      "items": {
+        "methods_detail": { "decision": "Yes|No|Partial", "justification": "..." },
+        "parameters_specified": { "decision": "Yes|No|Partial", "justification": "..." },
+        "controls_defined": { "decision": "Yes|No|Partial", "justification": "..." },
+        "model_choice_justified": { "decision": "Yes|No|Partial", "justification": "..." },
+        "outcomes_linked_to_aims": { "decision": "Yes|No|Partial", "justification": "..." }
+      }
     },
     "statistical_analysis_plan": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence>",
-      "flags": ["<issue>"],
-      "stats_plan": "Yes" | "No" | "Partial",
-      "power_analysis": "Yes" | "No" | "Partial",
-      "multiple_comparisons": "Yes" | "No" | "Partial",
-      "evaluation_metrics": "Yes" | "No" | "Partial"
-    },
-    "data_code_transparency": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence>",
-      "flags": ["<issue>"],
-      "data_sharing_plan": "Yes" | "No" | "Partial",
-      "code_sharing_plan": "Yes" | "No" | "Partial",
-      "pi_data_history": "Yes" | "No" | "Partial",
-      "data_management": "Yes" | "No" | "Partial"
-    },
-    "gold_standard_methodology": {
-      "score": "High" | "Medium" | "Low" | "N/A",
-      "rationale": "<specific evidence or reason for N/A>",
-      "flags": ["<issue>"],
-      "gold_standard_used": "Yes" | "No" | "Partial" | "N/A",
-      "non_standard_justified": "Yes" | "No" | "Partial" | "N/A",
-      "justification_compelling": "Yes" | "No" | "Partial" | "N/A",
-      "novel_method_validated": "Yes" | "No" | "Partial" | "N/A",
-      "literature_support": "Yes" | "No" | "Partial" | "N/A",
-      "prior_studies_cited": "Yes" | "No" | "Partial" | "N/A",
-      "gold_standard_correctly_applied": "Yes" | "No" | "Partial" | "N/A"
-    },
-    "validation_robustness": {
-      "score": "High" | "Medium" | "Low",
-      "rationale": "<specific evidence>",
-      "flags": ["<issue>"],
-      "validation_strategies": "Yes" | "No" | "Partial"
-    }
-  },
-
-  "editorial_summary": {
-    "recommendation": "<one sentence: e.g. Fundable with minor revisions / Not fundable / Requires major revision>",
-    "consensus_summary": "<3-4 sentences synthesising key strengths, weaknesses, and cross-dimension consensus>",
-    "priority_action_items": [
-      {
-        "severity": "Major" | "Moderate" | "Minor",
-        "description": "<one-line description of the issue>",
-        "suggested_fix": "<one-line concrete fix>",
-        "priority": "Must-fix" | "High" | "Medium"
+      "score": "High|Medium|Low|N/A",
+      "rationale": "...",
+      "items": {
+        "analysis_present": { "decision": "Yes|No|Partial|N/A", "justification": "..." },
+        "power_analysis": { "decision": "Yes|No|Partial|N/A", "justification": "..." },
+        "multiple_comparisons": { "decision": "Yes|No|Partial|N/A", "justification": "..." },
+        "metrics_defined": { "decision": "Yes|No|Partial|N/A", "justification": "..." },
+        "analysis_matches_design": { "decision": "Yes|No|Partial|N/A", "justification": "..." }
       }
-    ]
-  },
-
-  "issue_table": [
-    {
-      "severity": "Major" | "Moderate" | "Minor",
-      "category": "Timeline" | "Budget" | "Methods" | "Novelty" | "Impact" | "Feasibility" | "Reproducibility" | "Other",
-      "issue": "<concise issue description>",
-      "suggested_fix": "<concise fix>",
-      "priority": "Must-fix" | "High" | "Medium" | "Low"
-    }
-  ],
-
-  "feasibility_timeline_notes": {
-    "milestone_assessment": "<1-2 sentences on timeline realism and critical path>",
-    "go_no_go_criteria": "<1-2 sentences on pass/fail criteria identified or missing>",
-    "resource_flags": ["<flag string>"]
-  },
-
-  "budget_notes": {
-    "line_item_flags": ["<flag string>"],
-    "recommended_adjustments": [
-      {
-        "line_item": "<budget item name>",
-        "proposed": "<proposed amount or FTE>",
-        "recommended": "<recommended value>",
-        "rationale": "<one-line reason>"
+    },
+    "feasibility_and_execution": {
+      "score": "High|Medium|Low",
+      "rationale": "...",
+      "items": {
+        "recruitment_feasible": { "decision": "Yes|No|Partial", "justification": "..." },
+        "procedures_feasible": { "decision": "Yes|No|Partial", "justification": "..." },
+        "timeline_milestones": { "decision": "Yes|No|Partial", "justification": "..." },
+        "team_environment": { "decision": "Yes|No|Partial", "justification": "..." },
+        "ethics_data_quality": { "decision": "Yes|No|Partial", "justification": "..." }
       }
-    ]
+    },
+    "scientific_impact": {
+      "score": "High|Medium|Low",
+      "rationale": "...",
+      "items": {
+        "advances_understanding": { "decision": "Yes|No|Partial", "justification": "..." },
+        "generalizability": { "decision": "Yes|No|Partial", "justification": "..." },
+        "opens_new_directions": { "decision": "Yes|No|Partial", "justification": "..." }
+      }
+    },
+    "clinical_or_translational_impact": {
+      "score": "High|Medium|Low|N/A",
+      "rationale": "...",
+      "items": {
+        "clinical_pathway": { "decision": "Yes|No|Partial|N/A", "justification": "..." },
+        "unmet_need": { "decision": "Yes|No|Partial|N/A", "justification": "..." },
+        "milestones_defined": { "decision": "Yes|No|Partial|N/A", "justification": "..." }
+      }
+    },
+    "societal_and_broader_impact": {
+      "score": "High|Medium|Low|N/A",
+      "rationale": "...",
+      "items": {
+        "societal_challenge": { "decision": "Yes|No|Partial|N/A", "justification": "..." },
+        "public_communication": { "decision": "Yes|No|Partial|N/A", "justification": "..." },
+        "commercial_potential": { "decision": "Yes|No|Partial|N/A", "justification": "..." }
+      }
+    }
   }
 }
 
 ---
 
-### INSTRUCTIONS
+### Instructions
 
-1. **Mandatory sub-areas**: Answer every individual question as "Yes", "No", or "Partial" — NEVER "N/A".
-   Base each answer strictly on evidence present in the proposal text.
+1. Use plain ASCII in all narrative and justification fields. Avoid fancy punctuation (no em dashes); use "-" instead.
 
-2. **Optional sub-areas**: Use "N/A" for score AND all questions ONLY when the entire sub-area is
-   genuinely inapplicable (e.g., a basic-science proposal for track_record). When applicable, score
-   and answer all questions normally with "Yes"/"No"/"Partial".
+2. Rationale strings should cite concrete proposal sections or short quotes when possible.
 
-3. **Dimension overall_score**: Must reflect only mandatory + applicable optional sub-areas. If an
-   optional sub-area is "N/A", exclude it from the dimension consensus.
+3. If RFP context is provided, align fit and emphasis with that context. Do not invent evaluation criteria not grounded in the proposal or provided context.
 
-4. **Rationale strings**: Must cite specific sections, page numbers, or direct quotes where possible.
-   (e.g., "Section 2.3 states...", "Aim 1 budget table shows...", "The Gantt chart on page 8 shows...")
+4. Consistency check pass before final output:
+   - Recompute every category score from item decisions using the rubric and critical-fail caps.
+   - Ensure JSON keys, decisions, and category scores are internally consistent.
 
-5. **Flags**: Brief strings for concrete problems (e.g., "No power calculation provided").
-   Omit the flags array entirely when there are no issues.
+5. Output must be parseable by json.loads() with no surrounding commentary or markdown fences.
 
-6. **editorial_summary.priority_action_items**: Include 3–5 items ordered by severity (Major first).
-
-7. **issue_table**: Include ALL identified issues across all dimensions, not just the top issues.
-   Order by severity descending (Major → Moderate → Minor).
-
-8. **budget_notes.recommended_adjustments**: Include only when the proposal contains a budget table
-   or line items. If no budget details are present, use an empty array [].
-
-9. **feasibility_timeline_notes.resource_flags**: List specific resource gaps or concerns
-   (compute, personnel FTE, equipment, animal models, etc.). Use [] if none identified.
-
-10. Do NOT include any text, commentary, or markdown outside the JSON object.
-    Output must be parseable by json.loads() with no preprocessing.
-
-11. Use plain ASCII in narrative text fields. Avoid special symbols (e.g., bullets, arrows, stars, flags, em dashes).
-    Use simple punctuation or "-" instead.
-
-12. If RFP context is provided, align your assessments and recommendations with the funder's goals,
-    scope, and evaluation criteria described there. Do not invent criteria not present in the
-    proposal or the provided RFP context.
-
-13. Base your assessment only on the proposal text and any RFP context provided. Do not claim external verification you did not perform.
-
-14. Consistency check pass before final output:
-    - Recompute all sub-area and dimension scores from your Yes/No/Partial answers using the rubric above.
-    - Ensure labels, rationales, and issue severity are internally consistent.
-    - Return only the final reconciled JSON.
-
-15. Never output placeholder or truncated text in any field:
-    - Do NOT use "...", "[...]", "etc.", "TBD", or "omitted".
-    - Write complete, self-contained sentences in rationale and narrative fields.
+6. Never output placeholder or truncated text:
+   - Do NOT use "...", "[...]", "etc.", "TBD", or "omitted".
+   - Write complete sentences in rationale, justifications, and narrative fields.

--- a/src/ai_peer_review/serializers.py
+++ b/src/ai_peer_review/serializers.py
@@ -1,13 +1,17 @@
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import transaction
 from rest_framework import serializers
 
+from ai_peer_review.constants import CATEGORY_KEYS
 from ai_peer_review.models import (
     EditorialFeedback,
+    EditorialFeedbackCategory,
+    ExpertDimensionScore,
     ProposalReview,
     ReviewStatus,
     RFPSummary,
 )
-from ai_peer_review.services.proposal_review_scoring import dimension_overall_scores
+from ai_peer_review.services.proposal_review_scoring import category_scores
 
 
 class ProposalReviewCreateSerializer(serializers.Serializer):
@@ -27,6 +31,8 @@ class ProposalReviewSerializer(serializers.ModelSerializer):
             "created_by_id",
             "status",
             "overall_rating",
+            "overall_rationale",
+            "overall_confidence",
             "overall_score_numeric",
             "result_data",
             "error_message",
@@ -73,7 +79,14 @@ class RfpBriefRefreshSerializer(serializers.Serializer):
     force = serializers.BooleanField(required=False, default=False)
 
 
+class EditorialFeedbackCategoryEntrySerializer(serializers.Serializer):
+    category_code = serializers.ChoiceField(choices=[(k, k) for k in CATEGORY_KEYS])
+    score = serializers.ChoiceField(choices=ExpertDimensionScore.choices)
+
+
 class EditorialFeedbackSerializer(serializers.ModelSerializer):
+    categories = serializers.SerializerMethodField()
+
     class Meta:
         model = EditorialFeedback
         fields = [
@@ -81,11 +94,7 @@ class EditorialFeedbackSerializer(serializers.ModelSerializer):
             "unified_document_id",
             "created_by_id",
             "updated_by_id",
-            "fundability_expert",
-            "feasibility_expert",
-            "novelty_expert",
-            "impact_expert",
-            "reproducibility_expert",
+            "categories",
             "expert_insights",
             "created_date",
             "updated_date",
@@ -99,26 +108,74 @@ class EditorialFeedbackSerializer(serializers.ModelSerializer):
             "updated_date",
         ]
 
-
-class EditorialFeedbackUpsertSerializer(serializers.ModelSerializer):
-    """
-    Create: use partial=False (all five dimension scores required).
-    Update: partial=True (PATCH) or partial=False (PUT) as appropriate.
-    """
-
-    class Meta:
-        model = EditorialFeedback
-        fields = [
-            "fundability_expert",
-            "feasibility_expert",
-            "novelty_expert",
-            "impact_expert",
-            "reproducibility_expert",
-            "expert_insights",
+    def get_categories(self, obj):
+        rows = sorted(
+            obj.categories.all(),
+            key=lambda r: CATEGORY_KEYS.index(r.category_code)
+            if r.category_code in CATEGORY_KEYS
+            else 99,
+        )
+        return [
+            {"category_code": r.category_code, "score": r.score} for r in rows
         ]
-        extra_kwargs = {
-            "expert_insights": {"required": False, "allow_blank": True},
-        }
+
+
+class EditorialFeedbackUpsertSerializer(serializers.Serializer):
+    """
+    Create: all category codes required (partial=False on the view).
+    Update: optional fields; when ``categories`` is sent, child rows are replaced.
+    """
+
+    expert_insights = serializers.CharField(required=False, allow_blank=True)
+    categories = serializers.ListField(
+        child=EditorialFeedbackCategoryEntrySerializer(),
+        required=False,
+    )
+
+    def validate_categories(self, value):
+        codes = {entry["category_code"] for entry in value}
+        if len(codes) != len(value):
+            raise serializers.ValidationError("Duplicate category_code entries.")
+        return value
+
+    def validate(self, attrs):
+        is_create = self.context.get("is_create", False)
+        cats = attrs.get("categories")
+        if is_create:
+            if not cats:
+                raise serializers.ValidationError(
+                    {"categories": "This field is required when creating feedback."}
+                )
+            provided = {c["category_code"] for c in cats}
+            required = set(CATEGORY_KEYS)
+            if provided != required:
+                raise serializers.ValidationError(
+                    {
+                        "categories": (
+                            "Must include exactly one score per category. "
+                            f"Missing: {sorted(required - provided)} "
+                            f"Unexpected: {sorted(provided - required)}"
+                        )
+                    }
+                )
+        return attrs
+
+
+def replace_editorial_feedback_categories(
+    feedback: EditorialFeedback, categories: list[dict],
+) -> None:
+    with transaction.atomic():
+        feedback.categories.all().delete()
+        EditorialFeedbackCategory.objects.bulk_create(
+            [
+                EditorialFeedbackCategory(
+                    feedback=feedback,
+                    category_code=row["category_code"],
+                    score=row["score"],
+                )
+                for row in categories
+            ]
+        )
 
 
 def build_proposal_comparison_row(
@@ -134,11 +191,7 @@ def build_proposal_comparison_row(
         "status": None,
         "overall_rating": None,
         "overall_score_numeric": None,
-        "fundability": None,
-        "feasibility": None,
-        "novelty": None,
-        "impact": None,
-        "reproducibility": None,
+        "categories": None,
         "editorial_feedback": editorial_feedback,
     }
     if review is None:
@@ -148,10 +201,6 @@ def build_proposal_comparison_row(
     row["overall_rating"] = review.overall_rating
     row["overall_score_numeric"] = review.overall_score_numeric
     if review.status == ReviewStatus.COMPLETED and review.result_data:
-        dims = dimension_overall_scores(review.result_data)
-        row["fundability"] = dims.get("fundability")
-        row["feasibility"] = dims.get("feasibility")
-        row["novelty"] = dims.get("novelty")
-        row["impact"] = dims.get("impact")
-        row["reproducibility"] = dims.get("reproducibility")
+        cats = category_scores(review.result_data)
+        row["categories"] = {k: cats.get(k) for k in CATEGORY_KEYS}
     return row

--- a/src/ai_peer_review/services/proposal_review_scoring.py
+++ b/src/ai_peer_review/services/proposal_review_scoring.py
@@ -2,31 +2,18 @@ import json
 import re
 from typing import Optional
 
-from ai_peer_review.constants import (
-    DIMENSION_KEYS,
-    DIMENSION_SUB_AREAS,
-    OPTIONAL_SUB_AREAS,
-)
+from ai_peer_review.constants import CATEGORY_KEYS, OPTIONAL_CATEGORIES
 from ai_peer_review.models import OverallRating
 
 SCORE_MAP = {"High": 3, "Medium": 2, "Low": 1}
 
-ANSWER_TO_NUMERIC = {
-    "yes": 1.0,
-    "partial": 0.5,
-    "no": 0.0,
+_SCORE_ALIASES = {
+    "high": "High",
+    "medium": "Medium",
+    "low": "Low",
+    "n/a": "N/A",
+    "na": "N/A",
 }
-
-# Keep in sync with proposal_review_system.txt (Critical fail cap rule)
-CRITICAL_FAIL_KEYS = {
-    ("fundability", "timeline_realism", "go_no_go_gates"),
-    ("reproducibility", "statistical_analysis_plan", "stats_plan"),
-    ("reproducibility", "statistical_analysis_plan", "power_analysis"),
-    ("reproducibility", "methods_rigor", "methods_detail"),
-    ("reproducibility", "methods_rigor", "controls_defined"),
-}
-
-_RESERVED_SUB_AREA_KEYS = frozenset({"score", "rationale", "flags"})
 
 
 def parse_json_response(text: str) -> dict:
@@ -50,150 +37,99 @@ def parse_json_response(text: str) -> dict:
     raise ValueError("Could not extract valid JSON from LLM response")
 
 
-def _label_from_mean(mean_value: float) -> str:
-    if mean_value >= 0.75:
-        return "High"
-    if mean_value >= 0.40:
-        return "Medium"
-    return "Low"
-
-
-def _answer_to_numeric(value: Optional[str]) -> Optional[float]:
-    if not isinstance(value, str):
-        return None
-    value_lower = value.strip().lower()
-    if value_lower == "n/a":
-        return None
-    return ANSWER_TO_NUMERIC.get(value_lower)
-
-
-# Extra guard against critical fail rule violation
-def _cap_sub_area_for_critical_fail(
-    dim_key: str,
-    sub_key: str,
-    sub_area_data: dict,
-    current_label: str,
-) -> str:
-    if current_label != "High":
-        return current_label
-    for d, s, q in CRITICAL_FAIL_KEYS:
-        if d != dim_key or s != sub_key:
-            continue
-        q_val = sub_area_data.get(q)
-        if isinstance(q_val, str) and q_val.strip().lower() == "no":
-            return "Medium"
-    return current_label
-
-
-def _answer_keys_in_sub_area(sub_obj: dict) -> list[str]:
-    return [k for k in sub_obj.keys() if k not in _RESERVED_SUB_AREA_KEYS]
-
-
-def _gather_numeric_answers(
-    sub_obj: dict, answer_keys: list[str]
-) -> tuple[list[float], int]:
-    """Collect yes/partial/no as floats; ``na_count`` is explicit ``n/a`` answers only."""
-    question_values: list[float] = []
-    na_count = 0
-    for answer_key in answer_keys:
-        raw = sub_obj.get(answer_key)
-        numeric_val = _answer_to_numeric(raw)
-        if numeric_val is not None:
-            question_values.append(numeric_val)
-            continue
-        if isinstance(raw, str) and raw.strip().lower() == "n/a":
-            na_count += 1
-    return question_values, na_count
-
-
-def _sub_area_contribution_to_dimension_mean(
-    dim_key: str,
-    sub_key: str,
-    sub_obj: dict,
-    is_optional: bool,
-) -> Optional[float]:
-    """Write ``sub_obj['score']``; return mean for dimension rollup, or ``None`` if excluded."""
-    answer_keys = _answer_keys_in_sub_area(sub_obj)
-    question_values, na_count = _gather_numeric_answers(sub_obj, answer_keys)
-
-    if is_optional and answer_keys and na_count == len(answer_keys):
-        sub_obj["score"] = "N/A"
-        return None
-
-    if not question_values:
-        sub_obj["score"] = "Low"
-        return 0.0
-
-    mean_val = sum(question_values) / len(question_values)
-    score_label = _label_from_mean(mean_val)
-    score_label = _cap_sub_area_for_critical_fail(
-        dim_key, sub_key, sub_obj, score_label
-    )
-    sub_obj["score"] = score_label
-    return mean_val
+def _canonical_category_score(cat_key: str, raw) -> str:
+    """Map LLM text to stored category score; ``N/A`` only allowed for optional categories."""
+    if not isinstance(raw, str):
+        return "Low"
+    key = raw.strip().lower()
+    label = _SCORE_ALIASES.get(key)
+    if label is None:
+        return "Low"
+    if label == "N/A" and cat_key not in OPTIONAL_CATEGORIES:
+        return "Low"
+    return label
 
 
 def normalize_scores_from_answers(review_dict: dict) -> None:
-    """Derive High/Medium/Low (or N/A for optional rows) from raw LLM answers, in place.
-
-    ``review_dict`` matches the structured review shape: each dimension is a dict of
-    sub-area dicts. Sub-areas hold yes/partial/no (and metadata keys ``score``,
-    ``rationale``, ``flags``). This walk:
-
-    1. For each sub-area, averages numeric equivalents of question fields, maps the
-       mean to a label, writes ``sub_obj["score"]``, and records the mean for rollup.
-    2. Optional sub-areas whose every answer is ``n/a`` get ``score`` ``N/A`` and
-       are excluded from the dimension mean (not appended to ``sub_area_means``).
-    3. Sub-areas with no usable numeric answers default to ``Low`` and contribute
-       ``0.0`` so they still pull the dimension down.
-    4. Each dimension's ``overall_score`` is the label for the mean of sub-area
-       means (or ``Low`` if nothing contributed).
-    """
-    for dim_key, sub_area_keys in DIMENSION_SUB_AREAS.items():
-        dim_obj = review_dict.get(dim_key)
-        if not isinstance(dim_obj, dict):
+    """Canonicalize ``categories[*].score`` from the LLM in place (no item-level recompute)."""
+    cats = review_dict.get("categories")
+    if not isinstance(cats, dict):
+        return
+    for cat_key in CATEGORY_KEYS:
+        cat_obj = cats.get(cat_key)
+        if not isinstance(cat_obj, dict):
             continue
-
-        sub_area_means: list[float] = []
-        for sub_key in sub_area_keys:
-            sub_obj = dim_obj.get(sub_key)
-            if not isinstance(sub_obj, dict):
-                continue
-            is_optional = (dim_key, sub_key) in OPTIONAL_SUB_AREAS
-            contribution = _sub_area_contribution_to_dimension_mean(
-                dim_key, sub_key, sub_obj, is_optional
-            )
-            if contribution is not None:
-                sub_area_means.append(contribution)
-
-        if not sub_area_means:
-            dim_obj["overall_score"] = "Low"
-        else:
-            dim_mean = sum(sub_area_means) / len(sub_area_means)
-            dim_obj["overall_score"] = _label_from_mean(dim_mean)
+        cat_obj["score"] = _canonical_category_score(cat_key, cat_obj.get("score"))
 
 
-def compute_overall_rating(review_dict: dict) -> tuple[str, int]:
-    total = 0
-    for dim_key in DIMENSION_KEYS:
-        dim = review_dict.get(dim_key, {})
-        score = dim.get("overall_score", "Low")
-        total += SCORE_MAP.get(score, 1)
-    if total >= 13:
-        rating = OverallRating.EXCELLENT.value
-    elif total >= 8:
-        rating = OverallRating.GOOD.value
-    else:
-        rating = OverallRating.POOR.value
-    return rating, total
+def _category_score_label(categories: dict, cat_key: str) -> Optional[str]:
+    obj = categories.get(cat_key)
+    if not isinstance(obj, dict):
+        return None
+    score = obj.get("score")
+    if score in ("High", "Medium", "Low", "N/A"):
+        return score
+    return None
 
 
-def dimension_overall_scores(review_dict: dict) -> dict[str, Optional[str]]:
-    out = {}
-    for dim_key in DIMENSION_KEYS:
-        dim = review_dict.get(dim_key)
-        if isinstance(dim, dict):
-            out[dim_key] = dim.get("overall_score")
-        else:
-            out[dim_key] = None
+def _mean_applicable_category_numerics(review_dict: dict) -> Optional[float]:
+    cats = review_dict.get("categories")
+    if not isinstance(cats, dict):
+        return None
+    vals: list[int] = []
+    for key in CATEGORY_KEYS:
+        lab = _category_score_label(cats, key)
+        if lab in SCORE_MAP:
+            vals.append(SCORE_MAP[lab])
+    if not vals:
+        return None
+    return sum(vals) / len(vals)
+
+
+def _canonical_overall_rating(raw) -> Optional[str]:
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip().lower()
+    if s in OverallRating.values:
+        return s
+    return None
+
+
+def _canonical_overall_score_numeric(raw) -> Optional[int]:
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return min(3, max(1, int(v + 0.5)))
+
+
+def recompute_overall_fields(review_dict: dict) -> None:
+    """
+    Prefer LLM ``overall_rating`` / ``overall_score_numeric`` after canonicalization.
+    """
+    rating = _canonical_overall_rating(review_dict.get("overall_rating"))
+    review_dict["overall_rating"] = rating
+
+    raw_num = review_dict.get("overall_score_numeric")
+    if isinstance(raw_num, bool):
+        raw_num = None
+    numeric = _canonical_overall_score_numeric(raw_num)
+    if numeric is None:
+        mean = _mean_applicable_category_numerics(review_dict)
+        numeric = min(3, max(1, int(mean + 0.5))) if mean is not None else 1
+    review_dict["overall_score_numeric"] = numeric
+
+
+def category_scores(review_dict: dict) -> dict[str, Optional[str]]:
+    """Return each category ``score`` label (``High``/``Medium``/``Low``/``N/A``) after normalization."""
+    out: dict[str, Optional[str]] = {}
+    cats = review_dict.get("categories")
+    if not isinstance(cats, dict):
+        for key in CATEGORY_KEYS:
+            out[key] = None
+        return out
+    for key in CATEGORY_KEYS:
+        out[key] = _category_score_label(cats, key)
     return out

--- a/src/ai_peer_review/services/proposal_review_service.py
+++ b/src/ai_peer_review/services/proposal_review_service.py
@@ -2,7 +2,7 @@ import logging
 import time
 
 from ai_peer_review.constants import PROPOSAL_REVIEW_MAX_OUTPUT_TOKENS
-from ai_peer_review.models import ProposalReview, ReviewStatus
+from ai_peer_review.models import OverallConfidence, ProposalReview, ReviewStatus
 from ai_peer_review.prompts.proposal_review_prompts import (
     build_proposal_review_user_prompt,
     get_proposal_review_system_prompt,
@@ -13,9 +13,9 @@ from ai_peer_review.services.openai_web_context_service import (
     fetch_proposal_review_web_context,
 )
 from ai_peer_review.services.proposal_review_scoring import (
-    compute_overall_rating,
     normalize_scores_from_answers,
     parse_json_response,
+    recompute_overall_fields,
 )
 from ai_peer_review.services.researcher_external_context import (
     build_researcher_external_context,
@@ -123,12 +123,15 @@ def run_proposal_review(review_id: int) -> None:
         review.save(update_fields=["progress", "current_step", "updated_date"])
         review_dict = parse_json_response(raw)
         normalize_scores_from_answers(review_dict)
-        rating, numeric_total = compute_overall_rating(review_dict)
-        review_dict["overall_rating"] = rating
-        review_dict["overall_score_numeric"] = numeric_total
+        recompute_overall_fields(review_dict)
+        rating = review_dict["overall_rating"]
+        numeric_total = review_dict["overall_score_numeric"]
         elapsed = time.monotonic() - t0
         review.status = ReviewStatus.COMPLETED
         review.overall_rating = rating
+        review.overall_rationale = review_dict.get("overall_rationale", "") or ""
+        oc = review_dict.get("overall_confidence")
+        review.overall_confidence = oc if oc in OverallConfidence.values else None
         review.overall_score_numeric = numeric_total
         review.result_data = review_dict
         review.llm_model = llm.model_id

--- a/src/ai_peer_review/services/rfp_summary_service.py
+++ b/src/ai_peer_review/services/rfp_summary_service.py
@@ -10,7 +10,8 @@ from ai_peer_review.prompts.rfp_summary_prompts import (
     get_rfp_summary_system_prompt,
 )
 from ai_peer_review.services.bedrock_llm_service import BedrockLLMService
-from ai_peer_review.services.proposal_review_scoring import dimension_overall_scores
+from ai_peer_review.constants import CATEGORY_KEYS
+from ai_peer_review.services.proposal_review_scoring import category_scores
 from purchase.models import Grant
 
 logger = logging.getLogger(__name__)
@@ -78,16 +79,13 @@ def run_executive_comparison(grant_id: int, created_by_id: int) -> RFPSummary:
         ud = r.unified_document
         post = ud.posts.first()
         title = (post.title if post else "") or f"Document {ud.id}"
-        dims = dimension_overall_scores(r.result_data or {})
-        ed = (r.result_data or {}).get("editorial_summary") or {}
-        snippet = (ed.get("consensus_summary") or "")[:400]
+        cats = category_scores(r.result_data or {})
+        cat_parts = [f"{k}={cats.get(k)}" for k in CATEGORY_KEYS]
+        snippet = ((r.result_data or {}).get("overall_summary") or "")[:400]
         lines.append(
             f"- Title: {title[:200]}\n"
-            f"  Overall: {r.overall_rating} ({r.overall_score_numeric}/15)\n"
-            f"  Dimensions: fundability={dims.get('fundability')}, "
-            f"feasibility={dims.get('feasibility')}, novelty={dims.get('novelty')}, "
-            f"impact={dims.get('impact')}, "
-            f"reproducibility={dims.get('reproducibility')}\n"
+            f"  Overall: {r.overall_rating} (numeric {r.overall_score_numeric}, scale 1-3)\n"
+            f"  Categories: {', '.join(cat_parts)}\n"
             f"  Summary snippet: {snippet}"
         )
     if not lines:

--- a/src/ai_peer_review/tests/test_proposal_review_prompts.py
+++ b/src/ai_peer_review/tests/test_proposal_review_prompts.py
@@ -16,7 +16,9 @@ class ProposalReviewUserPromptTests(SimpleTestCase):
     def test_proposal_review_system_prompt_loads(self):
         text = get_proposal_review_system_prompt()
         self.assertIn("expert scientific grant reviewer", text)
-        self.assertIn("JSON STRUCTURE", text)
+        self.assertIn("OUTPUT JSON SHAPE", text)
+        self.assertIn("funding_opportunity_fit", text)
+        self.assertIn("Critical fail cap rule", text)
 
     def test_openai_web_context_system_prompt_loads(self):
         text = get_openai_web_context_system_prompt()
@@ -29,6 +31,7 @@ class ProposalReviewUserPromptTests(SimpleTestCase):
             external_researcher_context="OpenAlex stats here",
         )
         self.assertIn("EXTERNAL RESEARCHER CONTEXT", text)
+        self.assertIn("feasibility_and_execution.team_environment", text)
         self.assertIn("OpenAlex stats here", text)
 
     def test_includes_web_search_context_when_provided(self):

--- a/src/ai_peer_review/tests/test_proposal_review_scoring.py
+++ b/src/ai_peer_review/tests/test_proposal_review_scoring.py
@@ -1,71 +1,110 @@
 from django.test import SimpleTestCase
 
+from ai_peer_review.constants import CATEGORY_KEYS
 from ai_peer_review.models import OverallRating
 from ai_peer_review.services.proposal_review_scoring import (
-    compute_overall_rating,
+    category_scores,
     normalize_scores_from_answers,
     parse_json_response,
+    recompute_overall_fields,
 )
+
+
+def _cat(score: str) -> dict:
+    return {"score": score, "rationale": "R", "items": {}}
+
+
+def _all_categories(scores: dict[str, str]) -> dict:
+    return {k: _cat(scores.get(k, "High")) for k in CATEGORY_KEYS}
 
 
 class ProposalReviewScoringTests(SimpleTestCase):
     def test_parse_json_response_plain(self):
-        d = parse_json_response('{"fundability": {"overall_score": "High"}}')
-        self.assertEqual(d["fundability"]["overall_score"], "High")
+        d = parse_json_response(
+            '{"categories": {"methods_rigor": {"score": "High"}}}'
+        )
+        self.assertEqual(d["categories"]["methods_rigor"]["score"], "High")
 
     def test_parse_json_response_code_fence(self):
         raw = 'Here is JSON:\n```json\n{"a": 1}\n```'
         d = parse_json_response(raw)
         self.assertEqual(d["a"], 1)
 
-    def test_compute_overall_rating_excellent(self):
-        review = {
-            "fundability": {"overall_score": "High"},
-            "feasibility": {"overall_score": "High"},
-            "novelty": {"overall_score": "High"},
-            "impact": {"overall_score": "High"},
-            "reproducibility": {"overall_score": "High"},
-        }
-        rating, total = compute_overall_rating(review)
-        self.assertEqual(total, 15)
-        self.assertEqual(rating, OverallRating.EXCELLENT.value)
-
-    def test_compute_overall_rating_poor(self):
-        review = {
-            "fundability": {"overall_score": "Low"},
-            "feasibility": {"overall_score": "Low"},
-            "novelty": {"overall_score": "Low"},
-            "impact": {"overall_score": "Low"},
-            "reproducibility": {"overall_score": "Low"},
-        }
-        rating, total = compute_overall_rating(review)
-        self.assertEqual(total, 5)
-        self.assertEqual(rating, OverallRating.POOR.value)
-
-    def test_normalize_critical_fail_caps_high(self):
-        """Mean from answers is High, but go_no_go_gates No caps stored score to Medium."""
-        review = {
-            "fundability": {
-                "timeline_realism": {
-                    "score": "High",
-                    "rationale": "As if LLM mislabeled vs answers.",
-                    "flags": [],
-                    "timeline_realistic": "Yes",
-                    "milestones_sequenced": "Yes",
-                    "buffers_adequate": "Yes",
-                    "go_no_go_gates": "No",
-                }
-            },
-        }
-        normalize_scores_from_answers(review)
-        tl = review["fundability"]["timeline_realism"]
-        self.assertEqual(tl["go_no_go_gates"], "No")
-        self.assertEqual(tl["score"], "Medium")
-
     def test_parse_json_response_embedded_braces(self):
-        d = parse_json_response('noise {"fundability": {"overall_score": "Low"}} tail')
-        self.assertEqual(d["fundability"]["overall_score"], "Low")
+        d = parse_json_response(
+            'noise {"categories": {"methods_rigor": {"score": "Low"}}} tail'
+        )
+        self.assertEqual(d["categories"]["methods_rigor"]["score"], "Low")
 
     def test_parse_json_response_invalid_raises(self):
         with self.assertRaises(ValueError):
             parse_json_response("no json here")
+
+    def test_normalize_canonicalizes_case(self):
+        review = {
+            "categories": {"methods_rigor": _cat("medium")},
+        }
+        normalize_scores_from_answers(review)
+        self.assertEqual(review["categories"]["methods_rigor"]["score"], "Medium")
+
+    def test_normalize_na_only_on_optional_category(self):
+        review = {
+            "categories": {
+                "methods_rigor": _cat("N/A"),
+                "statistical_analysis_plan": _cat("n/a"),
+            },
+        }
+        normalize_scores_from_answers(review)
+        self.assertEqual(review["categories"]["methods_rigor"]["score"], "Low")
+        self.assertEqual(
+            review["categories"]["statistical_analysis_plan"]["score"], "N/A"
+        )
+
+    def test_recompute_trusts_llm_overall_when_valid(self):
+        review = {
+            "overall_rating": "Excellent",
+            "overall_score_numeric": 2.4,
+            "categories": _all_categories({k: "High" for k in CATEGORY_KEYS}),
+        }
+        normalize_scores_from_answers(review)
+        recompute_overall_fields(review)
+        self.assertEqual(review["overall_rating"], OverallRating.EXCELLENT.value)
+        self.assertEqual(review["overall_score_numeric"], 2)
+
+    def test_recompute_missing_overall_rating_stays_none(self):
+        review = {
+            "categories": _all_categories({k: "High" for k in CATEGORY_KEYS}),
+        }
+        normalize_scores_from_answers(review)
+        recompute_overall_fields(review)
+        self.assertIsNone(review["overall_rating"])
+
+    def test_recompute_invalid_overall_rating_becomes_none(self):
+        review = {
+            "overall_rating": "maybe",
+            "overall_score_numeric": 3,
+            "categories": _all_categories({}),
+        }
+        normalize_scores_from_answers(review)
+        recompute_overall_fields(review)
+        self.assertIsNone(review["overall_rating"])
+        self.assertEqual(review["overall_score_numeric"], 3)
+
+    def test_recompute_fallback_numeric_from_categories(self):
+        review = {
+            "overall_rating": "poor",
+            "overall_score_numeric": "not-a-number",
+            "categories": _all_categories(
+                {k: "Medium" for k in CATEGORY_KEYS},
+            ),
+        }
+        normalize_scores_from_answers(review)
+        recompute_overall_fields(review)
+        self.assertEqual(review["overall_rating"], OverallRating.POOR.value)
+        self.assertEqual(review["overall_score_numeric"], 2)
+
+    def test_category_scores_reads_normalized_labels(self):
+        review = {"categories": {"funding_opportunity_fit": _cat("low")}}
+        normalize_scores_from_answers(review)
+        scores = category_scores(review)
+        self.assertEqual(scores["funding_opportunity_fit"], "Low")

--- a/src/ai_peer_review/tests/test_proposal_review_views.py
+++ b/src/ai_peer_review/tests/test_proposal_review_views.py
@@ -5,6 +5,7 @@ from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from ai_peer_review.constants import CATEGORY_KEYS
 from ai_peer_review.models import ProposalReview, ReviewStatus, RFPSummary
 from purchase.models import Grant, GrantApplication
 from researchhub_document.helpers import create_post
@@ -86,8 +87,12 @@ class ProposalReviewAPITests(APITestCase):
             grant=self.grant,
             status=ReviewStatus.COMPLETED,
             overall_rating="good",
-            overall_score_numeric=10,
-            result_data={"fundability": {"overall_score": "High"}},
+            overall_score_numeric=2,
+            overall_rationale="Strong fit.",
+            overall_confidence="High",
+            result_data={
+                "categories": {"funding_opportunity_fit": {"score": "High"}},
+            },
         )
         self.client.force_authenticate(self.moderator)
         r_mod = self.client.get(self.detail_url(pr.id))
@@ -110,13 +115,17 @@ class ProposalReviewAPITests(APITestCase):
             grant=self.grant,
             status=ReviewStatus.COMPLETED,
             overall_rating="excellent",
-            overall_score_numeric=15,
+            overall_score_numeric=3,
             result_data={
-                "fundability": {"overall_score": "High"},
-                "feasibility": {"overall_score": "High"},
-                "novelty": {"overall_score": "High"},
-                "impact": {"overall_score": "High"},
-                "reproducibility": {"overall_score": "High"},
+                "categories": {
+                    "funding_opportunity_fit": {"score": "High"},
+                    "methods_rigor": {"score": "High"},
+                    "statistical_analysis_plan": {"score": "N/A"},
+                    "feasibility_and_execution": {"score": "High"},
+                    "scientific_impact": {"score": "High"},
+                    "clinical_or_translational_impact": {"score": "Medium"},
+                    "societal_and_broader_impact": {"score": "High"},
+                },
             },
         )
         self.client.force_authenticate(self.moderator)
@@ -125,17 +134,18 @@ class ProposalReviewAPITests(APITestCase):
         data = r.json()
         self.assertEqual(data["grant_id"], self.grant.id)
         self.assertEqual(len(data["proposals"]), 1)
-        self.assertEqual(data["proposals"][0]["fundability"], "High")
+        self.assertEqual(
+            data["proposals"][0]["categories"]["funding_opportunity_fit"], "High"
+        )
 
     def test_editorial_feedback_upsert_requires_editor(self):
         self.client.force_authenticate(self.user)
         url = f"/api/ai_peer_review/editorial-feedback/{self.ud.id}/"
         body = {
-            "fundability_expert": "high",
-            "feasibility_expert": "medium",
-            "novelty_expert": "low",
-            "impact_expert": "high",
-            "reproducibility_expert": "medium",
+            "expert_insights": "Solid.",
+            "categories": [
+                {"category_code": k, "score": "high"} for k in CATEGORY_KEYS
+            ],
         }
         r = self.client.post(url, body, format="json")
         self.assertEqual(r.status_code, status.HTTP_403_FORBIDDEN)
@@ -143,6 +153,26 @@ class ProposalReviewAPITests(APITestCase):
         self.client.force_authenticate(self.moderator)
         r2 = self.client.post(url, body, format="json")
         self.assertEqual(r2.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(len(r2.json()["categories"]), len(CATEGORY_KEYS))
+
+    def test_editorial_feedback_patch_replaces_categories(self):
+        url = f"/api/ai_peer_review/editorial-feedback/{self.ud.id}/"
+        create_body = {
+            "categories": [
+                {"category_code": k, "score": "high"} for k in CATEGORY_KEYS
+            ],
+        }
+        self.client.force_authenticate(self.moderator)
+        self.client.post(url, create_body, format="json")
+        patch_body = {
+            "categories": [
+                {"category_code": k, "score": "low"} for k in CATEGORY_KEYS
+            ],
+        }
+        r = self.client.patch(url, patch_body, format="json")
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        for row in r.json()["categories"]:
+            self.assertEqual(row["score"], "low")
 
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
@@ -207,14 +237,18 @@ class GrantExecutiveSummaryAPITests(APITestCase):
             grant=self.grant,
             status=ReviewStatus.COMPLETED,
             overall_rating="good",
-            overall_score_numeric=10,
+            overall_score_numeric=2,
             result_data={
-                "editorial_summary": {"consensus_summary": "Solid work."},
-                "fundability": {"overall_score": "High"},
-                "feasibility": {"overall_score": "Medium"},
-                "novelty": {"overall_score": "High"},
-                "impact": {"overall_score": "High"},
-                "reproducibility": {"overall_score": "Medium"},
+                "overall_summary": "Solid work across categories.",
+                "categories": {
+                    "funding_opportunity_fit": {"score": "High"},
+                    "methods_rigor": {"score": "High"},
+                    "statistical_analysis_plan": {"score": "Medium"},
+                    "feasibility_and_execution": {"score": "Medium"},
+                    "scientific_impact": {"score": "High"},
+                    "clinical_or_translational_impact": {"score": "N/A"},
+                    "societal_and_broader_impact": {"score": "High"},
+                },
             },
         )
         self.url = f"/api/ai_peer_review/rfp/{self.grant.id}/executive-summary/"

--- a/src/ai_peer_review/tests/test_serializers.py
+++ b/src/ai_peer_review/tests/test_serializers.py
@@ -1,9 +1,14 @@
 from unittest.mock import MagicMock
 
 from django.test import SimpleTestCase
+from rest_framework.exceptions import ValidationError
 
+from ai_peer_review.constants import CATEGORY_KEYS
 from ai_peer_review.models import ReviewStatus
-from ai_peer_review.serializers import build_proposal_comparison_row
+from ai_peer_review.serializers import (
+    EditorialFeedbackUpsertSerializer,
+    build_proposal_comparison_row,
+)
 
 
 class BuildProposalComparisonRowTests(SimpleTestCase):
@@ -12,9 +17,9 @@ class BuildProposalComparisonRowTests(SimpleTestCase):
         self.assertEqual(row["unified_document_id"], 42)
         self.assertEqual(row["proposal_title"], "My title")
         self.assertIsNone(row["review_id"])
-        self.assertIsNone(row["fundability"])
+        self.assertIsNone(row["categories"])
 
-    def test_non_completed_review_has_no_dimension_scores(self):
+    def test_non_completed_review_has_no_category_scores(self):
         review = MagicMock()
         review.id = 5
         review.status = ReviewStatus.PENDING
@@ -25,5 +30,42 @@ class BuildProposalComparisonRowTests(SimpleTestCase):
             review, 1, "T", {"id": 1, "expert_insights": "x"}
         )
         self.assertEqual(row["review_id"], 5)
-        self.assertIsNone(row["fundability"])
+        self.assertIsNone(row["categories"])
         self.assertEqual(row["editorial_feedback"]["expert_insights"], "x")
+
+    def test_completed_review_exposes_category_map(self):
+        review = MagicMock()
+        review.id = 1
+        review.status = ReviewStatus.COMPLETED
+        review.overall_rating = "good"
+        review.overall_score_numeric = 2
+        review.result_data = {
+            "categories": {
+                "funding_opportunity_fit": {"score": "Medium"},
+            }
+        }
+        row = build_proposal_comparison_row(review, 9, "Title", None)
+        self.assertEqual(row["categories"]["funding_opportunity_fit"], "Medium")
+        for key in CATEGORY_KEYS:
+            if key != "funding_opportunity_fit":
+                self.assertIsNone(row["categories"][key])
+
+
+class EditorialFeedbackUpsertSerializerTests(SimpleTestCase):
+    def test_create_requires_all_categories(self):
+        ser = EditorialFeedbackUpsertSerializer(
+            data={"expert_insights": "hi", "categories": []},
+            context={"is_create": True},
+        )
+        with self.assertRaises(ValidationError):
+            ser.is_valid(raise_exception=True)
+
+    def test_create_accepts_full_category_set(self):
+        cats = [
+            {"category_code": k, "score": "high"} for k in CATEGORY_KEYS
+        ]
+        ser = EditorialFeedbackUpsertSerializer(
+            data={"expert_insights": "hi", "categories": cats},
+            context={"is_create": True},
+        )
+        self.assertTrue(ser.is_valid(), ser.errors)

--- a/src/ai_peer_review/views/editorial_feedback_views.py
+++ b/src/ai_peer_review/views/editorial_feedback_views.py
@@ -11,6 +11,7 @@ from ai_peer_review.permissions import AIPeerReviewPermission
 from ai_peer_review.serializers import (
     EditorialFeedbackSerializer,
     EditorialFeedbackUpsertSerializer,
+    replace_editorial_feedback_categories,
 )
 from researchhub_document.models import ResearchhubUnifiedDocument
 from researchhub_document.related_models.constants.document_type import PREREGISTRATION
@@ -56,28 +57,39 @@ class EditorialFeedbackUpsertView(APIView):
             existing = None
 
         if existing is None:
-            ser = EditorialFeedbackUpsertSerializer(data=request.data, partial=False)
+            ser = EditorialFeedbackUpsertSerializer(
+                data=request.data,
+                partial=False,
+                context={"is_create": True},
+            )
         else:
             ser = EditorialFeedbackUpsertSerializer(
-                existing,
                 data=request.data,
                 partial=partial,
+                context={"is_create": False},
             )
         ser.is_valid(raise_exception=True)
+        validated = ser.validated_data
 
         if existing is None:
+            categories = validated["categories"]
             fb = EditorialFeedback.objects.create(
                 unified_document=ud,
                 created_by=request.user,
                 updated_by=request.user,
-                **ser.validated_data,
+                expert_insights=validated.get("expert_insights", ""),
             )
+            replace_editorial_feedback_categories(fb, categories)
             return Response(
                 EditorialFeedbackSerializer(fb).data,
                 status=status.HTTP_201_CREATED,
             )
-        for attr, value in ser.validated_data.items():
-            setattr(existing, attr, value)
+        if "expert_insights" in validated:
+            existing.expert_insights = validated["expert_insights"]
+        if "categories" in validated:
+            replace_editorial_feedback_categories(
+                existing, validated["categories"]
+            )
         existing.updated_by = request.user
         existing.save()
         return Response(EditorialFeedbackSerializer(existing).data)

--- a/src/ai_peer_review/views/proposal_review_views.py
+++ b/src/ai_peer_review/views/proposal_review_views.py
@@ -122,6 +122,8 @@ class ProposalReviewCreateView(APIView):
                 review.error_message = ""
                 review.result_data = {}
                 review.overall_rating = None
+                review.overall_rationale = ""
+                review.overall_confidence = None
                 review.overall_score_numeric = None
                 review.save(
                     update_fields=[
@@ -129,6 +131,8 @@ class ProposalReviewCreateView(APIView):
                         "error_message",
                         "result_data",
                         "overall_rating",
+                        "overall_rationale",
+                        "overall_confidence",
                         "overall_score_numeric",
                         "updated_date",
                     ]
@@ -195,7 +199,9 @@ class ProposalReviewByGrantView(APIView):
         ud_ids = [app.preregistration_post.unified_document_id for app in applications]
         feedback_by_ud = {
             fb.unified_document_id: EditorialFeedbackSerializer(fb).data
-            for fb in EditorialFeedback.objects.filter(unified_document_id__in=ud_ids)
+            for fb in EditorialFeedback.objects.filter(
+                unified_document_id__in=ud_ids
+            ).prefetch_related("categories")
         }
         proposals = []
         for app in applications:


### PR DESCRIPTION
…dating constants, models, serializers, and prompts. Introduce overall confidence and rationale fields in ProposalReview. Update tests to reflect new category structure and scoring logic.