### PR TITLE
Expert finder invite private access and manual addition

### DIFF
--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -204,6 +204,49 @@ class ExpertUpdateSerializer(serializers.ModelSerializer):
         return attrs
 
 
+class ManualExpertCreateSerializer(serializers.Serializer):
+    """POST body for ``/expert-finder/searches/<id>/experts/`` (manual entry).
+
+    Email is required; rest are optional. Existing emails are upserted (not
+    rejected), unlike :class:`ExpertUpdateSerializer` which forbids duplicates.
+    """
+
+    email = serializers.CharField(required=True, allow_blank=False)
+    honorific = serializers.CharField(required=False, allow_blank=True)
+    first_name = serializers.CharField(required=False, allow_blank=True)
+    middle_name = serializers.CharField(required=False, allow_blank=True)
+    last_name = serializers.CharField(required=False, allow_blank=True)
+    name_suffix = serializers.CharField(required=False, allow_blank=True)
+    academic_title = serializers.CharField(required=False, allow_blank=True)
+    affiliation = serializers.CharField(required=False, allow_blank=True)
+    expertise = serializers.CharField(required=False, allow_blank=True)
+    notes = serializers.CharField(required=False, allow_blank=True)
+
+    def validate_email(self, value):
+        email = ExpertDisplay.normalize_email(value)
+        if not email:
+            raise serializers.ValidationError("This field may not be blank.")
+        return email
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        capped_fields = {
+            "honorific": 64,
+            "first_name": 255,
+            "middle_name": 255,
+            "last_name": 255,
+            "name_suffix": 64,
+            "academic_title": 255,
+        }
+        for field, max_len in capped_fields.items():
+            if field in attrs:
+                attrs[field] = trimmed_str(attrs[field], max_len=max_len)
+        for field in ("affiliation", "expertise", "notes"):
+            if field in attrs:
+                attrs[field] = trimmed_str(attrs[field])
+        return attrs
+
+
 class ResearchAIAuthorSerializer(serializers.ModelSerializer):
     """Author (creator) for research_ai list/detail responses; no nested user."""
 

--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -211,7 +211,7 @@ class ManualExpertCreateSerializer(serializers.Serializer):
     rejected), unlike :class:`ExpertUpdateSerializer` which forbids duplicates.
     """
 
-    email = serializers.CharField(required=True, allow_blank=False)
+    email = serializers.EmailField(required=True, allow_blank=False)
     honorific = serializers.CharField(required=False, allow_blank=True)
     first_name = serializers.CharField(required=False, allow_blank=True)
     middle_name = serializers.CharField(required=False, allow_blank=True)

--- a/src/research_ai/services/expert_persist.py
+++ b/src/research_ai/services/expert_persist.py
@@ -87,3 +87,29 @@ class ExpertPersist:
         Expert.objects.filter(email__iexact=em).update(
             last_email_sent_at=timezone.now()
         )
+
+    @staticmethod
+    def tag_manual_source(expert: Expert, user) -> None:
+        """Append a ``{"type": "manual", ...}`` marker to ``expert.sources``.
+
+        Idempotent per user: skips if a manual entry by the same user is already
+        present. Existing (e.g. LLM-populated) source entries are preserved.
+        """
+        sources = expert.sources if isinstance(expert.sources, list) else []
+        user_id = getattr(user, "id", None)
+        for entry in sources:
+            if (
+                isinstance(entry, dict)
+                and entry.get("type") == "manual"
+                and entry.get("added_by") == user_id
+            ):
+                return
+        sources.append(
+            {
+                "type": "manual",
+                "added_by": user_id,
+                "added_at": timezone.now().isoformat(),
+            }
+        )
+        expert.sources = sources
+        expert.save(update_fields=["sources"])

--- a/src/research_ai/services/invited_experts_service.py
+++ b/src/research_ai/services/invited_experts_service.py
@@ -1,11 +1,20 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
+from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, Exists, OuterRef, Q
 from django.utils import timezone
 
 from research_ai.constants import EXPERT_REGISTERED_USER_LINK_WINDOW_DAYS
 from research_ai.models import Expert, ExpertSearch, GeneratedEmail, SearchExpert
+from researchhub_access_group.constants import VIEWER
+from researchhub_access_group.models import Permission
+from researchhub_document.related_models.constants.document_type import (
+    PREREGISTRATION,
+)
+from researchhub_document.related_models.researchhub_unified_document_model import (
+    ResearchhubUnifiedDocument,
+)
 
 INVITE_WINDOW_DAYS = 7
 
@@ -39,15 +48,69 @@ def link_experts_registered_user_for_signup(*, normalized_email: str, user) -> i
     )
 
 
+def grant_invited_expert_access_for_signup(*, normalized_email: str, user) -> int:
+    """
+    Create VIEWER ``Permission`` rows on private preregistrations the user was
+    invited to via expert finder outreach, when a ``GeneratedEmail`` with
+    ``status=SENT`` exists in the link window.
+    """
+    email = (normalized_email or "").strip().lower()
+    if not email:
+        return 0
+
+    date_joined = getattr(user, "date_joined", None) or timezone.now()
+    window_end = date_joined
+    window_start = window_end - timedelta(days=EXPERT_REGISTERED_USER_LINK_WINDOW_DAYS)
+
+    invited_doc_ids = (
+        GeneratedEmail.objects.filter(
+            expert_email__iexact=email,
+            status=GeneratedEmail.Status.SENT,
+            created_date__gte=window_start,
+            created_date__lte=window_end,
+            expert_search__unified_document__isnull=False,
+        )
+        .values_list("expert_search__unified_document_id", flat=True)
+        .distinct()
+    )
+
+    qualifying_doc_ids = list(
+        ResearchhubUnifiedDocument.objects.filter(
+            id__in=invited_doc_ids,
+            is_public=False,
+            posts__document_type=PREREGISTRATION,
+        )
+        .values_list("id", flat=True)
+        .distinct()
+    )
+    if not qualifying_doc_ids:
+        return 0
+
+    content_type = ContentType.objects.get_for_model(ResearchhubUnifiedDocument)
+    granted = 0
+    for doc_id in qualifying_doc_ids:
+        _, created = Permission.objects.get_or_create(
+            content_type=content_type,
+            object_id=doc_id,
+            user=user,
+            defaults={"access_type": VIEWER},
+        )
+        if created:
+            granted += 1
+    return granted
+
+
 def link_experts_for_new_user(*, normalized_email: str, user) -> None:
     """
