### PR TITLE
Use `/grant` and `/proposal` paths in unified document frontend links

### DIFF
--- a/src/researchhub_document/related_models/researchhub_unified_document_model.py
+++ b/src/researchhub_document/related_models/researchhub_unified_document_model.py
@@ -291,16 +291,20 @@ class ResearchhubUnifiedDocument(SoftDeletableModel, HotScoreMixin, DefaultModel
     def frontend_view_link(self):
         doc = self.get_document()
         document_type = self.document_type
-        if document_type in (
+        if document_type == GRANT:
+            path_segment = "grant"
+        elif document_type == PREREGISTRATION:
+            path_segment = "proposal"
+        elif document_type in (
             QUESTION,
             DISCUSSION,
             POSTS,
             BOUNTY,
-            PREREGISTRATION,
-            GRANT,
         ):
-            document_type = "post"
-        url = f"{BASE_FRONTEND_URL}/{document_type.lower()}/{doc.id}/{doc.slug}"
+            path_segment = "post"
+        else:
+            path_segment = document_type.lower()
+        url = f"{BASE_FRONTEND_URL}/{path_segment}/{doc.id}/{doc.slug}"
         return url
 
     # ========================================================================


### PR DESCRIPTION
What?
=====
- Updates `ResearchhubUnifiedDocument.frontend_view_link()` so `grant` and `preregistration` unified docs resolve to the correct frontend routes (`/grant/...` and `/proposal/...`). 
- Other post-like types (discussion, question, bounty, etc.) still use `/post/...`; 
- This affects any feature that builds URLs from this helper (notifications, emails, actions, etc.).