### PR TITLE
Add cached invited-experts overview endpoint

### DIFF
--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -1,3 +1,6 @@
+from datetime import datetime, time
+
+from django.utils import timezone
 from rest_framework import serializers
 
 from paper.serializers import PaperSerializer
@@ -367,6 +370,44 @@ class ExpertSearchDetailSerializer(serializers.ModelSerializer):
         if obj.report_csv_url:
             out["csv"] = obj.report_csv_url
         return out or None
+
+
+class InvitedExpertOverviewQuerySerializer(serializers.Serializer):
+    """Query params for GET invited-experts overview."""
+
+    unified_document_id = serializers.IntegerField(required=False, allow_null=True)
+    start = serializers.DateField(required=False, allow_null=True)
+    end = serializers.DateField(required=False, allow_null=True)
+
+    def validate(self, attrs):
+        start_date = attrs.get("start")
+        end_date = attrs.get("end")
+        if start_date is not None and end_date is not None and start_date > end_date:
+            raise serializers.ValidationError(
+                {"end": "Must be greater than or equal to start."}
+            )
+        tz = timezone.get_current_timezone()
+        if start_date is not None:
+            attrs["start"] = timezone.make_aware(
+                datetime.combine(start_date, time.min), tz
+            )
+        if end_date is not None:
+            attrs["end"] = timezone.make_aware(
+                datetime.combine(end_date, time.max), tz
+            )
+        return attrs
+
+
+class InvitedExpertOverviewSerializer(serializers.Serializer):
+    """Response body for invited-experts overview (counts + cache timestamp)."""
+
+    experts_total = serializers.IntegerField(read_only=True)
+    experts_signed_up = serializers.IntegerField(read_only=True)
+    emails_generated = serializers.IntegerField(read_only=True)
+    emails_sent = serializers.IntegerField(read_only=True)
+    emails_bounced = serializers.IntegerField(read_only=True)
+    emails_opened = serializers.IntegerField(read_only=True)
+    cached_at = serializers.DateTimeField(read_only=True)
 
 
 class InvitedExpertSerializer(serializers.Serializer):

--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -399,7 +399,7 @@ class InvitedExpertOverviewQuerySerializer(serializers.Serializer):
 
 
 class InvitedExpertOverviewSerializer(serializers.Serializer):
-    """Response body for invited-experts overview (counts + cache timestamp)."""
+    """Response body for invited-experts overview (counts)."""
 
     experts_total = serializers.IntegerField(read_only=True)
     experts_signed_up = serializers.IntegerField(read_only=True)
@@ -407,7 +407,6 @@ class InvitedExpertOverviewSerializer(serializers.Serializer):
     emails_sent = serializers.IntegerField(read_only=True)
     emails_bounced = serializers.IntegerField(read_only=True)
     emails_opened = serializers.IntegerField(read_only=True)
-    cached_at = serializers.DateTimeField(read_only=True)
 
 
 class InvitedExpertSerializer(serializers.Serializer):

--- a/src/research_ai/urls.py
+++ b/src/research_ai/urls.py
@@ -14,6 +14,7 @@ from research_ai.views.expert_finder_views import (
     ExpertSearchListCreateView,
     ExpertSearchProgressStreamView,
     ExpertSearchWorkView,
+    InvitedExpertOverviewView,
     InvitedExpertsDocumentView,
 )
 from research_ai.views.template_views import TemplateDetailView, TemplateListView
