### PR TITLE
Switch tooling to ruff

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,36 +31,23 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"ms-python.black-formatter",
+				"charliermarsh.ruff",
 				"ms-python.debugpy",
-				"ms-python.flake8",
-				"ms-python.isort",
 				"ms-python.vscode-python-envs"
 			],
 			"settings": {
 				"[python]": {
-					"editor.defaultFormatter": "ms-python.black-formatter",
+					"editor.defaultFormatter": "charliermarsh.ruff",
 					"editor.formatOnSave": true,
 					"editor.codeActionsOnSave": {
-						"source.organizeImports": "explicit",
-						"source.unusedImports": "never"
+						"source.organizeImports.ruff": "explicit"
 					}
 				},
-				// Align line length between black and flake8 to black's default of 88.
-				// See: https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length
-				"black-formatter.args": [
-					"--line-length=88"
-				],
 				"files.exclude": {
 					"**/__pycache__": true
 				},
-				"flake8.args": [
-					"--max-line-length=88"
-				],
 				"git.blame.editorDecoration.enabled": true,
 				"git.blame.statusBarItem.enabled": true,
-				// Import sorting, see: https://github.com/microsoft/vscode-isort?tab=readme-ov-file#usage-and-features
-				"isort.args":["--profile", "black"],
 				"python.analysis.autoImportCompletions": true,
 				"python.analysis.indexing": true,
 				"python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,11 @@ src = ["src"]
 extend-exclude = ["*/migrations/*"]
 
 [tool.ruff.lint]
-extend-select = ["I"]  # isort
+extend-select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "I",  # isort
+]
 extend-ignore = [
     # Temporarily ignore these violations until cleaned up:
     "E402",  # module-import-not-at-top-of-file

--- a/src/.pre-commit-config.yaml
+++ b/src/.pre-commit-config.yaml
@@ -9,21 +9,9 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 8.0.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
     hooks:
-      - id: isort
-        exclude: /migrations
-        args: [--profile=black]
-
-  - repo: https://github.com/psf/black
-    rev: 26.3.1
-    hooks:
-      - id: black
-        exclude: /migrations
-        # It is recommended to specify the latest version of Python
-        # supported by your project here, or alternatively use
-        # pre-commit's default_language_version, see
-        # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.13
-        additional_dependencies: ["click==8.0.4"]
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format


### PR DESCRIPTION
- Replace the black, flake8 and isort extensions with the ruff extension.
- Replace black and isort with ruff.