-    Link ``Expert`` rows for this signup email when outreach qualifies.
+    Link ``Expert`` rows for this signup email when outreach qualifies, and
+    grant access to any private preregistrations the user was invited to.
     """
     email = (normalized_email or "").strip().lower()
     if not email:
         return
 
     link_experts_registered_user_for_signup(normalized_email=email, user=user)
+    grant_invited_expert_access_for_signup(normalized_email=email, user=user)
 
 
 @dataclass(frozen=True)

--- a/src/research_ai/tests/test_expert_finder_views.py
+++ b/src/research_ai/tests/test_expert_finder_views.py
@@ -5,7 +5,7 @@ from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from research_ai.models import ExpertSearch
+from research_ai.models import Expert, ExpertSearch, GeneratedEmail, SearchExpert
 from user.tests.helpers import create_random_authenticated_user
 
 
@@ -97,3 +97,182 @@ class ExpertSearchListCreateViewTests(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+def _make_search(created_by, name="Manual Add Search"):
+    return ExpertSearch.objects.create(
+        created_by=created_by,
+        name=name,
+        query="ML",
+        input_type=ExpertSearch.InputType.CUSTOM_QUERY,
+        status=ExpertSearch.Status.COMPLETED,
+        progress=100,
+    )
+
+
+class ExpertSearchAddExpertViewTests(APITestCase):
+    def setUp(self):
+        self.moderator = create_random_authenticated_user("mod", moderator=True)
+        self.user = create_random_authenticated_user("user", moderator=False)
+        self.search = _make_search(self.moderator)
+        self.url = (
+            f"/api/research_ai/expert-finder/searches/{self.search.id}/experts/"
+        )
+
+    def _payload(self, **overrides):
+        payload = {
+            "email": "alice@example.com",
+            "first_name": "Alice",
+            "last_name": "Test",
+            "academic_title": "Professor",
+            "affiliation": "MIT",
+            "expertise": "ML",
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_post_requires_authentication(self):
+        response = self.client.post(self.url, self._payload(), format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_post_requires_editor(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.post(self.url, self._payload(), format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_post_404_for_unknown_search(self):
+        self.client.force_authenticate(self.moderator)
+        response = self.client.post(
+            "/api/research_ai/expert-finder/searches/999999/experts/",
+            self._payload(),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_post_email_required(self):
+        self.client.force_authenticate(self.moderator)
+        response = self.client.post(self.url, {"first_name": "Alice"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_post_creates_new_expert_and_search_expert(self):
+        self.client.force_authenticate(self.moderator)
+        response = self.client.post(self.url, self._payload(), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+        self.assertEqual(data["email"], "alice@example.com")
+        self.assertEqual(data["first_name"], "Alice")
+        self.assertEqual(data["academic_title"], "Professor")
+
+        expert = Expert.objects.get(email__iexact="alice@example.com")
+        self.assertEqual(data["id"], expert.id)
+        self.assertTrue(
+            SearchExpert.objects.filter(
+                expert_search=self.search, expert=expert
+            ).exists()
+        )
+
+    def test_post_normalizes_email_to_lowercase(self):
+        self.client.force_authenticate(self.moderator)
+        response = self.client.post(
+            self.url,
+            self._payload(email="Alice@Example.COM"),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(
+            Expert.objects.filter(email="alice@example.com").exists()
+        )
+
+    def test_post_upserts_existing_expert_preserving_non_blank_fields(self):
+        existing = Expert.objects.create(
+            email="bob@example.com",
+            first_name="Bob",
+            last_name="Llmfound",
+            academic_title="Associate Professor",
+            affiliation="Stanford",
+            expertise="NLP",
+        )
+        self.client.force_authenticate(self.moderator)
+        response = self.client.post(
+            self.url,
+            {"email": "bob@example.com"},  # blank everywhere else
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Expert.objects.filter(email="bob@example.com").count(), 1)
+
+        existing.refresh_from_db()
+        self.assertEqual(existing.first_name, "Bob")
+        self.assertEqual(existing.affiliation, "Stanford")
+
+    def test_post_appends_manual_source_tag(self):
+        existing = Expert.objects.create(
+            email="carol@example.com",
+            first_name="Carol",
+            sources=[{"type": "llm", "model": "test"}],
+        )
+        self.client.force_authenticate(self.moderator)
+        response = self.client.post(
+            self.url, self._payload(email="carol@example.com"), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        existing.refresh_from_db()
+        self.assertEqual(len(existing.sources), 2)
+        self.assertEqual(existing.sources[0]["type"], "llm")
+        self.assertEqual(existing.sources[1]["type"], "manual")
+        self.assertEqual(existing.sources[1]["added_by"], self.moderator.id)
+        self.assertIn("added_at", existing.sources[1])
+
+    def test_post_assigns_next_position(self):
+        for i, email in enumerate(["x@e.com", "y@e.com", "z@e.com"]):
+            ex = Expert.objects.create(email=email, first_name=email.split("@")[0])
+            SearchExpert.objects.create(
+                expert_search=self.search, expert=ex, position=i
+            )
+
+        self.client.force_authenticate(self.moderator)
+        response = self.client.post(self.url, self._payload(), format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        new_expert = Expert.objects.get(email="alice@example.com")
+        link = SearchExpert.objects.get(
+            expert_search=self.search, expert=new_expert
+        )
+        self.assertEqual(link.position, 3)
+
+    def test_post_duplicate_in_same_search_returns_409(self):
+        self.client.force_authenticate(self.moderator)
+        first = self.client.post(self.url, self._payload(), format="json")
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED)
+
+        second = self.client.post(self.url, self._payload(), format="json")
+        self.assertEqual(second.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(
+            SearchExpert.objects.filter(expert_search=self.search).count(), 1
+        )
+        self.assertEqual(
+            Expert.objects.filter(email="alice@example.com").count(), 1
+        )
+
+    @patch("research_ai.views.email_views.generate_expert_email")
+    def test_manual_expert_can_have_email_generated(self, mock_generate):
+        mock_generate.return_value = ("Subject", "Body")
+        self.client.force_authenticate(self.moderator)
+        add_response = self.client.post(self.url, self._payload(), format="json")
+        self.assertEqual(add_response.status_code, status.HTTP_201_CREATED)
+
+        gen_response = self.client.post(
+            "/api/research_ai/expert-finder/generate-email/",
+            {
+                "expert_search_id": self.search.id,
+                "expert_email": "alice@example.com",
+                "template": "collaboration",
+            },
+            format="json",
+        )
+        self.assertEqual(gen_response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(GeneratedEmail.objects.count(), 1)
+        rec = GeneratedEmail.objects.get()
+        self.assertEqual(rec.expert_email, "alice@example.com")
+        self.assertEqual(rec.expert_search_id, self.search.id)

--- a/src/research_ai/tests/test_invited_experts_service.py
+++ b/src/research_ai/tests/test_invited_experts_service.py
@@ -1,9 +1,20 @@
 from datetime import timedelta
 
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from research_ai.models import Expert, ExpertSearch, GeneratedEmail, SearchExpert
+from researchhub_access_group.constants import NO_ACCESS, VIEWER
+from researchhub_access_group.models import Permission
+from researchhub_document.helpers import create_post
+from researchhub_document.related_models.constants.document_type import (
+    DISCUSSION,
+    PREREGISTRATION,
+)
+from researchhub_document.related_models.researchhub_unified_document_model import (
+    ResearchhubUnifiedDocument,
+)
 from user.tests.helpers import create_user
 
 
@@ -144,3 +155,195 @@ class InvitedExpertsSignalTests(TestCase):
         )
         ex.refresh_from_db()
         self.assertEqual(ex.registered_user_id, new_user.id)
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+class GrantInvitedExpertAccessTests(TestCase):
+    """Signup grants VIEWER permission on private preregistrations the user was
+    invited to via a sent expert-finder outreach email."""
+
+    def setUp(self):
+        self.creator = create_user(email="creator@invited.test")
+        self.unified_doc_ct = ContentType.objects.get_for_model(
+            ResearchhubUnifiedDocument
+        )
+
+    def _make_private_preregistration(self):
+        post = create_post(
+            title="Private prereg",
+            created_by=self.creator,
+            document_type=PREREGISTRATION,
+        )
+        post.unified_document.is_public = False
+        post.unified_document.save(update_fields=["is_public"])
+        return post
+
+    def _make_search(self, unified_document, completed_at):
+        return ExpertSearch.objects.create(
+            created_by=self.creator,
+            unified_document=unified_document,
+            query="Test",
+            status=ExpertSearch.Status.COMPLETED,
+            completed_at=completed_at,
+        )
+
+    def _make_generated_email(
+        self,
+        *,
+        search,
+        email,
+        status=GeneratedEmail.Status.SENT,
+        created_at=None,
+    ):
+        ge = GeneratedEmail.objects.create(
+            created_by=self.creator,
+            expert_search=search,
+            expert_email=email,
+            status=status,
+        )
+        if created_at is not None:
+            GeneratedEmail.objects.filter(pk=ge.pk).update(created_date=created_at)
+        return ge
+
+    def test_sent_email_in_window_grants_viewer_permission(self):
+        when = timezone.now() - timedelta(days=2)
+        post = self._make_private_preregistration()
+        search = self._make_search(post.unified_document, when)
+        self._make_generated_email(
+            search=search, email="invitee@example.com", created_at=when
+        )
+
+        new_user = create_user(
+            email="invitee@example.com", first_name="In", last_name="Vitee"
+        )
+
+        perm = Permission.objects.get(
+            content_type=self.unified_doc_ct,
+            object_id=post.unified_document_id,
+            user=new_user,
+        )
+        self.assertEqual(perm.access_type, VIEWER)
+
+    def test_draft_email_does_not_grant_permission(self):
+        when = timezone.now() - timedelta(days=1)
+        post = self._make_private_preregistration()
+        search = self._make_search(post.unified_document, when)
+        self._make_generated_email(
+            search=search,
+            email="draftonly@example.com",
+            status=GeneratedEmail.Status.DRAFT,
+            created_at=when,
+        )
+
+        new_user = create_user(
+            email="draftonly@example.com", first_name="D", last_name="Raft"
+        )
+
+        self.assertFalse(
+            Permission.objects.filter(
+                content_type=self.unified_doc_ct,
+                object_id=post.unified_document_id,
+                user=new_user,
+            ).exists()
+        )
+
+    def test_sent_email_outside_window_does_not_grant_permission(self):
+        when = timezone.now() - timedelta(days=10)
+        post = self._make_private_preregistration()
+        search = self._make_search(post.unified_document, when)
+        self._make_generated_email(
+            search=search, email="late@example.com", created_at=when
+        )
+
+        new_user = create_user(
+            email="late@example.com", first_name="La", last_name="Te"
+        )
+
+        self.assertFalse(
+            Permission.objects.filter(
+                content_type=self.unified_doc_ct,
+                object_id=post.unified_document_id,
+                user=new_user,
+            ).exists()
+        )
+
+    def test_public_document_does_not_grant_permission(self):
+        when = timezone.now() - timedelta(days=2)
+        public_post = create_post(
+            title="Public prereg",
+            created_by=self.creator,
+            document_type=PREREGISTRATION,
+        )
+        # default is_public=True
+        search = self._make_search(public_post.unified_document, when)
+        self._make_generated_email(
+            search=search, email="onpublic@example.com", created_at=when
+        )
+
+        new_user = create_user(
+            email="onpublic@example.com", first_name="O", last_name="Pub"
+        )
+
+        self.assertFalse(
+            Permission.objects.filter(
+                content_type=self.unified_doc_ct,
+                object_id=public_post.unified_document_id,
+                user=new_user,
+            ).exists()
+        )
+
+    def test_non_preregistration_document_does_not_grant_permission(self):
+        when = timezone.now() - timedelta(days=2)
+        post = create_post(
+            title="Private discussion",
+            created_by=self.creator,
+            document_type=DISCUSSION,
+        )
+        post.unified_document.is_public = False
+        post.unified_document.save(update_fields=["is_public"])
+
+        search = self._make_search(post.unified_document, when)
+        self._make_generated_email(
+            search=search, email="notprereg@example.com", created_at=when
+        )
+
+        new_user = create_user(
+            email="notprereg@example.com", first_name="N", last_name="P"
+        )
+
+        self.assertFalse(
+            Permission.objects.filter(
+                content_type=self.unified_doc_ct,
+                object_id=post.unified_document_id,
+                user=new_user,
+            ).exists()
+        )
+
+    def test_grant_is_idempotent(self):
+        when = timezone.now() - timedelta(days=2)
+        post = self._make_private_preregistration()
+        search = self._make_search(post.unified_document, when)
+        self._make_generated_email(
+            search=search, email="dupe@example.com", created_at=when
+        )
+
+        from research_ai.services.invited_experts_service import (
+            grant_invited_expert_access_for_signup,
+        )
+
+        new_user = create_user(
+            email="dupe@example.com", first_name="D", last_name="Upe"
+        )
+
+        # Re-run the granter; should not create a second Permission row.
+        grant_invited_expert_access_for_signup(
+            normalized_email="dupe@example.com", user=new_user
+        )
+        self.assertEqual(
+            Permission.objects.filter(
+                content_type=self.unified_doc_ct,
+                object_id=post.unified_document_id,
+                user=new_user,
+            ).count(),
+            1,
+        )

--- a/src/research_ai/tests/test_invited_experts_service.py
+++ b/src/research_ai/tests/test_invited_experts_service.py
@@ -4,8 +4,12 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
+from paper.tests.helpers import create_paper
 from research_ai.models import Expert, ExpertSearch, GeneratedEmail, SearchExpert
-from researchhub_access_group.constants import NO_ACCESS, VIEWER
+from research_ai.services.invited_experts_service import (
+    grant_invited_expert_access_for_signup,
+)
+from researchhub_access_group.constants import VIEWER
 from researchhub_access_group.models import Permission
 from researchhub_document.helpers import create_post
 from researchhub_document.related_models.constants.document_type import (
@@ -23,8 +27,6 @@ class InvitedExpertsSignalTests(TestCase):
     """Signup links ``Expert.registered_user`` when outreach qualifies."""
 
     def setUp(self):
-        from paper.tests.helpers import create_paper
-
         self.creator = create_user(email="creator@signal.test")
         self.paper = create_paper(
             title="Signal doc",
@@ -325,10 +327,6 @@ class GrantInvitedExpertAccessTests(TestCase):
         search = self._make_search(post.unified_document, when)
         self._make_generated_email(
             search=search, email="dupe@example.com", created_at=when
-        )
-
-        from research_ai.services.invited_experts_service import (
-            grant_invited_expert_access_for_signup,
         )
 
         new_user = create_user(

--- a/src/research_ai/urls.py
+++ b/src/research_ai/urls.py
@@ -10,6 +10,7 @@ from research_ai.views.email_views import (
 )
 from research_ai.views.expert_finder_views import (
     ExpertDetailView,
+    ExpertSearchAddExpertView,
     ExpertSearchDetailView,
     ExpertSearchListCreateView,
     ExpertSearchProgressStreamView,
@@ -23,6 +24,10 @@ urlpatterns = [
     path(
         "expert-finder/searches/<int:search_id>/",
         ExpertSearchDetailView.as_view(),
+    ),
+    path(
+        "expert-finder/searches/<int:search_id>/experts/",
+        ExpertSearchAddExpertView.as_view(),
     ),
     path(
         "expert-finder/experts/<int:expert_id>/",

--- a/src/research_ai/views/expert_finder_views.py
+++ b/src/research_ai/views/expert_finder_views.py
@@ -2,7 +2,8 @@ import json
 import logging
 
 from django.core.cache import cache
-from django.db.models import Prefetch
+from django.db import IntegrityError, transaction
+from django.db.models import Max, Prefetch
 from django.http import StreamingHttpResponse
 from django.utils import timezone
 from rest_framework import status
@@ -21,9 +22,11 @@ from research_ai.serializers import (
     ExpertUpdateSerializer,
     InvitedExpertOverviewQuerySerializer,
     InvitedExpertOverviewSerializer,
+    ManualExpertCreateSerializer,
     resolve_work_for_unified_document,
 )
 from research_ai.services.expert_finder_service import get_document_content
+from research_ai.services.expert_persist import ExpertPersist
 from research_ai.services.invited_experts_service import get_invited_expert_overview
 from research_ai.services.progress_service import ProgressService, TaskType
 from research_ai.tasks import run_expert_finder_search
@@ -228,6 +231,63 @@ class ExpertDetailView(APIView):
         ser.is_valid(raise_exception=True)
         ser.save()
         return Response(ExpertSerializer(expert).data)
+
+
+class ExpertSearchAddExpertView(APIView):
+    """POST ``/expert-finder/searches/<search_id>/experts/`` — manually add an expert.
+
+    Upserts the canonical ``Expert`` (one row per email) and links it to the
+    given ``ExpertSearch`` via a new ``SearchExpert`` row appended at the end
+    of the existing ordering.
+    """
+
+    permission_classes = [
+        IsAuthenticated,
+        ResearchAIPermission,
+        UserIsEditor | IsModerator,
+    ]
+
+    def post(self, request, search_id):
+        try:
+            expert_search = ExpertSearch.objects.get(id=search_id)
+        except ExpertSearch.DoesNotExist:
+            return Response(
+                {"detail": "Expert search not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        ser = ManualExpertCreateSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        data = ser.validated_data
+
+        try:
+            with transaction.atomic():
+                expert = ExpertPersist.upsert_from_parsed_dict(data)
+                ExpertPersist.tag_manual_source(expert, request.user)
+                max_position = SearchExpert.objects.filter(
+                    expert_search_id=expert_search.id
+                ).aggregate(Max("position"))["position__max"]
+                next_position = (max_position if max_position is not None else -1) + 1
+                SearchExpert.objects.create(
+                    expert_search_id=expert_search.id,
+                    expert_id=expert.id,
+                    position=next_position,
+                )
+        except IntegrityError:
+            return Response(
+                {"detail": "This expert is already in this search."},
+                status=status.HTTP_409_CONFLICT,
+            )
+        except ValueError as e:
+            return Response(
+                {"detail": str(e)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return Response(
+            ExpertSerializer(expert).data,
+            status=status.HTTP_201_CREATED,
+        )
 
 
 INVITED_OVERVIEW_CACHE_TTL = 60 * 60 * 1  # 1 hour

--- a/src/researchhub_document/related_models/researchhub_post_model.py
+++ b/src/researchhub_document/related_models/researchhub_post_model.py
@@ -5,6 +5,7 @@ from django.db.models.functions import Cast
 
 from discussion.models import AbstractGenericReactionModel, Vote
 from purchase.models import Purchase
+from researchhub_access_group.constants import NO_ACCESS
 from researchhub_comment.models import RhCommentThreadModel
 from researchhub_document.related_models.constants.document_type import (
     DISCUSSION,
@@ -30,8 +31,6 @@ class ResearchhubPostQuerySet(models.QuerySet):
         users with a non-revoked Permission on the post's unified document
         (e.g. invited experts).
         """
