### PR TITLE
[expert-finder] 7 - async signup signal to store as invited

### DIFF
--- a/src/research_ai/management/commands/migrate_expert_results_to_models.py
+++ b/src/research_ai/management/commands/migrate_expert_results_to_models.py
@@ -1,0 +1,109 @@
+"""
+Backfill ``Expert`` and ``SearchExpert`` from legacy ``ExpertSearch.expert_results``.
+
+Uses ``expert_results_legacy_migration`` (MIGRATION-ONLY heuristics) and
+``ExpertPersist.replace_search_experts_for_search``. Safe to re-run with
+``--force-replace``; default skips searches that already have ``SearchExpert`` rows.
+"""
+
+from django.core.management.base import BaseCommand
+from django.db.models import Count
+
+from research_ai.models import ExpertSearch
+from research_ai.services.expert_persist import ExpertPersist
+from research_ai.services.expert_results_legacy_migration import (
+    legacy_expert_results_to_persist_rows,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Backfill Expert + SearchExpert rows from ExpertSearch.expert_results JSON. "
+        "Skips searches with no expert_results rows. By default skips searches that "
+        "already have SearchExpert links unless --force-replace is set."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report counts and actions without writing to the database.",
+        )
+        parser.add_argument(
+            "--force-replace",
+            action="store_true",
+            help="Replace SearchExpert links from expert_results even if links already exist.",
+        )
+        parser.add_argument(
+            "--search-id",
+            type=int,
+            default=None,
+            help="Only process the given ExpertSearch primary key.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Process at most this many searches (stable order by id ascending).",
+        )
+
+    def handle(self, *args, **options):
+        dry_run: bool = options["dry_run"]
+        force_replace: bool = options["force_replace"]
+        search_id: int | None = options["search_id"]
+        limit: int | None = options["limit"]
+
+        qs = ExpertSearch.objects.annotate(
+            _se_count=Count("search_experts", distinct=True)
+        ).order_by("id")
+
+        if search_id is not None:
+            qs = qs.filter(id=search_id)
+
+        if not force_replace:
+            qs = qs.filter(_se_count=0)
+
+        candidates = []
+        for search in qs.iterator():
+            raw = search.expert_results
+            if not isinstance(raw, list) or len(raw) == 0:
+                continue
+            rows = legacy_expert_results_to_persist_rows(raw)
+            if not rows:
+                continue
+            candidates.append((search, rows))
+            if limit is not None and len(candidates) >= limit:
+                break
+
+        self.stdout.write(
+            f"Searches to migrate: {len(candidates)} "
+            f"(dry_run={dry_run}, force_replace={force_replace})"
+        )
+
+        if dry_run:
+            for search, rows in candidates:
+                self.stdout.write(
+                    f"  would migrate search_id={search.id} "
+                    f"legacy_items={len(search.expert_results)} "
+                    f"valid_rows={len(rows)}"
+                )
+            self.stdout.write(self.style.WARNING("Dry run — no database writes."))
+            return
+
+        migrated = 0
+        experts_linked = 0
+        for search, rows in candidates:
+            n = ExpertPersist.replace_search_experts_for_search(search.id, rows)
+            migrated += 1
+            experts_linked += n
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"migrated search_id={search.id} search_expert_rows={n}"
+                )
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done. Searches migrated: {migrated}, SearchExpert rows written: {experts_linked}."
+            )
+        )

--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -261,14 +261,23 @@ class ResearchAIAuthorSerializer(serializers.ModelSerializer):
         return None
 
 
+def _get_user_with_author_payload(user):
+    """
+    Build ``{ user_id, author }`` for a ``User``.
+    Returns ``None`` if ``user`` is None.
+    """
+    if user is None:
+        return None
+    author = getattr(user, "author_profile", None)
+    author_data = ResearchAIAuthorSerializer(author).data if author else None
+    return {"user_id": user.id, "author": author_data}
+
+
 def _get_created_by_payload(obj):
     """
     Build { user_id: int, author: {...} } for list/detail responses.
     """
-    created_by = obj.created_by
-    author = getattr(created_by, "author_profile", None)
-    author_data = ResearchAIAuthorSerializer(author).data if author else None
-    return {"user_id": created_by.id, "author": author_data}
+    return _get_user_with_author_payload(obj.created_by)
 
 
 def resolve_work_for_unified_document(unified_doc, context=None):
@@ -500,6 +509,23 @@ class InvitedExpertSerializer(serializers.Serializer):
         if author is None:
             return None
         return SimpleAuthorSerializer(author).data
