### PR TITLE
Remove AI peer review from funding feed and grant application serialization

### DIFF
--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -5,8 +5,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.files.storage import default_storage
 from rest_framework import serializers
 
-from ai_peer_review.models import Status
-from ai_peer_review.serializers import serialize_ai_peer_review_summary
 from hub.models import Hub
 from paper.models import Paper
 from purchase.serializers import DynamicPurchaseSerializer
@@ -921,7 +919,6 @@ class FundingFeedEntrySerializer(FeedEntrySerializer):
     is_nonprofit = serializers.SerializerMethodField()
     nonprofit = serializers.SerializerMethodField()
     associated_grants = serializers.SerializerMethodField()
-    ai_peer_review = serializers.SerializerMethodField()
 
     class Meta:
         model = FeedEntry
@@ -929,7 +926,6 @@ class FundingFeedEntrySerializer(FeedEntrySerializer):
             "is_nonprofit",
             "nonprofit",
             "associated_grants",
-            "ai_peer_review",
         ]
 
     def get_nonprofit(self, obj):
@@ -952,25 +948,6 @@ class FundingFeedEntrySerializer(FeedEntrySerializer):
 
     def get_is_nonprofit(self, obj):
         return self.get_nonprofit(obj) is not None
-
-    def get_ai_peer_review(self, obj):
-        if not obj.unified_document:
-            return None
-        reviews = list(obj.unified_document.proposal_reviews.all())
-        if not reviews:
-            return None
-        completed = [r for r in reviews if r.status == Status.COMPLETED]
-        if completed:
-            review = max(
-                completed,
-                key=lambda r: (r.updated_date or r.created_date, r.id),
-            )
-        else:
-            review = max(
-                reviews,
-                key=lambda r: (r.updated_date or r.created_date, r.id),
-            )
-        return serialize_ai_peer_review_summary(review)
 
     def get_associated_grants(self, obj):
         if not obj.item or not hasattr(obj.item, "grant_applications"):

--- a/src/feed/views/funding_feed_view.py
+++ b/src/feed/views/funding_feed_view.py
@@ -111,7 +111,6 @@ class FundingFeedViewSet(FundingCacheMixin, FeedViewMixin, ModelViewSet):
                 "unified_document__hubs",
                 "unified_document__fundraises",
                 "unified_document__fundraises__nonprofit_links__nonprofit",
-                "unified_document__proposal_reviews",
                 "grant_applications__grant__unified_document__posts",
                 "grant_applications__grant__applications",
             )

--- a/src/feed/views/grant_feed_view.py
+++ b/src/feed/views/grant_feed_view.py
@@ -110,7 +110,6 @@ class GrantFeedViewSet(GrantCacheMixin, FeedViewMixin, ModelViewSet):
                         "created_by__author_profile"
                     ),
                 ),
-                "unified_document__grants__proposal_reviews",
                 "unified_document__grants__applications__applicant__author_profile",
                 Prefetch(
                     "unified_document__grants__applications__preregistration_post__unified_document__reviews",

--- a/src/purchase/serializers/grant_serializer.py
+++ b/src/purchase/serializers/grant_serializer.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
 
-from ai_peer_review.serializers import serialize_ai_peer_review_summary
 from purchase.models import Grant
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
 from researchhub.serializers import DynamicModelFieldSerializer
@@ -85,7 +84,6 @@ class DynamicGrantSerializer(DynamicModelFieldSerializer):
     def get_applications(self, grant):
         """Return grant applications with applicant and fundraise information"""
 
-        review_by_ud = {r.unified_document_id: r for r in grant.proposal_reviews.all()}
         application_data = []
         for application in grant.applications.all():
             if (
@@ -97,10 +95,6 @@ class DynamicGrantSerializer(DynamicModelFieldSerializer):
                     application.applicant.author_profile
                 ).data
 
-                ai_rev = None
-                if application.preregistration_post_id:
-                    ud = application.preregistration_post.unified_document
-                    ai_rev = review_by_ud.get(ud.id)
                 entry = {
                     "id": application.id,
                     "created_date": application.created_date,
@@ -111,7 +105,6 @@ class DynamicGrantSerializer(DynamicModelFieldSerializer):
                         else None
                     ),
                     "fundraise": self._serialize_application_fundraise(application),
-                    "ai_peer_review": serialize_ai_peer_review_summary(ai_rev),
                 }
                 application_data.append(entry)
 


### PR DESCRIPTION
- funding feed
    - Drops top-level `ai_peer_review` from `FundingFeedEntrySerializer` .
    
- grant feed
    - Removes `ai_peer_review` from each entry in `DynamicGrantSerializer.get_applications`

**Breaking**: Web app must not rely on these fields in those responses