### PR TITLE
Bounty guard

### DIFF
--- a/src/reputation/permissions.py
+++ b/src/reputation/permissions.py
@@ -84,6 +84,9 @@ class UserCanCancelBounty(BasePermission):
     def has_object_permission(self, request, view, obj):
         self.message = "Invalid Bounty user"
 
+        if obj.parent_id:
+            obj = obj.parent
+
         if obj.status not in (Bounty.OPEN, Bounty.ASSESSMENT):
             self.message = "Bounty is closed."
             return False

--- a/src/reputation/permissions.py
+++ b/src/reputation/permissions.py
@@ -48,6 +48,9 @@ class UserCanApproveBounty(BasePermission):
     def has_object_permission(self, request, view, obj):
         self.message = "Invalid Bounty user"
 
+        if obj.parent_id:
+            obj = obj.parent
+
         if obj.status not in (Bounty.OPEN, Bounty.ASSESSMENT):
             self.message = "Bounty is closed."
             return False

--- a/src/reputation/tests/test_bounties.py
+++ b/src/reputation/tests/test_bounties.py
@@ -747,6 +747,15 @@ class BountyViewTests(APITestCase):
 
         self.assertEqual(cancel_bounty_res_1.status_code, 403)
 
+    def test_contributor_cannot_cancel_via_child_bounty_id(self):
+        bounty_1, bounty_2 = self.test_user_can_contribute_to_bounty()
+        self.client.force_authenticate(self.user_2)
+        cancel_bounty_res = self.client.post(
+            f"/api/bounty/{bounty_2.data['id']}/cancel_bounty/",
+        )
+
+        self.assertEqual(cancel_bounty_res.status_code, 403)
+
     def test_random_user_cant_cancel_multi_bounty(self):
         self.client.force_authenticate(self.user)
 

--- a/src/reputation/tests/test_bounties.py
+++ b/src/reputation/tests/test_bounties.py
@@ -17,7 +17,7 @@ from paper.tests.helpers import create_paper
 from reputation.constants.bounty import ASSESSMENT_PERIOD_DAYS
 from reputation.distributions import Distribution as Dist
 from reputation.distributor import Distributor
-from reputation.models import Bounty, BountyFee, BountySolution, Distribution, Escrow
+from reputation.models import Bounty, BountyFee, BountySolution, Distribution
 from reputation.tasks import check_open_bounties
 from researchhub_comment.constants.rh_comment_thread_types import PEER_REVIEW
 from researchhub_comment.models import RhCommentModel, RhCommentThreadModel
@@ -28,7 +28,7 @@ from researchhub_document.related_models.researchhub_unified_document_model impo
     ResearchhubUnifiedDocument,
 )
 from user.models import User
-from user.related_models.user_model import FOUNDATION_EMAIL, FOUNDATION_REVENUE_EMAIL
+from user.related_models.user_model import FOUNDATION_REVENUE_EMAIL
 from user.tests.helpers import create_moderator, create_random_default_user, create_user
 
 
@@ -640,38 +640,6 @@ class BountyViewTests(APITestCase):
         )
 
         self.assertEqual(approve_bounty_res.status_code, 200)
-
-    def test_cannot_contribute_to_foundation_review_bounty(self):
-        foundation = create_user(email=FOUNDATION_EMAIL)
-        comment_ct = ContentType.objects.get_for_model(self.comment)
-        escrow = Escrow.objects.create(
-            hold_type=Escrow.BOUNTY,
-            created_by=foundation,
-            content_type=comment_ct,
-            object_id=self.comment.id,
-            amount_holding=100,
-        )
-        Bounty.objects.create(
-            created_by=foundation,
-            escrow=escrow,
-            item=self.comment,
-            unified_document=self.comment.unified_document,
-            amount=100,
-            bounty_type=Bounty.Type.REVIEW,
-            status=Bounty.OPEN,
-        )
-
-        self.client.force_authenticate(self.user_2)
-        contribute_res = self.client.post(
-            "/api/bounty/",
-            {
-                "amount": 10,
-                "item_content_type": self.comment._meta.model_name,
-                "item_object_id": self.comment.id,
-            },
-        )
-
-        self.assertEqual(contribute_res.status_code, 403)
 
     def test_user_can_cancel_bounty(self):
         self.client.force_authenticate(self.user)

--- a/src/reputation/tests/test_bounties.py
+++ b/src/reputation/tests/test_bounties.py
@@ -17,7 +17,7 @@ from paper.tests.helpers import create_paper
 from reputation.constants.bounty import ASSESSMENT_PERIOD_DAYS
 from reputation.distributions import Distribution as Dist
 from reputation.distributor import Distributor