+
+    def get_expert_search_id(self, obj):
+        return obj.expert_search_id
+
+    def get_generated_email_id(self, obj):
+        return obj.generated_email_id
+
+
+class InvitedExpertSerializerV2(serializers.Serializer):
+
+    user = serializers.SerializerMethodField()
+    expert_search_id = serializers.SerializerMethodField()
+    generated_email_id = serializers.SerializerMethodField()
+    invited_at = serializers.DateTimeField(source="created_date", read_only=True)
+
+    def get_user(self, obj):
+        return _get_user_with_author_payload(getattr(obj, "user", None))
 
     def get_expert_search_id(self, obj):
         return obj.expert_search_id

--- a/src/research_ai/services/expert_finder_json.py
+++ b/src/research_ai/services/expert_finder_json.py
@@ -26,7 +26,7 @@ class ExpertFinderJson:
         return True
 
     @staticmethod
-    def _normalize_sources(raw: Any) -> list[dict[str, str]]:
+    def normalize_sources(raw: Any) -> list[dict[str, str]]:
         if not isinstance(raw, list):
             return []
         out: list[dict[str, str]] = []
@@ -108,7 +108,7 @@ class ExpertFinderJson:
                 "affiliation": trimmed_str(row.get("affiliation", "")),
                 "expertise": trimmed_str(row.get("expertise", "")),
                 "notes": trimmed_str(row.get("notes", "")),
-                "sources": ExpertFinderJson._normalize_sources(row.get("sources")),
+                "sources": ExpertFinderJson.normalize_sources(row.get("sources")),
             }
             out.append(row_dict)
 