-        from researchhub_access_group.constants import NO_ACCESS
-
         public = Q(unified_document__is_public=True)
         if user is None or not getattr(user, "is_authenticated", False):
             return self.filter(public)

--- a/src/researchhub_document/related_models/researchhub_post_model.py
+++ b/src/researchhub_document/related_models/researchhub_post_model.py
@@ -25,14 +25,24 @@ class ResearchhubPostQuerySet(models.QuerySet):
         """Restrict to posts the given user is allowed to see.
 
         Public posts (unified_document.is_public=True) are visible to anyone.
-        Private posts are visible only to their author and to the creator of
-        any grant the post has applied to (via GrantApplication).
+        Private posts are visible only to their author, to the creator of
+        any grant the post has applied to (via GrantApplication), and to
+        users with a non-revoked Permission on the post's unified document
+        (e.g. invited experts).
         """
+        from researchhub_access_group.constants import NO_ACCESS
+
         public = Q(unified_document__is_public=True)
         if user is None or not getattr(user, "is_authenticated", False):
             return self.filter(public)
         return self.filter(
-            public | Q(created_by=user) | Q(grant_applications__grant__created_by=user)
+            public
+            | Q(created_by=user)
+            | Q(grant_applications__grant__created_by=user)
+            | (
+                Q(unified_document__permissions__user=user)
+                & ~Q(unified_document__permissions__access_type=NO_ACCESS)
+            )
         ).distinct()
 
 

