### PR TITLE
Add `AI_PEER_REVIEW_BEDROCK_MODEL_ID` to Django settings (env / keys)

### DIFF
--- a/src/ai_peer_review/services/bedrock_llm_service.py
+++ b/src/ai_peer_review/services/bedrock_llm_service.py
@@ -12,7 +12,7 @@ _DEFAULT_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 BEDROCK_MODEL_ID = getattr(
     settings,
     "AI_PEER_REVIEW_BEDROCK_MODEL_ID",
-    getattr(settings, "RESEARCH_AI_BEDROCK_MODEL_ID", _DEFAULT_MODEL),
+    _DEFAULT_MODEL,
 )
 
 

--- a/src/ai_peer_review/services/bedrock_llm_service.py
+++ b/src/ai_peer_review/services/bedrock_llm_service.py
@@ -15,6 +15,18 @@ BEDROCK_MODEL_ID = getattr(
     _DEFAULT_MODEL,
 )
 
+_BEDROCK_OMIT_TEMPERATURE_SUBSTRINGS: tuple[str, ...] = ("opus-4-7",)
+
+
+def _converse_inference_config(
+    model_id: str, *, max_tokens: int, temperature: float
+) -> dict:
+    config: dict[str, int | float] = {"maxTokens": max_tokens}
+    lower = model_id.lower()
+    if not any(s in lower for s in _BEDROCK_OMIT_TEMPERATURE_SUBSTRINGS):
+        config["temperature"] = temperature
+    return config
+
 
 class BedrockLLMService:
     """Invoke Bedrock for structured proposal review JSON (and related tasks)."""
@@ -41,10 +53,11 @@ class BedrockLLMService:
                         "content": [{"text": user_prompt}],
                     }
                 ],
-                inferenceConfig={
-                    "maxTokens": max_tokens,
-                    "temperature": temperature,
-                },
+                inferenceConfig=_converse_inference_config(
+                    self.model_id,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                ),
             )
         except Exception as e:
             sentry.log_error(

--- a/src/ai_peer_review/tests/test_author_and_llm_services.py
+++ b/src/ai_peer_review/tests/test_author_and_llm_services.py
@@ -203,6 +203,19 @@ class BedrockLLMServiceTests(SimpleTestCase):
         self.assertEqual(kwargs["inferenceConfig"]["temperature"], 0.1)
 
     @patch("ai_peer_review.services.bedrock_llm_service.bedrock_runtime_client")
+    def test_invoke_omits_temperature_for_opus_4_7(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.converse.return_value = {
+            "output": {"message": {"content": [{"text": "x"}]}}
+        }
+        svc = BedrockLLMService()
+        svc.model_id = "us.anthropic.claude-opus-4-7-20250514-v1:0"
+        svc.invoke("s", "u", max_tokens=50, temperature=0.1)
+        ic = mock_client.converse.call_args.kwargs["inferenceConfig"]
+        self.assertEqual(ic, {"maxTokens": 50})
+
+    @patch("ai_peer_review.services.bedrock_llm_service.bedrock_runtime_client")
     @patch("ai_peer_review.services.bedrock_llm_service.sentry.log_error")
     def test_invoke_raises_on_client_error(self, mock_sentry, mock_create_client):
         mock_client = MagicMock()

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -560,6 +560,11 @@ OPENAI_API_KEY = os.environ.get(
     getattr(keys, "OPENAI_API_KEY", ""),
 )
 
+AI_PEER_REVIEW_BEDROCK_MODEL_ID = os.environ.get(
+    "AI_PEER_REVIEW_BEDROCK_MODEL_ID",
+    getattr(keys, "AI_PEER_REVIEW_BEDROCK_MODEL_ID", ""),
+)
+
 if not (CLOUD or TESTING) and os.environ.get("AWS_PROFILE") is None:
     # Set AWS profile for local development
     os.environ["AWS_PROFILE"] = keys.AWS_PROFILE


### PR DESCRIPTION
## Summary
- Define `AI_PEER_REVIEW_BEDROCK_MODEL_ID` in Django settings, sourced from the `AI_PEER_REVIEW_BEDROCK_MODEL_ID` environment variable

- Error after switching to this model: `Bedrock invoke failed: An error occurred (ValidationException) when calling the Converse operation: The model returned the following errors: {"type":"error","request_id":"req_4zbow7qklohh4l76le5h5trd7lewjjdk4jxwijvvxqpp7oocgd3q","error":{"type":"invalid_request_error","message":"`temperature` is deprecated for this model."}}`

> Claude Opus 4.7 is Anthropic's newest and most advanced model, and they've removed the temperature parameter to optimize its performance. The model uses its own internal optimization instead.

- Fix: remove`temperature` fro configs for Opus 4.7