--- a/src/research_ai/services/expert_results_legacy_migration.py
+++ b/src/research_ai/services/expert_results_legacy_migration.py
@@ -1,0 +1,228 @@
+"""
+MIGRATION-ONLY: map legacy ``ExpertSearch.expert_results`` JSON rows to dicts for
+``ExpertPersist.upsert_from_parsed_dict``. Remove this module when v1 expert
+finder and ``expert_results`` storage are deleted (see strangler plan PR9).
+
+Legacy v1 rows (markdown table pipeline) use keys: ``name``, ``title``,
+``affiliation``, ``expertise``, ``email``, ``notes``, ``sources``. Structured
+name fields are absent; ``title`` maps to ``Expert.academic_title``.
+
+**Name splitting (heuristic, backfill-only):** There is no reliable inverse of
+a free-form ``name`` string. This code applies small, deterministic rules so
+rows are *mostly* usable for display and dedupe by email:
+
+- Strip a short trailing segment after the last comma when it looks like a
+  credential suffix (e.g. ``", PhD"``, ``", M.D."``).
+- Strip a leading honorific token when it matches a small allowlist
+  (Dr., Prof., Professor, Mr./Ms./Mrs., etc.).
+- If the remainder contains a comma, treat it as ``Last, First [Middle]``:
+  everything before the first comma is ``last_name``; after the comma, first
+  token is ``first_name``, rest is ``middle_name``.
+- Otherwise split on whitespace: one token → ``last_name`` only; two →
+  ``first_name``, ``last_name``; three → ``first``, ``middle``, ``last``;
+  four or more → ``first``, ``middle`` = middle tokens joined, ``last`` = last
+  token.
+
+Wrong splits are acceptable for a one-time backfill; operators can fix
+individual ``Expert`` rows afterward. Rows already containing structured keys
+(``first_name``, ``last_name``, ``honorific``, ``academic_title``) are merged
+with legacy keys so partially filled JSON still migrates.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+
+from research_ai.services.expert_display import ExpertDisplay
+from research_ai.services.expert_finder_json import ExpertFinderJson
+from research_ai.utils import trimmed_str
+
+# Leading tokens treated as honorific (comparison is case-insensitive, period optional).
+_HONORIFIC_PREFIXES: frozenset[str] = frozenset(
+    {
+        "dr",
+        "prof",
+        "professor",
+        "mr",
+        "mrs",
+        "ms",
+        "miss",
+        "sir",
+        "dame",
+    }
+)
+
+_SUFFIX_AFTER_COMMA = re.compile(
+    r"^(ph\.?d\.?|m\.?d\.?|d\.?d\.?s\.?|jr\.?|sr\.?|ii|iii|iv|esq\.?)$",
+    re.IGNORECASE,
+)
+
+
+def _token_key(t: str) -> str:
+    return t.strip().rstrip(".").lower()
+
+
+def _strip_trailing_comma_suffix(display: str) -> tuple[str, str]:
+    """If ``display`` ends with ``, <short suffix>``, drop suffix for name parsing."""
+    display = display.strip()
+    if "," not in display:
+        return display, ""
+    left, right = display.rsplit(",", 1)
+    right_stripped = right.strip()
+    if not right_stripped or len(right_stripped) > 32 or " " in right_stripped:
+        return display, ""
+    if _SUFFIX_AFTER_COMMA.match(right_stripped):
+        return left.strip(), right_stripped
+    return display, ""
+
+
+def _strip_leading_honorific(tokens: list[str]) -> tuple[str, list[str]]:
+    honorific = ""
+    if not tokens:
+        return honorific, tokens
+    key = _token_key(tokens[0])
+    if key in _HONORIFIC_PREFIXES:
+        honorific = tokens[0]
+        return honorific, tokens[1:]
+    return honorific, tokens
+
+
+def _split_core_name_tokens(tokens: list[str]) -> tuple[str, str, str]:
+    """Return first_name, middle_name, last_name from whitespace tokens."""
+    if not tokens:
+        return "", "", ""
+    core = " ".join(tokens).strip()
+    if "," in core:
+        left, right = core.split(",", 1)
+        last_chunk = left.strip()
+        right_tokens = right.split()
+        if last_chunk and right_tokens:
+            return (
+                right_tokens[0],
+                " ".join(right_tokens[1:]).strip(),
+                last_chunk,
+            )
+    n = len(tokens)
+    if n == 1:
+        return "", "", tokens[0]
+    if n == 2:
+        return tokens[0], "", tokens[1]
+    if n == 3:
+        return tokens[0], tokens[1], tokens[2]
+    return tokens[0], " ".join(tokens[1:-1]), tokens[-1]
+
+
+def split_legacy_display_name_for_migration(display_name: str) -> dict[str, str]:
+    """
+    Best-effort structured name fields from a legacy ``name`` string.
+
+    See module docstring for limitations. Intended only for backfill.
+    """
+    body, comma_suffix = _strip_trailing_comma_suffix((display_name or "").strip())
+    honorific, tokens = _strip_leading_honorific(body.split())
+    first, middle, last = _split_core_name_tokens(tokens)
+    name_suffix = comma_suffix
+    return {
+        "honorific": honorific,
+        "first_name": first,
+        "middle_name": middle,
+        "last_name": last,
+        "name_suffix": name_suffix,
+    }
+
+
+def _email_ok(email: str) -> bool:
+    if not email:
+        return False
+    try:
+        validate_email(email)
+    except ValidationError:
+        return False
+    return True
+
+
+def legacy_expert_result_row_to_parsed_dict(row: Any) -> dict[str, Any] | None:
+    """
+    Convert one legacy ``expert_results`` element to a dict for
+    ``ExpertPersist.upsert_from_parsed_dict``.
+
+    Returns ``None`` if the row is unusable (not a dict, missing/invalid email).
+    """
+    if not isinstance(row, dict):
+        return None
+
+    email = ExpertDisplay.normalize_email(trimmed_str(row.get("email", "")))
+    if not email or not _email_ok(email):
+        return None
+
+    has_structured = any(
+        trimmed_str(row.get(k, ""))
+        for k in ("first_name", "last_name", "honorific", "academic_title")
+    )
+
+    parsed_from_name = split_legacy_display_name_for_migration(
+        trimmed_str(row.get("name", ""))
+    )
+
+    if has_structured:
+        parts = {
+            "honorific": trimmed_str(row.get("honorific", ""), max_len=64)
+            or parsed_from_name["honorific"],
+            "first_name": trimmed_str(row.get("first_name", ""), max_len=255)
+            or parsed_from_name["first_name"],
+            "middle_name": trimmed_str(row.get("middle_name", ""), max_len=255)
+            or parsed_from_name["middle_name"],
+            "last_name": trimmed_str(row.get("last_name", ""), max_len=255)
+            or parsed_from_name["last_name"],
+            "name_suffix": trimmed_str(row.get("name_suffix", ""), max_len=64)
+            or parsed_from_name["name_suffix"],
+        }
+    else:
+        parts = parsed_from_name
+
+    academic = trimmed_str(row.get("academic_title", ""), max_len=255)
+    if not academic:
+        academic = trimmed_str(row.get("title", ""), max_len=255)
+
+    return {
+        "email": email,
+        "honorific": parts["honorific"],
+        "first_name": parts["first_name"],
+        "middle_name": parts["middle_name"],
+        "last_name": parts["last_name"],
+        "name_suffix": parts["name_suffix"],
+        "academic_title": academic,
+        "affiliation": trimmed_str(row.get("affiliation", "")),
+        "expertise": trimmed_str(row.get("expertise", "")),
+        "notes": trimmed_str(row.get("notes", "")),
+        "sources": ExpertFinderJson.normalize_sources(row.get("sources")),
+    }
+
+
+def legacy_expert_results_to_persist_rows(
+    expert_results: Any,
+) -> list[dict[str, Any]]:
+    """
+    Map ``ExpertSearch.expert_results`` (legacy JSON list) to ordered, de-duplicated
+    rows for ``ExpertPersist.replace_search_experts_for_search``. First row wins
+    per normalized email.
+    """
+    if not isinstance(expert_results, list):
+        return []
+
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in expert_results:
+        parsed = legacy_expert_result_row_to_parsed_dict(item)
+        if parsed is None:
+            continue
+        em = parsed["email"]
+        if em in seen:
+            continue
+        seen.add(em)
+        out.append(parsed)
+    return out

--- a/src/research_ai/services/invited_experts_service.py
+++ b/src/research_ai/services/invited_experts_service.py
@@ -1,8 +1,70 @@
 from datetime import timedelta
 
-from research_ai.models import GeneratedEmail
+from django.db.models import Exists, OuterRef
+from django.utils import timezone
+
+from research_ai.constants import EXPERT_REGISTERED_USER_LINK_WINDOW_DAYS
+from research_ai.models import DocumentInvitedExpert, Expert, GeneratedEmail
 
 INVITE_WINDOW_DAYS = 7
+
+
+def link_experts_registered_user_for_signup(*, normalized_email: str, user) -> int:
+    """
+    Set ``Expert.registered_user`` for rows matching the signup email when a qualifying
+    ``GeneratedEmail`` exists in the link window.
+    """
+    email = (normalized_email or "").strip().lower()
+    if not email:
+        return 0
+
+    date_joined = getattr(user, "date_joined", None) or timezone.now()
+    window_end = date_joined
+    window_start = window_end - timedelta(days=EXPERT_REGISTERED_USER_LINK_WINDOW_DAYS)
+
+    qualifying_ge = GeneratedEmail.objects.filter(
+        expert_email__iexact=OuterRef("email"),
+        created_date__gte=window_start,
+        created_date__lte=window_end,
+    ).exclude(status=GeneratedEmail.Status.CLOSED)
+
+    return (
+        Expert.objects.filter(
+            email__iexact=email,
+            registered_user__isnull=True,
+        )
+        .filter(Exists(qualifying_ge))
+        .update(registered_user_id=user.id)
+    )
+
+
+def materialize_document_invited_experts_for_user(
+    *, normalized_email: str, user
+) -> None:
+    """
+    Link ``Expert`` rows for this signup email, then create ``DocumentInvitedExpert`` rows
+    for document-backed outreach within INVITE_WINDOW_DAYS.
+    """
+    email = (normalized_email or "").strip().lower()
+    if not email:
+        return
+
+    date_joined = getattr(user, "date_joined", None)
+    if not date_joined:
+        return
+
+    link_experts_registered_user_for_signup(normalized_email=email, user=user)
+
+    candidates = get_document_invite_candidates_for_email(email, date_joined)
+    for unified_document_id, expert_search_id, generated_email_id in candidates:
+        DocumentInvitedExpert.objects.get_or_create(
+            unified_document_id=unified_document_id,
+            user=user,
+            defaults={
+                "expert_search_id": expert_search_id,
+                "generated_email_id": generated_email_id,
+            },
+        )
 
 
 def get_document_invite_candidates_for_email(normalized_email, date_joined):

--- a/src/research_ai/signals.py
+++ b/src/research_ai/signals.py
@@ -2,10 +2,7 @@ from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from research_ai.models import DocumentInvitedExpert
-from research_ai.services.invited_experts_service import (
-    get_document_invite_candidates_for_email,
-)
+from research_ai.tasks import materialize_document_invited_experts_async
 
 User = get_user_model()
 
@@ -19,9 +16,8 @@ def on_user_created_maybe_add_document_invited_expert(
     sender, instance, created, **kwargs
 ):
     """