-from reputation.models import Bounty, BountyFee, BountySolution, Distribution
+from reputation.models import Bounty, BountyFee, BountySolution, Distribution, Escrow
 from reputation.tasks import check_open_bounties
 from researchhub_comment.constants.rh_comment_thread_types import PEER_REVIEW
 from researchhub_comment.models import RhCommentModel, RhCommentThreadModel
@@ -28,7 +28,7 @@ from researchhub_document.related_models.researchhub_unified_document_model impo
     ResearchhubUnifiedDocument,
 )
 from user.models import User
-from user.related_models.user_model import FOUNDATION_REVENUE_EMAIL
+from user.related_models.user_model import FOUNDATION_EMAIL, FOUNDATION_REVENUE_EMAIL
 from user.tests.helpers import create_moderator, create_random_default_user, create_user
 
 
@@ -600,6 +600,78 @@ class BountyViewTests(APITestCase):
         )
 
         self.assertEqual(approve_bounty_res.status_code, 403)
+
+    def test_contributor_cannot_approve_via_child_bounty_id(self):
+        bounty_1, bounty_2 = self.test_user_can_contribute_to_bounty(
+            amount_1=600, amount_2=400
+        )
+        parent_bounty = Bounty.objects.get(id=bounty_1.data["id"])
+        total_pool = parent_bounty.escrow.amount_holding
+
+        self.client.force_authenticate(self.user_2)
+        approve_bounty_res = self.client.post(
+            f"/api/bounty/{bounty_2.data['id']}/approve_bounty/",
+            [
+                {
+                    "amount": str(total_pool),
+                    "object_id": self.comment.id,
+                    "content_type": self.comment._meta.model_name,
+                }
+            ],
+        )
+
+        self.assertEqual(approve_bounty_res.status_code, 403)
+
+    def test_parent_creator_can_still_approve_multi_contributor_bounty(self):
+        bounty_1, _bounty_2 = self.test_user_can_contribute_to_bounty(
+            amount_1=600, amount_2=400
+        )
+
+        self.client.force_authenticate(self.user)
+        approve_bounty_res = self.client.post(
+            f"/api/bounty/{bounty_1.data['id']}/approve_bounty/",
+            [
+                {
+                    "amount": "200",
+                    "object_id": self.comment.id,
+                    "content_type": self.comment._meta.model_name,
+                }
+            ],
+        )
+
+        self.assertEqual(approve_bounty_res.status_code, 200)
+
+    def test_cannot_contribute_to_foundation_review_bounty(self):
+        foundation = create_user(email=FOUNDATION_EMAIL)
+        comment_ct = ContentType.objects.get_for_model(self.comment)
+        escrow = Escrow.objects.create(
+            hold_type=Escrow.BOUNTY,
+            created_by=foundation,
+            content_type=comment_ct,
+            object_id=self.comment.id,
+            amount_holding=100,
+        )
+        Bounty.objects.create(
+            created_by=foundation,
+            escrow=escrow,
+            item=self.comment,
+            unified_document=self.comment.unified_document,
+            amount=100,
+            bounty_type=Bounty.Type.REVIEW,
+            status=Bounty.OPEN,
+        )
+
+        self.client.force_authenticate(self.user_2)
+        contribute_res = self.client.post(
+            "/api/bounty/",
+            {
+                "amount": 10,
+                "item_content_type": self.comment._meta.model_name,
+                "item_object_id": self.comment.id,
+            },
+        )
+
+        self.assertEqual(contribute_res.status_code, 403)
 
     def test_user_can_cancel_bounty(self):
         self.client.force_authenticate(self.user)

