### PR TITLE
[expert-finder] 2 - Add expert helper service modules

### DIFF
--- a/src/research_ai/services/expert_display.py
+++ b/src/research_ai/services/expert_display.py
@@ -1,7 +1,3 @@
-"""
-Display / API shaping helpers for Expert name fields and legacy dict rows.
-"""
-
 from typing import Any
 
 from research_ai.models import Expert
@@ -23,8 +19,7 @@ def build_expert_display_name(
     name_suffix: str = "",
 ) -> str:
     """
-    One-line display from structured name parts (honorific through last), then suffix
-    with a comma when both the base and suffix are non-empty (e.g. "Jane Smith, PhD").
+    One-line display from structured name parts (e.g. "Dr Jane Smith, PhD").
     """
     parts: list[str] = []
     for s in (honorific, first_name, middle_name, last_name):
@@ -48,6 +43,7 @@ def expert_model_display_name(expert: Expert) -> str:
     )
 
 
+# TODO: Remove after expert-finder uses only Expert/SearchExpert; drop legacy name/title shims.
 def expert_dict_to_api_payload(d: dict[str, Any] | None) -> dict[str, Any]:
     """
     Normalize a flat or legacy expert dict for list/detail API responses.
@@ -89,10 +85,17 @@ def expert_dict_to_api_payload(d: dict[str, Any] | None) -> dict[str, Any]:
 def expert_name_for_generated_email_storage(
     expert_row: dict[str, Any] | None,
 ) -> str:
-    """Single-line `GeneratedEmail.expert_name` from a structured or legacy row."""
+    """
+    Single line for `GeneratedEmail.expert_name` from structured name fields
+    (honorific / first / middle / last / suffix) only. Truncated to 255 characters.
+
+    If the row only has legacy `name`, return empty; use
+    `expert_name_for_legacy_generated_email_storage` until the transition is done, or
+    `build_expert_display_name` with explicit kwargs at the call site.
+    """
     if not expert_row:
         return ""
-    any_structured = any(
+    if not any(
         (expert_row.get(k) or "").strip()
         for k in (
             "honorific",
@@ -101,26 +104,52 @@ def expert_name_for_generated_email_storage(
             "last_name",
             "name_suffix",
         )
-    )
-    if any_structured:
-        return build_expert_display_name(
-            honorific=(expert_row.get("honorific") or ""),
-            first_name=(expert_row.get("first_name") or ""),
-            middle_name=(expert_row.get("middle_name") or ""),
-            last_name=(expert_row.get("last_name") or ""),
-            name_suffix=(expert_row.get("name_suffix") or ""),
-        )[:255]
-    name = (expert_row.get("name") or "").strip()
-    return name[:255]
+    ):
+        return ""
+    return build_expert_display_name(
+        honorific=(expert_row.get("honorific") or ""),
+        first_name=(expert_row.get("first_name") or ""),
+        middle_name=(expert_row.get("middle_name") or ""),
+        last_name=(expert_row.get("last_name") or ""),
+        name_suffix=(expert_row.get("name_suffix") or ""),
+    )[:255]
+
+
+# TODO: Remove when expert-finder no longer uses expert_results JSON with a single `name` field.
+def expert_name_for_legacy_generated_email_storage(
+    expert_row: dict[str, Any] | None,
+) -> str:
+    """`GeneratedEmail.expert_name` from legacy `expert_results` `name` only. Max 255 chars."""
+    if not expert_row:
+        return ""
+    return (expert_row.get("name") or "").strip()[:255]
 
 
 def expert_title_for_generated_email_storage(
     expert_row: dict[str, Any] | None,
 ) -> str:
-    """`GeneratedEmail.expert_title` from `academic_title` or legacy `title`."""
+    """
+    `GeneratedEmail.expert_title` from `academic_title` only. Max 255 characters.
+
+    If the row only has legacy `title`, return empty; use
+    `expert_title_for_legacy_generated_email_storage` during the transition.
+    """
     if not expert_row:
         return ""
-    t = (expert_row.get("academic_title") or expert_row.get("title") or "").strip()
+    t = (expert_row.get("academic_title") or "").strip()
+    if not isinstance(t, str):
+        return ""
+    return t[:255]
+
+
+# TODO: Remove when expert-finder no longer uses expert_results JSON with a `title` field.
+def expert_title_for_legacy_generated_email_storage(
+    expert_row: dict[str, Any] | None,
+) -> str:
+    """`GeneratedEmail.expert_title` from legacy `expert_results` `title` only. Max 255 chars."""
+    if not expert_row:
+        return ""
+    t = (expert_row.get("title") or "").strip()
     if not isinstance(t, str):
         return ""
     return t[:255]

--- a/src/research_ai/services/expert_display.py
+++ b/src/research_ai/services/expert_display.py
@@ -1,0 +1,126 @@
+"""
+Display / API shaping helpers for Expert name fields and legacy dict rows.
+"""
+
+from typing import Any
+
+from research_ai.models import Expert
+
+
+def normalize_expert_email(email: str | None) -> str:
+    """Lowercase, strip; empty string if missing or invalid type."""
+    if not email or not isinstance(email, str):
+        return ""
+    return email.strip().lower()
+
+
+def build_expert_display_name(
+    *,
+    honorific: str = "",
+    first_name: str = "",
+    middle_name: str = "",
+    last_name: str = "",
+    name_suffix: str = "",
+) -> str:
+    """
+    One-line display from structured name parts (honorific through last), then suffix
+    with a comma when both the base and suffix are non-empty (e.g. "Jane Smith, PhD").
+    """
+    parts: list[str] = []
+    for s in (honorific, first_name, middle_name, last_name):
+        t = (s or "").strip()
+        if t:
+            parts.append(t)
+    base = " ".join(parts)
+    suf = (name_suffix or "").strip()
+    if base and suf:
+        return f"{base}, {suf}"
+    return base or suf
+
+
+def expert_model_display_name(expert: Expert) -> str:
+    return build_expert_display_name(
+        honorific=expert.honorific,
+        first_name=expert.first_name,
+        middle_name=expert.middle_name,
+        last_name=expert.last_name,
+        name_suffix=expert.name_suffix,
+    )
+
+
+def expert_dict_to_api_payload(d: dict[str, Any] | None) -> dict[str, Any]:
+    """
+    Normalize a flat or legacy expert dict for list/detail API responses.
+    Fills `name` from structured parts when any are present, else from legacy `name`.
+    Synchronizes `academic_title` and legacy `title` (academic / role name).
+    """
+    if not d:
+        return {}
+    result: dict[str, Any] = {**d}
+    any_structured = any(
+        (result.get(k) or "").strip()
+        for k in (
+            "honorific",
+            "first_name",
+            "middle_name",
+            "last_name",
+            "name_suffix",
+        )
+    )
+    if any_structured:
+        result["name"] = build_expert_display_name(
+            honorific=(result.get("honorific") or ""),
+            first_name=(result.get("first_name") or ""),
+            middle_name=(result.get("middle_name") or ""),
+            last_name=(result.get("last_name") or ""),
+            name_suffix=(result.get("name_suffix") or ""),
+        )
+    else:
+        result["name"] = (result.get("name") or "").strip()
+
+    at = (result.get("academic_title") or result.get("title") or "").strip()
+    if not isinstance(at, str):
+        at = ""
+    result["academic_title"] = at
+    result["title"] = at
+    return result
+
+
+def expert_name_for_generated_email_storage(
+    expert_row: dict[str, Any] | None,
+) -> str:
+    """Single-line `GeneratedEmail.expert_name` from a structured or legacy row."""
+    if not expert_row:
+        return ""
+    any_structured = any(
+        (expert_row.get(k) or "").strip()
+        for k in (
+            "honorific",
+            "first_name",
+            "middle_name",
+            "last_name",
+            "name_suffix",
+        )
+    )
+    if any_structured:
+        return build_expert_display_name(
+            honorific=(expert_row.get("honorific") or ""),
+            first_name=(expert_row.get("first_name") or ""),
+            middle_name=(expert_row.get("middle_name") or ""),
+            last_name=(expert_row.get("last_name") or ""),
+            name_suffix=(expert_row.get("name_suffix") or ""),
+        )[:255]
+    name = (expert_row.get("name") or "").strip()
+    return name[:255]
+
+
+def expert_title_for_generated_email_storage(
+    expert_row: dict[str, Any] | None,
+) -> str:
+    """`GeneratedEmail.expert_title` from `academic_title` or legacy `title`."""
+    if not expert_row:
+        return ""
+    t = (expert_row.get("academic_title") or expert_row.get("title") or "").strip()
+    if not isinstance(t, str):
+        return ""
+    return t[:255]

--- a/src/research_ai/services/expert_llm_table.py
+++ b/src/research_ai/services/expert_llm_table.py
@@ -1,0 +1,203 @@
+"""
+Strict markdown table parsing for the expert-finder LLM: fixed 10-column header.
+"""
+
+import logging
+import re
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.core.validators import EmailValidator
+
+logger = logging.getLogger(__name__)
+
+# Must stay aligned with the expert-finder system prompt and parse_expert_markdown_table_strict.
+EXPERT_LLM_TABLE_HEADERS: tuple[str, ...] = (
+    "Honorific",
+    "First",
+    "Middle",
+    "Last",
+    "Suffix",
+    "Academic title",
+    "Affiliation",
+    "Expertise",
+    "Email",
+    "Notes",
+)
+
+N_EXPERT_COLUMNS = len(EXPERT_LLM_TABLE_HEADERS)
+EXPERT_LLM_TABLE_HEADER_LINE: str = (
+    "| " + " | ".join(EXPERT_LLM_TABLE_HEADERS) + " |"
+)
+EXPERT_LLM_TABLE_SEPARATOR_LINE: str = (
+    "| " + " | ".join("---" for _ in range(N_EXPERT_COLUMNS)) + " |"
+)
+
+
+class ExpertTableSchemaError(ValueError):
+    """Raised when the model output is not a valid 10-column expert table."""
+
+
+def clean_expert_table_url(url: str) -> str:
+    """Remove UTM and tracking query params (same behavior as the legacy table parser)."""
+    if "?" not in url:
+        return url
+    base, qs = url.split("?", 1)
+    params = [p for p in qs.split("&") if not p.startswith("utm_")]
+    return f"{base}?{'&'.join(params)}" if params else base
+
+
+def extract_citations_from_notes(text: str) -> tuple[str, list[dict[str, str]]]:
+    """
+    Extract markdown links [text](url) from notes; return (cleaned_text, citations list).
+    """
+    citations: list[dict[str, str]] = []
+    citation_pattern = r"\[([^\]]+)\]\(([^)]*)\)"
+    for m in re.finditer(citation_pattern, text or ""):
+        raw_url = (m.group(2) or "").strip()
+        if not raw_url:
+            continue
+        url = clean_expert_table_url(raw_url)
+        citations.append({"text": m.group(1), "url": url})
+    cleaned = re.sub(citation_pattern, "", text or "")
+    cleaned = re.sub(r"\(\)", "", cleaned).strip()
+    return cleaned, citations
+
+
+def _split_pipe_row(line: str) -> list[str]:
+    s = (line or "").rstrip()
+    if "|" not in s:
+        return []
+    parts = s.split("|")
+    if len(parts) < 3:
+        return []
+    return [p.strip() for p in parts[1:-1]]
+
+
+def _normalize_header_cell(s: str) -> str:
+    return " ".join(s.split()).casefold()
+
+
+def _is_markdown_alignment_separator_line(line: str) -> bool:
+    """
+    True for rows like | --- | --- |: alignment rows only, not | | A | (empty honorific + data).
+    The legacy pattern ^\\s*\\|[\\s\\-:]+\\| matches a single space as \\s+ between pipes and wrongly
+    drops any row whose first cell is empty.
+    """
+    cells = _split_pipe_row(line)
+    if not cells:
+        return False
+    if not any("-" in c for c in cells):
+        return False
+    for c in cells:
+        t = c.strip()
+        if t == "":
+            continue
+        if not re.fullmatch(r"[-\s:]+", t):
+            return False
+    return True
+
+
+def _row_is_table_separator(cells: list[str]) -> bool:
+    if not cells:
+        return True
+    if not any("-" in c for c in cells):
+        return False
+    return all(
+        c.strip() == "" or re.fullmatch(r"[-\s:]+", c) for c in cells
+    )
+
+
+def _table_lines_from_markdown(markdown_text: str) -> list[str]:
+    """First contiguous run of | lines, skipping leading separator lines."""
+    table_lines: list[str] = []
+    in_table = False
+    for line in (markdown_text or "").splitlines():
+        if "|" in line:
+            if _is_markdown_alignment_separator_line(line):
+                continue
+            table_lines.append(line)
+            in_table = True
+        elif in_table and not line.strip():
+            break
+    if not table_lines:
+        return []
+    return table_lines
+
+
+def _header_matches(cells: list[str]) -> bool:
+    if len(cells) != N_EXPERT_COLUMNS:
+        return False
+    for i, expected in enumerate(EXPERT_LLM_TABLE_HEADERS):
+        got = cells[i]
+        if _normalize_header_cell(got) != _normalize_header_cell(expected):
+            return False
+    return True
+
+
+def parse_expert_markdown_table_strict(markdown_text: str) -> list[dict[str, Any]]:
+    """
+    Parse the expert markdown table into a list of expert dicts.
+    Enforces 10 headers and 10 data cells per row. Skips data rows with invalid email.
+    """
+    table_lines = _table_lines_from_markdown(markdown_text)
+    if not table_lines:
+        raise ExpertTableSchemaError("No markdown table with pipe delimiters in response")
+
+    header_cells = _split_pipe_row(table_lines[0])
+    if not _header_matches(header_cells):
+        raise ExpertTableSchemaError(
+            "Invalid table header: expected "
+            f"{N_EXPERT_COLUMNS} columns: {', '.join(EXPERT_LLM_TABLE_HEADERS)}"
+        )
+
+    out: list[dict[str, Any]] = []
+    for line in table_lines[1:]:
+        if not line or not line.strip():
+            continue
+        if "|" not in line:
+            break
+        row_cells = _split_pipe_row(line)
+        if _row_is_table_separator(row_cells) or not any(c.strip() for c in row_cells):
+            continue
+        if len(row_cells) != N_EXPERT_COLUMNS:
+            raise ExpertTableSchemaError(
+                f"Table row has {len(row_cells)} cells; expected {N_EXPERT_COLUMNS}. "
+                f"Row: {line[:200]!r}"
+            )
+        (
+            honorific,
+            first,
+            middle,
+            last,
+            suffix,
+            academic,
+            affil,
+            expertise,
+            email_raw,
+            notes_raw,
+        ) = row_cells
+        notes_clean, citations = extract_citations_from_notes(notes_raw)
+        expert = {
+            "honorific": honorific,
+            "first_name": first,
+            "middle_name": middle,
+            "last_name": last,
+            "name_suffix": suffix,
+            "academic_title": academic,
+            "affiliation": affil,
+            "expertise": expertise,
+            "email": (email_raw or "").strip().lower(),
+            "notes": notes_clean,
+            "sources": citations if citations else [],
+        }
+        try:
+            EmailValidator()(expert["email"])
+        except ValidationError:
+            logger.warning(
+                "Strict expert table: skipping row: invalid email %r",
+                email_raw,
+            )
+            continue
+        out.append(expert)
+    return out

--- a/src/research_ai/services/expert_persist.py
+++ b/src/research_ai/services/expert_persist.py
@@ -1,0 +1,92 @@
+"""
+Persistence helpers for Expert and SearchExpert (upsert, replace, email timestamps).
+"""
+
+from datetime import datetime
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.core.validators import EmailValidator
+from django.db import transaction
+from django.utils import timezone
+
+from research_ai.models import Expert, ExpertSearch, SearchExpert
+from research_ai.services.expert_display import normalize_expert_email
+
+
+def upsert_expert_from_parsed_dict(data: dict[str, Any]) -> Expert:
+    """
+    Create or update an Expert by normalized email. Does not change `registered_user`
+    or `last_email_sent_at` (those are managed elsewhere).
+    """
+    email = normalize_expert_email(data.get("email", ""))
+    if not email:
+        raise ValueError("expert email is required")
+    try:
+        EmailValidator()(email)
+    except ValidationError as e:
+        raise ValueError("invalid expert email") from e
+
+    def _s(key: str) -> str:
+        v = data.get(key, "")
+        return (v if isinstance(v, str) else str(v or "")).strip()
+
+    sources = data.get("sources")
+    if sources is None:
+        sources = []
+    if not isinstance(sources, list):
+        sources = list(sources) if sources else []
+
+    defaults = {
+        "honorific": _s("honorific"),
+        "first_name": _s("first_name"),
+        "middle_name": _s("middle_name"),
+        "last_name": _s("last_name"),
+        "name_suffix": _s("name_suffix"),
+        "academic_title": _s("academic_title"),
+        "affiliation": _s("affiliation"),
+        "expertise": _s("expertise"),
+        "notes": _s("notes"),
+        "sources": sources,
+    }
+    expert, _ = Expert.objects.update_or_create(email=email, defaults=defaults)
+    return expert
+
+
+@transaction.atomic
+def replace_search_experts_for_search(
+    search_id: int, experts: list[dict[str, Any]]
+) -> int:
+    """
+    Replace all SearchExpert rows for this search with the given experts in order.
+    Upserts Expert rows. Returns the number of membership rows created.
+    """
+    ExpertSearch.objects.get(pk=search_id)
+
+    SearchExpert.objects.filter(expert_search_id=search_id).delete()
+    n = 0
+    for pos, row in enumerate(experts):
+        ex = upsert_expert_from_parsed_dict(row)
+        SearchExpert.objects.create(
+            expert_search_id=search_id,
+            expert=ex,
+            position=pos,
+        )
+        n += 1
+    return n
+
+
+def mark_expert_last_email_sent_at(
+    email: str,
+    *,
+    at: datetime | None = None,
+) -> int:
+    """
+    Set `last_email_sent_at` for the Expert with this email. Returns the number
+    of rows updated (0 or 1).
+    """
+    em = normalize_expert_email(email)
+    if not em:
+        return 0
+    ts = at if at is not None else timezone.now()
+    return Expert.objects.filter(email=em).update(last_email_sent_at=ts)

--- a/src/research_ai/services/expert_results_payload.py
+++ b/src/research_ai/services/expert_results_payload.py
@@ -1,0 +1,59 @@
+"""
+Build expert result lists for API from ExpertSearch (relational or legacy JSON).
+"""
+
+from typing import Any
+
+from research_ai.models import Expert, ExpertSearch, SearchExpert
+from research_ai.services.expert_display import (
+    expert_dict_to_api_payload,
+    expert_model_display_name,
+)
+
+
+def expert_model_to_flat_dict(expert: Expert) -> dict[str, Any]:
+    """
+    Expert ORM row to the flat dict shape used in expert_results-style payloads.
+    Includes legacy `title` as an alias for `academic_title` and computed `name`.
+    """
+    display = expert_model_display_name(expert)
+    at = (expert.academic_title or "").strip()
+    return {
+        "id": expert.id,
+        "email": expert.email,
+        "honorific": expert.honorific,
+        "first_name": expert.first_name,
+        "middle_name": expert.middle_name,
+        "last_name": expert.last_name,
+        "name_suffix": expert.name_suffix,
+        "academic_title": at,
+        "name": display,
+        "title": at,
+        "affiliation": expert.affiliation,
+        "expertise": expert.expertise,
+        "notes": expert.notes,
+        "sources": expert.sources or [],
+    }
+
+
+def get_expert_results_payload(expert_search: ExpertSearch) -> list[dict[str, Any]]:
+    """
+    Return ordered expert rows for the search: SearchExpert + Expert when present,
+    otherwise fall back to legacy `expert_search.expert_results` JSON.
+    """
+    rows: list[dict[str, Any]] = []
+    se_list = list(
+        SearchExpert.objects.filter(expert_search=expert_search)
+        .select_related("expert")
+        .order_by("position", "id")
+    )
+    if se_list:
+        for se in se_list:
+            flat = expert_model_to_flat_dict(se.expert)
+            rows.append(expert_dict_to_api_payload(flat))
+        return rows
+    for item in expert_search.expert_results or []:
+        if not isinstance(item, dict):
+            continue
+        rows.append(expert_dict_to_api_payload(item))
+    return rows

--- a/src/research_ai/tests/test_expert_helpers.py
+++ b/src/research_ai/tests/test_expert_helpers.py
@@ -1,0 +1,332 @@
+"""Unit tests for expert_display, expert_llm_table, expert_persist, expert_results_payload."""
+
+from django.test import TestCase
+from django.utils import timezone
+
+from research_ai.models import Expert, ExpertSearch, SearchExpert
+from research_ai.services.expert_display import (
+    build_expert_display_name,
+    expert_dict_to_api_payload,
+    expert_model_display_name,
+    expert_name_for_generated_email_storage,
+    expert_title_for_generated_email_storage,
+    normalize_expert_email,
+)
+from research_ai.services.expert_llm_table import (
+    EXPERT_LLM_TABLE_HEADERS,
+    EXPERT_LLM_TABLE_HEADER_LINE,
+    EXPERT_LLM_TABLE_SEPARATOR_LINE,
+    ExpertTableSchemaError,
+    clean_expert_table_url,
+    extract_citations_from_notes,
+    parse_expert_markdown_table_strict,
+)
+from research_ai.services.expert_persist import (
+    mark_expert_last_email_sent_at,
+    replace_search_experts_for_search,
+    upsert_expert_from_parsed_dict,
+)
+from research_ai.services.expert_results_payload import (
+    expert_model_to_flat_dict,
+    get_expert_results_payload,
+)
+from user.tests.helpers import create_user
+
+
+# --- expert_display ---
+
+
+class ExpertDisplayTests(TestCase):
+    def test_build_expert_display_name_joins_parts_and_suffix(self):
+        self.assertEqual(
+            build_expert_display_name(
+                honorific="Dr",
+                first_name="Jane",
+                middle_name="Q",
+                last_name="Smith",
+                name_suffix="PhD",
+            ),
+            "Dr Jane Q Smith, PhD",
+        )
+
+    def test_normalize_expert_email(self):
+        self.assertEqual(
+            normalize_expert_email("  Test@EXAMPLE.com "),
+            "test@example.com",
+        )
+        self.assertEqual(normalize_expert_email(None), "")
+
+    def test_expert_model_display_name_uses_expert_instance(self):
+        e = Expert(
+            email="a@b.com",
+            honorific="Prof",
+            first_name="A",
+            middle_name="",
+            last_name="B",
+            name_suffix="",
+        )
+        self.assertEqual(expert_model_display_name(e), "Prof A B")
+
+    def test_expert_dict_to_api_payload_structured_and_legacy(self):
+        structured = expert_dict_to_api_payload(
+            {
+                "honorific": "Dr",
+                "first_name": "X",
+                "last_name": "Y",
+                "academic_title": "Professor",
+            }
+        )
+        self.assertEqual(structured["name"], "Dr X Y")
+        self.assertEqual(structured["title"], "Professor")
+        self.assertEqual(structured["academic_title"], "Professor")
+
+        legacy = expert_dict_to_api_payload(
+            {"name": "Only Name", "title": "Title X", "email": "e@e.com"}
+        )
+        self.assertEqual(legacy["name"], "Only Name")
+        self.assertEqual(legacy["title"], "Title X")
+        self.assertEqual(legacy["academic_title"], "Title X")
+
+    def test_expert_name_and_title_for_generated_email_storage(self):
+        row = {
+            "honorific": "Dr",
+            "first_name": "J",
+            "last_name": "Doe",
+            "academic_title": "Prof",
+        }
+        self.assertEqual(
+            expert_name_for_generated_email_storage(row),
+            "Dr J Doe",
+        )
+        self.assertEqual(
+            expert_title_for_generated_email_storage(row),
+            "Prof",
+        )
+        self.assertEqual(
+            expert_name_for_generated_email_storage({"name": "Legacy Name"}),
+            "Legacy Name",
+        )
+
+
+# --- expert_llm_table ---
+
+
+class ExpertLlmTableTests(TestCase):
+    def test_header_and_separator_line_column_count(self):
+        n = len(EXPERT_LLM_TABLE_HEADERS)
+        self.assertEqual(n, 10)
+        self.assertEqual(EXPERT_LLM_TABLE_HEADER_LINE.count("|"), n + 1)
+        self.assertEqual(EXPERT_LLM_TABLE_SEPARATOR_LINE.count("---"), n)
+
+    def test_parse_strict_two_rows(self):
+        md = f"""
+{EXPERT_LLM_TABLE_HEADER_LINE}
+{EXPERT_LLM_TABLE_SEPARATOR_LINE}
+| Dr | Jane |  | Smith | PhD | Professor | MIT | ML | jane@mit.edu | See [p](https://q.com) |
+|  | John | M | Smith |  | Dr | Stanford | CS | john@stanford.edu | n |
+"""
+        out = parse_expert_markdown_table_strict(md)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[0]["email"], "jane@mit.edu")
+        self.assertEqual(out[0]["first_name"], "Jane")
+        self.assertEqual(out[0]["last_name"], "Smith")
+        self.assertEqual(out[0]["academic_title"], "Professor")
+        self.assertEqual(out[0]["name_suffix"], "PhD")
+        self.assertEqual(len(out[0]["sources"]), 1)
+        self.assertEqual(out[1]["email"], "john@stanford.edu")
+        self.assertEqual(out[1]["first_name"], "John")
+        self.assertEqual(out[1]["last_name"], "Smith")
+
+    def test_parse_preserves_empty_middle_column(self):
+        h = EXPERT_LLM_TABLE_HEADER_LINE
+        s = EXPERT_LLM_TABLE_SEPARATOR_LINE
+        md = f"""{h}
+{s}
+| | A |  | B | | | U | E | a@a.com | n |
+"""
+        out = parse_expert_markdown_table_strict(md)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["honorific"], "")
+        self.assertEqual(out[0]["first_name"], "A")
+        self.assertEqual(out[0]["middle_name"], "")
+
+    def test_parse_skips_invalid_email(self):
+        h = EXPERT_LLM_TABLE_HEADER_LINE
+        s = EXPERT_LLM_TABLE_SEPARATOR_LINE
+        md = f"""{h}
+{s}
+| | | | | | | | | bad | n |
+| | j | | | | | | | j@j.com | n |
+"""
+        out = parse_expert_markdown_table_strict(md)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["email"], "j@j.com")
+
+    def test_parse_raises_on_bad_header(self):
+        h = EXPERT_LLM_TABLE_HEADER_LINE.replace("Honorific", "Wrong")
+        s = EXPERT_LLM_TABLE_SEPARATOR_LINE
+        with self.assertRaises(ExpertTableSchemaError):
+            parse_expert_markdown_table_strict(
+                f"""{h}
+{s}
+| | | | | | | | | x@x.com | n |
+"""
+            )
+
+    def test_parse_raises_on_row_wrong_length(self):
+        h = EXPERT_LLM_TABLE_HEADER_LINE
+        s = EXPERT_LLM_TABLE_SEPARATOR_LINE
+        with self.assertRaises(ExpertTableSchemaError):
+            parse_expert_markdown_table_strict(
+                f"""{h}
+{s}
+| a | b | c |
+"""
+            )
+
+    def test_parse_raises_on_no_table(self):
+        with self.assertRaises(ExpertTableSchemaError):
+            parse_expert_markdown_table_strict("no pipes here at all")
+
+    def test_extract_citations_and_clean_url(self):
+        text = "X [L](https://e.com/l?utm_abc=1&x=1) y"
+        clean, cits = extract_citations_from_notes(text)
+        self.assertEqual(len(cits), 1)
+        self.assertIn("e.com", cits[0]["url"])
+        self.assertNotIn("utm_", cits[0]["url"])
+        self.assertNotIn("L", clean)
+        self.assertEqual(
+            clean_expert_table_url("https://x.com"), "https://x.com"
+        )
+        self.assertEqual(
+            clean_expert_table_url("https://x.com?utm_x=1&a=1"),
+            "https://x.com?a=1",
+        )
+
+
+# --- expert_persist + expert_results_payload ---
+
+
+class ExpertPersistAndPayloadTests(TestCase):
+    def setUp(self):
+        self.user = create_user(email="owner@test.com")
+        self.search = ExpertSearch.objects.create(
+            created_by=self.user,
+            query="q",
+            status=ExpertSearch.Status.PENDING,
+        )
+
+    def _row(self, email: str, first: str = "F") -> dict:
+        return {
+            "honorific": "Dr",
+            "first_name": first,
+            "middle_name": "",
+            "last_name": "L",
+            "name_suffix": "",
+            "academic_title": "Prof",
+            "affiliation": "U",
+            "expertise": "E",
+            "email": email,
+            "notes": "n",
+            "sources": [],
+        }
+
+    def test_upsert_expert_from_parsed_dict_creates_and_updates(self):
+        r = self._row("drift@u.edu", first="One")
+        e1 = upsert_expert_from_parsed_dict(r)
+        self.assertIsNotNone(e1.id)
+        e1.refresh_from_db()
+        self.assertEqual(e1.first_name, "One")
+        r2 = self._row("drift@u.edu", first="Two")
+        e2 = upsert_expert_from_parsed_dict(r2)
+        self.assertEqual(e1.id, e2.id)
+        e2.refresh_from_db()
+        self.assertEqual(e2.first_name, "Two")
+
+    def test_replace_search_experts_for_search_atomic_order(self):
+        rows = [self._row("a1@u.edu", "A"), self._row("a2@u.edu", "B")]
+        n = replace_search_experts_for_search(self.search.id, rows)
+        self.assertEqual(n, 2)
+        ses = list(
+            SearchExpert.objects.filter(expert_search=self.search)
+            .select_related("expert")
+            .order_by("position")
+        )
+        self.assertEqual(ses[0].position, 0)
+        self.assertEqual(ses[0].expert.email, "a1@u.edu")
+        self.assertEqual(ses[1].expert.first_name, "B")
+
+    def test_replace_clears_previous_search_experts(self):
+        replace_search_experts_for_search(
+            self.search.id, [self._row("only@u.edu")]
+        )
+        replace_search_experts_for_search(
+            self.search.id, [self._row("new@u.edu")]
+        )
+        self.assertEqual(
+            SearchExpert.objects.filter(expert_search=self.search).count(), 1
+        )
+
+    def test_replace_raises_when_search_missing(self):
+        with self.assertRaises(ExpertSearch.DoesNotExist):
+            replace_search_experts_for_search(999_999, [self._row("x@u.edu")])
+
+    def test_mark_expert_last_email_sent_at(self):
+        em = "mark@u.edu"
+        expert = upsert_expert_from_parsed_dict(
+            {**self._row(em), "affiliation": "X"}
+        )
+        ts = timezone.now()
+        c = mark_expert_last_email_sent_at(em, at=ts)
+        self.assertEqual(c, 1)
+        expert.refresh_from_db()
+        self.assertIsNotNone(expert.last_email_sent_at)
+
+    def test_expert_model_to_flat_dict(self):
+        ex = upsert_expert_from_parsed_dict(
+            {**self._row("flat@u.edu", first="Jane"), "academic_title": "Assoc Prof"}
+        )
+        d = expert_model_to_flat_dict(ex)
+        self.assertEqual(d["id"], ex.id)
+        self.assertIn("Jane", d["name"])
+        self.assertEqual(d["academic_title"], "Assoc Prof")
+        self.assertEqual(d["title"], "Assoc Prof")
+
+    def test_get_expert_results_payload_from_search_experts(self):
+        replace_search_experts_for_search(
+            self.search.id,
+            [self._row("g1@u.edu"), self._row("g2@u.edu")],
+        )
+        out = get_expert_results_payload(self.search)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(
+            {r["email"] for r in out},
+            {"g1@u.edu", "g2@u.edu"},
+        )
+
+    def test_get_expert_results_payload_falls_back_to_expert_results_json(self):
+        self.search.expert_results = [
+            {"name": "Legacy L", "title": "T", "email": "l@e.com", "expertise": "x"},
+        ]
+        self.search.save(update_fields=["expert_results"])
+        out = get_expert_results_payload(self.search)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["name"], "Legacy L")
+        self.assertEqual(out[0]["title"], "T")
+        self.assertEqual(out[0]["email"], "l@e.com")
+
+    def test_get_expert_results_payload_prefers_relational_over_json(self):
+        self.search.expert_results = [
+            {"name": "Json Only", "email": "j@e.com", "expertise": "x", "title": "t"},
+        ]
+        self.search.save()
+        replace_search_experts_for_search(
+            self.search.id, [self._row("db@u.edu", first="Db")]
+        )
+        out = get_expert_results_payload(self.search)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["email"], "db@u.edu")
+        self.assertIn("Db", out[0]["name"])
+
+    def test_get_expert_results_payload_empty(self):
+        self.assertEqual(get_expert_results_payload(self.search), [])

--- a/src/research_ai/tests/test_expert_helpers.py
+++ b/src/research_ai/tests/test_expert_helpers.py
@@ -9,7 +9,9 @@ from research_ai.services.expert_display import (
     expert_dict_to_api_payload,
     expert_model_display_name,
     expert_name_for_generated_email_storage,
+    expert_name_for_legacy_generated_email_storage,
     expert_title_for_generated_email_storage,
+    expert_title_for_legacy_generated_email_storage,
     normalize_expert_email,
 )
 from research_ai.services.expert_llm_table import (
@@ -102,9 +104,18 @@ class ExpertDisplayTests(TestCase):
             expert_title_for_generated_email_storage(row),
             "Prof",
         )
+
+    def test_expert_name_and_title_legacy_only_rows(self):
+        legacy = {"name": "Legacy Name", "title": "Title X", "email": "e@e.com"}
+        self.assertEqual(expert_name_for_generated_email_storage(legacy), "")
+        self.assertEqual(expert_title_for_generated_email_storage(legacy), "")
         self.assertEqual(
-            expert_name_for_generated_email_storage({"name": "Legacy Name"}),
+            expert_name_for_legacy_generated_email_storage(legacy),
             "Legacy Name",
+        )
+        self.assertEqual(
+            expert_title_for_legacy_generated_email_storage(legacy),
+            "Title X",
         )
 
 


### PR DESCRIPTION
What?
=====
- Add shared helpers: display, LLM table parse, persist/upsert, and API payload builders (_no call-site wiring yet_).