-    When a new user is created, if their email was surfaced for a document
-    in expert-finder and they joined within 7 days of that, add a
-    DocumentInvitedExpert row for that document.
+    When a new user is created, enqueue work to link ``Expert.registered_user`` when
+    outreach qualifies and to add ``DocumentInvitedExpert`` rows for matching documents.
     """
     if not created:
         return
@@ -29,17 +25,7 @@ def on_user_created_maybe_add_document_invited_expert(
     if not email:
         return
     normalized = email.lower()
-    date_joined = getattr(instance, "date_joined", None)
-    if not date_joined:
-        return
-
-    candidates = get_document_invite_candidates_for_email(normalized, date_joined)
-    for unified_document_id, expert_search_id, generated_email_id in candidates:
-        DocumentInvitedExpert.objects.get_or_create(
-            unified_document_id=unified_document_id,
-            user=instance,
-            defaults={
-                "expert_search_id": expert_search_id,
-                "generated_email_id": generated_email_id,
-            },
-        )
+    materialize_document_invited_experts_async.delay(
+        normalized_email=normalized,
+        user_id=instance.pk,
+    )

--- a/src/research_ai/tasks.py
+++ b/src/research_ai/tasks.py
@@ -12,6 +12,9 @@ from research_ai.services.email_sending_service import send_plain_email
 from research_ai.services.expert_finder_service import ExpertFinderService
 from research_ai.services.expert_finder_v2 import run_v2_expert_search
 from research_ai.services.expert_persist import ExpertPersist
+from research_ai.services.invited_experts_service import (
+    materialize_document_invited_experts_for_user,
+)
 from researchhub.celery import app
 from user.models import User
 from utils import sentry
@@ -161,6 +164,29 @@ def _finalize_v2_expert_search_in_db(
         llm_model=result.get("llm_model", ""),
     )
     return False
+
+
+@app.task
+def materialize_document_invited_experts_async(
+    normalized_email: str,
+    user_id: int,
+) -> None:
+    """
+    For a newly created user: link ``Expert`` rows (``registered_user``) when outreach
+    qualifies, then create ``DocumentInvitedExpert`` rows where applicable.
+    """
+    try:
+        user = User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        logger.warning(
+            "materialize_document_invited_experts_async: user_id=%s not found",
+            user_id,
+        )
+        return
+    materialize_document_invited_experts_for_user(
+        normalized_email=normalized_email,
+        user=user,
+    )
 
 
 @app.task(bind=True)

--- a/src/research_ai/tests/test_email_views.py
+++ b/src/research_ai/tests/test_email_views.py
@@ -405,7 +405,7 @@ class BulkGenerateEmailViewV2Tests(APITestCase):
             status=ExpertSearch.Status.COMPLETED,
         )
         self.expert = Expert.objects.create(
-            email="bulklinked@edu",
+            email="bulklinked@example.edu",
             first_name="B",
             last_name="ULK",
             academic_title="PI",
@@ -426,7 +426,7 @@ class BulkGenerateEmailViewV2Tests(APITestCase):
             self.url,
             {
                 "expert_search_id": self.search.id,
-                "experts": [{"expert_email": "bulklinked@edu"}],
+                "experts": [{"expert_email": "bulklinked@example.edu"}],
                 "template": "collaboration",
             },
             format="json",
@@ -435,7 +435,7 @@ class BulkGenerateEmailViewV2Tests(APITestCase):
         body = r.json()
         self.assertEqual(len(body["ids"]), 1)
         rec = GeneratedEmail.objects.get(id=body["ids"][0])
-        self.assertEqual(rec.expert_email, "bulklinked@edu")
+        self.assertEqual(rec.expert_email, "bulklinked@example.edu")
         self.assertEqual(rec.expert_title, "PI")
         self.assertEqual(rec.notes, "bulk note")
         mock_bulk_task.delay.assert_called_once()

--- a/src/research_ai/tests/test_expert_email_resolution_v2.py
+++ b/src/research_ai/tests/test_expert_email_resolution_v2.py
@@ -50,7 +50,7 @@ class ResolveExpertFromSearchV2Tests(TestCase):
         out = resolve_expert_from_search_v2(self.search, " ada@uni.edu ")
         self.assertIsNotNone(out)
         assert out is not None
-        self.assertEqual(out["email"], "Ada@Uni.EDU")
+        self.assertEqual(out["email"], "ada@uni.edu")
         self.assertEqual(out["title"], "Professor")
         self.assertEqual(out["affiliation"], "Uni")
         self.assertEqual(out["expertise"], "Computing")

--- a/src/research_ai/tests/test_expert_results_legacy_migration.py
+++ b/src/research_ai/tests/test_expert_results_legacy_migration.py
@@ -1,0 +1,189 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+from research_ai.models import Expert, ExpertSearch, SearchExpert
+from research_ai.services.expert_results_legacy_migration import (
+    legacy_expert_result_row_to_parsed_dict,
+    legacy_expert_results_to_persist_rows,
+    split_legacy_display_name_for_migration,
+)
+from user.tests.helpers import create_random_authenticated_user
+
+
+class SplitLegacyDisplayNameTests(TestCase):
+    def test_last_first_comma_form(self):
+        p = split_legacy_display_name_for_migration("Smith, John")
+        self.assertEqual(p["last_name"], "Smith")
+        self.assertEqual(p["first_name"], "John")
+        self.assertEqual(p["middle_name"], "")
+
+    def test_last_first_middle_comma_form(self):
+        p = split_legacy_display_name_for_migration("Smith, John Q.")
+        self.assertEqual(p["last_name"], "Smith")
+        self.assertEqual(p["first_name"], "John")
+        self.assertEqual(p["middle_name"], "Q.")
+
+    def test_honorific_and_trailing_suffix(self):
+        p = split_legacy_display_name_for_migration("Dr. Jane Q. Public, PhD")
+        self.assertEqual(p["honorific"], "Dr.")
+        self.assertEqual(p["first_name"], "Jane")
+        self.assertEqual(p["middle_name"], "Q.")
+        self.assertEqual(p["last_name"], "Public")
+        self.assertEqual(p["name_suffix"], "PhD")
+
+    def test_two_tokens(self):
+        p = split_legacy_display_name_for_migration("Jane Public")
+        self.assertEqual(p["first_name"], "Jane")
+        self.assertEqual(p["last_name"], "Public")
+
+    def test_single_token_goes_to_last_name(self):
+        p = split_legacy_display_name_for_migration("Cher")
+        self.assertEqual(p["first_name"], "")
+        self.assertEqual(p["last_name"], "Cher")
+
+
+class LegacyExpertResultRowTests(TestCase):
+    def test_maps_title_to_academic_title(self):
+        d = legacy_expert_result_row_to_parsed_dict(
+            {
+                "name": "Dr. A",
+                "title": "Professor",
+                "affiliation": "MIT",
+                "expertise": "ML",
+                "email": "A@MIT.EDU",
+                "notes": "n",
+                "sources": [{"text": "t", "url": "https://x"}],
+            }
+        )
+        assert d is not None
+        self.assertEqual(d["email"], "a@mit.edu")
+        self.assertEqual(d["academic_title"], "Professor")
+        self.assertEqual(d["affiliation"], "MIT")
+        self.assertEqual(d["sources"], [{"text": "t", "url": "https://x"}])
+
+    def test_invalid_email_returns_none(self):
+        self.assertIsNone(
+            legacy_expert_result_row_to_parsed_dict(
+                {"name": "X", "email": "not-an-email"}
+            )
+        )
+
+    def test_prefers_structured_name_fields(self):
+        d = legacy_expert_result_row_to_parsed_dict(
+            {
+                "first_name": "Pat",
+                "last_name": "Lee",
+                "honorific": "Dr.",
+                "email": "pat@x.org",
+                "name": "Ignored Name",
+            }
+        )
+        assert d is not None
+        self.assertEqual(d["first_name"], "Pat")
+        self.assertEqual(d["last_name"], "Lee")
+        self.assertEqual(d["honorific"], "Dr.")
+
+
+class LegacyExpertResultsDedupeTests(TestCase):
+    def test_dedupes_by_email_preserving_order(self):
+        rows = legacy_expert_results_to_persist_rows(
+            [
+                {"name": "A", "email": "dup@x.com"},
+                {"name": "B", "email": "dup@x.com"},
+                {"name": "C", "email": "other@x.com"},
+            ]
+        )
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["email"], "dup@x.com")
+        self.assertEqual(rows[1]["email"], "other@x.com")
+
+
+class MigrateExpertResultsCommandTests(TestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("migrate_cmd_user")
+
+    def test_dry_run_does_not_create_search_expert(self):
+        from io import StringIO
+
+        search = ExpertSearch.objects.create(
+            created_by=self.user,
+            query="q",
+            expert_results=[
+                {
+                    "name": "Dr. Test",
+                    "title": "Prof",
+                    "affiliation": "U",
+                    "expertise": "x",
+                    "email": "tester@university.edu",
+                    "notes": "",
+                    "sources": [],
+                }
+            ],
+        )
+        call_command(
+            "migrate_expert_results_to_models",
+            dry_run=True,
+            stdout=StringIO(),
+        )
+        self.assertEqual(SearchExpert.objects.filter(expert_search=search).count(), 0)
+
+    def test_migrate_creates_expert_and_search_expert(self):
+        from io import StringIO
+
+        buf = StringIO()
+        search = ExpertSearch.objects.create(
+            created_by=self.user,
+            query="q",
+            expert_results=[
+                {
+                    "name": "Dr. Test",
+                    "title": "Prof",
+                    "affiliation": "U",
+                    "expertise": "x",
+                    "email": "migrate_one@university.edu",
+                    "notes": "",
+                    "sources": [],
+                }
+            ],
+        )
+        call_command("migrate_expert_results_to_models", stdout=buf)
+        self.assertEqual(SearchExpert.objects.filter(expert_search=search).count(), 1)
+        ex = Expert.objects.get(email="migrate_one@university.edu")
+        self.assertEqual(ex.academic_title, "Prof")
+        self.assertIn("migrated", buf.getvalue().lower())
+
+    def test_skips_when_search_expert_exists_unless_force(self):
+        from io import StringIO
+
+        search = ExpertSearch.objects.create(
+            created_by=self.user,
+            query="q",
+            expert_results=[
+                {
+                    "name": "X",
+                    "title": "",
+                    "affiliation": "",
+                    "expertise": "",
+                    "email": "exists@university.edu",
+                    "notes": "",
+                    "sources": [],
+                }
+            ],
+        )
+        expert = Expert.objects.create(email="exists@university.edu")
+        SearchExpert.objects.create(
+            expert_search=search, expert=expert, position=0
+        )
+        buf = StringIO()
+        call_command("migrate_expert_results_to_models", stdout=buf)
+        self.assertEqual(SearchExpert.objects.filter(expert_search=search).count(), 1)
+
+        buf2 = StringIO()
+        call_command(
+            "migrate_expert_results_to_models",
+            force_replace=True,
+            stdout=buf2,
+        )
+        self.assertEqual(SearchExpert.objects.filter(expert_search=search).count(), 1)
+        se = SearchExpert.objects.get(expert_search=search)
+        self.assertEqual(se.expert.email, "exists@university.edu")

--- a/src/research_ai/tests/test_invited_experts_service.py
+++ b/src/research_ai/tests/test_invited_experts_service.py
@@ -1,9 +1,9 @@
 from datetime import timedelta
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
-from research_ai.models import DocumentInvitedExpert, ExpertSearch, GeneratedEmail
+from research_ai.models import DocumentInvitedExpert, Expert, ExpertSearch, GeneratedEmail
 from research_ai.services.invited_experts_service import (
     get_document_invite_candidates_for_email,
 )
@@ -151,6 +151,7 @@ class GetDocumentInviteCandidatesForEmailTests(TestCase):
         self.assertEqual(ge_id, ge.id)
 
 
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class DocumentInvitedExpertSignalTests(TestCase):
     """Test that creating a User with matching email creates DocumentInvitedExpert."""
 
@@ -191,6 +192,36 @@ class DocumentInvitedExpertSignalTests(TestCase):
         )
         self.assertEqual(records.count(), 1)
         self.assertEqual(records.first().expert_search_id, search.id)
+
+    def test_user_created_sets_expert_registered_user_when_expert_row_exists(self):
+        first_seen = timezone.now() - timedelta(days=2)
+        search = ExpertSearch.objects.create(
+            created_by=self.creator,
+            unified_document_id=self.ud_id,
+            query="Test",
+            status=ExpertSearch.Status.COMPLETED,
+            completed_at=first_seen,
+            expert_results=[],
+        )
+        GeneratedEmail.objects.create(
+            created_by=self.creator,
+            expert_search=search,
+            expert_email="linkedexpert@example.com",
+            created_date=first_seen,
+        )
+        Expert.objects.create(
+            email="linkedexpert@example.com",
+            first_name="Link",
+            last_name="Expert",
+        )
+        new_user = create_user(
+            email="linkedexpert@example.com",
+            first_name="Link",
+            last_name="User",
+        )
+        expert = Expert.objects.get(email="linkedexpert@example.com")
+        expert.refresh_from_db()
+        self.assertEqual(expert.registered_user_id, new_user.id)
 
     def test_user_created_after_7_days_does_not_create_row(self):
         first_seen = timezone.now() - timedelta(days=10)

--- a/src/research_ai/tests/test_views.py
+++ b/src/research_ai/tests/test_views.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.test import override_settings
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -395,6 +396,71 @@ class InvitedExpertsDocumentViewTests(APITestCase):
         self.assertIn("author", item)
         self.assertIn("expert_search_id", item)
         self.assertIn("generated_email_id", item)
+
+
+class InvitedExpertsDocumentViewV2Tests(APITestCase):
+    def setUp(self):
+        self.moderator = create_random_authenticated_user("mod_inv2", moderator=True)
+        self.user = create_random_authenticated_user("user_inv2", moderator=False)
+
+    def test_v2_invited_requires_authentication(self):
+        response = self.client.get(
+            "/api/research_ai/expert-finder/v2/documents/1/invited/"
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_v2_invited_requires_moderator(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(
+            "/api/research_ai/expert-finder/v2/documents/1/invited/"
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_v2_invited_nonexistent_document_returns_404(self):
+        self.client.force_authenticate(self.moderator)
+        response = self.client.get(
+            "/api/research_ai/expert-finder/v2/documents/999999/invited/"
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_v2_invited_returns_user_and_author_not_expert_entity(self):
+        from paper.tests.helpers import create_paper
+
+        paper = create_paper(
+            title="V2 invited paper",
+            paper_publish_date="2021-01-01",
+        )
+        ud_id = paper.unified_document_id
+
+        ExpertSearch.objects.create(
+            created_by=self.moderator,
+            unified_document_id=ud_id,
+            query="Test",
+            status=ExpertSearch.Status.COMPLETED,
+            completed_at=timezone.now(),
+            expert_results=[],
+        )
+
+        DocumentInvitedExpert.objects.create(
+            unified_document_id=ud_id,
+            user=self.moderator,
+            expert_search_id=None,
+            generated_email_id=None,
+        )
+
+        self.client.force_authenticate(self.moderator)
+        response = self.client.get(
+            f"/api/research_ai/expert-finder/v2/documents/{ud_id}/invited/"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["total_count"], 1)
+        item = data["invited"][0]
+        self.assertNotIn("expert", item)
+        self.assertNotIn("author", item)
+        self.assertIn("user", item)
+        self.assertEqual(item["user"]["user_id"], self.moderator.id)
+        self.assertIsInstance(item["user"]["author"], (dict, type(None)))
 
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)

--- a/src/research_ai/urls.py
+++ b/src/research_ai/urls.py
@@ -24,6 +24,7 @@ from research_ai.views.expert_finder_views_v2 import (
     ExpertDetailViewV2,
     ExpertSearchDetailViewV2,
     ExpertSearchListCreateViewV2,
+    InvitedExpertsDocumentViewV2,
 )
 from research_ai.views.template_views import TemplateDetailView, TemplateListView
 
@@ -53,6 +54,10 @@ urlpatterns = [
     path(
         "expert-finder/v2/experts/<int:expert_id>/",
         ExpertDetailViewV2.as_view(),
+    ),
+    path(
+        "expert-finder/v2/documents/<int:unified_document_id>/invited/",
+        InvitedExpertsDocumentViewV2.as_view(),
     ),
     path(
         "expert-finder/v2/generate-email/",

--- a/src/research_ai/views/expert_finder_views_v2.py
+++ b/src/research_ai/views/expert_finder_views_v2.py
@@ -1,11 +1,13 @@
 from django.db.models import Prefetch
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from research_ai.constants import ExpertiseLevel, Gender, Region
-from research_ai.models import Expert, ExpertSearch, SearchExpert
+from research_ai.models import DocumentInvitedExpert, Expert, ExpertSearch, SearchExpert
 from research_ai.permissions import ResearchAIPermission
 from research_ai.serializers import (
     ExpertSearchCreateSerializerV2,
@@ -13,10 +15,16 @@ from research_ai.serializers import (
     ExpertSearchListItemSerializerV2,
     ExpertSerializer,
     ExpertUpdateSerializerV2,
+    InvitedExpertSerializerV2,
 )
 from research_ai.services.expert_finder_service import get_document_content
 from research_ai.tasks import run_expert_finder_search_v2
-from research_ai.views.expert_finder_views import _get_document_title, _get_sse_url
+from research_ai.views.expert_finder_views import (
+    INVITED_CACHE_SEC,
+    INVITED_LIMIT,
+    _get_document_title,
+    _get_sse_url,
+)
 from researchhub_document.models import ResearchhubUnifiedDocument
 from user.permissions import IsModerator, UserIsEditor
 
@@ -198,3 +206,46 @@ class ExpertDetailViewV2(APIView):
         ser.is_valid(raise_exception=True)
         ser.save()
         return Response(ExpertSerializer(expert).data)
+
+
+class InvitedExpertsDocumentViewV2(APIView):
+    """
+    GET ``/expert-finder/v2/documents/<unified_document_id>/invited/``.
+
+    Each row includes the invited RH account as ``user`` (``user_id`` + ``author``).
+    """
+
+    permission_classes = [
+        IsAuthenticated,
+        ResearchAIPermission,
+        UserIsEditor | IsModerator,
+    ]
+
+    @method_decorator(cache_page(INVITED_CACHE_SEC))
+    def get(self, request, unified_document_id):
+        try:
+            ResearchhubUnifiedDocument.objects.get(id=unified_document_id)
+        except ResearchhubUnifiedDocument.DoesNotExist:
+            return Response(
+                {"detail": "Unified document not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        qs = (
+            DocumentInvitedExpert.objects.filter(
+                unified_document_id=unified_document_id
+            )
+            .select_related(
+                "user", "user__author_profile", "expert_search", "generated_email"
+            )
+            .order_by("-created_date")
+        )
+        total_count = qs.count()
+        page = list(qs[:INVITED_LIMIT])
+        invited_data = InvitedExpertSerializerV2(page, many=True).data
+        return Response(
+            {
+                "unified_document_id": unified_document_id,
+                "invited": invited_data,
+                "total_count": total_count,
+            }
+        )


### PR DESCRIPTION
What?
=====
- This change adds the v2 `/invited-experts` endpoint which returns a list of `user.authors`
- Celery task to mark an expert as registered user