@@ -27,6 +28,10 @@ urlpatterns = [
     path(
         "expert-finder/experts/<int:expert_id>/",
         ExpertDetailView.as_view(),
+    ),
+    path(
+        "expert-finder/invited-experts/overview/",
+        InvitedExpertOverviewView.as_view(),
     ),
     path(
         "expert-finder/documents/<int:unified_document_id>/invited/",

--- a/src/research_ai/views/expert_finder_views.py
+++ b/src/research_ai/views/expert_finder_views.py
@@ -242,15 +242,6 @@ INVITED_CACHE_SEC = 60 * 60 * 3  # 3 hours
 INVITED_OVERVIEW_CACHE_TTL = 60 * 60 * 1  # 1 hour
 
 
-def _invited_expert_overview_cache_key(*, unified_document_id, start, end):
-    ud_part = (
-        str(int(unified_document_id)) if unified_document_id is not None else "none"
-    )
-    start_part = start.isoformat() if start is not None else "none"
-    end_part = end.isoformat() if end is not None else "none"
-    return f"invited_expert_overview:ud={ud_part}:start={start_part}:end={end_part}"
-
-
 class InvitedExpertOverviewView(APIView):
     """
     GET ``/expert-finder/invited-experts/overview/``.
@@ -264,6 +255,15 @@ class InvitedExpertOverviewView(APIView):
         ResearchAIPermission,
         UserIsEditor | IsModerator,
     ]
+
+    @staticmethod
+    def _cache_key(*, unified_document_id, start, end):
+        ud_part = (
+            str(int(unified_document_id)) if unified_document_id is not None else "none"
+        )
+        start_part = start.isoformat() if start is not None else "none"
+        end_part = end.isoformat() if end is not None else "none"
+        return f"invited_expert_overview:ud={ud_part}:start={start_part}:end={end_part}"
 
     def get(self, request):
         qser = InvitedExpertOverviewQuerySerializer(data=request.query_params)
@@ -282,25 +282,27 @@ class InvitedExpertOverviewView(APIView):
                     status=status.HTTP_404_NOT_FOUND,
                 )
 
-        cache_key = _invited_expert_overview_cache_key(
+        cache_key = self._cache_key(
             unified_document_id=unified_document_id,
             start=start,
             end=end,
         )
-        cached_payload = cache.get(cache_key)
-        if cached_payload is not None:
-            return Response(cached_payload)
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return Response(cached)
 
         overview = get_invited_expert_overview(
             unified_document_id=unified_document_id,
             start=start,
             end=end,
         )
-        cached_at = timezone.now()
-        body = {**overview, "cached_at": cached_at}
-        response_data = InvitedExpertOverviewSerializer(body).data
-        cache.set(cache_key, response_data, INVITED_OVERVIEW_CACHE_TTL)
-        return Response(response_data)
+        response_data = InvitedExpertOverviewSerializer(overview).data
+        payload = {
+            **response_data,
+            "meta": {"cached_at": timezone.now().isoformat()},
+        }
+        cache.set(cache_key, payload, INVITED_OVERVIEW_CACHE_TTL)
+        return Response(payload)
 
 
 class InvitedExpertsDocumentView(APIView):

--- a/src/research_ai/views/expert_finder_views.py
+++ b/src/research_ai/views/expert_finder_views.py
@@ -1,8 +1,10 @@
 import json
 import logging
 
+from django.core.cache import cache
 from django.db.models import Prefetch
 from django.http import StreamingHttpResponse
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from rest_framework import status
@@ -19,11 +21,14 @@ from research_ai.serializers import (
     ExpertSearchListItemSerializer,
     ExpertSerializer,
     ExpertUpdateSerializer,
+    InvitedExpertOverviewQuerySerializer,
+    InvitedExpertOverviewSerializer,
     InvitedExpertSerializer,
     resolve_work_for_unified_document,
 )
 from research_ai.services.expert_finder_service import get_document_content
 from research_ai.services.invited_experts_service import (
+    get_invited_expert_overview,
     get_invited_rows_for_unified_document,
 )
 from research_ai.services.progress_service import ProgressService, TaskType
@@ -203,9 +208,7 @@ class ExpertSearchDetailView(APIView):
                 {"detail": "Expert search not found."},
                 status=status.HTTP_404_NOT_FOUND,
             )
-        ser = ExpertSearchDetailSerializer(
-            expert_search, context={"request": request}
-        )
+        ser = ExpertSearchDetailSerializer(expert_search, context={"request": request})
         return Response(ser.data)
 
 
@@ -235,6 +238,69 @@ class ExpertDetailView(APIView):
 
 INVITED_LIMIT = 20
 INVITED_CACHE_SEC = 60 * 60 * 3  # 3 hours
+
+INVITED_OVERVIEW_CACHE_TTL = 60 * 60 * 1  # 1 hour
+
+
+def _invited_expert_overview_cache_key(*, unified_document_id, start, end):
+    ud_part = (
+        str(int(unified_document_id)) if unified_document_id is not None else "none"
+    )
+    start_part = start.isoformat() if start is not None else "none"
+    end_part = end.isoformat() if end is not None else "none"
+    return f"invited_expert_overview:ud={ud_part}:start={start_part}:end={end_part}"
+
+
+class InvitedExpertOverviewView(APIView):
+    """
+    GET ``/expert-finder/invited-experts/overview/``.
+
+    Aggregates invited experts and generated-email metrics for ``ExpertSearch`` rows,
+    optionally scoped by unified document and ``created_date`` (calendar-day bounds).
+    """
+
+    permission_classes = [
+        IsAuthenticated,
+        ResearchAIPermission,
+        UserIsEditor | IsModerator,
+    ]
+
+    def get(self, request):
+        qser = InvitedExpertOverviewQuerySerializer(data=request.query_params)
+        qser.is_valid(raise_exception=True)
+        params = qser.validated_data
+        unified_document_id = params.get("unified_document_id")
+        start = params.get("start")
+        end = params.get("end")
+
+        if unified_document_id is not None:
+            try:
+                ResearchhubUnifiedDocument.objects.get(id=unified_document_id)
+            except ResearchhubUnifiedDocument.DoesNotExist:
+                return Response(
+                    {"detail": "Unified document not found."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+
+        cache_key = _invited_expert_overview_cache_key(
+            unified_document_id=unified_document_id,
+            start=start,
+            end=end,
+        )
+        cached_payload = cache.get(cache_key)
+        if cached_payload is not None:
+            return Response(cached_payload)
+
+        overview = get_invited_expert_overview(
+            unified_document_id=unified_document_id,
+            start=start,
+            end=end,
+        )
+        cached_at = timezone.now()
+        body = {**overview, "cached_at": cached_at}
+        response_data = InvitedExpertOverviewSerializer(body).data
+        cache.set(cache_key, response_data, INVITED_OVERVIEW_CACHE_TTL)
+        return Response(response_data)
 
 
 class InvitedExpertsDocumentView(APIView):


### PR DESCRIPTION
What?
=====

- Introduces **GET** `/expert-finder/invited-experts/overview/`, same auth/permissions as other expert-finder views.
- Query filters: 
  - optional `unified_document_id`, 
  - optional `start` / `end` as calendar dates; 
- Responses cached for 1h with a stable cache key from those params.

Example: `.../api/research_ai/expert-finder/invited-experts/overview/?unified_document_id=42&start=2026-01-01`