### PR TITLE
Replace invited-experts list endpoint with overview

### DIFF
--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -392,9 +392,7 @@ class InvitedExpertOverviewQuerySerializer(serializers.Serializer):
                 datetime.combine(start_date, time.min), tz
             )
         if end_date is not None:
-            attrs["end"] = timezone.make_aware(
-                datetime.combine(end_date, time.max), tz
-            )
+            attrs["end"] = timezone.make_aware(datetime.combine(end_date, time.max), tz)
         return attrs
 
 
@@ -408,23 +406,6 @@ class InvitedExpertOverviewSerializer(serializers.Serializer):
     emails_bounced = serializers.IntegerField(read_only=True)
     emails_opened = serializers.IntegerField(read_only=True)
     cached_at = serializers.DateTimeField(read_only=True)
-
-
-class InvitedExpertSerializer(serializers.Serializer):
-
-    user = serializers.SerializerMethodField()
-    expert_search_id = serializers.SerializerMethodField()
-    generated_email_id = serializers.SerializerMethodField()
-    invited_at = serializers.DateTimeField(source="created_date", read_only=True)
-
-    def get_user(self, obj):
-        return _get_user_with_author_payload(getattr(obj, "user", None))
-
-    def get_expert_search_id(self, obj):
-        return obj.expert_search_id
-
-    def get_generated_email_id(self, obj):
-        return obj.generated_email_id
 
 
 class ExpertSearchSubmitResponseSerializer(serializers.Serializer):

--- a/src/research_ai/services/invited_experts_service.py
+++ b/src/research_ai/services/invited_experts_service.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from types import SimpleNamespace
 
 from django.db.models import Count, Exists, OuterRef, Q
 from django.utils import timezone
@@ -37,45 +36,6 @@ def link_experts_registered_user_for_signup(*, normalized_email: str, user) -> i
         .filter(Exists(qualifying_ge))
         .update(registered_user_id=user.id)
     )
-
-
-def get_invited_rows_for_unified_document(unified_document_id: int) -> list:
-    """
-    Users linked as ``Expert.registered_user`` after appearing on an expert search for
-    this document. One row per user (most recent ``SearchExpert`` link first).
-
-    Each item has ``user``, ``expert_search_id``, ``generated_email_id`` (or None),
-    and ``created_date`` (for ``invited_at``).
-    """
-    ses = (
-        SearchExpert.objects.filter(
-            expert_search__unified_document_id=unified_document_id,
-            expert__registered_user__isnull=False,
-        )
-        .select_related("expert", "expert__registered_user", "expert_search")
-        .order_by("-created_date")
-    )
-    by_user: dict[int, SimpleNamespace] = {}
-    for se in ses:
-        user = se.expert.registered_user
-        if user is None or user.id in by_user:
-            continue
-        ge_id = (
-            GeneratedEmail.objects.filter(
-                expert_search_id=se.expert_search_id,
-                expert_email__iexact=se.expert.email,
-            )
-            .order_by("-created_date")
-            .values_list("id", flat=True)
-            .first()
-        )
-        by_user[user.id] = SimpleNamespace(
-            user=user,
-            expert_search_id=se.expert_search_id,
-            generated_email_id=ge_id,
-            created_date=se.created_date,
-        )
-    return sorted(by_user.values(), key=lambda x: x.created_date, reverse=True)
 
 
 def link_experts_for_new_user(*, normalized_email: str, user) -> None:

--- a/src/research_ai/tests/test_invited_experts_service.py
+++ b/src/research_ai/tests/test_invited_experts_service.py
@@ -4,9 +4,6 @@ from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from research_ai.models import Expert, ExpertSearch, GeneratedEmail, SearchExpert
-from research_ai.services.invited_experts_service import (
-    get_invited_rows_for_unified_document,
-)
 from user.tests.helpers import create_user
 
 
@@ -54,9 +51,6 @@ class InvitedExpertsSignalTests(TestCase):
         )
         ex.refresh_from_db()
         self.assertEqual(ex.registered_user_id, new_user.id)
-        rows = get_invited_rows_for_unified_document(self.ud_id)
-        self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0].user.id, new_user.id)
 
     def test_user_created_sets_expert_registered_user_when_expert_row_exists(self):
         first_seen = timezone.now() - timedelta(days=2)
@@ -115,18 +109,14 @@ class InvitedExpertsSignalTests(TestCase):
         )
         ex.refresh_from_db()
         self.assertIsNone(ex.registered_user_id)
