### PR TITLE
Add unique supported-institutions to funder funding overview API

### DIFF
--- a/src/purchase/serializers/funding_overview_serializer.py
+++ b/src/purchase/serializers/funding_overview_serializer.py
@@ -36,3 +36,4 @@ class FundingOverviewSerializer(serializers.Serializer):
     matched_funds = CurrencyBreakdownSerializer()
     distributed_funds = CurrencyBreakdownSerializer()
     supported_proposals = SupportedProposalSerializer(many=True)
+    supported_institutions_count = serializers.IntegerField()

--- a/src/purchase/serializers/funding_overview_serializer.py
+++ b/src/purchase/serializers/funding_overview_serializer.py
@@ -36,4 +36,4 @@ class FundingOverviewSerializer(serializers.Serializer):
     matched_funds = CurrencyBreakdownSerializer()
     distributed_funds = CurrencyBreakdownSerializer()
     supported_proposals = SupportedProposalSerializer(many=True)
-    supported_institutions_count = serializers.IntegerField()
+    supported_institutions = serializers.ListField(child=serializers.DictField())

--- a/src/purchase/services/funding_overview_service.py
+++ b/src/purchase/services/funding_overview_service.py
@@ -1,11 +1,14 @@
 """Services for funding and grant overview dashboard metrics."""
 
+from django.db.models import Count
+
 from purchase.models import Grant, GrantApplication
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
 from purchase.services.overview_mixin import OverviewMixin
 from purchase.utils import get_funded_fundraise_ids
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 from user.models import User
+from user.related_models.author_institution import AuthorInstitution
 
 
 class FundingOverviewService(OverviewMixin):
@@ -24,6 +27,9 @@ class FundingOverviewService(OverviewMixin):
                 user.id, all_funded_ids
             ),
             "supported_proposals": self._supported_proposals(all_funded_ids),
+            "supported_institutions_count": self._distinct_supported_institution_count(
+                all_funded_ids
+            ),
         }
 
     def _grant_fundraise_ids(self, user: User) -> list[int]:
@@ -54,6 +60,25 @@ class FundingOverviewService(OverviewMixin):
         )
 
         return [self._serialize_proposal(post) for post in posts]
+
+    @staticmethod
+    def _distinct_supported_institution_count(funded_fundraise_ids: list[int]) -> int:
+        """Count distinct Institution ids for AuthorInstitution of supported proposal creators."""
+        if not funded_fundraise_ids:
+            return 0
+
+        author_ids = (
+            ResearchhubPost.objects.filter(
+                unified_document__fundraises__id__in=funded_fundraise_ids,
+                created_by__author_profile__isnull=False,
+            )
+            .values_list("created_by__author_profile__id", flat=True)
+            .distinct()
+        )
+        row = AuthorInstitution.objects.filter(author_id__in=author_ids).aggregate(
+            n=Count("institution_id", distinct=True),
+        )
+        return row["n"] or 0
 
     def _serialize_proposal(self, post: ResearchhubPost) -> dict:
         creator = post.created_by

--- a/src/purchase/services/funding_overview_service.py
+++ b/src/purchase/services/funding_overview_service.py
@@ -1,7 +1,7 @@
 """Services for funding and grant overview dashboard metrics."""
 
-from django.db.models import Count
-
+from institution.models import Institution
+from institution.serializers import DynamicInstitutionSerializer
 from purchase.models import Grant, GrantApplication
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
 from purchase.services.overview_mixin import OverviewMixin
@@ -27,7 +27,7 @@ class FundingOverviewService(OverviewMixin):
                 user.id, all_funded_ids
             ),
             "supported_proposals": self._supported_proposals(all_funded_ids),
-            "supported_institutions_count": self._distinct_supported_institution_count(
+            "supported_institutions": self._supported_institutions_serialized(
                 all_funded_ids
             ),
         }
@@ -62,10 +62,10 @@ class FundingOverviewService(OverviewMixin):
         return [self._serialize_proposal(post) for post in posts]
 
     @staticmethod
-    def _distinct_supported_institution_count(funded_fundraise_ids: list[int]) -> int:
-        """Count distinct Institution ids for AuthorInstitution of supported proposal creators."""
+    def _supported_institutions_serialized(funded_fundraise_ids: list[int]) -> list:
+        """Distinct institutions for supported proposal creators."""
         if not funded_fundraise_ids:
