### PR TITLE
Funding Opportunities no longer show removed Proposals

### DIFF
--- a/src/discussion/views.py
+++ b/src/discussion/views.py
@@ -14,6 +14,7 @@ from discussion.permissions import CensorDiscussion as CensorDiscussionPermissio
 from discussion.permissions import EditorCensorDiscussion
 from discussion.permissions import Vote as VotePermission
 from discussion.serializers import FlagSerializer, VoteSerializer
+from feed.views.grant_cache_mixin import GrantCacheMixin
 from paper.models import Paper
 from purchase.models import RscExchangeRate
 from reputation.models import Contribution
@@ -55,6 +56,8 @@ def censor(item):
     if purchases := getattr(item, "purchases", None):
         for purchase in purchases.iterator():
             purchase.actions.update(is_removed=True, display=False)
+
+    GrantCacheMixin.invalidate_if_grant_linked(getattr(item, "unified_document", None))
 
     return True
 

--- a/src/feed/filters.py
+++ b/src/feed/filters.py
@@ -219,7 +219,10 @@ class FundOrderingFilter(OrderingFilter):
             return queryset.annotate(
                 application_count=Count(
                     "unified_document__grants__applications",
-                    distinct=True
+                    distinct=True,
+                    filter=Q(
+                        unified_document__grants__applications__preregistration_post__unified_document__is_removed=False
+                    ),
                 )
             ).order_by("-application_count", "-created_date")
         else:

--- a/src/feed/tests/views/test_grant_feed_view.py
+++ b/src/feed/tests/views/test_grant_feed_view.py
@@ -736,3 +736,93 @@ class GrantFeedViewTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         titles = [r["content_object"]["title"] for r in response.data["results"]]
         self.assertEqual(titles, ["Pending Grant"])
+
+    def test_removed_proposals_excluded_from_applications(self):
+        """Censored proposals must not appear in a grant's applications list."""
+        # Arrange
+        applicant1 = create_random_authenticated_user("app_removed_1")
+        applicant2 = create_random_authenticated_user("app_removed_2")
+        post1 = create_post(
+            created_by=applicant1, document_type=PREREGISTRATION, title="Visible"
+        )
+        post2 = create_post(
+            created_by=applicant2, document_type=PREREGISTRATION, title="Removed"
+        )
+        GrantApplication.objects.create(
+            grant=self.open_grant, preregistration_post=post1, applicant=applicant1
+        )
+        GrantApplication.objects.create(
+            grant=self.open_grant, preregistration_post=post2, applicant=applicant2
+        )
+        post2.unified_document.is_removed = True
+        post2.unified_document.save()
+        self.client.force_authenticate(self.user)
+
+        # Act
+        response = self.client.get("/api/grant_feed/")
+
+        # Assert
+        grant_entry = next(
+            e for e in response.data["results"]
+            if e["content_object"]["id"] == self.open_post.id
+        )
+        applications = grant_entry["content_object"]["grant"]["applications"]
+        self.assertEqual(len(applications), 1)
+        self.assertEqual(applications[0]["preregistration_post_id"], post1.id)
+
+    def test_most_applicants_sorting_excludes_removed(self):
+        """most_applicants ordering must not count removed proposals."""
+        # Arrange
+        applicant = create_random_authenticated_user("sort_applicant")
+        visible = create_post(
+            created_by=applicant, document_type=PREREGISTRATION, title="Visible"
+        )
+        removed = create_post(
+            created_by=applicant, document_type=PREREGISTRATION, title="Removed"
+        )
+        GrantApplication.objects.create(
+            grant=self.closed_grant, preregistration_post=visible, applicant=applicant
+        )
+        GrantApplication.objects.create(
+            grant=self.open_grant, preregistration_post=removed, applicant=applicant
+        )
+        removed.unified_document.is_removed = True
+        removed.unified_document.save()
+        self.client.force_authenticate(self.user)
+
+        # Act
+        response = self.client.get("/api/grant_feed/?ordering=-most_applicants")
+
+        # Assert — closed_grant (1 visible) ranks above open_grant (0 visible)
+        titles = [r["content_object"]["title"] for r in response.data["results"]]
+        self.assertLess(titles.index("Closed Grant"), titles.index("Open Grant"))
+
+    def test_invalidate_if_grant_linked(self):
+        """invalidate_if_grant_linked clears cache for grant-linked docs only."""
+        from feed.views.grant_cache_mixin import GrantCacheMixin
+
+        # Arrange
+        applicant = create_random_authenticated_user("cache_applicant")
+        proposal = create_post(
+            created_by=applicant, document_type=PREREGISTRATION, title="Proposal"
+        )
+        unrelated = create_post(
+            created_by=self.user, document_type=PREREGISTRATION, title="Unrelated"
+        )
+        GrantApplication.objects.create(
+            grant=self.open_grant, preregistration_post=proposal, applicant=applicant
+        )
+        self.client.force_authenticate(self.user)
+        self.client.get("/api/grant_feed/")
+        cache_key = (
+            f"grants_feed:popular:all:all:none:1-{FeedPagination.page_size}::"
+        )
+        self.assertIsNotNone(cache.get(cache_key))
+
+        # Act + Assert — unrelated doc does not clear cache
+        GrantCacheMixin.invalidate_if_grant_linked(unrelated.unified_document)
+        self.assertIsNotNone(cache.get(cache_key))
+
+        # Act + Assert — grant-linked doc clears cache
+        GrantCacheMixin.invalidate_if_grant_linked(proposal.unified_document)
+        self.assertIsNone(cache.get(cache_key))

