### PR TITLE
Add handlers for SES events

### DIFF
--- a/src/research_ai/signals.py
+++ b/src/research_ai/signals.py
@@ -1,13 +1,19 @@
+import logging
+
 from django.contrib.auth import get_user_model
+from django.db.models import F
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from django.utils.dateparse import parse_datetime
+from django_ses.signals import bounce_received, open_received
 
-from research_ai.models import DocumentInvitedExpert
+from research_ai.models import DocumentInvitedExpert, GeneratedEmail
 from research_ai.services.invited_experts_service import (
     get_document_invite_candidates_for_email,
 )
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
 @receiver(
@@ -43,3 +49,66 @@ def on_user_created_maybe_add_document_invited_expert(
                 "generated_email_id": generated_email_id,
             },
         )
+
+
+@receiver(open_received)
+def handle_ses_open_event(
+    sender: object,
+    mail_obj: dict | None,
+    open_obj: dict | None,
+    **kwargs,
+) -> None:
+    """
+    Handle SES open event.
+    """
+    ses_message_id = (mail_obj or {}).get("messageId", "")
+    email = _get_generated_email(ses_message_id)
+    if email is None:
+        return
+
+    # Set opened timestamp and increment open count.
+    open_timestamp = parse_datetime((open_obj or {}).get("timestamp", ""))
+    update_kwargs: dict = {"open_count": F("open_count") + 1}
+    if email.opened_at is None and open_timestamp:
+        update_kwargs["opened_at"] = open_timestamp
+
+    GeneratedEmail.objects.filter(id=email.id).update(**update_kwargs)
+
+
+@receiver(bounce_received)
+def handle_ses_bounce_event(
+    sender: object,
+    mail_obj: dict | None,
+    bounce_obj: dict | None,
+    **kwargs,
+) -> None:
+    """
+    Handle SES bounce event.
+    """
+    ses_message_id = (mail_obj or {}).get("messageId", "")
+    email = _get_generated_email(ses_message_id)
+    if email is None:
+        return
+
+    # Set status to bounced and record bounce timestamp.
+    bounce_timestamp = parse_datetime((bounce_obj or {}).get("timestamp", ""))
+    GeneratedEmail.objects.filter(id=email.id).update(
+        status=GeneratedEmail.Status.BOUNCED,
+        bounced_at=bounce_timestamp,
+    )
+
+
+def _get_generated_email(ses_message_id: str) -> GeneratedEmail | None:
+    """
+    Look up a `GeneratedEmail` by SES MessageId.
+    Returns `None` if not found or on lookup failure.
+    """
+    if not ses_message_id:
+        return None
+    try:
+        return GeneratedEmail.objects.get(ses_message_id=ses_message_id)
+    except GeneratedEmail.DoesNotExist:
+        return None
+    except GeneratedEmail.MultipleObjectsReturned:
+        logger.error("Multiple GeneratedEmail for SES message ID=%s", ses_message_id)
+        return None

--- a/src/research_ai/signals.py
+++ b/src/research_ai/signals.py
@@ -92,7 +92,10 @@ def handle_ses_bounce_event(
 
     # Set status to bounced and record bounce timestamp.
     bounce_timestamp = parse_datetime((bounce_obj or {}).get("timestamp", ""))
-    GeneratedEmail.objects.filter(id=email.id).update(
+    GeneratedEmail.objects.filter(
+        id=email.id,
+        status=GeneratedEmail.Status.SENT,
+    ).update(
         status=GeneratedEmail.Status.BOUNCED,
         bounced_at=bounce_timestamp,
     )

--- a/src/research_ai/tests/test_signals.py
+++ b/src/research_ai/tests/test_signals.py
@@ -69,3 +69,16 @@ class SesEventSignalTests(TestCase):
         self.email.refresh_from_db()
         self.assertEqual(self.email.status, GeneratedEmail.Status.BOUNCED)
         self.assertIsNotNone(self.email.bounced_at)
+
+    def test_bounce_does_not_reopen_closed_email(self):
+        # Arrange
+        self.email.status = GeneratedEmail.Status.CLOSED
+        self.email.save(update_fields=["status"])
+
+        # Act
+        self._send_bounce()
+
+        # Assert
+        self.email.refresh_from_db()
+        self.assertEqual(self.email.status, GeneratedEmail.Status.CLOSED)
+        self.assertIsNone(self.email.bounced_at)

--- a/src/research_ai/tests/test_signals.py
+++ b/src/research_ai/tests/test_signals.py
@@ -1,0 +1,71 @@
+from django.test import TestCase
+from django_ses.signals import bounce_received, open_received
+
+from research_ai.models import GeneratedEmail
+from user.tests.helpers import create_random_authenticated_user
+
+
+class SesEventSignalTests(TestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("ses_events")
+        self.email = GeneratedEmail.objects.create(
+            created_by=self.user,
+            expert_email="expert@researchhub.com",
+            email_subject="subject1",
+            email_body="body1",
+            ses_message_id="messageId1",
+            status=GeneratedEmail.Status.SENT,
+        )
+
+    def _send_open(self, message_id="messageId1", timestamp="2026-05-01T12:00:00.000Z"):
+        open_received.send(
+            sender=self.__class__,
+            mail_obj={"messageId": message_id},
+            open_obj={"timestamp": timestamp},
+            raw_message=b"",
+        )
+
+    def _send_bounce(
+        self, message_id="messageId1", timestamp="2026-05-01T12:00:00.000Z"
+    ):
+        bounce_received.send(
+            sender=self.__class__,
+            mail_obj={"messageId": message_id},
+            bounce_obj={
+                "timestamp": timestamp,
+                "bouncedRecipients": [{"emailAddress": "expert@researchhub.com"}],
+            },
+            raw_message=b"",
+        )
+
+    def test_first_open_sets_opened_at_and_increments_count(self):
+        # Act
+        self._send_open()
+
+        # Assert
+        self.email.refresh_from_db()
+        self.assertEqual(self.email.open_count, 1)
+        self.assertIsNotNone(self.email.opened_at)
+
+    def test_subsequent_opens_increment_count_but_keep_first_opened_at(self):
+        # Arrange
+        self._send_open(timestamp="2026-05-01T12:00:00.000Z")
+        self.email.refresh_from_db()
+        first_opened_at = self.email.opened_at
+
+        # Act
+        self._send_open(timestamp="2026-05-02T15:00:00.000Z")
+
+        # Assert
+        self.email.refresh_from_db()
+        self.assertEqual(self.email.open_count, 2)
+        self.assertEqual(self.email.opened_at, first_opened_at)
+
+    def test_bounce_sets_status_and_timestamp(self):
+        # Act
+        self._send_bounce()
+
+        # Assert
+        self.email.refresh_from_db()
+        self.assertEqual(self.email.status, GeneratedEmail.Status.BOUNCED)
+        self.assertIsNotNone(self.email.bounced_at)


### PR DESCRIPTION
Handle SES events for open and bounce by updating the corresponding generated emails (identified by their SES message ID).