### PR TITLE
Add private preregistration posts via is_public flag

### DIFF
--- a/src/feed/signals/post_signals.py
+++ b/src/feed/signals/post_signals.py
@@ -31,6 +31,10 @@ def handle_post_create_feed_entry(sender, instance, **kwargs):
     if instance.document_type == GRANT:
         return
 
+    unified_document = getattr(instance, "unified_document", None)
+    if unified_document is not None and not unified_document.is_public:
+        return
+
     try:
         _create_post_feed_entries(instance)
     except Exception as e:

--- a/src/feed/signals/post_signals.py
+++ b/src/feed/signals/post_signals.py
@@ -31,10 +31,6 @@ def handle_post_create_feed_entry(sender, instance, **kwargs):
     if instance.document_type == GRANT:
         return
 
-    unified_document = getattr(instance, "unified_document", None)
-    if unified_document is not None and not unified_document.is_public:
-        return
-
     try:
         _create_post_feed_entries(instance)
     except Exception as e:

--- a/src/feed/tasks.py
+++ b/src/feed/tasks.py
@@ -52,6 +52,11 @@ def create_feed_entry(
 
     unified_document = _get_unified_document(item, item_content_type)
 
+    # Suppress feed entries for items attached to a private unified document.
+    # Covers posts, comments, bounties, and fundraise contributions in one place.
+    if unified_document is not None and not unified_document.is_public:
+        return None
+
     content = serialize_feed_item(item, item_content_type)
     if content is None:
         logger.warning(

--- a/src/feed/tests/views/test_funding_feed_view.py
+++ b/src/feed/tests/views/test_funding_feed_view.py
@@ -197,7 +197,8 @@ class FundingFeedViewSetTests(AWSMockTestCase):
         mock_cache.get.return_value = None
 
         url = reverse("funding_feed-list")
-        response = self.client.get(url)
+        anonymous_client = APIClient()
+        response = anonymous_client.get(url)
 
         self.assertTrue(mock_cache.get.called)
         self.assertTrue(mock_cache.set.called)
@@ -209,7 +210,7 @@ class FundingFeedViewSetTests(AWSMockTestCase):
         mock_cache.get.return_value = mock_cache.set.call_args[0][1]
         mock_cache.set.reset_mock()
 
-        response2 = self.client.get(url)
+        response2 = anonymous_client.get(url)
 
         self.assertTrue(mock_cache.get.called)
         self.assertFalse(mock_cache.set.called)
@@ -253,8 +254,8 @@ class FundingFeedViewSetTests(AWSMockTestCase):
         self.assertEqual(vote_type, 1)  # 1 corresponds to UPVOTE
 
     @patch("feed.views.funding_feed_view.cache")
-    def test_add_user_votes_with_cached_response(self, mock_cache):
-        """Test that user votes are added even with cached response"""
+    def test_authenticated_request_bypasses_cached_response(self, mock_cache):
+        """Authenticated funding feed responses are viewer-specific."""
         # Create a vote for the post
         post_content_type = ContentType.objects.get_for_model(ResearchhubPost)
         vote = Vote.objects.create(
@@ -285,11 +286,16 @@ class FundingFeedViewSetTests(AWSMockTestCase):
         url = reverse("funding_feed-list")
         response = self.client.get(url)
 
-        # Check that votes were added to the cached response
+        self.assertFalse(mock_cache.get.called)
+        self.assertFalse(mock_cache.set.called)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data["results"]), 1)
-        self.assertIn("user_vote", response.data["results"][0])
-        self.assertEqual(response.data["results"][0]["user_vote"]["id"], vote.id)
+        post_data = next(
+            item
+            for item in response.data["results"]
+            if item["content_object"]["id"] == self.post.id
+        )
+        self.assertIn("user_vote", post_data)
+        self.assertEqual(post_data["user_vote"]["id"], vote.id)
 
     def test_get_cache_key(self):
         """Test cache key generation logic"""

--- a/src/feed/views/funding_feed_view.py
+++ b/src/feed/views/funding_feed_view.py
@@ -102,7 +102,8 @@ class FundingFeedViewSet(FundingCacheMixin, FeedViewMixin, ModelViewSet):
         funded_by = self.request.query_params.get("funded_by")
 
         queryset = (
-            ResearchhubPost.objects.select_related(
+            ResearchhubPost.objects.visible_to(self.request.user)
+            .select_related(
                 "created_by",
                 "created_by__author_profile",
                 "unified_document",

--- a/src/feed/views/funding_feed_view.py
+++ b/src/feed/views/funding_feed_view.py
@@ -51,6 +51,7 @@ class FundingFeedViewSet(FundingCacheMixin, FeedViewMixin, ModelViewSet):
         cache_key = self.get_cache_key(request, "funding")
         use_cache = (
             page_num <= FUNDING_FEED_MAX_CACHED_PAGE
+            and not request.user.is_authenticated
             and grant_id is None
             and created_by is None
             and funded_by is None

--- a/src/purchase/serializers/grant_serializer.py
+++ b/src/purchase/serializers/grant_serializer.py
@@ -86,6 +86,14 @@ class DynamicGrantSerializer(DynamicModelFieldSerializer):
     def get_applications(self, grant):
         """Return grant applications with applicant and fundraise information"""
 
+        request = self.context.get("request")
+        viewer = getattr(request, "user", None) if request else None
+        is_grant_reviewer = (
+            viewer is not None
+            and getattr(viewer, "is_authenticated", False)
+            and grant.created_by_id == viewer.id
+        )
+
         review_by_ud = {r.unified_document_id: r for r in grant.proposal_reviews.all()}
         application_data = []
         for application in grant.applications.all():
@@ -96,6 +104,12 @@ class DynamicGrantSerializer(DynamicModelFieldSerializer):
             ud = getattr(application.preregistration_post, "unified_document", None)
             if ud and ud.is_removed:
                 continue
+
+            if ud and not ud.is_public and not is_grant_reviewer:
+                if not viewer or not getattr(viewer, "is_authenticated", False):
+                    continue
+                if application.applicant_id != viewer.id:
+                    continue
 
             application_data.append(
                 {

--- a/src/researchhub_document/related_models/researchhub_post_model.py
+++ b/src/researchhub_document/related_models/researchhub_post_model.py
@@ -1,6 +1,6 @@
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
-from django.db.models import IntegerField, Sum
+from django.db.models import IntegerField, Q, Sum
 from django.db.models.functions import Cast
 
 from discussion.models import AbstractGenericReactionModel, Vote
@@ -18,6 +18,22 @@ from researchhub_document.related_models.researchhub_unified_document_model impo
     ResearchhubUnifiedDocument,
 )
 from user.models import Author, User
+
+
+class ResearchhubPostQuerySet(models.QuerySet):
+    def visible_to(self, user):
+        """Restrict to posts the given user is allowed to see.
+
+        Public posts (unified_document.is_public=True) are visible to anyone.
+        Private posts are visible only to their author and to the creator of
+        any grant the post has applied to (via GrantApplication).
+        """
+        public = Q(unified_document__is_public=True)
+        if user is None or not getattr(user, "is_authenticated", False):
+            return self.filter(public)
+        return self.filter(
+            public | Q(created_by=user) | Q(grant_applications__grant__created_by=user)
+        ).distinct()
 
 
 class ResearchhubPost(AbstractGenericReactionModel):
@@ -124,6 +140,8 @@ class ResearchhubPost(AbstractGenericReactionModel):
     doi = models.CharField(
         max_length=255, default=None, null=True, blank=True, unique=True
     )
+
+    objects = ResearchhubPostQuerySet.as_manager()
 
     @property
     def is_latest_version(self):

--- a/src/researchhub_document/tests/test_private_preregistration.py
+++ b/src/researchhub_document/tests/test_private_preregistration.py
@@ -28,6 +28,7 @@ from researchhub_document.related_models.researchhub_post_model import (
 from researchhub_document.related_models.researchhub_unified_document_model import (
     ResearchhubUnifiedDocument,
 )
+from user.models import Action
 from user.tests.helpers import make_user_verified
 from utils.test_helpers import AWSMockTestCase
 
@@ -93,6 +94,32 @@ class PrivatePreregistrationCreateTests(AWSMockTestCase):
         self.assertEqual(response.status_code, 200)
         post = ResearchhubPost.objects.get(id=response.data["id"])
         self.assertFalse(post.unified_document.is_public)
+
+    def test_is_public_false_string_marks_unified_doc_private(self):
+        response = self.client.post(
+            "/api/researchhubpost/",
+            self._payload(is_public="false"),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        post = ResearchhubPost.objects.get(id=response.data["id"])
+        self.assertFalse(post.unified_document.is_public)
+
+    def test_private_preregistration_action_is_hidden(self):
+        response = self.client.post(
+            "/api/researchhubpost/",
+            self._payload(is_public=False),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        post = ResearchhubPost.objects.get(id=response.data["id"])
+        action = Action.objects.get(
+            content_type=ContentType.objects.get_for_model(ResearchhubPost),
+            object_id=post.id,
+        )
+        self.assertFalse(action.display)
 
     def test_is_public_false_ignored_for_non_preregistration(self):
         response = self.client.post(
@@ -301,6 +328,18 @@ class FundingFeedPrivacyTests(AWSMockTestCase):
         response = client.get(reverse("funding_feed-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn(self.private_post.id, self._ids(response))
+
+    def test_authenticated_private_response_not_cached_for_anonymous(self):
+        author_client = APIClient()
+        author_client.force_authenticate(self.author)
+        author_response = author_client.get(reverse("funding_feed-list"))
+        self.assertEqual(author_response.status_code, status.HTTP_200_OK)
+        self.assertIn(self.private_post.id, self._ids(author_response))
+
+        anonymous_client = APIClient()
+        anonymous_response = anonymous_client.get(reverse("funding_feed-list"))
+        self.assertEqual(anonymous_response.status_code, status.HTTP_200_OK)
+        self.assertNotIn(self.private_post.id, self._ids(anonymous_response))
 
 
 class FeedEntrySuppressionTests(AWSMockTestCase):

--- a/src/researchhub_document/tests/test_private_preregistration.py
+++ b/src/researchhub_document/tests/test_private_preregistration.py
@@ -1,0 +1,296 @@
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from hub.models import Hub
+from purchase.related_models.constants.currency import USD
+from purchase.related_models.grant_application_model import GrantApplication
+from purchase.related_models.grant_model import Grant
+from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
+from researchhub_document.helpers import create_post
+from researchhub_document.related_models.constants.document_type import (
+    PREREGISTRATION,
+)
+from researchhub_document.related_models.researchhub_post_model import (
+    ResearchhubPost,
+)
+from researchhub_document.related_models.researchhub_unified_document_model import (
+    ResearchhubUnifiedDocument,
+)
+from user.tests.helpers import make_user_verified
+from utils.test_helpers import AWSMockTestCase
+
+User = get_user_model()
+
+LONG_TITLE = "sufficiently long title. sufficiently long title."
+LONG_BODY = (
+    "sufficiently long body. sufficiently long body. "
+    "sufficiently long body. sufficiently long body. "
+    "sufficiently long body."
+)
+
+
+def _make_user(name):
+    user = User.objects.create_user(
+        username=f"{name}-{uuid.uuid4().hex[:8]}",
+        password=uuid.uuid4().hex,
+    )
+    make_user_verified(user)
+    return user
+
+
+class PrivatePreregistrationCreateTests(AWSMockTestCase):
+    """Posting `is_public=False` makes the unified document private."""
+
+    def setUp(self):
+        super().setUp()
+        self.author = _make_user("author")
+        self.hub = Hub.objects.create(name=f"hub-{uuid.uuid4().hex[:8]}")
+        RscExchangeRate.objects.create(rate=1.0)
+        self.client = APIClient()
+        self.client.force_authenticate(self.author)
+
+    def _payload(self, **overrides):
+        payload = {
+            "document_type": PREREGISTRATION,
+            "created_by": self.author.id,
+            "full_src": "body",
+            "renderable_text": LONG_BODY,
+            "title": LONG_TITLE,
+            "hubs": [self.hub.id],
+            "fundraise_goal_amount": 1000,
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_default_post_is_public(self):
+        response = self.client.post(
+            "/api/researchhubpost/", self._payload(), format="json"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        post = ResearchhubPost.objects.get(id=response.data["id"])
+        self.assertTrue(post.unified_document.is_public)
+
+    def test_is_public_false_marks_unified_doc_private(self):
+        response = self.client.post(
+            "/api/researchhubpost/",
+            self._payload(is_public=False),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        post = ResearchhubPost.objects.get(id=response.data["id"])
+        self.assertFalse(post.unified_document.is_public)
+
+    def test_is_public_false_ignored_for_non_preregistration(self):
+        response = self.client.post(
+            "/api/researchhubpost/",
+            self._payload(
+                document_type="DISCUSSION",
+                is_public=False,
+                fundraise_goal_amount=None,
+            ),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        post = ResearchhubPost.objects.get(id=response.data["id"])
+        self.assertTrue(post.unified_document.is_public)
+
+
+class VisibleToQuerySetTests(AWSMockTestCase):
+    """ResearchhubPost.objects.visible_to filters by is_public + permissions."""
+
+    def setUp(self):
+        super().setUp()
+        self.author = _make_user("author")
+        self.outsider = _make_user("outsider")
+        self.grant_owner = _make_user("grant_owner")
+
+        self.public_post = create_post(
+            title="Public post", created_by=self.author, document_type=PREREGISTRATION
+        )
+        self.private_post = create_post(
+            title="Private post",
+            created_by=self.author,
+            document_type=PREREGISTRATION,
+        )
+        self.private_post.unified_document.is_public = False
+        self.private_post.unified_document.save()
+
+        # Grant owned by `grant_owner`; the private post applies to it.
+        self.grant_doc = ResearchhubUnifiedDocument.objects.create(
+            document_type="GRANT"
+        )
+        self.grant = Grant.objects.create(
+            created_by=self.grant_owner,
+            unified_document=self.grant_doc,
+            amount=1000,
+            currency=USD,
+            organization="Org",
+            description="desc",
+        )
+        GrantApplication.objects.create(
+            grant=self.grant,
+            preregistration_post=self.private_post,
+            applicant=self.author,
+        )
+
+    def test_anonymous_only_sees_public(self):
+        ids = set(ResearchhubPost.objects.visible_to(None).values_list("id", flat=True))
+        self.assertIn(self.public_post.id, ids)
+        self.assertNotIn(self.private_post.id, ids)
+
+    def test_outsider_only_sees_public(self):
+        ids = set(
+            ResearchhubPost.objects.visible_to(self.outsider).values_list(
+                "id", flat=True
+            )
+        )
+        self.assertIn(self.public_post.id, ids)
+        self.assertNotIn(self.private_post.id, ids)
+
+    def test_author_sees_own_private(self):
+        ids = set(
+            ResearchhubPost.objects.visible_to(self.author).values_list("id", flat=True)
+        )
+        self.assertIn(self.public_post.id, ids)
+        self.assertIn(self.private_post.id, ids)
+
+    def test_grant_owner_sees_application_private(self):
+        ids = set(
+            ResearchhubPost.objects.visible_to(self.grant_owner).values_list(
+                "id", flat=True
+            )
+        )
+        self.assertIn(self.private_post.id, ids)
+
+
+class PostViewSetVisibilityTests(AWSMockTestCase):
+    """ResearchhubPostViewSet hides private posts from non-authorized requesters."""
+
+    def setUp(self):
+        super().setUp()
+        self.author = _make_user("author")
+        self.outsider = _make_user("outsider")
+        self.grant_owner = _make_user("grant_owner")
+
+        self.private_post = create_post(
+            title="Private", created_by=self.author, document_type=PREREGISTRATION
+        )
+        self.private_post.unified_document.is_public = False
+        self.private_post.unified_document.save()
+
+        self.grant_doc = ResearchhubUnifiedDocument.objects.create(
+            document_type="GRANT"
+        )
+        self.grant = Grant.objects.create(
+            created_by=self.grant_owner,
+            unified_document=self.grant_doc,
+            amount=1000,
+            currency=USD,
+            organization="Org",
+            description="desc",
+        )
+        GrantApplication.objects.create(
+            grant=self.grant,
+            preregistration_post=self.private_post,
+            applicant=self.author,
+        )
+
+    def test_outsider_cannot_retrieve_private_post(self):
+        client = APIClient()
+        client.force_authenticate(self.outsider)
+        response = client.get(f"/api/researchhubpost/{self.private_post.id}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_anonymous_cannot_retrieve_private_post(self):
+        client = APIClient()
+        response = client.get(f"/api/researchhubpost/{self.private_post.id}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_author_can_retrieve_private_post(self):
+        client = APIClient()
+        client.force_authenticate(self.author)
+        response = client.get(f"/api/researchhubpost/{self.private_post.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_grant_owner_can_retrieve_private_post(self):
+        client = APIClient()
+        client.force_authenticate(self.grant_owner)
+        response = client.get(f"/api/researchhubpost/{self.private_post.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class FundingFeedPrivacyTests(AWSMockTestCase):
+    """Funding feed excludes private posts unless the requester can see them."""
+
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        self.author = _make_user("author")
+        self.outsider = _make_user("outsider")
+        self.grant_owner = _make_user("grant_owner")
+
+        self.public_post = create_post(
+            title="Public", created_by=self.author, document_type=PREREGISTRATION
+        )
+        self.private_post = create_post(
+            title="Private", created_by=self.author, document_type=PREREGISTRATION
+        )
+        self.private_post.unified_document.is_public = False
+        self.private_post.unified_document.save()
+
+        self.grant_doc = ResearchhubUnifiedDocument.objects.create(
+            document_type="GRANT"
+        )
+        self.grant = Grant.objects.create(
+            created_by=self.grant_owner,
+            unified_document=self.grant_doc,
+            amount=1000,
+            currency=USD,
+            organization="Org",
+            description="desc",
+        )
+        GrantApplication.objects.create(
+            grant=self.grant,
+            preregistration_post=self.private_post,
+            applicant=self.author,
+        )
+
+    def _ids(self, response):
+        return {item["content_object"]["id"] for item in response.data["results"]}
+
+    def test_anonymous_does_not_see_private(self):
+        client = APIClient()
+        response = client.get(reverse("funding_feed-list"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._ids(response)
+        self.assertIn(self.public_post.id, ids)
+        self.assertNotIn(self.private_post.id, ids)
+
+    def test_outsider_does_not_see_private(self):
+        client = APIClient()
+        client.force_authenticate(self.outsider)
+        response = client.get(reverse("funding_feed-list"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn(self.private_post.id, self._ids(response))
+
+    def test_author_sees_own_private(self):
+        client = APIClient()
+        client.force_authenticate(self.author)
+        response = client.get(reverse("funding_feed-list"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(self.private_post.id, self._ids(response))
+
+    def test_grant_owner_sees_application_private(self):
+        client = APIClient()
+        client.force_authenticate(self.grant_owner)
+        response = client.get(reverse("funding_feed-list"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(self.private_post.id, self._ids(response))

--- a/src/researchhub_document/tests/test_private_preregistration.py
+++ b/src/researchhub_document/tests/test_private_preregistration.py
@@ -1,16 +1,23 @@
 import uuid
 
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from feed.models import FeedEntry
+from feed.tasks import create_feed_entry
 from hub.models import Hub
 from purchase.related_models.constants.currency import USD
 from purchase.related_models.grant_application_model import GrantApplication
 from purchase.related_models.grant_model import Grant
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
+from researchhub_comment.related_models.rh_comment_model import RhCommentModel
+from researchhub_comment.related_models.rh_comment_thread_model import (
+    RhCommentThreadModel,
+)
 from researchhub_document.helpers import create_post
 from researchhub_document.related_models.constants.document_type import (
     PREREGISTRATION,
@@ -294,3 +301,99 @@ class FundingFeedPrivacyTests(AWSMockTestCase):
         response = client.get(reverse("funding_feed-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn(self.private_post.id, self._ids(response))
+
+
+class FeedEntrySuppressionTests(AWSMockTestCase):
+    """create_feed_entry must skip any item whose unified document is private.
+
+    Centralizes the rule at the chokepoint so posts, comments, bounties, and
+    fundraise contributions on a private preregistration all stay out of feeds.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.author = _make_user("author")
+
+        self.public_post = create_post(
+            title="Public", created_by=self.author, document_type=PREREGISTRATION
+        )
+        self.private_post = create_post(
+            title="Private", created_by=self.author, document_type=PREREGISTRATION
+        )
+        self.private_post.unified_document.is_public = False
+        self.private_post.unified_document.save()
+
+        self.post_ct = ContentType.objects.get_for_model(ResearchhubPost)
+        self.comment_ct = ContentType.objects.get_for_model(RhCommentModel)
+
+    def _make_comment(self, post):
+        thread = RhCommentThreadModel.objects.create(
+            content_type=self.post_ct,
+            object_id=post.id,
+            created_by=self.author,
+        )
+        return RhCommentModel.objects.create(thread=thread, created_by=self.author)
+
+    def test_post_on_private_doc_skips_feed_entry(self):
+        result = create_feed_entry(
+            item_id=self.private_post.id,
+            item_content_type_id=self.post_ct.id,
+            action=FeedEntry.PUBLISH,
+            user_id=self.author.id,
+        )
+
+        self.assertIsNone(result)
+        self.assertFalse(
+            FeedEntry.objects.filter(
+                content_type=self.post_ct, object_id=self.private_post.id
+            ).exists()
+        )
+
+    def test_post_on_public_doc_creates_feed_entry(self):
+        result = create_feed_entry(
+            item_id=self.public_post.id,
+            item_content_type_id=self.post_ct.id,
+            action=FeedEntry.PUBLISH,
+            user_id=self.author.id,
+        )
+
+        self.assertIsNotNone(result)
+        self.assertTrue(
+            FeedEntry.objects.filter(
+                content_type=self.post_ct, object_id=self.public_post.id
+            ).exists()
+        )
+
+    def test_comment_on_private_doc_skips_feed_entry(self):
+        comment = self._make_comment(self.private_post)
+
+        result = create_feed_entry(
+            item_id=comment.id,
+            item_content_type_id=self.comment_ct.id,
+            action=FeedEntry.PUBLISH,
+            user_id=self.author.id,
+        )
+
+        self.assertIsNone(result)
+        self.assertFalse(
+            FeedEntry.objects.filter(
+                content_type=self.comment_ct, object_id=comment.id
+            ).exists()
+        )
+
+    def test_comment_on_public_doc_creates_feed_entry(self):
+        comment = self._make_comment(self.public_post)
+
+        result = create_feed_entry(
+            item_id=comment.id,
+            item_content_type_id=self.comment_ct.id,
+            action=FeedEntry.PUBLISH,
+            user_id=self.author.id,
+        )
+
+        self.assertIsNotNone(result)
+        self.assertTrue(
+            FeedEntry.objects.filter(
+                content_type=self.comment_ct, object_id=comment.id
+            ).exists()
+        )

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -539,13 +539,15 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
             request_data = request.data
             hubs = Hub.objects.filter(id__in=request_data.get("hubs", [])).all()
             document_type = request_data.get("document_type")
-            is_public = request_data.get("is_public", True)
+            is_public = True
             # Only PREREGISTRATION posts may be created as private today.
-            if document_type != PREREGISTRATION:
-                is_public = True
+            if document_type == PREREGISTRATION:
+                is_public = serializers.BooleanField().run_validation(
+                    request_data.get("is_public", True)
+                )
             uni_doc = ResearchhubUnifiedDocument.objects.create(
                 document_type=document_type,
-                is_public=bool(is_public),
+                is_public=is_public,
             )
             uni_doc.hubs.add(*hubs)
             uni_doc.save()

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -74,7 +74,7 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
         request = self.request
         try:
             query_set = (
-                ResearchhubPost.objects.all()
+                ResearchhubPost.objects.visible_to(request.user)
                 .select_related("unified_document")
                 .prefetch_related(
                     Prefetch(
@@ -538,8 +538,14 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
         try:
             request_data = request.data
             hubs = Hub.objects.filter(id__in=request_data.get("hubs", [])).all()
+            document_type = request_data.get("document_type")
+            is_public = request_data.get("is_public", True)
+            # Only PREREGISTRATION posts may be created as private today.
+            if document_type != PREREGISTRATION:
+                is_public = True
             uni_doc = ResearchhubUnifiedDocument.objects.create(
-                document_type=request_data.get("document_type"),
+                document_type=document_type,
+                is_public=bool(is_public),
             )
             uni_doc.hubs.add(*hubs)
             uni_doc.save()

--- a/src/search/documents/post.py
+++ b/src/search/documents/post.py
@@ -162,4 +162,4 @@ class PostDocument(BaseDocument):
 
     @override
     def should_index_object(self, obj) -> bool:  # type: ignore[override]
-        return not obj.is_removed
+        return not obj.is_removed and obj.unified_document.is_public

--- a/src/search/tests/test_post_document.py
+++ b/src/search/tests/test_post_document.py
@@ -69,3 +69,13 @@ class PostDocumentTests(TestCase):
 
         self.assertEqual(result, 0)
 
+    def test_should_index_object_excludes_private_unified_document(self):
+        post = self._create_post("Private Post")
+        post.unified_document.is_public = False
+
+        self.assertFalse(self.document.should_index_object(post))
+
+    def test_should_index_object_includes_public_unremoved_post(self):
+        post = self._create_post("Public Post")
+
+        self.assertTrue(self.document.should_index_object(post))

--- a/src/user/signals/signals.py
+++ b/src/user/signals/signals.py
@@ -62,6 +62,10 @@ def create_action(sender, instance, created, **kwargs):
                     and (hasattr(instance, "is_removed") and instance.is_removed)
                 )
                 or (sender == RhCommentModel and not instance.is_public)
+                or (
+                    sender == ResearchhubPost
+                    and not instance.unified_document.is_public
+                )
                 or (sender == Bounty and instance.parent)  # Only show parent bounties
             )
             else True


### PR DESCRIPTION
- Step 1 of adding our privacy settings to preregistrations and rfps