### PR TITLE
Task populates DOIs for Notebook Posts

### DIFF
--- a/src/researchhub/celery.py
+++ b/src/researchhub/celery.py
@@ -186,6 +186,15 @@ app.conf.beat_schedule = {
             "queue": QUEUE_PURCHASES,
         },
     },
+    # Preregistration DOI assignment
+    "researchhub-document_assign-preregistration-dois": {
+        "task": "researchhub_document.tasks.assign_preregistration_dois",
+        "schedule": crontab(hour=6, minute=0),
+        "options": {
+            "priority": 3,
+            "queue": QUEUE_PAPER_MISC,
+        },
+    },
     # Paper ingestion tasks
     "paper-fetch-all": {
         "task": "paper.ingestion.pipeline.fetch_all_papers",

--- a/src/researchhub/celery.py
+++ b/src/researchhub/celery.py
@@ -186,9 +186,9 @@ app.conf.beat_schedule = {
             "queue": QUEUE_PURCHASES,
         },
     },
-    # Preregistration DOI assignment
-    "researchhub-document_assign-preregistration-dois": {
-        "task": "researchhub_document.tasks.assign_preregistration_dois",
+    # Post DOI assignment
+    "researchhub-document_assign-post-dois": {
+        "task": "researchhub_document.tasks.assign_post_dois",
         "schedule": crontab(hour=6, minute=0),
         "options": {
             "priority": 3,

--- a/src/researchhub_document/tasks.py
+++ b/src/researchhub_document/tasks.py
@@ -42,14 +42,12 @@ def assign_post_dois():
                 post.save(update_fields=["doi"])
                 assigned_count += 1
             else:
-                sentry.log_error(
-                    RuntimeError(
-                        f"Crossref API failure for post {post.id}: "
-                        f"status {response.status_code}"
-                    )
+                logger.error(
+                    f"Crossref API failure for post {post.id}: "
+                    f"status {response.status_code}"
                 )
-        except Exception as error:
-            sentry.log_error(error)
+        except Exception:
+            logger.exception(f"Failed to assign DOI to post {post.id}")
 
     logger.info(f"Assigned DOIs to {assigned_count}/{total} eligible posts")
 

--- a/src/researchhub_document/tasks.py
+++ b/src/researchhub_document/tasks.py
@@ -43,7 +43,7 @@ def assign_preregistration_dois():
                 assigned_count += 1
             else:
                 sentry.log_error(
-                    Exception(
+                    RuntimeError(
                         f"Crossref API failure for post {post.id}: "
                         f"status {response.status_code}"
                     )

--- a/src/researchhub_document/tasks.py
+++ b/src/researchhub_document/tasks.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 from researchhub.celery import QUEUE_HOT_SCORE, QUEUE_PAPER_MISC, app
 from researchhub_document.models import ResearchhubPost
-from researchhub_document.related_models.constants.document_type import PREREGISTRATION
+from researchhub_document.related_models.constants.document_type import GRANT
 from utils import sentry
 from utils.doi import DOI
 
@@ -14,17 +14,17 @@ logger = logging.getLogger(__name__)
 
 
 @app.task(queue=QUEUE_PAPER_MISC)
-def assign_preregistration_dois():
+def assign_post_dois():
     week_ago = timezone.now() - timedelta(days=7)
 
     eligible_posts = (
         ResearchhubPost.objects.filter(
-            document_type=PREREGISTRATION,
             doi__isnull=True,
             created_date__lte=week_ago,
             unified_document__is_removed=False,
             flags__isnull=True,
         )
+        .exclude(document_type=GRANT)
         .select_related("created_by__author_profile", "unified_document")
     )
 
@@ -51,7 +51,7 @@ def assign_preregistration_dois():
         except Exception as error:
             sentry.log_error(error)
 
-    logger.info(f"Assigned DOIs to {assigned_count}/{total} preregistration posts")
+    logger.info(f"Assigned DOIs to {assigned_count}/{total} eligible posts")
 
 
 @app.task(queue=QUEUE_HOT_SCORE)

--- a/src/researchhub_document/tasks.py
+++ b/src/researchhub_document/tasks.py
@@ -1,7 +1,57 @@
-from django.contrib.contenttypes.models import ContentType
+import logging
+from datetime import timedelta
 
-from researchhub.celery import QUEUE_HOT_SCORE, app
+from django.contrib.contenttypes.models import ContentType
+from django.utils import timezone
+
+from researchhub.celery import QUEUE_HOT_SCORE, QUEUE_PAPER_MISC, app
+from researchhub_document.models import ResearchhubPost
+from researchhub_document.related_models.constants.document_type import PREREGISTRATION
 from utils import sentry
+from utils.doi import DOI
+
+logger = logging.getLogger(__name__)
+
+
+@app.task(queue=QUEUE_PAPER_MISC)
+def assign_preregistration_dois():
+    week_ago = timezone.now() - timedelta(days=7)
+
+    eligible_posts = (
+        ResearchhubPost.objects.filter(
+            document_type=PREREGISTRATION,
+            doi__isnull=True,
+            created_date__lte=week_ago,
+            unified_document__is_removed=False,
+            flags__isnull=True,
+        )
+        .select_related("created_by__author_profile", "unified_document")
+    )
+
+    total = eligible_posts.count()
+    assigned_count = 0
+
+    for post in eligible_posts:
+        try:
+            doi = DOI()
+            author = post.created_by.author_profile
+            response = doi.register_doi_for_post([author], post.title, post)
+
+            if response.status_code == 200:
+                post.doi = doi.doi
+                post.save(update_fields=["doi"])
+                assigned_count += 1
+            else:
+                sentry.log_error(
+                    Exception(
+                        f"Crossref API failure for post {post.id}: "
+                        f"status {response.status_code}"
+                    )
+                )
+        except Exception as error:
+            sentry.log_error(error)
+
+    logger.info(f"Assigned DOIs to {assigned_count}/{total} preregistration posts")
 
 
 @app.task(queue=QUEUE_HOT_SCORE)

--- a/src/researchhub_document/tasks.py
+++ b/src/researchhub_document/tasks.py
@@ -6,7 +6,10 @@ from django.utils import timezone
 
 from researchhub.celery import QUEUE_HOT_SCORE, QUEUE_PAPER_MISC, app
 from researchhub_document.models import ResearchhubPost
-from researchhub_document.related_models.constants.document_type import GRANT
+from researchhub_document.related_models.constants.document_type import (
+    DISCUSSION,
+    PREREGISTRATION,
+)
 from utils import sentry
 from utils.doi import DOI
 
@@ -19,12 +22,12 @@ def assign_post_dois():
 
     eligible_posts = (
         ResearchhubPost.objects.filter(
+            document_type__in=[DISCUSSION, PREREGISTRATION],
             doi__isnull=True,
             created_date__lte=week_ago,
             unified_document__is_removed=False,
             flags__isnull=True,
         )
-        .exclude(document_type=GRANT)
         .select_related("created_by__author_profile", "unified_document")
     )
 

--- a/src/researchhub_document/tests/test_tasks.py
+++ b/src/researchhub_document/tests/test_tasks.py
@@ -88,7 +88,8 @@ class AssignPreregistrationDoisTests(TestCase):
         self._create_preregistration(days_old=10)
         self._create_preregistration(days_old=14)
 
-        failing_doi = self._build_mock_doi("10.55277/fail", status_code=500)
+        failing_doi = self._build_mock_doi("10.55277/fail")
+        failing_doi.register_doi_for_post.side_effect = RuntimeError("Network error")
         success_doi = self._build_mock_doi("10.55277/ok")
         mock_doi_cls.side_effect = [failing_doi, success_doi]
 

--- a/src/researchhub_document/tests/test_tasks.py
+++ b/src/researchhub_document/tests/test_tasks.py
@@ -59,12 +59,13 @@ class AssignPostDoisTests(TestCase):
     @patch("researchhub_document.tasks.DOI")
     def test_skips_ineligible_posts(self, mock_doi_cls):
         """Posts that are too young, already have a DOI, are removed,
-        are flagged, or are grants should all be skipped."""
+        are flagged, or are non-notebook types should all be skipped."""
         # Arrange
         self._create_post(days_old=3)
         self._create_post(days_old=10, doi="10.55277/existing")
         self._create_post(days_old=10, is_removed=True)
         self._create_post(document_type="GRANT", days_old=10)
+        self._create_post(document_type="QUESTION", days_old=10)
 
         flagged = self._create_post(days_old=10)
         ct = ContentType.objects.get_for_model(flagged)

--- a/src/researchhub_document/tests/test_tasks.py
+++ b/src/researchhub_document/tests/test_tasks.py
@@ -7,19 +7,19 @@ from django.utils import timezone
 
 from discussion.models import Flag
 from researchhub_document.helpers import create_post
-from researchhub_document.tasks import assign_preregistration_dois
+from researchhub_document.tasks import assign_post_dois
 from user.tests.helpers import create_random_default_user
 
 
-class AssignPreregistrationDoisTests(TestCase):
+class AssignPostDoisTests(TestCase):
     def setUp(self):
         self.user = create_random_default_user("doi_test_user")
 
-    def _create_preregistration(self, days_old=10, doi=None, is_removed=False):
+    def _create_post(self, document_type="PREREGISTRATION", days_old=10, doi=None, is_removed=False):
         post = create_post(
-            title="Test Preregistration",
+            title="Test Post",
             created_by=self.user,
-            document_type="PREREGISTRATION",
+            document_type=document_type,
         )
         post.doi = doi
         post.created_date = timezone.now() - timedelta(days=days_old)
@@ -38,28 +38,35 @@ class AssignPreregistrationDoisTests(TestCase):
         return mock
 
     @patch("researchhub_document.tasks.DOI")
-    def test_assigns_doi_to_eligible_preregistration(self, mock_doi_cls):
+    def test_assigns_doi_to_eligible_posts(self, mock_doi_cls):
         # Arrange
-        mock_doi_cls.return_value = self._build_mock_doi()
-        post = self._create_preregistration(days_old=10)
+        mock_doi_cls.side_effect = [
+            self._build_mock_doi("10.55277/doi1"),
+            self._build_mock_doi("10.55277/doi2"),
+        ]
+        preregistration = self._create_post("PREREGISTRATION", days_old=10)
+        discussion = self._create_post("DISCUSSION", days_old=10)
 
         # Act
-        assign_preregistration_dois()
+        assign_post_dois()
 
         # Assert
-        post.refresh_from_db()
-        self.assertEqual(post.doi, "10.55277/test123")
+        preregistration.refresh_from_db()
+        discussion.refresh_from_db()
+        self.assertEqual(preregistration.doi, "10.55277/doi1")
+        self.assertEqual(discussion.doi, "10.55277/doi2")
 
     @patch("researchhub_document.tasks.DOI")
     def test_skips_ineligible_posts(self, mock_doi_cls):
         """Posts that are too young, already have a DOI, are removed,
-        are flagged, or are non-preregistration should all be skipped."""
+        are flagged, or are grants should all be skipped."""
         # Arrange
-        self._create_preregistration(days_old=3)
-        self._create_preregistration(days_old=10, doi="10.55277/existing")
-        self._create_preregistration(days_old=10, is_removed=True)
+        self._create_post(days_old=3)
+        self._create_post(days_old=10, doi="10.55277/existing")
+        self._create_post(days_old=10, is_removed=True)
+        self._create_post(document_type="GRANT", days_old=10)
 
-        flagged = self._create_preregistration(days_old=10)
+        flagged = self._create_post(days_old=10)
         ct = ContentType.objects.get_for_model(flagged)
         Flag.objects.create(
             content_type=ct,
@@ -68,16 +75,8 @@ class AssignPreregistrationDoisTests(TestCase):
             reason="spam",
         )
 
-        discussion = create_post(
-            title="Regular Discussion Post",
-            created_by=self.user,
-            document_type="DISCUSSION",
-        )
-        discussion.created_date = timezone.now() - timedelta(days=10)
-        discussion.save(update_fields=["created_date"])
-
         # Act
-        assign_preregistration_dois()
+        assign_post_dois()
 
         # Assert
         mock_doi_cls.assert_not_called()
@@ -85,8 +84,8 @@ class AssignPreregistrationDoisTests(TestCase):
     @patch("researchhub_document.tasks.DOI")
     def test_handles_crossref_failure_and_continues(self, mock_doi_cls):
         # Arrange
-        self._create_preregistration(days_old=10)
-        self._create_preregistration(days_old=14)
+        self._create_post(days_old=10)
+        self._create_post(days_old=14)
 
         failing_doi = self._build_mock_doi("10.55277/fail")
         failing_doi.register_doi_for_post.side_effect = RuntimeError("Network error")
@@ -94,7 +93,7 @@ class AssignPreregistrationDoisTests(TestCase):
         mock_doi_cls.side_effect = [failing_doi, success_doi]
 
         # Act
-        assign_preregistration_dois()
+        assign_post_dois()
 
         # Assert
         from researchhub_document.models import ResearchhubPost

--- a/src/researchhub_document/tests/test_tasks.py
+++ b/src/researchhub_document/tests/test_tasks.py
@@ -38,9 +38,9 @@ class AssignPreregistrationDoisTests(TestCase):
         return mock
 
     @patch("researchhub_document.tasks.DOI")
-    def test_assigns_doi_to_eligible_preregistration(self, MockDOI):
+    def test_assigns_doi_to_eligible_preregistration(self, mock_doi_cls):
         # Arrange
-        MockDOI.return_value = self._build_mock_doi()
+        mock_doi_cls.return_value = self._build_mock_doi()
         post = self._create_preregistration(days_old=10)
 
         # Act
@@ -51,7 +51,7 @@ class AssignPreregistrationDoisTests(TestCase):
         self.assertEqual(post.doi, "10.55277/test123")
 
     @patch("researchhub_document.tasks.DOI")
-    def test_skips_ineligible_posts(self, MockDOI):
+    def test_skips_ineligible_posts(self, mock_doi_cls):
         """Posts that are too young, already have a DOI, are removed,
         are flagged, or are non-preregistration should all be skipped."""
         # Arrange
@@ -80,17 +80,17 @@ class AssignPreregistrationDoisTests(TestCase):
         assign_preregistration_dois()
 
         # Assert
-        MockDOI.assert_not_called()
+        mock_doi_cls.assert_not_called()
 
     @patch("researchhub_document.tasks.DOI")
-    def test_handles_crossref_failure_and_continues(self, MockDOI):
+    def test_handles_crossref_failure_and_continues(self, mock_doi_cls):
         # Arrange
         self._create_preregistration(days_old=10)
         self._create_preregistration(days_old=14)
 
         failing_doi = self._build_mock_doi("10.55277/fail", status_code=500)
         success_doi = self._build_mock_doi("10.55277/ok")
-        MockDOI.side_effect = [failing_doi, success_doi]
+        mock_doi_cls.side_effect = [failing_doi, success_doi]
 
         # Act
         assign_preregistration_dois()

--- a/src/researchhub_document/tests/test_tasks.py
+++ b/src/researchhub_document/tests/test_tasks.py
@@ -1,0 +1,105 @@
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from django.utils import timezone
+
+from discussion.models import Flag
+from researchhub_document.helpers import create_post
+from researchhub_document.tasks import assign_preregistration_dois
+from user.tests.helpers import create_random_default_user
+
+
+class AssignPreregistrationDoisTests(TestCase):
+    def setUp(self):
+        self.user = create_random_default_user("doi_test_user")
+
+    def _create_preregistration(self, days_old=10, doi=None, is_removed=False):
+        post = create_post(
+            title="Test Preregistration",
+            created_by=self.user,
+            document_type="PREREGISTRATION",
+        )
+        post.doi = doi
+        post.created_date = timezone.now() - timedelta(days=days_old)
+        post.save(update_fields=["doi", "created_date"])
+
+        if is_removed:
+            post.unified_document.is_removed = True
+            post.unified_document.save(update_fields=["is_removed"])
+
+        return post
+
+    def _build_mock_doi(self, doi_value="10.55277/test123", status_code=200):
+        mock = MagicMock()
+        mock.doi = doi_value
+        mock.register_doi_for_post.return_value = MagicMock(status_code=status_code)
+        return mock
+
+    @patch("researchhub_document.tasks.DOI")
+    def test_assigns_doi_to_eligible_preregistration(self, MockDOI):
+        # Arrange
+        MockDOI.return_value = self._build_mock_doi()
+        post = self._create_preregistration(days_old=10)
+
+        # Act
+        assign_preregistration_dois()
+
+        # Assert
+        post.refresh_from_db()
+        self.assertEqual(post.doi, "10.55277/test123")
+
+    @patch("researchhub_document.tasks.DOI")
+    def test_skips_ineligible_posts(self, MockDOI):
+        """Posts that are too young, already have a DOI, are removed,
+        are flagged, or are non-preregistration should all be skipped."""
+        # Arrange
+        self._create_preregistration(days_old=3)
+        self._create_preregistration(days_old=10, doi="10.55277/existing")
+        self._create_preregistration(days_old=10, is_removed=True)
+
+        flagged = self._create_preregistration(days_old=10)
+        ct = ContentType.objects.get_for_model(flagged)
+        Flag.objects.create(
+            content_type=ct,
+            object_id=flagged.id,
+            created_by=create_random_default_user("flagger"),
+            reason="spam",
+        )
+
+        discussion = create_post(
+            title="Regular Discussion Post",
+            created_by=self.user,
+            document_type="DISCUSSION",
+        )
+        discussion.created_date = timezone.now() - timedelta(days=10)
+        discussion.save(update_fields=["created_date"])
+
+        # Act
+        assign_preregistration_dois()
+
+        # Assert
+        MockDOI.assert_not_called()
+
+    @patch("researchhub_document.tasks.DOI")
+    def test_handles_crossref_failure_and_continues(self, MockDOI):
+        # Arrange
+        self._create_preregistration(days_old=10)
+        self._create_preregistration(days_old=14)
+
+        failing_doi = self._build_mock_doi("10.55277/fail", status_code=500)
+        success_doi = self._build_mock_doi("10.55277/ok")
+        MockDOI.side_effect = [failing_doi, success_doi]
+
+        # Act
+        assign_preregistration_dois()
+
+        # Assert
+        from researchhub_document.models import ResearchhubPost
+
+        posts = ResearchhubPost.objects.filter(document_type="PREREGISTRATION")
+        assigned = posts.exclude(doi__isnull=True).count()
+        unassigned = posts.filter(doi__isnull=True).count()
+        self.assertEqual(assigned, 1)
+        self.assertEqual(unassigned, 1)


### PR DESCRIPTION
## Overview ##

Part 2 of  https://github.com/ResearchHub/researchhub-backend/pull/3335

Now that DOIs are not created when a work is published, we need a task.  This task runs daily, and checks for any proposals that are older than 7 days, and assigns them a DOI.  This 7 day grace period allows us to detect and remove spam works before assigning them DOIs..  It will not assign DOI's to both removed and flagged content.