### PR TITLE
Adding is_funder parameter

### DIFF
--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -477,7 +477,7 @@ class UserSerializer(ModelSerializer):
         ]
 
     def get_is_funder(self, obj):
-        return getattr(obj, "_is_funder", False)
+        return getattr(obj, "is_funder", False)
 
     def get_balance(self, obj):
         if (
@@ -568,7 +568,7 @@ class UserEditableSerializer(ModelSerializer):
         read_only_fields = ["moderator", "referral_code"]
 
     def get_is_funder(self, obj):
-        return getattr(obj, "_is_funder", False)
+        return getattr(obj, "is_funder", False)
 
     def get_auth_provider(self, obj):
         social_account = obj.socialaccount_set.first()
@@ -724,7 +724,7 @@ class DynamicUserSerializer(DynamicModelFieldSerializer):
         exclude = ("password",)
 
     def get_is_funder(self, obj):
-        return getattr(obj, "_is_funder", False)
+        return getattr(obj, "is_funder", False)
 
     def get_author_profile(self, user):
         context = self.context

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -427,6 +427,7 @@ class UserSerializer(ModelSerializer):
     author_profile = AuthorSerializer(read_only=True)
     balance = SerializerMethodField(read_only=True)
     balances = SerializerMethodField(read_only=True)
+    is_funder = SerializerMethodField()
     subscribed = SerializerMethodField(read_only=True)
     hub_rep = SerializerMethodField()
     time_rep = SerializerMethodField()
@@ -442,6 +443,7 @@ class UserSerializer(ModelSerializer):
             "created_date",
             "has_seen_first_coin_modal",
             "has_seen_orcid_connect_modal",
+            "is_funder",
             "is_staking_opted_in",
             "is_suspended",
             "probable_spammer",
@@ -460,6 +462,7 @@ class UserSerializer(ModelSerializer):
             "created_date",
             "has_seen_first_coin_modal",
             "has_seen_orcid_connect_modal",
+            "is_funder",
             "is_staking_opted_in",
             "is_suspended",
             "probable_spammer",
@@ -472,6 +475,9 @@ class UserSerializer(ModelSerializer):
             "hub_rep",
             "time_rep",
         ]
+
+    def get_is_funder(self, obj):
+        return getattr(obj, "_is_funder", False)
 
     def get_balance(self, obj):
         if (
@@ -536,6 +542,7 @@ class UserEditableSerializer(ModelSerializer):
     author_profile = AuthorSerializer()
     balance = SerializerMethodField()
     balances = SerializerMethodField()
+    is_funder = SerializerMethodField()
     locked_balance = SerializerMethodField()
     balance_history = SerializerMethodField()
     email = SerializerMethodField()
@@ -559,6 +566,9 @@ class UserEditableSerializer(ModelSerializer):
             "date_joined",
         ]
         read_only_fields = ["moderator", "referral_code"]
+
+    def get_is_funder(self, obj):
+        return getattr(obj, "_is_funder", False)
 
     def get_auth_provider(self, obj):
         social_account = obj.socialaccount_set.first()
@@ -702,6 +712,7 @@ class RegisterSerializer(rest_auth_serializers.RegisterSerializer):
 
 class DynamicUserSerializer(DynamicModelFieldSerializer):
     author_profile = SerializerMethodField()
+    is_funder = SerializerMethodField()
     rsc_earned = SerializerMethodField()
     balances = SerializerMethodField()
     benefits_expire_on = SerializerMethodField()
@@ -711,6 +722,9 @@ class DynamicUserSerializer(DynamicModelFieldSerializer):
     class Meta:
         model = User
         exclude = ("password",)
+
+    def get_is_funder(self, obj):
+        return getattr(obj, "_is_funder", False)
 
     def get_author_profile(self, user):
         context = self.context

--- a/src/user/views/user_views.py
+++ b/src/user/views/user_views.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from allauth.account.models import EmailAddress
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import F, Q, Sum
+from django.db.models import Exists, F, OuterRef, Q, Sum
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -21,6 +21,7 @@ from rest_framework.response import Response
 from paper.models import Paper
 from paper.serializers import DynamicPaperSerializer
 from paper.utils import PAPER_SCORE_Q_ANNOTATION
+from purchase.related_models.grant_model import Grant
 from reputation.models import Distribution
 from reputation.serializers import (
     DynamicBountySerializer,
@@ -49,9 +50,18 @@ from utils.http import POST, RequestMethods
 
 
 class UserViewSet(FollowViewActionMixin, viewsets.ModelViewSet):
-    queryset = User.objects.select_related(
-        "userverification",
-    ).filter(is_suspended=False)
+    queryset = (
+        User.objects.select_related("userverification")
+        .annotate(
+            _is_funder=Exists(
+                Grant.objects.filter(
+                    created_by=OuterRef("pk"),
+                    status__in=[Grant.OPEN, Grant.CLOSED, Grant.COMPLETED],
+                )
+            ),
+        )
+        .filter(is_suspended=False)
+    )
     serializer_class = UserEditableSerializer
     permission_classes = [IsAuthenticatedOrReadOnly, DeleteUserPermission]
     filter_backends = (DjangoFilterBackend,)

--- a/src/user/views/user_views.py
+++ b/src/user/views/user_views.py
@@ -53,10 +53,11 @@ class UserViewSet(FollowViewActionMixin, viewsets.ModelViewSet):
     queryset = (
         User.objects.select_related("userverification")
         .annotate(
-            _is_funder=Exists(
+            is_funder=Exists(
                 Grant.objects.filter(
                     created_by=OuterRef("pk"),
-                    status__in=[Grant.OPEN, Grant.CLOSED, Grant.COMPLETED],
+                    status__in=[Grant.OPEN, Grant.COMPLETED],
+                    unified_document__is_removed=False,
                 )
             ),
         )


### PR DESCRIPTION
## Overview ##

This PR adds the is_funder parameter on the user to help the front end determine whether or not a user should see the funder dashboard 

Based on if the user has created funding opportunities that have been approved by the moderation team.