-            return 0
+            return []
 
         author_ids = (
             ResearchhubPost.objects.filter(
@@ -75,10 +75,21 @@ class FundingOverviewService(OverviewMixin):
             .values_list("created_by__author_profile__id", flat=True)
             .distinct()
         )
-        row = AuthorInstitution.objects.filter(author_id__in=author_ids).aggregate(
-            n=Count("institution_id", distinct=True),
+        institution_ids = (
+            AuthorInstitution.objects.filter(author_id__in=author_ids)
+            .values_list("institution_id", flat=True)
+            .distinct()
         )
-        return row["n"] or 0
+        institutions = Institution.objects.filter(id__in=institution_ids).order_by(
+            "display_name",
+            "id",
+        )
+
+        return DynamicInstitutionSerializer(
+            institutions,
+            many=True,
+            _exclude_fields=["institutions"],
+        ).data
 
     def _serialize_proposal(self, post: ResearchhubPost) -> dict:
         creator = post.created_by
@@ -91,12 +102,14 @@ class FundingOverviewService(OverviewMixin):
                 "slug": post.slug,
             },
             "id": post.id,
-            "created_by": {
-                "id": creator.id,
-                "author_profile": self._serialize_author_profile(author),
-            }
-            if creator
-            else None,
+            "created_by": (
+                {
+                    "id": creator.id,
+                    "author_profile": self._serialize_author_profile(author),
+                }
+                if creator
+                else None
+            ),
         }
 
     @staticmethod

--- a/src/purchase/tests/test_funder_view.py
+++ b/src/purchase/tests/test_funder_view.py
@@ -26,7 +26,7 @@ class FunderViewTests(APITestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.data, dict)
-        self.assertIn("supported_institutions_count", response.data)
+        self.assertIn("supported_institutions", response.data)
 
     def test_funding_overview_returns_200(self):
         self.client.force_authenticate(self.user)
@@ -35,7 +35,7 @@ class FunderViewTests(APITestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.data, dict)
-        self.assertIn("supported_institutions_count", response.data)
+        self.assertIn("supported_institutions", response.data)
 
     def test_funding_impact_requires_authentication(self):
         self.client.logout()

--- a/src/purchase/tests/test_funder_view.py
+++ b/src/purchase/tests/test_funder_view.py
@@ -26,6 +26,7 @@ class FunderViewTests(APITestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.data, dict)
+        self.assertIn("supported_institutions_count", response.data)
 
     def test_funding_overview_returns_200(self):
         self.client.force_authenticate(self.user)
@@ -34,6 +35,7 @@ class FunderViewTests(APITestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.data, dict)
+        self.assertIn("supported_institutions_count", response.data)
 
     def test_funding_impact_requires_authentication(self):
         self.client.logout()

--- a/src/purchase/tests/test_funding_overview_service.py
+++ b/src/purchase/tests/test_funding_overview_service.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
+from institution.models import Institution
 from purchase.models import Fundraise, Grant, GrantApplication, Purchase
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
 from purchase.related_models.usd_fundraise_contribution_model import UsdFundraiseContribution
@@ -12,6 +13,7 @@ from researchhub_document.related_models.constants.document_type import (
     GRANT as GRANT_DOC_TYPE,
     PREREGISTRATION,
 )
+from user.related_models.author_institution import AuthorInstitution
 from user.tests.helpers import create_random_authenticated_user
 
 
@@ -84,6 +86,7 @@ class TestFundingOverviewService(TestCase):
         self.assertEqual(result["matched_funds"], {"rsc": 0.0, "usd": 0.0})
         self.assertEqual(result["distributed_funds"], {"rsc": 0.0, "usd": 0.0})
         self.assertEqual(result["supported_proposals"], [])
+        self.assertEqual(result["supported_institutions_count"], 0)
 
     def test_distributed_funds_tracks_funder_contributions(self):
         # Arrange
@@ -142,6 +145,7 @@ class TestFundingOverviewService(TestCase):
         self.assertEqual(proposal["created_by"]["author_profile"]["id"], author.id)
         self.assertEqual(proposal["created_by"]["author_profile"]["first_name"], author.first_name)
         self.assertEqual(proposal["created_by"]["author_profile"]["last_name"], author.last_name)
+        self.assertEqual(result["supported_institutions_count"], 0)
 
     def test_supported_proposals_empty_when_not_funded(self):
         # Arrange
@@ -152,6 +156,91 @@ class TestFundingOverviewService(TestCase):
 
         # Assert
         self.assertEqual(result["supported_proposals"], [])
