### PR TITLE
[expert-finder] 8 - One-time backfill from expert_results JSON to Expert

### DIFF
--- a/src/research_ai/management/commands/migrate_expert_results_to_models.py
+++ b/src/research_ai/management/commands/migrate_expert_results_to_models.py
@@ -1,0 +1,109 @@
+"""
+Backfill ``Expert`` and ``SearchExpert`` from legacy ``ExpertSearch.expert_results``.
+
+Uses ``expert_results_legacy_migration`` (MIGRATION-ONLY heuristics) and
+``ExpertPersist.replace_search_experts_for_search``. Safe to re-run with
+``--force-replace``; default skips searches that already have ``SearchExpert`` rows.
+"""
+
+from django.core.management.base import BaseCommand
+from django.db.models import Count
+
+from research_ai.models import ExpertSearch
+from research_ai.services.expert_persist import ExpertPersist
+from research_ai.services.expert_results_legacy_migration import (
+    legacy_expert_results_to_persist_rows,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Backfill Expert + SearchExpert rows from ExpertSearch.expert_results JSON. "
+        "Skips searches with no expert_results rows. By default skips searches that "
+        "already have SearchExpert links unless --force-replace is set."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report counts and actions without writing to the database.",
+        )
+        parser.add_argument(
+            "--force-replace",
+            action="store_true",
+            help="Replace SearchExpert links from expert_results even if links already exist.",
+        )
+        parser.add_argument(
+            "--search-id",
+            type=int,
+            default=None,
+            help="Only process the given ExpertSearch primary key.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Process at most this many searches (stable order by id ascending).",
+        )
+
+    def handle(self, *args, **options):
+        dry_run: bool = options["dry_run"]
+        force_replace: bool = options["force_replace"]
+        search_id: int | None = options["search_id"]
+        limit: int | None = options["limit"]
+
+        qs = ExpertSearch.objects.annotate(
+            _se_count=Count("search_experts", distinct=True)
+        ).order_by("id")
+
+        if search_id is not None:
+            qs = qs.filter(id=search_id)
+
+        if not force_replace:
+            qs = qs.filter(_se_count=0)
+
+        candidates = []
+        for search in qs.iterator():
+            raw = search.expert_results
+            if not isinstance(raw, list) or len(raw) == 0:
+                continue
+            rows = legacy_expert_results_to_persist_rows(raw)
+            if not rows:
+                continue
+            candidates.append((search, rows))
+            if limit is not None and len(candidates) >= limit:
+                break
+
+        self.stdout.write(
+            f"Searches to migrate: {len(candidates)} "
+            f"(dry_run={dry_run}, force_replace={force_replace})"
+        )
+
+        if dry_run:
+            for search, rows in candidates:
+                self.stdout.write(
+                    f"  would migrate search_id={search.id} "
+                    f"legacy_items={len(search.expert_results)} "
+                    f"valid_rows={len(rows)}"
+                )
+            self.stdout.write(self.style.WARNING("Dry run — no database writes."))
+            return
+
+        migrated = 0
+        experts_linked = 0
+        for search, rows in candidates:
+            n = ExpertPersist.replace_search_experts_for_search(search.id, rows)
+            migrated += 1
+            experts_linked += n
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"migrated search_id={search.id} search_expert_rows={n}"
+                )
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done. Searches migrated: {migrated}, SearchExpert rows written: {experts_linked}."
+            )
+        )

--- a/src/research_ai/services/expert_finder_json.py
+++ b/src/research_ai/services/expert_finder_json.py
@@ -26,7 +26,7 @@ class ExpertFinderJson:
         return True
 
     @staticmethod
-    def _normalize_sources(raw: Any) -> list[dict[str, str]]:
+    def normalize_sources(raw: Any) -> list[dict[str, str]]:
         if not isinstance(raw, list):
             return []
         out: list[dict[str, str]] = []
@@ -108,7 +108,7 @@ class ExpertFinderJson:
                 "affiliation": trimmed_str(row.get("affiliation", "")),
                 "expertise": trimmed_str(row.get("expertise", "")),
                 "notes": trimmed_str(row.get("notes", "")),