--- a/src/reputation/tests/test_bounties.py
+++ b/src/reputation/tests/test_bounties.py
@@ -374,7 +374,7 @@ class BountyViewTests(APITestCase):
 
         bounty_2 = self.test_user_can_create_larger_bounty()
         approve_bounty_res_2 = self.client.post(
-            f"/api/bounty/{bounty_2.data['id']}/approve_bounty/",
+            f"/api/bounty/{bounty_1.data['id']}/approve_bounty/",
             [
                 {
                     "amount": decimal.Decimal(bounty_2.data["amount"]) / 2,

--- a/src/reputation/tests/test_bounties.py
+++ b/src/reputation/tests/test_bounties.py
@@ -115,6 +115,30 @@ class BountyViewTests(APITestCase):
         )
         return vote
 
+    def _create_pooled_bounty_on_comment(self, parent_amount=100, child_amount=200):
+        self.client.force_authenticate(self.user)
+        parent_response = self.client.post(
+            "/api/bounty/",
+            {
+                "amount": parent_amount,
+                "item_content_type": self.comment._meta.model_name,
+                "item_object_id": self.comment.id,
+            },
+        )
+        self.assertEqual(parent_response.status_code, 201)
+
+        self.client.force_authenticate(self.user_2)
+        child_response = self.client.post(
+            "/api/bounty/",
+            {
+                "amount": child_amount,
+                "item_content_type": self.comment._meta.model_name,
+                "item_object_id": self.comment.id,
+            },
+        )
+        self.assertEqual(child_response.status_code, 201)
+        return parent_response, child_response
+
     def test_user_can_create_bounty(self, amount=100):
         self.client.force_authenticate(self.user)
 
@@ -601,45 +625,45 @@ class BountyViewTests(APITestCase):
 
         self.assertEqual(approve_bounty_res.status_code, 403)
 
-    def test_contributor_cannot_approve_via_child_bounty_id(self):
-        bounty_1, bounty_2 = self.test_user_can_contribute_to_bounty(
-            amount_1=600, amount_2=400
-        )
-        parent_bounty = Bounty.objects.get(id=bounty_1.data["id"])
-        total_pool = parent_bounty.escrow.amount_holding
-
+    def test_contributor_cannot_approve_pooled_bounty_via_child_id(self):
+        parent_response, child_response = self._create_pooled_bounty_on_comment()
         self.client.force_authenticate(self.user_2)
-        approve_bounty_res = self.client.post(
-            f"/api/bounty/{bounty_2.data['id']}/approve_bounty/",
+        response = self.client.post(
+            f"/api/bounty/{child_response.data['id']}/approve_bounty/",
             [
                 {
-                    "amount": str(total_pool),
+                    "amount": "100",
                     "object_id": self.comment.id,
                     "content_type": self.comment._meta.model_name,
                 }
             ],
         )
+        self.assertEqual(response.status_code, 403)
 
-        self.assertEqual(approve_bounty_res.status_code, 403)
-
-    def test_parent_creator_can_still_approve_multi_contributor_bounty(self):
-        bounty_1, _bounty_2 = self.test_user_can_contribute_to_bounty(
-            amount_1=600, amount_2=400
-        )
-
+    def test_parent_creator_can_approve_pooled_bounty_via_parent_id(self):
+        parent_response, _child_response = self._create_pooled_bounty_on_comment()
         self.client.force_authenticate(self.user)
-        approve_bounty_res = self.client.post(
-            f"/api/bounty/{bounty_1.data['id']}/approve_bounty/",
+        response = self.client.post(
+            f"/api/bounty/{parent_response.data['id']}/approve_bounty/",
             [
                 {
-                    "amount": "200",
+                    "amount": "50",
                     "object_id": self.comment.id,
                     "content_type": self.comment._meta.model_name,
                 }
             ],
         )
+        self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(approve_bounty_res.status_code, 200)
+    def test_contributor_cannot_cancel_pooled_bounty_via_child_id(self):
+        parent_response, child_response = self._create_pooled_bounty_on_comment()
+        self.client.force_authenticate(self.user_2)
+        response = self.client.post(
+            f"/api/bounty/{child_response.data['id']}/cancel_bounty/",
+        )
+        self.assertEqual(response.status_code, 403)
+        parent_bounty = Bounty.objects.get(id=parent_response.data["id"])
+        self.assertEqual(parent_bounty.status, Bounty.OPEN)
 
     def test_user_can_cancel_bounty(self):
         self.client.force_authenticate(self.user)
@@ -746,15 +770,6 @@ class BountyViewTests(APITestCase):
         )
 
         self.assertEqual(cancel_bounty_res_1.status_code, 403)
-
-    def test_contributor_cannot_cancel_via_child_bounty_id(self):
-        bounty_1, bounty_2 = self.test_user_can_contribute_to_bounty()
-        self.client.force_authenticate(self.user_2)
-        cancel_bounty_res = self.client.post(
-            f"/api/bounty/{bounty_2.data['id']}/cancel_bounty/",
-        )
-
-        self.assertEqual(cancel_bounty_res.status_code, 403)
 
     def test_random_user_cant_cancel_multi_bounty(self):
         self.client.force_authenticate(self.user)

--- a/src/reputation/tests/test_bounties.py
+++ b/src/reputation/tests/test_bounties.py
@@ -655,6 +655,22 @@ class BountyViewTests(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_parent_creator_must_approve_pooled_bounty_via_parent_id(self):
+        _parent_response, child_response = self._create_pooled_bounty_on_comment()
+        self.client.force_authenticate(self.user)
+        response = self.client.post(
+            f"/api/bounty/{child_response.data['id']}/approve_bounty/",
+            [
+                {
+                    "amount": "50",
+                    "object_id": self.comment.id,
+                    "content_type": self.comment._meta.model_name,
+                }
+            ],
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["error"], "Please approve parent bounty")
+
     def test_contributor_cannot_cancel_pooled_bounty_via_child_id(self):
         parent_response, child_response = self._create_pooled_bounty_on_comment()
         self.client.force_authenticate(self.user_2)

--- a/src/reputation/views/bounty_view.py
+++ b/src/reputation/views/bounty_view.py
@@ -78,6 +78,33 @@ def _create_bounty_checks(user, amount, item_content_type, bypass_user_balance=F
     return (amount, fee_amount, rh_fee, dao_fee, current_bounty_fee)
 
 
+def _check_existing_bounty_contribution_allowed(item_content_type, item_object_id):
+    content_type = ContentType.objects.get(model=item_content_type)
+    existing_bounties = Bounty.objects.filter(
+        status__in=(Bounty.OPEN, Bounty.ASSESSMENT),
+        item_content_type=content_type,
+        item_object_id=item_object_id,
+    )
+    if not existing_bounties.exists():
+        return None
+
+    parent = existing_bounties.first()
+    if (
+        User.is_rh_community_account(parent.created_by)
+        and parent.bounty_type == Bounty.Type.REVIEW
+    ):
+        return Response(
+            {
+                "detail": (
+                    "Contributions to ResearchHub Foundation peer-review "
+                    "bounties are not allowed."
+                )
+            },
+            status=status.HTTP_403_FORBIDDEN,
+        )
+    return None
+
+
 def _create_bounty(
     user,
     data,
@@ -252,6 +279,12 @@ class BountyViewSet(viewsets.ModelViewSet):
             else:
                 amount, fee_amount, rh_fee, dao_fee, current_bounty_fee = response
 
+            contribution_response = _check_existing_bounty_contribution_allowed(
+                item_content_type, item_object_id
+            )
+            if contribution_response is not None:
+                return contribution_response
+
             deduct_bounty_fees(user, fee_amount, rh_fee, dao_fee, current_bounty_fee)
             bounty = _create_bounty(
                 user,
@@ -313,8 +346,11 @@ class BountyViewSet(viewsets.ModelViewSet):
         data = request.data
         with transaction.atomic():
             bounty = self.get_object()
-            if bounty.parent:
-                bounty = bounty.parent
+            if bounty.parent_id is not None:
+                return Response(
+                    {"error": "Please approve parent bounty"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
             # Validate total payout amount doesn't exceed bounty amount
             total_payout = sum(

--- a/src/reputation/views/bounty_view.py
+++ b/src/reputation/views/bounty_view.py
@@ -78,33 +78,6 @@ def _create_bounty_checks(user, amount, item_content_type, bypass_user_balance=F
     return (amount, fee_amount, rh_fee, dao_fee, current_bounty_fee)
 
 
-def _check_existing_bounty_contribution_allowed(item_content_type, item_object_id):
-    content_type = ContentType.objects.get(model=item_content_type)
-    existing_bounties = Bounty.objects.filter(
-        status__in=(Bounty.OPEN, Bounty.ASSESSMENT),
-        item_content_type=content_type,
-        item_object_id=item_object_id,
-    )
-    if not existing_bounties.exists():
-        return None
-
-    parent = existing_bounties.first()
-    if (
-        User.is_rh_community_account(parent.created_by)
-        and parent.bounty_type == Bounty.Type.REVIEW
-    ):
-        return Response(
-            {
-                "detail": (
-                    "Contributions to ResearchHub Foundation peer-review "
-                    "bounties are not allowed."
-                )
-            },
-            status=status.HTTP_403_FORBIDDEN,
-        )
-    return None
-
-
 def _create_bounty(
     user,
     data,
@@ -278,12 +251,6 @@ class BountyViewSet(viewsets.ModelViewSet):
                 return response
             else:
                 amount, fee_amount, rh_fee, dao_fee, current_bounty_fee = response
-
-            contribution_response = _check_existing_bounty_contribution_allowed(
-                item_content_type, item_object_id
-            )
-            if contribution_response is not None:
-                return contribution_response
 
             deduct_bounty_fees(user, fee_amount, rh_fee, dao_fee, current_bounty_fee)
             bounty = _create_bounty(


### PR DESCRIPTION
## Issue

- Pooled bounties use a parent escrow, but contributions create a child Bounty row with the contributor as created_by.
- UserCanApproveBounty checked the child row; approve_bounty paid from the parent escrow.
- A contributor could call approve_bounty on their child id and award the full pool (e.g. Foundation’s ~$150 peer-review bounty plus their contribution) to a recipient of their choice.

## Solution

- Resolve child bounties to the parent in UserCanApproveBounty before checking who may approve, so only the parent creator (or question author for document bounties) can disburse that escrow.
- Return 400 on approve_bounty when the URL targets a child bounty id ("Please approve parent bounty"), matching cancel_bounty.
- Add regression tests: contributors get 403 on child-id approve; parent creator can still approve via the parent id.