### PR TITLE
Remove documents for suspended users

### DIFF
--- a/src/search/apps.py
+++ b/src/search/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class SearchConfig(AppConfig):
     name = "search"
+
+    def ready(self):
+        import search.signals.user_events  # noqa: F401

--- a/src/search/documents/person.py
+++ b/src/search/documents/person.py
@@ -134,6 +134,15 @@ class PersonDocument(BaseDocument):
 
         return suggestions
 
+    @override
+    def should_index_object(self, obj: Author) -> bool:  # type: ignore[override]
+        if obj.user is None:
+            # Leave authors without user accounts in the index:
+            return True
+
+        # only index if the user is not suspended:
+        return not obj.user.is_suspended
+
     def get_instances_from_related(
         self,
         related_instance: User,

--- a/src/search/signals/user_events.py
+++ b/src/search/signals/user_events.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from django.dispatch import receiver
+
+from search.tasks import update_user_related_documents
+from user.events import (
+    UserReinstatedEvent,
+    UserSuspendedEvent,
+    user_reinstated,
+    user_suspended,
+)
+
+
+@receiver(user_suspended, dispatch_uid="search_user_suspended")
+def handle_user_suspended(
+    sender: Any, event: UserSuspendedEvent, **kwargs: Any
+) -> None:
+    update_user_related_documents.delay(event.user_id)
+
+
+@receiver(user_reinstated, dispatch_uid="search_user_reinstated")
+def handle_user_reinstated(
+    sender: Any, event: UserReinstatedEvent, **kwargs: Any
+) -> None:
+    update_user_related_documents.delay(event.user_id)

--- a/src/search/tasks.py
+++ b/src/search/tasks.py
@@ -1,0 +1,74 @@
+import logging
+from collections.abc import Iterable, Iterator
+from itertools import islice
+
+from paper.models import Paper
+from researchhub.celery import QUEUE_ELASTIC_SEARCH, app
+from researchhub_document.models import ResearchhubPost
+from search.documents.base import BaseDocument
+from search.documents.paper import PaperDocument
+from search.documents.person import PersonDocument
+from search.documents.post import PostDocument
+from search.documents.user import UserDocument
+from user.models import Author, User
+
+logger = logging.getLogger(__name__)
+
+
+@app.task(queue=QUEUE_ELASTIC_SEARCH, ignore_result=True)
+def update_user_related_documents(user_id: int, batch_size: int = 500) -> None:
+    """
+    Update search documents related to the given user.
+    """
+
+    user = User.objects.filter(id=user_id).first()
+    if user is None:
+        logger.info("Skipping index updates due to user_id=%s not found", user_id)
+        return
+
+    # Update papers
+    _update_document(
+        PaperDocument(),
+        Paper.objects.filter(uploaded_by=user).iterator(chunk_size=batch_size),
+        batch_size=batch_size,
+    )
+
+    # Update posts
+    _update_document(
+        PostDocument(),
+        ResearchhubPost.objects.filter(created_by=user)
+        .select_related("unified_document")
+        .iterator(chunk_size=batch_size),
+        batch_size=batch_size,
+    )
+
+    # Update users
+    _update_document(
+        UserDocument(),
+        [user],
+        batch_size=batch_size,
+    )
+
+    # Update authors
+    author = Author.objects.filter(user=user).select_related("user").first()
+    if author is not None:
+        _update_document(
+            PersonDocument(),
+            [author],
+            batch_size=batch_size,
+        )
+
+
+def _iter_batches(
+    iterable: Iterable[object], batch_size: int
+) -> Iterator[list[object]]:
+    iterator = iter(iterable)
+    while batch := list(islice(iterator, batch_size)):
+        yield batch
+
+
+def _update_document(
+    document: BaseDocument, objects: Iterable[object], batch_size: int = 500
+) -> None:
+    for batch in _iter_batches(objects, batch_size):
+        document.update(batch, action="index", raise_on_error=False)

--- a/src/search/tests/test_person_document.py
+++ b/src/search/tests/test_person_document.py
@@ -139,3 +139,38 @@ class PersonDocumentTests(TestCase):
 
         # Assert
         self.assertEqual(result, 0)
+
+    def test_should_index_object(self):
+        # Arrange
+        document = PersonDocument()
+        author = Mock()
+        author.user.is_suspended = False
+
+        # Act
+        result = document.should_index_object(author)
+
+        # Assert
+        self.assertTrue(result)
+
+    def test_should_index_object_includes_author_without_user(self):
+        # Arrange
+        document = PersonDocument()
+        author = Mock(user=None)
+
+        # Act
+        result = document.should_index_object(author)
+
+        # Assert
+        self.assertTrue(result)
+
+    def test_should_index_object_excludes_suspended_linked_user(self):
+        # Arrange
+        document = PersonDocument()
+        author = Mock()
+        author.user.is_suspended = True
+
+        # Act
+        result = document.should_index_object(author)
+
+        # Assert
+        self.assertFalse(result)

--- a/src/search/tests/test_signal_user_events.py
+++ b/src/search/tests/test_signal_user_events.py
@@ -1,0 +1,38 @@
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from user.events import (
+    UserReinstatedEvent,
+    UserSuspendedEvent,
+    user_reinstated,
+    user_suspended,
+)
+from user.models import User
+
+
+class UserSearchDocumentUpdateSignalTests(TestCase):
+    @patch("search.signals.user_events.update_user_related_documents.delay")
+    def test_user_suspended_event_schedules_update(self, delay_mock: Mock):
+        # Arrange
+        event = UserSuspendedEvent(user_id=123)
+
+        # Act
+        user_suspended.send(
+            sender=User,
+            event=event,
+        )
+
+        # Assert
+        delay_mock.assert_called_once_with(123)
+
+    @patch("search.signals.user_events.update_user_related_documents.delay")
+    def test_user_reinstated_event_schedules_update(self, delay_mock: Mock):
+        # Arrange
+        event = UserReinstatedEvent(user_id=123)
+
+        # Act
+        user_reinstated.send(sender=User, event=event)
+
+        # Assert
+        delay_mock.assert_called_once_with(123)

--- a/src/search/tests/test_tasks.py
+++ b/src/search/tests/test_tasks.py
@@ -1,0 +1,94 @@
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from paper.tests.helpers import create_paper
+from researchhub_document.models import ResearchhubPost, ResearchhubUnifiedDocument
+from search.tasks import update_user_related_documents
+from user.tests.helpers import create_random_authenticated_user
+
+
+class UserSearchDocumentUpdateTaskTests(TestCase):
+    def setUp(self):
+        self.user1 = create_random_authenticated_user("search_update_user")
+        self.user2 = create_random_authenticated_user("search_update_other")
+        self.paper1 = create_paper(title="paper1", uploaded_by=self.user1)
+        self.paper2 = create_paper(title="paper2", uploaded_by=self.user2)
+        self.post = ResearchhubPost.objects.create(
+            created_by=self.user1,
+            title="User Post",
+            renderable_text="User post content",
+            document_type="DISCUSSION",
+            unified_document=ResearchhubUnifiedDocument.objects.create(
+                document_type="DISCUSSION"
+            ),
+        )
+        self.other_post = ResearchhubPost.objects.create(
+            created_by=self.user2,
+            title="Other Post",
+            renderable_text="Other post content",
+            document_type="DISCUSSION",
+            unified_document=ResearchhubUnifiedDocument.objects.create(
+                document_type="DISCUSSION"
+            ),
+        )
+
+    @patch("search.tasks.PersonDocument.update")
+    @patch("search.tasks.UserDocument.update")
+    @patch("search.tasks.PostDocument.update")
+    @patch("search.tasks.PaperDocument.update")
+    def test_update_user_related_documents(
+        self,
+        paper_update_mock: Mock,
+        post_update_mock: Mock,
+        user_update_mock: Mock,
+        person_update_mock: Mock,
+    ):
+        """
+        Test that update_user_related_documents updates the documents
+        for the given user.
+        """
+        # Arrange
+        user_id = self.user1.id
+
+        # Act
+        update_user_related_documents(user_id)
+
+        # Assert
+        self.assertEqual(_get_updated_ids(paper_update_mock), [self.paper1.id])
+        self.assertEqual(_get_updated_ids(post_update_mock), [self.post.id])
+        self.assertEqual(_get_updated_ids(user_update_mock), [self.user1.id])
+        self.assertEqual(
+            _get_updated_ids(person_update_mock), [self.user1.author_profile.id]
+        )
+
+    @patch("search.tasks.PersonDocument.update")
+    @patch("search.tasks.UserDocument.update")
+    @patch("search.tasks.PostDocument.update")
+    @patch("search.tasks.PaperDocument.update")
+    def test_update_user_related_documents_missing_user(
+        self,
+        paper_update_mock: Mock,
+        post_update_mock: Mock,
+        user_update_mock: Mock,
+        person_update_mock: Mock,
+    ):
+        """
+        Test that update_user_related_documents does not attempt to update
+        documents when the user does not exist.
+        """
+        # Arrange
+        missing_user_id = -999999
+
+        # Act
+        update_user_related_documents(missing_user_id)
+
+        # Assert
+        paper_update_mock.assert_not_called()
+        post_update_mock.assert_not_called()
+        user_update_mock.assert_not_called()
+        person_update_mock.assert_not_called()
+
+
+def _get_updated_ids(mock_update: Mock) -> list[int]:
+    return [obj.id for obj in mock_update.call_args[0][0]]

--- a/src/user/tests/test_tasks.py
+++ b/src/user/tests/test_tasks.py
@@ -115,6 +115,7 @@ class HandleSpamUserTaskTests(TestCase):
         # Assert
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0].user_id, self.user.id)
+        self.assertEqual(events[0].requestor_id, self.moderator.id)
 
     def test_reinstate_user_task_emits_user_reinstated_event(self):
         # Arrange


### PR DESCRIPTION
This change adds signal handlers for user-suspension events to the search app. When a published suspension event is handled, a new task is invoked that updates all search documents (indexes) related to the user.