### PR TITLE
Defensive check that ensure content_object exists

### DIFF
--- a/src/researchhub_comment/related_models/rh_comment_thread_model.py
+++ b/src/researchhub_comment/related_models/rh_comment_thread_model.py
@@ -123,7 +123,26 @@ class RhCommentThreadModel(AbstractGenericRelationModel):
 
     @property
     def unified_document(self):
-        content_object = self.content_object
+        content_object = self._safe_content_object()
         if content_object is None:
             return None
         return content_object.unified_document
+
+    def _safe_content_object(self):
+        """
+        Resolve `content_object` defensively.
+
+        Returns None if the underlying ContentType points to a model that is
+        no longer registered (stale `django_content_type` row, e.g. from a
+        removed/renamed app) or if the target object no longer exists.
+        """
+        try:
+            model_class = self.content_type.model_class()
+        except Exception:
+            return None
+        if model_class is None:
+            return None
+        try:
+            return self.content_object
+        except (AttributeError, model_class.DoesNotExist):
+            return None

--- a/src/researchhub_comment/serializers/rh_comment_thread_serializer.py
+++ b/src/researchhub_comment/serializers/rh_comment_thread_serializer.py
@@ -102,7 +102,10 @@ class DynamicRhThreadSerializer(DynamicModelFieldSerializer):
 
         context = self.context
         _context_fields = context.get("rhc_dts_get_content_object", {})
-        content_object = thread.content_object
+        content_object = thread._safe_content_object()
+
+        if content_object is None:
+            return None
 
         # Use depth limiting to prevent circular dependencies
         if should_use_reference_only(context):


### PR DESCRIPTION
Fixes issue on datadog https://us3.datadoghq.com/logs?query=-status%3A%28warn%20OR%20info%29%20-env%3Astaging&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ2dYalz1odICgAAABhBWjJkWWJvNUFBQXdQbVlrMEs1YmxRQUEAAAAkZjE5ZDlkNjUtNTExZC00Mzg4LWFmODEtMGNjY2Q5MmFkN2IyAAAAAw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1776461503539&to_ts=1776462403539&live=true

which causes profile page to be broken in some instances when a comment refers to a model that no longer exists