+        self.assertEqual(result["supported_institutions_count"], 0)
+
+    def test_supported_institutions_count_one_linked_institution(self):
+        _, proposal_post, fundraise, applicant = self._create_grant_with_proposal()
+        institution = Institution.objects.create(
+            openalex_id="https://openalex.org/S1234567890",
+            ror_id="https://ror.org/00test0001",
+            display_name="Test University",
+            type="education",
+            associated_institutions=[],
+        )
+        AuthorInstitution.objects.create(
+            author=applicant.author_profile,
+            institution=institution,
+            years=[],
+        )
+        self._contribute(self.user, fundraise, rsc=100)
+
+        result = self.service.get_funding_overview(self.user)
+
+        self.assertEqual(result["supported_institutions_count"], 1)
+
+    def test_supported_institutions_count_dedupes_same_institution_across_pis(self):
+        """Two funded proposals / two PIs linked to the same Institution count once."""
+        applicant1 = create_random_authenticated_user("pi_one")
+        applicant2 = create_random_authenticated_user("pi_two")
+        institution = Institution.objects.create(
+            openalex_id="https://openalex.org/Sshared0001",
+            ror_id="https://ror.org/00shared01",
+            display_name="Shared Lab",
+            type="facility",
+            associated_institutions=[],
+        )
+        AuthorInstitution.objects.create(
+            author=applicant1.author_profile,
+            institution=institution,
+            years=[],
+        )
+        AuthorInstitution.objects.create(
+            author=applicant2.author_profile,
+            institution=institution,
+            years=[],
+        )
+
+        grant_post = create_post(created_by=self.user, document_type=GRANT_DOC_TYPE)
+        grant = Grant.objects.create(
+            created_by=self.user,
+            unified_document=grant_post.unified_document,
+            amount=Decimal("2000"),
+            status=Grant.OPEN,
+        )
+
+        proposal1 = create_post(created_by=applicant1, document_type=PREREGISTRATION)
+        fr1 = Fundraise.objects.create(
+            created_by=applicant1,
+            unified_document=proposal1.unified_document,
+            goal_amount=Decimal("500"),
+            goal_currency="USD",
+        )
+        GrantApplication.objects.create(
+            grant=grant,
+            preregistration_post=proposal1,
+            applicant=applicant1,
+        )
+
+        proposal2 = create_post(created_by=applicant2, document_type=PREREGISTRATION)
+        fr2 = Fundraise.objects.create(
+            created_by=applicant2,
+            unified_document=proposal2.unified_document,
+            goal_amount=Decimal("500"),
+            goal_currency="USD",
+        )
+        GrantApplication.objects.create(
+            grant=grant,
+            preregistration_post=proposal2,
+            applicant=applicant2,
+        )
+
+        self._contribute(self.user, fr1, rsc=50)
+        self._contribute(self.user, fr2, rsc=50)
+
+        result = self.service.get_funding_overview(self.user)
+
+        self.assertEqual(len(result["supported_proposals"]), 2)
+        self.assertEqual(result["supported_institutions_count"], 1)
 
     def test_supported_proposals_deduplicates_by_post(self):
         # Arrange
@@ -194,3 +283,4 @@ class TestFundingOverviewService(TestCase):
 
         # Assert
         self.assertEqual(len(result["supported_proposals"]), 1)
+        self.assertEqual(result["supported_institutions_count"], 0)

--- a/src/purchase/tests/test_funding_overview_service.py
+++ b/src/purchase/tests/test_funding_overview_service.py
@@ -6,13 +6,15 @@ from django.test import TestCase
 from institution.models import Institution
 from purchase.models import Fundraise, Grant, GrantApplication, Purchase
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
-from purchase.related_models.usd_fundraise_contribution_model import UsdFundraiseContribution
+from purchase.related_models.usd_fundraise_contribution_model import (
+    UsdFundraiseContribution,
+)
 from purchase.services.funding_overview_service import FundingOverviewService
 from researchhub_document.helpers import create_post
 from researchhub_document.related_models.constants.document_type import (
     GRANT as GRANT_DOC_TYPE,
-    PREREGISTRATION,
 )
+from researchhub_document.related_models.constants.document_type import PREREGISTRATION
 from user.related_models.author_institution import AuthorInstitution
 from user.tests.helpers import create_random_authenticated_user
 
