### PR TITLE
Add domain events for user suspension and reinstatement

### DIFF
--- a/src/user/events.py
+++ b/src/user/events.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+from typing import Any
+
+from django.db import transaction
+from django.dispatch import Signal
+
+
+@dataclass(frozen=True)
+class UserSuspendedEvent:
+    user_id: int
+
+
+@dataclass(frozen=True)
+class UserReinstatedEvent:
+    user_id: int
+
+
+user_suspended = Signal()
+user_reinstated = Signal()
+
+
+def publish_user_suspended(*, sender: Any, user_id: int) -> None:
+    """
+    Publish a user suspended event.
+
+    This function is transaction-aware and will send the signal after the current
+    transaction commits successfully.
+
+        Args:
+            sender: The sender of the signal, typically the model class.
+            user_id: The ID of the user who was suspended.
+    """
+    event = UserSuspendedEvent(user_id=user_id)
+    transaction.on_commit(
+        lambda: user_suspended.send(
+            sender=sender,
+            event=event,
+        )
+    )
+
+
+def publish_user_reinstated(*, sender: Any, user_id: int) -> None:
+    """
+    Publish a user reinstated event.
+
+    This function is transaction-aware and will send the signal after the current
+    transaction commits successfully.
+
+        Args:
+            sender: The sender of the signal, typically the model class.
+            user_id: The ID of the user who was reinstated.
+    """
+    event = UserReinstatedEvent(user_id=user_id)
+    transaction.on_commit(
+        lambda: user_reinstated.send(
+            sender=sender,
+            event=event,
+        )
+    )

--- a/src/user/events.py
+++ b/src/user/events.py
@@ -15,8 +15,8 @@ class UserReinstatedEvent:
     user_id: int
 
 
-user_suspended = Signal()
-user_reinstated = Signal()
+user_suspended: Signal = Signal()
+user_reinstated: Signal = Signal()
 
 
 def publish_user_suspended(*, sender: Any, user_id: int) -> None:

--- a/src/user/tasks/tasks.py
+++ b/src/user/tasks/tasks.py
@@ -21,6 +21,7 @@ from researchhub_document.models import ResearchhubUnifiedDocument
 from review.models.peer_review_model import PeerReview
 from review.models.review_model import Review
 from user.editor_payout_tasks import editor_daily_payout_task
+from user.events import publish_user_reinstated, publish_user_suspended
 from user.models import User
 from user.related_models.verdict_model import Verdict
 from user.rsc_exchange_rate_record_tasks import rsc_exchange_rate_record_tasks
@@ -96,6 +97,8 @@ def handle_spam_user_task(user_id, requestor=None):
 
     # Resolve any open moderation flags on the user's content
     _resolve_open_flags_for_user(user, requestor)
+
+    publish_user_suspended(sender=User, user_id=user.id)
 
 
 def _resolve_open_flags_for_user(user, requestor=None):
@@ -181,6 +184,8 @@ def reinstate_user_task(user_id):
     Review.all_objects.filter(created_by=user).update(
         is_removed=False, is_public=True, is_removed_date=None
     )
+
+    publish_user_reinstated(sender=User, user_id=user.id)
 
 
 def get_latest_actions(cursor):

--- a/src/user/tests/test_tasks.py
+++ b/src/user/tests/test_tasks.py
@@ -20,6 +20,7 @@ from researchhub_document.models import ResearchhubUnifiedDocument
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 from review.models.peer_review_model import PeerReview
 from review.models.review_model import Review
+from user.events import user_reinstated, user_suspended
 from user.models import Action
 from user.related_models.verdict_model import Verdict
 from user.tasks import get_latest_actions, handle_spam_user_task, reinstate_user_task
@@ -92,6 +93,51 @@ class HandleSpamUserTaskTests(TestCase):
             content_type=ContentType.objects.get_for_model(self.paper),
             object_id=self.paper.id,
         )
+
+    def test_handle_spam_user_task_emits_user_suspended_event(self):
+        # Arrange
+        events = []
+
+        def receiver(sender, event, **kwargs):
+            events.append(event)
+
+        user_suspended.connect(
+            receiver, dispatch_uid="test_user_suspended_event", weak=False
+        )
+
+        # Act
+        try:
+            with self.captureOnCommitCallbacks(execute=True):
+                handle_spam_user_task(self.user.id, self.moderator)
+        finally:
+            user_suspended.disconnect(dispatch_uid="test_user_suspended_event")
+
+        # Assert
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].user_id, self.user.id)
+
+    def test_reinstate_user_task_emits_user_reinstated_event(self):
+        # Arrange
+        handle_spam_user_task(self.user.id, self.moderator)
+        events = []
+
+        def receiver(sender, event, **kwargs):
+            events.append(event)
+
+        user_reinstated.connect(
+            receiver, dispatch_uid="test_user_reinstated_event", weak=False
+        )
+
+        # Act
+        try:
+            with self.captureOnCommitCallbacks(execute=True):
+                reinstate_user_task(self.user.id)
+        finally:
+            user_reinstated.disconnect(dispatch_uid="test_user_reinstated_event")
+
+        # Assert
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].user_id, self.user.id)
 
     def test_handle_spam_user_task_without_requestor(self):
         """Test that the task properly marks content as removed without a requestor"""


### PR DESCRIPTION
This change adds the two domain events for signaling user suspension and reinstatement. These domain events are published in the existing tasks where users are suspended or reinstated. The events help with loosely coupling components interested in processing them, for example, the search app that updates the corresponding indexes.