### PR TITLE
Revert "Add `AI_PEER_REVIEW_BEDROCK_MODEL_ID` to Django settings (env / keys)"

### DIFF
--- a/src/ai_peer_review/services/bedrock_llm_service.py
+++ b/src/ai_peer_review/services/bedrock_llm_service.py
@@ -12,7 +12,7 @@ _DEFAULT_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 BEDROCK_MODEL_ID = getattr(
     settings,
     "AI_PEER_REVIEW_BEDROCK_MODEL_ID",
-    _DEFAULT_MODEL,
+    getattr(settings, "RESEARCH_AI_BEDROCK_MODEL_ID", _DEFAULT_MODEL),
 )
 
 

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -560,11 +560,6 @@ OPENAI_API_KEY = os.environ.get(
     getattr(keys, "OPENAI_API_KEY", ""),
 )
 
-AI_PEER_REVIEW_BEDROCK_MODEL_ID = os.environ.get(
-    "AI_PEER_REVIEW_BEDROCK_MODEL_ID",
-    getattr(keys, "AI_PEER_REVIEW_BEDROCK_MODEL_ID", ""),
-)
-
 if not (CLOUD or TESTING) and os.environ.get("AWS_PROFILE") is None:
     # Set AWS profile for local development
     os.environ["AWS_PROFILE"] = keys.AWS_PROFILE


### PR DESCRIPTION
Reverts ResearchHub/researchhub-backend#3355