### PR TITLE
Fix flaky paper view test

### DIFF
--- a/src/paper/tests/test_views.py
+++ b/src/paper/tests/test_views.py
@@ -27,10 +27,13 @@ fixtures_dir = Path(__file__).parent / "fixtures"
 
 
 class PaperApiTests(APITestCase):
-    @patch.object(settings, "RESEARCHHUB_JOURNAL_ID", "123")
     def setUp(self):
-        # Create the hub with the same ID we mocked
-        Hub.objects.create(id=123)
+        self.journal = Hub.objects.create(name="ResearchHub Journal")
+        journal_id_patcher = patch.object(
+            settings, "RESEARCHHUB_JOURNAL_ID", str(self.journal.id)
+        )
+        journal_id_patcher.start()
+        self.addCleanup(journal_id_patcher.stop)
 
     @patch.object(OpenAlex, "get_data_from_doi")
     @patch.object(OpenAlex, "get_works")
@@ -633,7 +636,6 @@ class PaperApiTests(APITestCase):
         self.assertTrue(paper_v3.doi.startswith(doi_base))
 
     @patch("utils.doi.requests.post")
-    @patch.object(settings, "RESEARCHHUB_JOURNAL_ID", "123")
     def test_create_researchhub_paper_preserves_publication_metadata(
         self, crossref_post_mock
     ):
@@ -732,7 +734,6 @@ class PaperApiTests(APITestCase):
         self.assertEqual(paper_version_v3.publication_status, PaperVersion.PUBLISHED)
 
     @patch("utils.doi.requests.post")
-    @patch.object(settings, "RESEARCHHUB_JOURNAL_ID", "123")
     def test_researchhub_journal_hub_preserved_across_versions(
         self, crossref_post_mock
     ):
@@ -743,7 +744,7 @@ class PaperApiTests(APITestCase):
         self.client.force_authenticate(user)
 
         # Get the ResearchHub Journal hub
-        researchhub_journal_hub = Hub.objects.get(id=123)
+        researchhub_journal_hub = self.journal
 
         # Create an author
         author = Author.objects.create(first_name="Test", last_name="Author")


### PR DESCRIPTION
This change fixes the following flaky test that occurs when the database sequence hits the hard-coded ID:
```
======================================================================
ERROR: test_create_researchhub_paper_creates_first_version (paper.tests.test_views.PaperApiTests.test_create_researchhub_paper_creates_first_version)
Test that creating a new paper sets version 1
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
    ^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/psycopg/cursor.py", line 117, in execute
    raise ex.with_traceback(None)
    ^^^^^^^^^^^
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "hub_hub_pkey"
DETAIL:  Key (id)=(123) already exists.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/runner/work/_temp/uv-python-dir/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/home/runner/work/_temp/uv-python-dir/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/unittest/case.py", line 651, in run
    self._callTestMethod(testMethod)
    
  File "/home/runner/work/_temp/uv-python-dir/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/unittest/case.py", line 606, in _callTestMethod
    if method() is not None:
    ^^^^^^^^^^^^^^^
  File "/home/runner/work/_temp/uv-python-dir/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/unittest/mock.py", line 1432, in patched
    return func(*newargs, **newkeywargs)
    ^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/src/paper/tests/test_views.py", line 175, in test_create_researchhub_paper_creates_first_version
    hub = Hub.objects.create(name="Test Hub")
    ^^^^^^^^^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
    ^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/models/query.py", line 665, in create
    obj.save(force_insert=True, using=self.db)
    ^^^^^^^^^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/src/hub/models.py", line 122, in save
    return super(Hub, self).save(*args, **kwargs)
    ^^^^^^^^^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/models/base.py", line 902, in save
    self.save_base(
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/models/base.py", line 1008, in save_base
    updated = self._save_table(
    ^^^^^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/models/base.py", line 1169, in _save_table
    results = self._do_insert(
    ^^^^^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/models/base.py", line 1210, in _do_insert
    return manager._insert(
    ^^^^^^^^^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
    ^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/models/query.py", line 1873, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
    ^^^^^^^^^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/models/sql/compiler.py", line 1882, in execute_sql
    cursor.execute(sql, params)
    ^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/backends/utils.py", line 79, in execute
    return self._execute_with_wrappers(
    ^^^^^^^^^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/backends/utils.py", line 92, in _execute_with_wrappers
    return executor(sql, params, many, context)
    ^^^^^^^^^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/backends/utils.py", line 100, in _execute
    with self.db.wrap_database_errors:
    ^^^^^^^^^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
    ^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
    ^^^^^^^
  File "/home/runner/work/researchhub-backend/researchhub-backend/.venv/lib/python3.13/site-packages/psycopg/cursor.py", line 117, in execute
    raise ex.with_traceback(None)
    ^^^^^^^^^^^
django.db.utils.IntegrityError: duplicate key value violates unique constraint "hub_hub_pkey"
DETAIL:  Key (id)=(123) already exists.

----------------------------------------------------------------------
```