--- a/src/researchhub_document/related_models/researchhub_post_model.py
+++ b/src/researchhub_document/related_models/researchhub_post_model.py
@@ -1,11 +1,13 @@
 from django.contrib.contenttypes.fields import GenericRelation
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.db.models import IntegerField, Q, Sum
+from django.db.models import Exists, IntegerField, OuterRef, Q, Sum
 from django.db.models.functions import Cast
 
 from discussion.models import AbstractGenericReactionModel, Vote
 from purchase.models import Purchase
 from researchhub_access_group.constants import NO_ACCESS
+from researchhub_access_group.models import Permission
 from researchhub_comment.models import RhCommentThreadModel
 from researchhub_document.related_models.constants.document_type import (
     DISCUSSION,
@@ -29,19 +31,27 @@ class ResearchhubPostQuerySet(models.QuerySet):
         Private posts are visible only to their author, to the creator of
         any grant the post has applied to (via GrantApplication), and to
         users with a non-revoked Permission on the post's unified document
-        (e.g. invited experts).
+        (e.g. invited experts). A NO_ACCESS Permission row revokes access even
+        when other (e.g. stale VIEWER) rows exist for the same user/document.
         """
         public = Q(unified_document__is_public=True)
         if user is None or not getattr(user, "is_authenticated", False):
             return self.filter(public)
+
+        ud_ct = ContentType.objects.get_for_model(ResearchhubUnifiedDocument)
+        user_perms = Permission.objects.filter(
+            content_type=ud_ct,
+            object_id=OuterRef("unified_document_id"),
+            user=user,
+        )
+        allowed = user_perms.exclude(access_type=NO_ACCESS)
+        revoked = user_perms.filter(access_type=NO_ACCESS)
+
         return self.filter(
             public
             | Q(created_by=user)
             | Q(grant_applications__grant__created_by=user)
-            | (
-                Q(unified_document__permissions__user=user)
-                & ~Q(unified_document__permissions__access_type=NO_ACCESS)
-            )
+            | (Exists(allowed) & ~Exists(revoked))
         ).distinct()
 
 

--- a/src/researchhub_document/tests/test_private_preregistration.py
+++ b/src/researchhub_document/tests/test_private_preregistration.py
@@ -14,6 +14,8 @@ from purchase.related_models.constants.currency import USD
 from purchase.related_models.grant_application_model import GrantApplication
 from purchase.related_models.grant_model import Grant
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
+from researchhub_access_group.constants import NO_ACCESS, VIEWER
+from researchhub_access_group.models import Permission
 from researchhub_comment.related_models.rh_comment_model import RhCommentModel
 from researchhub_comment.related_models.rh_comment_thread_model import (
     RhCommentThreadModel,
@@ -205,9 +207,6 @@ class VisibleToQuerySetTests(AWSMockTestCase):
         self.assertIn(self.private_post.id, ids)
 
     def test_invited_expert_with_viewer_permission_sees_private(self):
-        from researchhub_access_group.constants import NO_ACCESS, VIEWER
-        from researchhub_access_group.models import Permission
-
         invited = _make_user("invited")
         revoked = _make_user("revoked")
 

--- a/src/researchhub_document/tests/test_private_preregistration.py
+++ b/src/researchhub_document/tests/test_private_preregistration.py
@@ -209,20 +209,19 @@ class VisibleToQuerySetTests(AWSMockTestCase):
     def test_invited_expert_with_viewer_permission_sees_private(self):
         invited = _make_user("invited")
         revoked = _make_user("revoked")
+        ud_ct = ContentType.objects.get_for_model(
+            self.private_post.unified_document.__class__
+        )
 
         Permission.objects.create(
             access_type=VIEWER,
-            content_type=ContentType.objects.get_for_model(
-                self.private_post.unified_document.__class__
-            ),
+            content_type=ud_ct,
             object_id=self.private_post.unified_document_id,
             user=invited,
         )
         Permission.objects.create(
             access_type=NO_ACCESS,
-            content_type=ContentType.objects.get_for_model(
-                self.private_post.unified_document.__class__
-            ),
+            content_type=ud_ct,
             object_id=self.private_post.unified_document_id,
             user=revoked,
         )
@@ -236,6 +235,34 @@ class VisibleToQuerySetTests(AWSMockTestCase):
             ResearchhubPost.objects.visible_to(revoked).values_list("id", flat=True)
         )
         self.assertNotIn(self.private_post.id, revoked_ids)
+
+    def test_no_access_revokes_even_when_viewer_row_exists(self):
+        """A NO_ACCESS row must override any other Permission rows for the same
+        user on the same document — the model has no uniqueness constraint, so
+        stale VIEWER rows can coexist with a later NO_ACCESS revocation.
+        """
+        user = _make_user("dual")
+        ud_ct = ContentType.objects.get_for_model(
+            self.private_post.unified_document.__class__
+        )
+
+        Permission.objects.create(
+            access_type=VIEWER,
+            content_type=ud_ct,
+            object_id=self.private_post.unified_document_id,
+            user=user,
+        )
+        Permission.objects.create(
+            access_type=NO_ACCESS,
+            content_type=ud_ct,
+            object_id=self.private_post.unified_document_id,
+            user=user,
+        )
+
+        ids = set(
+            ResearchhubPost.objects.visible_to(user).values_list("id", flat=True)
+        )
+        self.assertNotIn(self.private_post.id, ids)
 
 
 class PostViewSetVisibilityTests(AWSMockTestCase):

--- a/src/researchhub_document/tests/test_private_preregistration.py
+++ b/src/researchhub_document/tests/test_private_preregistration.py
@@ -204,6 +204,40 @@ class VisibleToQuerySetTests(AWSMockTestCase):
         )
         self.assertIn(self.private_post.id, ids)
 
+    def test_invited_expert_with_viewer_permission_sees_private(self):
+        from researchhub_access_group.constants import NO_ACCESS, VIEWER
+        from researchhub_access_group.models import Permission
+
+        invited = _make_user("invited")
+        revoked = _make_user("revoked")
+
+        Permission.objects.create(
+            access_type=VIEWER,
+            content_type=ContentType.objects.get_for_model(
+                self.private_post.unified_document.__class__
+            ),
+            object_id=self.private_post.unified_document_id,
+            user=invited,
+        )
+        Permission.objects.create(
+            access_type=NO_ACCESS,
+            content_type=ContentType.objects.get_for_model(
+                self.private_post.unified_document.__class__
+            ),
+            object_id=self.private_post.unified_document_id,
+            user=revoked,
+        )
+
+        invited_ids = set(
+            ResearchhubPost.objects.visible_to(invited).values_list("id", flat=True)
+        )
+        self.assertIn(self.private_post.id, invited_ids)
+
+        revoked_ids = set(
+            ResearchhubPost.objects.visible_to(revoked).values_list("id", flat=True)
+        )
+        self.assertNotIn(self.private_post.id, revoked_ids)
+
 
 class PostViewSetVisibilityTests(AWSMockTestCase):
     """ResearchhubPostViewSet hides private posts from non-authorized requesters."""


### PR DESCRIPTION
- Allow user to create manual expert
- Invited experts should have access to private preregistration they're invited to