-        self.assertEqual(
-            len(get_invited_rows_for_unified_document(self.ud_id)),
-            0,
-        )
 
     def test_user_created_email_not_in_any_search_does_not_link(self):
-        create_user(
+        stranger = create_user(
             email="stranger@example.com",
             first_name="Stranger",
             last_name="User",
         )
-        self.assertEqual(len(get_invited_rows_for_unified_document(self.ud_id)), 0)
+        self.assertFalse(Expert.objects.filter(registered_user_id=stranger.id).exists())
 
     def test_case_insensitive_email_links_expert(self):
         first_seen = timezone.now() - timedelta(days=2)
@@ -154,4 +144,3 @@ class InvitedExpertsSignalTests(TestCase):
         )
         ex.refresh_from_db()
         self.assertEqual(ex.registered_user_id, new_user.id)
-        self.assertEqual(len(get_invited_rows_for_unified_document(self.ud_id)), 1)

--- a/src/research_ai/tests/test_views.py
+++ b/src/research_ai/tests/test_views.py
@@ -1,5 +1,7 @@
+from datetime import timedelta
 from unittest.mock import patch
 
+from django.core.cache import cache
 from django.test import override_settings
 from django.utils import timezone
 from rest_framework import status
@@ -222,63 +224,47 @@ class ExpertSearchWorkViewTests(APITestCase):
         self.assertIsNone(data["work"])
 
 
-class InvitedExpertsDocumentViewTests(APITestCase):
+class InvitedExpertOverviewViewTests(APITestCase):
+    URL = "/api/research_ai/expert-finder/invited-experts/overview/"
+
+    OVERVIEW_FIELDS = (
+        "experts_total",
+        "experts_signed_up",
+        "emails_generated",
+        "emails_sent",
+        "emails_bounced",
+        "emails_opened",
+    )
+
     def setUp(self):