--- a/src/feed/views/grant_cache_mixin.py
+++ b/src/feed/views/grant_cache_mixin.py
@@ -1,6 +1,8 @@
 from django.core.cache import cache
 
 from feed.views.common import FeedPagination
+from feed.views.funding_cache_mixin import FundingCacheMixin
+from purchase.models import GrantApplication
 from researchhub_document.related_models.constants.document_type import GRANT
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 
@@ -42,3 +44,16 @@ class GrantCacheMixin:
                             f"{page}-{page_size}{sort_part}:{status}:{created_by}"
                         )
                         cache.delete(cache_key)
+
+    @staticmethod
+    def invalidate_if_grant_linked(unified_document):
+        if unified_document is None:
+            return
+        if (
+            unified_document.grants.exists()
+            or GrantApplication.objects.filter(
+                preregistration_post__unified_document=unified_document
+            ).exists()
+        ):
+            GrantCacheMixin.invalidate_grant_feed_cache()
+            FundingCacheMixin.invalidate_funding_feed_cache()

--- a/src/purchase/serializers/grant_serializer.py
+++ b/src/purchase/serializers/grant_serializer.py
@@ -89,19 +89,19 @@ class DynamicGrantSerializer(DynamicModelFieldSerializer):
         review_by_ud = {r.unified_document_id: r for r in grant.proposal_reviews.all()}
         application_data = []
         for application in grant.applications.all():
-            if (
-                application.applicant
-                and hasattr(application.applicant, "author_profile")
-                and application.applicant.author_profile
-            ):
-                applicant_data = DynamicAuthorSerializer(
-                    application.applicant.author_profile
-                ).data
+            author_profile = getattr(application.applicant, "author_profile", None)
+            if not author_profile:
+                continue
 
-                entry = {
+            ud = getattr(application.preregistration_post, "unified_document", None)
+            if ud and ud.is_removed:
+                continue
+
+            application_data.append(
+                {
                     "id": application.id,
                     "created_date": application.created_date,
-                    "applicant": applicant_data,
+                    "applicant": DynamicAuthorSerializer(author_profile).data,
                     "preregistration_post_id": (
                         application.preregistration_post.id
                         if application.preregistration_post
@@ -112,7 +112,7 @@ class DynamicGrantSerializer(DynamicModelFieldSerializer):
                         application, review_by_ud
                     ),
                 }
-                application_data.append(entry)
+            )
 
         return application_data
 

--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -9,6 +9,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from discussion.models import Vote
 from discussion.serializers import VoteSerializer
+from feed.views.grant_cache_mixin import GrantCacheMixin
 from paper.models import Paper
 from researchhub_document.filters import UnifiedDocumentFilter
 from researchhub_document.models import ResearchhubPost, ResearchhubUnifiedDocument
@@ -72,6 +73,8 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
             action.display = False
             action.save()
 
+        GrantCacheMixin.invalidate_if_grant_linked(doc)
+
         return Response(self.get_serializer(instance=doc).data, status=200)
 
     @action(
@@ -94,6 +97,8 @@ class ResearchhubUnifiedDocumentViewSet(ModelViewSet):
             action.is_removed = False
             action.display = True
             action.save()
+
+        GrantCacheMixin.invalidate_if_grant_linked(doc)
 
         return Response(self.get_serializer(instance=doc).data, status=200)
 


### PR DESCRIPTION
## Overview ##

This PR updates the grant feed for funding opportunities to no longer show deleted/removed proposals.  It also updates the cache during the delete/removal process so stale deleted data won't show under funding opportunities.