### PR TITLE
Use logging in Amplitude webhook

### DIFF
--- a/src/analytics/views/amplitude_webhook_view.py
+++ b/src/analytics/views/amplitude_webhook_view.py
@@ -67,10 +67,10 @@ class AmplitudeWebhookView(APIView):
                 status=status.HTTP_200_OK,
             )
 
-        except json.JSONDecodeError as e:
+        except json.JSONDecodeError:
             logger.exception("Invalid JSON payload")
             return Response(
-                {"message": f"Invalid JSON payload: {e}"},
+                {"message": "Invalid JSON payload"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except Exception:

--- a/src/analytics/views/amplitude_webhook_view.py
+++ b/src/analytics/views/amplitude_webhook_view.py
@@ -8,7 +8,6 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from analytics.tasks import process_amplitude_event
-from utils.sentry import log_error, log_info
 
 logger = logging.getLogger(__name__)
 
@@ -43,14 +42,14 @@ class AmplitudeWebhookView(APIView):
             if "events" in payload:
                 events = payload.get("events", [])
                 if not events:
-                    log_info("Empty events array received in webhook payload")
+                    logger.info("Empty events array received in webhook payload")
                     return Response(
                         {"message": "Empty events array"},
                         status=status.HTTP_400_BAD_REQUEST,
                     )
             else:
                 if not payload.get("event_type"):
-                    log_info("Invalid event format - missing event_type")
+                    logger.info("Invalid event format - missing event_type")
                     return Response(
                         {"message": "Invalid event format - missing event_type"},
                         status=status.HTTP_400_BAD_REQUEST,
@@ -69,14 +68,13 @@ class AmplitudeWebhookView(APIView):
             )
 
         except json.JSONDecodeError as e:
-            logger.error(f"Invalid JSON payload: {e}")
-            log_info("Invalid JSON payload received", error=e)
+            logger.exception("Invalid JSON payload")
             return Response(
                 {"message": f"Invalid JSON payload: {e}"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        except Exception as e:
-            log_error(e, message="Failed to process Amplitude webhook")
+        except Exception:
+            logger.exception("Failed to process Amplitude webhook")
             return Response(
                 {"message": "Internal server error"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
- Use logger instead of Sentry utils (error-level logs are automatically be pushed to Sentry).
- Don't reveal exception to caller (Amplitude).