@@ -86,7 +88,7 @@ class TestFundingOverviewService(TestCase):
         self.assertEqual(result["matched_funds"], {"rsc": 0.0, "usd": 0.0})
         self.assertEqual(result["distributed_funds"], {"rsc": 0.0, "usd": 0.0})
         self.assertEqual(result["supported_proposals"], [])
-        self.assertEqual(result["supported_institutions_count"], 0)
+        self.assertEqual(result["supported_institutions"], [])
 
     def test_distributed_funds_tracks_funder_contributions(self):
         # Arrange
@@ -137,15 +139,21 @@ class TestFundingOverviewService(TestCase):
         self.assertEqual(len(result["supported_proposals"]), 1)
         proposal = result["supported_proposals"][0]
         self.assertEqual(proposal["id"], proposal_post.id)
-        self.assertEqual(proposal["unified_document"]["id"], proposal_post.unified_document_id)
+        self.assertEqual(
+            proposal["unified_document"]["id"], proposal_post.unified_document_id
+        )
         self.assertEqual(proposal["unified_document"]["title"], proposal_post.title)
         self.assertEqual(proposal["unified_document"]["slug"], proposal_post.slug)
         self.assertEqual(proposal["created_by"]["id"], applicant.id)
         author = applicant.author_profile
         self.assertEqual(proposal["created_by"]["author_profile"]["id"], author.id)
-        self.assertEqual(proposal["created_by"]["author_profile"]["first_name"], author.first_name)
-        self.assertEqual(proposal["created_by"]["author_profile"]["last_name"], author.last_name)
-        self.assertEqual(result["supported_institutions_count"], 0)
+        self.assertEqual(
+            proposal["created_by"]["author_profile"]["first_name"], author.first_name
+        )
+        self.assertEqual(
+            proposal["created_by"]["author_profile"]["last_name"], author.last_name
+        )
+        self.assertEqual(result["supported_institutions"], [])
 
     def test_supported_proposals_empty_when_not_funded(self):
         # Arrange
@@ -156,9 +164,9 @@ class TestFundingOverviewService(TestCase):
 
         # Assert
         self.assertEqual(result["supported_proposals"], [])
-        self.assertEqual(result["supported_institutions_count"], 0)
+        self.assertEqual(result["supported_institutions"], [])
 
-    def test_supported_institutions_count_one_linked_institution(self):
+    def test_supported_institutions_one_linked_institution(self):
         _, proposal_post, fundraise, applicant = self._create_grant_with_proposal()
         institution = Institution.objects.create(
             openalex_id="https://openalex.org/S1234567890",
@@ -176,10 +184,14 @@ class TestFundingOverviewService(TestCase):
 
         result = self.service.get_funding_overview(self.user)
 
-        self.assertEqual(result["supported_institutions_count"], 1)
+        insts = result["supported_institutions"]
+        self.assertEqual(len(insts), 1)
+        self.assertEqual(insts[0]["id"], institution.id)
+        self.assertEqual(insts[0]["display_name"], "Test University")
+        self.assertEqual(insts[0]["type"], "education")
 
-    def test_supported_institutions_count_dedupes_same_institution_across_pis(self):
-        """Two funded proposals / two PIs linked to the same Institution count once."""
+    def test_supported_institutions_dedupes_same_institution_across_pis(self):
+        """Two funded proposals / two PIs linked to the same Institution appear once."""
         applicant1 = create_random_authenticated_user("pi_one")
         applicant2 = create_random_authenticated_user("pi_two")
         institution = Institution.objects.create(
@@ -240,7 +252,8 @@ class TestFundingOverviewService(TestCase):
         result = self.service.get_funding_overview(self.user)
 
         self.assertEqual(len(result["supported_proposals"]), 2)
-        self.assertEqual(result["supported_institutions_count"], 1)
+        self.assertEqual(len(result["supported_institutions"]), 1)
+        self.assertEqual(result["supported_institutions"][0]["id"], institution.id)
 
     def test_supported_proposals_deduplicates_by_post(self):
         # Arrange
@@ -283,4 +296,6 @@ class TestFundingOverviewService(TestCase):
 
         # Assert
         self.assertEqual(len(result["supported_proposals"]), 1)
-        self.assertEqual(result["supported_institutions_count"], 0)
+        self.assertEqual(result["supported_institutions"], [])
+        self.assertEqual(len(result["supported_proposals"]), 1)
+        self.assertEqual(result["supported_institutions"], [])


### PR DESCRIPTION
What?
=====

- Extends `/api/funder/funding_overview/` with `supported_institutions_count`.