-        self.moderator = create_random_authenticated_user("mod_inv", moderator=True)
-        self.user = create_random_authenticated_user("user_inv", moderator=False)
-
-    def test_invited_requires_authentication(self):
-        response = self.client.get(
-            "/api/research_ai/expert-finder/documents/1/invited/"
+        self.moderator = create_random_authenticated_user(
+            "mod_overview", moderator=True
         )
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.user = create_random_authenticated_user("user_overview", moderator=False)
+        cache.clear()
 
-    def test_invited_requires_moderator(self):
+    def tearDown(self):
+        cache.clear()
+
+    def test_overview_requires_moderator(self):
         self.client.force_authenticate(self.user)
-        response = self.client.get(
-            "/api/research_ai/expert-finder/documents/1/invited/"
-        )
+        response = self.client.get(self.URL)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_invited_nonexistent_document_returns_404(self):
+    def test_overview_nonexistent_document_returns_404(self):
         self.client.force_authenticate(self.moderator)
-        response = self.client.get(
-            "/api/research_ai/expert-finder/documents/999999/invited/"
-        )
+        response = self.client.get(self.URL, {"unified_document_id": 999999})
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(
             response.json().get("detail"),
             "Unified document not found.",
         )
 
-    def test_invited_valid_document_returns_200_and_structure(self):
+    def test_overview_aggregates_counts_for_document(self):
         from paper.tests.helpers import create_paper
 
         paper = create_paper(
-            title="Invited endpoint paper",
-            paper_publish_date="2021-01-01",
-        )
-        self.client.force_authenticate(self.moderator)
-        response = self.client.get(
-            "/api/research_ai/expert-finder/documents/{}/invited/".format(
-                paper.unified_document_id
-            )
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()
-        self.assertIn("unified_document_id", data)
-        self.assertEqual(data["unified_document_id"], paper.unified_document_id)
-        self.assertIn("invited", data)
-        self.assertIsInstance(data["invited"], list)
-        self.assertIn("total_count", data)
-        self.assertEqual(data["total_count"], 0)
-        self.assertEqual(len(data["invited"]), 0)
-
-    def test_invited_returns_chain_ids_and_user_payload(self):
-        from paper.tests.helpers import create_paper
-
-        paper = create_paper(
-            title="Invited with data",
+            title="Overview paper",
             paper_publish_date="2021-01-01",
         )
         ud_id = paper.unified_document_id
@@ -286,38 +272,117 @@ class InvitedExpertsDocumentViewTests(APITestCase):
         search = ExpertSearch.objects.create(
             created_by=self.moderator,
             unified_document_id=ud_id,
-            query="Test",
+            query="Overview",
             status=ExpertSearch.Status.COMPLETED,
             completed_at=timezone.now(),
         )
-        ex = Expert.objects.create(
-            email="invited-view@edu",
-            first_name="Inv",
-            last_name="Expert",
+        signed_up_expert = Expert.objects.create(
+            email="signedup@example.com",
+            first_name="Signed",
+            last_name="Up",
             registered_user=self.moderator,
         )
-        SearchExpert.objects.create(expert_search=search, expert=ex, position=0)
+        not_signed_up_expert = Expert.objects.create(
+            email="invited@example.com",
+            first_name="Inv",
+            last_name="Expert",
+        )
+        SearchExpert.objects.create(
+            expert_search=search, expert=signed_up_expert, position=0
+        )
+        SearchExpert.objects.create(
+            expert_search=search, expert=not_signed_up_expert, position=1
+        )
         GeneratedEmail.objects.create(
             created_by=self.moderator,
             expert_search=search,
-            expert_email="invited-view@edu",
+            expert_email="signedup@example.com",
+            status=GeneratedEmail.Status.SENT,
+            opened_at=timezone.now(),
+            open_count=2,
         )
+        GeneratedEmail.objects.create(
+            created_by=self.moderator,
+            expert_search=search,
+            expert_email="invited@example.com",
+            status=GeneratedEmail.Status.BOUNCED,
+            bounced_at=timezone.now(),
+        )
+        GeneratedEmail.objects.create(
+            created_by=self.moderator,
+            expert_search=search,
+            expert_email="other@example.com",
+            status=GeneratedEmail.Status.DRAFT,
+        )
+
         self.client.force_authenticate(self.moderator)
-        response = self.client.get(
-            "/api/research_ai/expert-finder/documents/{}/invited/".format(ud_id)
-        )
+        response = self.client.get(self.URL, {"unified_document_id": ud_id})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
-        self.assertEqual(data["total_count"], 1)
-        self.assertEqual(len(data["invited"]), 1)
-        item = data["invited"][0]
-        self.assertNotIn("expert", item)
-        self.assertNotIn("author", item)
-        self.assertIn("user", item)
-        self.assertEqual(item["user"]["user_id"], self.moderator.id)
-        self.assertIsInstance(item["user"]["author"], (dict, type(None)))
-        self.assertIn("expert_search_id", item)
-        self.assertIn("generated_email_id", item)
+        self.assertEqual(data["experts_total"], 2)
+        self.assertEqual(data["experts_signed_up"], 1)
+        self.assertEqual(data["emails_generated"], 3)
+        self.assertEqual(data["emails_sent"], 1)
+        self.assertEqual(data["emails_bounced"], 1)
+        self.assertEqual(data["emails_opened"], 1)
+        self.assertIn("cached_at", data)
+
+    def test_overview_filters_by_date_range(self):
+        old_search = ExpertSearch.objects.create(
+            created_by=self.moderator,
+            query="Old",
+            status=ExpertSearch.Status.COMPLETED,
+        )
+        ExpertSearch.objects.filter(pk=old_search.pk).update(
+            created_date=timezone.now() - timedelta(days=30)
+        )
+        recent_search = ExpertSearch.objects.create(
+            created_by=self.moderator,
+            query="Recent",
+            status=ExpertSearch.Status.COMPLETED,
+        )
+        old_expert = Expert.objects.create(email="old@example.com")
+        recent_expert = Expert.objects.create(email="recent@example.com")
+        SearchExpert.objects.create(
+            expert_search=old_search, expert=old_expert, position=0
+        )
+        SearchExpert.objects.create(
+            expert_search=recent_search, expert=recent_expert, position=0
+        )
+        GeneratedEmail.objects.create(
+            created_by=self.moderator,
+            expert_search=old_search,
+            expert_email="old@example.com",
+            status=GeneratedEmail.Status.SENT,
+        )
+        GeneratedEmail.objects.create(
+            created_by=self.moderator,
+            expert_search=recent_search,
+            expert_email="recent@example.com",
+            status=GeneratedEmail.Status.SENT,
+        )
+
+        self.client.force_authenticate(self.moderator)
+        today = timezone.localdate()
+        start = (today - timedelta(days=2)).isoformat()
+        response = self.client.get(self.URL, {"start": start})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["experts_total"], 1)
+        self.assertEqual(data["emails_generated"], 1)
+        self.assertEqual(data["emails_sent"], 1)
+
+    def test_overview_invalid_date_range_returns_400(self):
+        self.client.force_authenticate(self.moderator)
+        today = timezone.localdate()
+        response = self.client.get(
+            self.URL,
+            {
+                "start": today.isoformat(),
+                "end": (today - timedelta(days=1)).isoformat(),
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)

--- a/src/research_ai/urls.py
+++ b/src/research_ai/urls.py
@@ -15,7 +15,6 @@ from research_ai.views.expert_finder_views import (
     ExpertSearchProgressStreamView,
     ExpertSearchWorkView,
     InvitedExpertOverviewView,
-    InvitedExpertsDocumentView,
 )
 from research_ai.views.template_views import TemplateDetailView, TemplateListView
 
@@ -32,10 +31,6 @@ urlpatterns = [
     path(
         "expert-finder/invited-experts/overview/",
         InvitedExpertOverviewView.as_view(),
-    ),
-    path(
-        "expert-finder/documents/<int:unified_document_id>/invited/",
-        InvitedExpertsDocumentView.as_view(),
     ),
     path(
         "expert-finder/work/<int:unified_document_id>/",

--- a/src/research_ai/views/expert_finder_views.py
+++ b/src/research_ai/views/expert_finder_views.py
@@ -5,8 +5,6 @@ from django.core.cache import cache
 from django.db.models import Prefetch
 from django.http import StreamingHttpResponse
 from django.utils import timezone
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -23,14 +21,10 @@ from research_ai.serializers import (
     ExpertUpdateSerializer,
     InvitedExpertOverviewQuerySerializer,
     InvitedExpertOverviewSerializer,
-    InvitedExpertSerializer,
     resolve_work_for_unified_document,
 )
 from research_ai.services.expert_finder_service import get_document_content
-from research_ai.services.invited_experts_service import (
-    get_invited_expert_overview,
-    get_invited_rows_for_unified_document,
-)
+from research_ai.services.invited_experts_service import get_invited_expert_overview
 from research_ai.services.progress_service import ProgressService, TaskType
 from research_ai.tasks import run_expert_finder_search
 from researchhub_document.models import ResearchhubUnifiedDocument
@@ -236,9 +230,6 @@ class ExpertDetailView(APIView):
         return Response(ExpertSerializer(expert).data)
 
 
-INVITED_LIMIT = 20
-INVITED_CACHE_SEC = 60 * 60 * 3  # 3 hours
-
 INVITED_OVERVIEW_CACHE_TTL = 60 * 60 * 1  # 1 hour
 
 
@@ -301,41 +292,6 @@ class InvitedExpertOverviewView(APIView):
         response_data = InvitedExpertOverviewSerializer(body).data
         cache.set(cache_key, response_data, INVITED_OVERVIEW_CACHE_TTL)
         return Response(response_data)
-
-
-class InvitedExpertsDocumentView(APIView):
-    """
-    GET ``/expert-finder/documents/<unified_document_id>/invited/``.
-
-    Each row includes the invited RH account as ``user`` (``user_id`` + ``author``).
-    """
-
-    permission_classes = [
-        IsAuthenticated,
-        ResearchAIPermission,
-        UserIsEditor | IsModerator,
-    ]
-
-    @method_decorator(cache_page(INVITED_CACHE_SEC))
-    def get(self, request, unified_document_id):
-        try:
-            ResearchhubUnifiedDocument.objects.get(id=unified_document_id)
-        except ResearchhubUnifiedDocument.DoesNotExist:
-            return Response(
-                {"detail": "Unified document not found."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-        rows = get_invited_rows_for_unified_document(unified_document_id)
-        total_count = len(rows)
-        page = rows[:INVITED_LIMIT]
-        invited_data = InvitedExpertSerializer(page, many=True).data
-        return Response(
-            {
-                "unified_document_id": unified_document_id,
-                "invited": invited_data,
-                "total_count": total_count,
-            }
-        )
 
 
 class ExpertSearchWorkView(APIView):


### PR DESCRIPTION
## What?
- Remove the `documents/<id>/invited/` route
- Wire **GET** `/expert-finder/invited-experts/overview/` as the sole invited-experts endpoint
- Update tests
