### PR TITLE
Add grants + AI proposal review to prereg researchhubpost serializer

### DIFF
--- a/src/researchhub_document/serializers/researchhub_post_serializer.py
+++ b/src/researchhub_document/serializers/researchhub_post_serializer.py
@@ -1,6 +1,8 @@
 from django.core.files.storage import default_storage
 from rest_framework.serializers import CharField, ModelSerializer, SerializerMethodField
 
+from ai_peer_review.models import ProposalReview
+from ai_peer_review.serializers import ProposalReviewSerializer
 from discussion.models import Vote
 from discussion.serializers import (
     DynamicVoteSerializer,  # Import is needed for discussion serializer imports
@@ -11,6 +13,7 @@ from purchase.models import Purchase
 from researchhub.serializers import DynamicModelFieldSerializer
 from researchhub_document.models import ResearchhubPost
 from researchhub_document.related_models.constants.document_type import (
+    PREREGISTRATION,
     RESEARCHHUB_POST_DOCUMENT_TYPES,
 )
 from review.serializers.review_serializer import DynamicReviewSerializer
@@ -38,6 +41,7 @@ class ResearchhubPostSerializer(ModelSerializer, GenericReactionSerializerMixin)
             "doi",
             "editor_type",
             "full_markdown",
+            "grants",
             "hubs",
             "id",
             "image",
@@ -65,6 +69,7 @@ class ResearchhubPostSerializer(ModelSerializer, GenericReactionSerializerMixin)
             "created_by",
             "created_date",
             "discussion_count",
+            "grants",
             "image_url",
             "is_latest_version",
             "is_root_version",
@@ -88,6 +93,7 @@ class ResearchhubPostSerializer(ModelSerializer, GenericReactionSerializerMixin)
     created_by = SerializerMethodField(method_name="get_created_by")
     peer_reviews = SerializerMethodField()
     full_markdown = SerializerMethodField(method_name="get_full_markdown")
+    grants = SerializerMethodField()
     hubs = SerializerMethodField(method_name="get_hubs")
     image = CharField(write_only=True, required=False, allow_null=True)
     image_url = SerializerMethodField()
@@ -204,6 +210,55 @@ class ResearchhubPostSerializer(ModelSerializer, GenericReactionSerializerMixin)
 
     def get_hubs(self, instance):
         return SimpleHubSerializer(instance.unified_document.hubs, many=True).data
+
+    def get_grants(self, post):
+        if post.document_type != PREREGISTRATION:
+            return []
+
+        unified_document = post.unified_document
+        if unified_document is None:
+            return []
+
+        reviews_by_grant_id = {}
+        prefetched_reviews = getattr(
+            unified_document, "_prefetched_objects_cache", {}
+        ).get("proposal_reviews")
+        if prefetched_reviews is not None:
+            for review in prefetched_reviews:
+                if review.grant_id is not None:
+                    reviews_by_grant_id[review.grant_id] = review
+        else:
+            for review in ProposalReview.objects.filter(
+                unified_document=unified_document,
+                grant__isnull=False,
+            ):
+                reviews_by_grant_id[review.grant_id] = review
+
+        ud_id = unified_document.id
+        out = []
+        for application in post.grant_applications.all():
+            grant = application.grant
+            review = reviews_by_grant_id.get(grant.id)
+            ai_peer_review = (
+                ProposalReviewSerializer(review, context=self.context).data
+                if review is not None
+                else None
+            )
+            out.append(
+                {
+                    "id": grant.id,
+                    "short_title": grant.short_title,
+                    "status": grant.status,
+                    "organization": grant.organization,
+                    "amount": str(grant.amount),
+                    "currency": grant.currency,
+                    "proposal": {
+                        "unified_document_id": ud_id,
+                        "ai_peer_review": ai_peer_review,
+                    },
+                }
+            )
+        return out
 
     def get_peer_reviews(self, instance):
         from review.models import Review

--- a/src/researchhub_document/tests/test_view.py
+++ b/src/researchhub_document/tests/test_view.py
@@ -1,3 +1,4 @@
+import json
 import time
 from datetime import datetime, timedelta
 from decimal import Decimal
@@ -6,8 +7,11 @@ from unittest.mock import patch
 import pytz
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
+from rest_framework.renderers import JSONRenderer
 from rest_framework.test import APITestCase
 
+from ai_peer_review.models import OverallRating, ProposalReview, ReviewStatus
+from ai_peer_review.serializers import ProposalReviewSerializer
 from hub.models import Hub
 from hub.tests.helpers import create_hub
 from note.tests.helpers import create_note
@@ -20,7 +24,10 @@ from researchhub_access_group.constants import SENIOR_EDITOR
 from researchhub_access_group.models import Permission
 from researchhub_document.helpers import create_post
 from researchhub_document.models import ResearchhubUnifiedDocument
-from researchhub_document.related_models.constants.document_type import GRANT
+from researchhub_document.related_models.constants.document_type import (
+    GRANT,
+    PREREGISTRATION,
+)
 from researchhub_document.serializers.researchhub_post_serializer import (
     ResearchhubPostSerializer,
 )
@@ -1904,6 +1911,99 @@ class PreregistrationGrantAutoAttachTests(APITestCase):
         # Assert
         self.assertEqual(response.status_code, 200)
         self.assertFalse(GrantApplication.objects.exists())
+
+
+class PreregistrationGrantsPayloadTests(APITestCase):
+    """GET researchhubpost returns grants[] with proposal.ai_peer_review for preregistrations."""
+
+    def setUp(self):
+        self.user = create_random_default_user("prereg_grants_user")
+        make_user_verified(self.user)
+        self.hub = create_hub("prereg_grants_hub")
+        self.moderator = create_random_default_user("prereg_grants_mod")
+        make_user_verified(self.moderator)
+
+        def make_grant(short_suffix):
+            grant_post = create_post(created_by=self.moderator, document_type=GRANT)
+            return Grant.objects.create(
+                created_by=self.moderator,
+                unified_document=grant_post.unified_document,
+                amount=Decimal("10000.00"),
+                currency="USD",
+                organization=f"Org {short_suffix}",
+                short_title=f"Grant {short_suffix}",
+                description="Test grant",
+                status=Grant.OPEN,
+            )
+
+        self.grant_a = make_grant("A")
+        self.grant_b = make_grant("B")
+
+        self.prereg_post = create_post(
+            title="Prereg title for grants payload",
+            renderable_text="x" * MIN_POST_BODY_LENGTH,
+            created_by=self.user,
+            document_type=PREREGISTRATION,
+        )
+        GrantApplication.objects.create(
+            grant=self.grant_a,
+            preregistration_post=self.prereg_post,
+            applicant=self.user,
+        )
+        GrantApplication.objects.create(
+            grant=self.grant_b,
+            preregistration_post=self.prereg_post,
+            applicant=self.user,
+        )
+        ProposalReview.objects.create(
+            unified_document=self.prereg_post.unified_document,
+            grant=self.grant_a,
+            status=ReviewStatus.COMPLETED,
+            overall_rating=OverallRating.GOOD,
+            overall_score_numeric=82,
+        )
+
+    def test_get_preregistration_includes_grants_and_ai_peer_review(self):
+        url = f"/api/researchhubpost/{self.prereg_post.id}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        grants = response.data["grants"]
+        self.assertEqual(len(grants), 2)
+        by_grant_id = {g["id"]: g for g in grants}
+        self.assertEqual(set(by_grant_id), {self.grant_a.id, self.grant_b.id})
+
+        entry_a = by_grant_id[self.grant_a.id]
+        self.assertEqual(entry_a["short_title"], "Grant A")
+        self.assertEqual(entry_a["status"], Grant.OPEN)
+        self.assertEqual(entry_a["organization"], "Org A")
+        self.assertEqual(entry_a["currency"], "USD")
+        proposal_a = entry_a["proposal"]
+        self.assertEqual(
+            proposal_a["unified_document_id"], self.prereg_post.unified_document_id
+        )
+        review_a = proposal_a["ai_peer_review"]
+        self.assertIsNotNone(review_a)
+        review_obj = ProposalReview.objects.get(
+            unified_document=self.prereg_post.unified_document,
+            grant=self.grant_a,
+        )
+        expected_review = ProposalReviewSerializer(review_obj).data
+        expected_json = json.loads(JSONRenderer().render(expected_review).decode())
+        self.assertEqual(dict(review_a), expected_json)
+
+        entry_b = by_grant_id[self.grant_b.id]
+        self.assertIsNone(entry_b["proposal"]["ai_peer_review"])
+
+    def test_get_non_preregistration_returns_empty_grants(self):
+        discussion = create_post(
+            title="Discussion post",
+            renderable_text="x" * MIN_POST_BODY_LENGTH,
+            created_by=self.user,
+            document_type="DISCUSSION",
+        )
+        response = self.client.get(f"/api/researchhubpost/{discussion.id}/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["grants"], [])
 
 
 class PostPeerReviewTests(TestCase):

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -1,11 +1,13 @@
 from django.core.files.base import ContentFile
 from django.db import transaction
+from django.db.models import Prefetch
 from django.utils.text import slugify
 from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
+from ai_peer_review.models import ProposalReview
 from analytics.amplitude import track_event
 from discussion.views import ReactionViewActionMixin
 from feed.views.grant_cache_mixin import GrantCacheMixin
@@ -72,7 +74,26 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
     def get_queryset(self):
         request = self.request
         try:
-            query_set = ResearchhubPost.objects.all()
+            query_set = (
+                ResearchhubPost.objects.all()
+                .select_related("unified_document")
+                .prefetch_related(
+                    Prefetch(
+                        "grant_applications",
+                        queryset=GrantApplication.objects.select_related("grant"),
+                    ),
+                    Prefetch(
+                        "unified_document__proposal_reviews",
+                        queryset=ProposalReview.objects.filter(
+                            grant__isnull=False,
+                        )
+                        .select_related("grant", "unified_document")
+                        .prefetch_related(
+                            "unified_document__ai_peer_review_editorial_feedback__categories",
+                        ),
+                    ),
+                )
+            )
             query_params = request.query_params
             created_by_id = query_params.get("created_by")
             post_id = query_params.get("post_id")
@@ -262,9 +283,7 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
                     try:
                         target_grant = Grant.objects.get(id=grant_id)
                     except (Grant.DoesNotExist, ValueError, TypeError):
-                        raise serializers.ValidationError(
-                            "Grant not found"
-                        )
+                        raise serializers.ValidationError("Grant not found")
                     if not target_grant.is_active():
                         raise serializers.ValidationError(
                             "Grant is no longer accepting applications"


### PR DESCRIPTION
## What?
- **GET** `/api/researchhubpost/:id/` now includes a `grants` array from `GrantApplication`, 
  - each with minimal grant fields 
  - and `proposal.ai_peer_review` _(`ProposalReviewSerializer` payload when a grant-scoped review exists, otherwise null)._ 
  - Non-prereg posts return `grants: []`.