-                "sources": ExpertFinderJson._normalize_sources(row.get("sources")),
+                "sources": ExpertFinderJson.normalize_sources(row.get("sources")),
             }
             out.append(row_dict)
 

--- a/src/research_ai/services/expert_results_legacy_migration.py
+++ b/src/research_ai/services/expert_results_legacy_migration.py
@@ -1,0 +1,228 @@
+"""
+MIGRATION-ONLY: map legacy ``ExpertSearch.expert_results`` JSON rows to dicts for
+``ExpertPersist.upsert_from_parsed_dict``. Remove this module when v1 expert
+finder and ``expert_results`` storage are deleted (see strangler plan PR9).
+
+Legacy v1 rows (markdown table pipeline) use keys: ``name``, ``title``,
+``affiliation``, ``expertise``, ``email``, ``notes``, ``sources``. Structured
+name fields are absent; ``title`` maps to ``Expert.academic_title``.
+
+**Name splitting (heuristic, backfill-only):** There is no reliable inverse of
+a free-form ``name`` string. This code applies small, deterministic rules so
+rows are *mostly* usable for display and dedupe by email:
+
+- Strip a short trailing segment after the last comma when it looks like a
+  credential suffix (e.g. ``", PhD"``, ``", M.D."``).
+- Strip a leading honorific token when it matches a small allowlist
+  (Dr., Prof., Professor, Mr./Ms./Mrs., etc.).
+- If the remainder contains a comma, treat it as ``Last, First [Middle]``:
+  everything before the first comma is ``last_name``; after the comma, first
+  token is ``first_name``, rest is ``middle_name``.
+- Otherwise split on whitespace: one token → ``last_name`` only; two →
+  ``first_name``, ``last_name``; three → ``first``, ``middle``, ``last``;
+  four or more → ``first``, ``middle`` = middle tokens joined, ``last`` = last
+  token.
+
+Wrong splits are acceptable for a one-time backfill; operators can fix
+individual ``Expert`` rows afterward. Rows already containing structured keys
+(``first_name``, ``last_name``, ``honorific``, ``academic_title``) are merged
+with legacy keys so partially filled JSON still migrates.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+
+from research_ai.services.expert_display import ExpertDisplay
+from research_ai.services.expert_finder_json import ExpertFinderJson
+from research_ai.utils import trimmed_str
+
+# Leading tokens treated as honorific (comparison is case-insensitive, period optional).
+_HONORIFIC_PREFIXES: frozenset[str] = frozenset(
+    {
+        "dr",
+        "prof",
+        "professor",
+        "mr",
+        "mrs",
+        "ms",
+        "miss",
+        "sir",
+        "dame",
+    }
+)
+
+_SUFFIX_AFTER_COMMA = re.compile(
+    r"^(ph\.?d\.?|m\.?d\.?|d\.?d\.?s\.?|jr\.?|sr\.?|ii|iii|iv|esq\.?)$",
+    re.IGNORECASE,
+)
+
+
+def _token_key(t: str) -> str:
+    return t.strip().rstrip(".").lower()
+
+
+def _strip_trailing_comma_suffix(display: str) -> tuple[str, str]:
+    """If ``display`` ends with ``, <short suffix>``, drop suffix for name parsing."""
+    display = display.strip()
+    if "," not in display:
+        return display, ""
+    left, right = display.rsplit(",", 1)
+    right_stripped = right.strip()
+    if not right_stripped or len(right_stripped) > 32 or " " in right_stripped:
+        return display, ""
+    if _SUFFIX_AFTER_COMMA.match(right_stripped):
+        return left.strip(), right_stripped
+    return display, ""
+
+
+def _strip_leading_honorific(tokens: list[str]) -> tuple[str, list[str]]:
+    honorific = ""
+    if not tokens:
+        return honorific, tokens
+    key = _token_key(tokens[0])
+    if key in _HONORIFIC_PREFIXES:
+        honorific = tokens[0]
+        return honorific, tokens[1:]
+    return honorific, tokens
+
+
+def _split_core_name_tokens(tokens: list[str]) -> tuple[str, str, str]:
+    """Return first_name, middle_name, last_name from whitespace tokens."""
+    if not tokens:
+        return "", "", ""
+    core = " ".join(tokens).strip()
+    if "," in core:
+        left, right = core.split(",", 1)
+        last_chunk = left.strip()
+        right_tokens = right.split()
+        if last_chunk and right_tokens:
+            return (
+                right_tokens[0],
+                " ".join(right_tokens[1:]).strip(),
+                last_chunk,
+            )
+    n = len(tokens)
+    if n == 1:
+        return "", "", tokens[0]
+    if n == 2:
+        return tokens[0], "", tokens[1]
+    if n == 3:
+        return tokens[0], tokens[1], tokens[2]
+    return tokens[0], " ".join(tokens[1:-1]), tokens[-1]
+
+
+def split_legacy_display_name_for_migration(display_name: str) -> dict[str, str]:
+    """
+    Best-effort structured name fields from a legacy ``name`` string.
+
+    See module docstring for limitations. Intended only for backfill.
+    """
+    body, comma_suffix = _strip_trailing_comma_suffix((display_name or "").strip())
+    honorific, tokens = _strip_leading_honorific(body.split())
+    first, middle, last = _split_core_name_tokens(tokens)
+    name_suffix = comma_suffix
+    return {
+        "honorific": honorific,
+        "first_name": first,
+        "middle_name": middle,
+        "last_name": last,
+        "name_suffix": name_suffix,
+    }
+
+
+def _email_ok(email: str) -> bool:
+    if not email:
+        return False
+    try:
+        validate_email(email)
+    except ValidationError:
+        return False
+    return True
+
+
+def legacy_expert_result_row_to_parsed_dict(row: Any) -> dict[str, Any] | None:
+    """
+    Convert one legacy ``expert_results`` element to a dict for
+    ``ExpertPersist.upsert_from_parsed_dict``.
+
+    Returns ``None`` if the row is unusable (not a dict, missing/invalid email).
+    """
+    if not isinstance(row, dict):
+        return None
+
+    email = ExpertDisplay.normalize_email(trimmed_str(row.get("email", "")))
+    if not email or not _email_ok(email):
+        return None
+
+    has_structured = any(
+        trimmed_str(row.get(k, ""))
+        for k in ("first_name", "last_name", "honorific", "academic_title")
+    )
+
+    parsed_from_name = split_legacy_display_name_for_migration(
+        trimmed_str(row.get("name", ""))
+    )
+
+    if has_structured:
+        parts = {
+            "honorific": trimmed_str(row.get("honorific", ""), max_len=64)
+            or parsed_from_name["honorific"],
+            "first_name": trimmed_str(row.get("first_name", ""), max_len=255)
+            or parsed_from_name["first_name"],
+            "middle_name": trimmed_str(row.get("middle_name", ""), max_len=255)
+            or parsed_from_name["middle_name"],
+            "last_name": trimmed_str(row.get("last_name", ""), max_len=255)
+            or parsed_from_name["last_name"],
+            "name_suffix": trimmed_str(row.get("name_suffix", ""), max_len=64)
+            or parsed_from_name["name_suffix"],
+        }
+    else:
+        parts = parsed_from_name
+
+    academic = trimmed_str(row.get("academic_title", ""), max_len=255)
+    if not academic:
+        academic = trimmed_str(row.get("title", ""), max_len=255)
+
+    return {
+        "email": email,
+        "honorific": parts["honorific"],
+        "first_name": parts["first_name"],
+        "middle_name": parts["middle_name"],
+        "last_name": parts["last_name"],
+        "name_suffix": parts["name_suffix"],
+        "academic_title": academic,
+        "affiliation": trimmed_str(row.get("affiliation", "")),
+        "expertise": trimmed_str(row.get("expertise", "")),
+        "notes": trimmed_str(row.get("notes", "")),
+        "sources": ExpertFinderJson.normalize_sources(row.get("sources")),
+    }
+
+
+def legacy_expert_results_to_persist_rows(
+    expert_results: Any,
+) -> list[dict[str, Any]]:
+    """
+    Map ``ExpertSearch.expert_results`` (legacy JSON list) to ordered, de-duplicated
+    rows for ``ExpertPersist.replace_search_experts_for_search``. First row wins
+    per normalized email.
+    """
+    if not isinstance(expert_results, list):
+        return []
+
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in expert_results:
+        parsed = legacy_expert_result_row_to_parsed_dict(item)
+        if parsed is None:
+            continue
+        em = parsed["email"]
+        if em in seen:
+            continue
+        seen.add(em)
+        out.append(parsed)
+    return out

--- a/src/research_ai/tests/test_expert_results_legacy_migration.py
+++ b/src/research_ai/tests/test_expert_results_legacy_migration.py
@@ -1,0 +1,189 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+from research_ai.models import Expert, ExpertSearch, SearchExpert
+from research_ai.services.expert_results_legacy_migration import (
+    legacy_expert_result_row_to_parsed_dict,
+    legacy_expert_results_to_persist_rows,
+    split_legacy_display_name_for_migration,
+)
+from user.tests.helpers import create_random_authenticated_user
+
+
+class SplitLegacyDisplayNameTests(TestCase):
+    def test_last_first_comma_form(self):
+        p = split_legacy_display_name_for_migration("Smith, John")
+        self.assertEqual(p["last_name"], "Smith")
+        self.assertEqual(p["first_name"], "John")
+        self.assertEqual(p["middle_name"], "")
+
+    def test_last_first_middle_comma_form(self):
+        p = split_legacy_display_name_for_migration("Smith, John Q.")
+        self.assertEqual(p["last_name"], "Smith")
+        self.assertEqual(p["first_name"], "John")
+        self.assertEqual(p["middle_name"], "Q.")
+
+    def test_honorific_and_trailing_suffix(self):
+        p = split_legacy_display_name_for_migration("Dr. Jane Q. Public, PhD")
+        self.assertEqual(p["honorific"], "Dr.")
+        self.assertEqual(p["first_name"], "Jane")
+        self.assertEqual(p["middle_name"], "Q.")
+        self.assertEqual(p["last_name"], "Public")
+        self.assertEqual(p["name_suffix"], "PhD")
+
+    def test_two_tokens(self):
+        p = split_legacy_display_name_for_migration("Jane Public")
+        self.assertEqual(p["first_name"], "Jane")
+        self.assertEqual(p["last_name"], "Public")
+
+    def test_single_token_goes_to_last_name(self):
+        p = split_legacy_display_name_for_migration("Cher")
+        self.assertEqual(p["first_name"], "")
+        self.assertEqual(p["last_name"], "Cher")
+
+
+class LegacyExpertResultRowTests(TestCase):
+    def test_maps_title_to_academic_title(self):
+        d = legacy_expert_result_row_to_parsed_dict(
+            {
+                "name": "Dr. A",
+                "title": "Professor",
+                "affiliation": "MIT",
+                "expertise": "ML",
+                "email": "A@MIT.EDU",
+                "notes": "n",
+                "sources": [{"text": "t", "url": "https://x"}],
+            }
+        )
+        assert d is not None
+        self.assertEqual(d["email"], "a@mit.edu")
+        self.assertEqual(d["academic_title"], "Professor")
+        self.assertEqual(d["affiliation"], "MIT")
+        self.assertEqual(d["sources"], [{"text": "t", "url": "https://x"}])
+
+    def test_invalid_email_returns_none(self):
+        self.assertIsNone(
+            legacy_expert_result_row_to_parsed_dict(
+                {"name": "X", "email": "not-an-email"}
+            )
+        )
+
+    def test_prefers_structured_name_fields(self):
+        d = legacy_expert_result_row_to_parsed_dict(
+            {
+                "first_name": "Pat",
+                "last_name": "Lee",
+                "honorific": "Dr.",
+                "email": "pat@x.org",
+                "name": "Ignored Name",
+            }
+        )
+        assert d is not None
+        self.assertEqual(d["first_name"], "Pat")
+        self.assertEqual(d["last_name"], "Lee")
+        self.assertEqual(d["honorific"], "Dr.")
+
+
+class LegacyExpertResultsDedupeTests(TestCase):
+    def test_dedupes_by_email_preserving_order(self):
+        rows = legacy_expert_results_to_persist_rows(
+            [
+                {"name": "A", "email": "dup@x.com"},
+                {"name": "B", "email": "dup@x.com"},
+                {"name": "C", "email": "other@x.com"},
+            ]
+        )
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["email"], "dup@x.com")
+        self.assertEqual(rows[1]["email"], "other@x.com")
+
+
+class MigrateExpertResultsCommandTests(TestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("migrate_cmd_user")
+
+    def test_dry_run_does_not_create_search_expert(self):
+        from io import StringIO
+
+        search = ExpertSearch.objects.create(
+            created_by=self.user,
+            query="q",
+            expert_results=[
+                {
+                    "name": "Dr. Test",
+                    "title": "Prof",
+                    "affiliation": "U",
+                    "expertise": "x",
+                    "email": "tester@university.edu",
+                    "notes": "",
+                    "sources": [],
+                }
+            ],
+        )
+        call_command(
+            "migrate_expert_results_to_models",
+            dry_run=True,
+            stdout=StringIO(),
+        )
+        self.assertEqual(SearchExpert.objects.filter(expert_search=search).count(), 0)
+
+    def test_migrate_creates_expert_and_search_expert(self):
+        from io import StringIO
+
+        buf = StringIO()
+        search = ExpertSearch.objects.create(
+            created_by=self.user,
+            query="q",
+            expert_results=[
+                {
+                    "name": "Dr. Test",
+                    "title": "Prof",
+                    "affiliation": "U",
+                    "expertise": "x",
+                    "email": "migrate_one@university.edu",
+                    "notes": "",
+                    "sources": [],
+                }
+            ],
+        )
+        call_command("migrate_expert_results_to_models", stdout=buf)
+        self.assertEqual(SearchExpert.objects.filter(expert_search=search).count(), 1)
+        ex = Expert.objects.get(email="migrate_one@university.edu")
+        self.assertEqual(ex.academic_title, "Prof")
+        self.assertIn("migrated", buf.getvalue().lower())
+
+    def test_skips_when_search_expert_exists_unless_force(self):
+        from io import StringIO
+
+        search = ExpertSearch.objects.create(
+            created_by=self.user,
+            query="q",
+            expert_results=[
+                {
+                    "name": "X",
+                    "title": "",
+                    "affiliation": "",
+                    "expertise": "",
+                    "email": "exists@university.edu",
+                    "notes": "",
+                    "sources": [],
+                }
+            ],
+        )
+        expert = Expert.objects.create(email="exists@university.edu")
+        SearchExpert.objects.create(
+            expert_search=search, expert=expert, position=0
+        )
+        buf = StringIO()
+        call_command("migrate_expert_results_to_models", stdout=buf)
+        self.assertEqual(SearchExpert.objects.filter(expert_search=search).count(), 1)
+
+        buf2 = StringIO()
+        call_command(
+            "migrate_expert_results_to_models",
+            force_replace=True,
+            stdout=buf2,
+        )
+        self.assertEqual(SearchExpert.objects.filter(expert_search=search).count(), 1)
+        se = SearchExpert.objects.get(expert_search=search)
+        self.assertEqual(se.expert.email, "exists@university.edu")


### PR DESCRIPTION
What?
- Backfill legacy expert finder JSON (`ExpertSearch.expert_results`) into relational `Expert` and `SearchExpert` rows via `migrate_expert_results_to_models`
- 
> [!NOTE]
> This management command and the legacy migration helpers are intended as a one-time production migration path and will be removed after data has been backfilled and v1/expert_results is retired.  