### PR TITLE
Group balance lots by effective start date

### DIFF
--- a/src/reputation/serializers/staking_yield_serializer.py
+++ b/src/reputation/serializers/staking_yield_serializer.py
@@ -3,7 +3,6 @@ from rest_framework import serializers
 
 class StakingBalanceLotSerializer(serializers.Serializer):
     amount = serializers.DecimalField(max_digits=19, decimal_places=8)
-    created_date = serializers.DateField()
     effective_start_date = serializers.DateField()
     age_days = serializers.IntegerField()
     current_multiplier = serializers.DecimalField(max_digits=19, decimal_places=8)

--- a/src/reputation/services/staking_yield_service.py
+++ b/src/reputation/services/staking_yield_service.py
@@ -95,25 +95,37 @@ class StakingYieldService:
 
     @staticmethod
     def get_balance_lot_details(user, reference_date):
-        """Return per-lot staking multiplier details for the given user.
+        """Return staking multiplier details grouped by effective start date.
 
-        Each entry includes the lot's effective start date (respecting the
-        user's staking opt-in date), current age and multiplier, the next
-        tier the lot will reach (if any), and the projected overall
-        weighted-average multiplier across all lots on that tier transition
-        date, assuming balances don't change before then.
+        Lots that share an effective start date (most commonly, all deposits
+        made before the user opted into staking, which collapse onto the
+        opt-in date) are combined into a single entry — they accrue
+        identically going forward, so showing them separately is noise.
+
+        Each entry includes the effective start date, current age and
+        multiplier, the next tier the group will reach (if any), and the
+        projected overall weighted-average multiplier across all lots on
+        that tier transition date, assuming balances don't change before
+        then.
         """
         lots = user.get_unlocked_balance_lots_lifo()
         opt_in_date = (
             user.staking_opted_in_date.date() if user.staking_opted_in_date else None
         )
 
-        details = []
+        grouped_amounts: dict[date, Decimal] = {}
         for lot in lots:
             effective_start_date = lot.created_date
             if opt_in_date is not None:
                 effective_start_date = max(effective_start_date, opt_in_date)
+            grouped_amounts[effective_start_date] = (
+                grouped_amounts.get(effective_start_date, Decimal("0")) + lot.amount
+            )
 
+        details = []
+        for effective_start_date, total_amount in sorted(
+            grouped_amounts.items(), reverse=True
+        ):
             age_days = max((reference_date - effective_start_date).days, 0)
             current_multiplier = StakingYieldService.compute_balance_age_multiplier(
                 age_days
@@ -136,8 +148,7 @@ class StakingYieldService:
 
             details.append(
                 {
-                    "amount": lot.amount.quantize(QUANTIZE_8, rounding=ROUND_DOWN),
-                    "created_date": lot.created_date,
+                    "amount": total_amount.quantize(QUANTIZE_8, rounding=ROUND_DOWN),
                     "effective_start_date": effective_start_date,
                     "age_days": age_days,
                     "current_multiplier": current_multiplier,

--- a/src/reputation/tests/test_staking_yield_views.py
+++ b/src/reputation/tests/test_staking_yield_views.py
@@ -163,7 +163,6 @@ class StakingYieldDetailsBalanceLotsTest(StakingYieldViewSetTestBase):
         self.assertEqual(Decimal(lot["next_multiplier"]), Decimal("1.05"))
         self.assertEqual(lot["days_until_next_multiplier"], 20)
         self.assertEqual(lot["next_multiplier_date"], "2026-06-21")
-        self.assertEqual(lot["created_date"], "2026-05-22")
         self.assertEqual(lot["effective_start_date"], "2026-05-22")
         # Only lot on its tier transition date — overall == its own multiplier
         self.assertEqual(Decimal(lot["projected_overall_multiplier"]), Decimal("1.05"))
@@ -208,6 +207,30 @@ class StakingYieldDetailsBalanceLotsTest(StakingYieldViewSetTestBase):
         self.assertEqual(len(lots), 2)
         amounts = sorted(Decimal(lot["amount"]) for lot in lots)
         self.assertEqual(amounts, [Decimal("100"), Decimal("200")])
+
+    def test_lots_with_same_effective_start_date_are_grouped(self):
+        # Two pre-opt-in deposits collapse onto the opt-in date, plus two
+        # post-opt-in deposits on the same later day — should produce 2 entries.
+        self.user.staking_opted_in_date = datetime(2026, 5, 15, tzinfo=timezone.utc)
+        self.user.save()
+        self._create_balance("100", created_offset_days=400)
+        self._create_balance("200", created_offset_days=300)
+        self._create_balance("50", created_offset_days=10)
+        self._create_balance("25", created_offset_days=10)
+
+        resp = self._get_details()
+
+        lots = resp.data["balance_lots"]
+        self.assertEqual(len(lots), 2)
+        by_start = {lot["effective_start_date"]: lot for lot in lots}
+
+        pre_opt_in = by_start["2026-05-15"]
+        self.assertEqual(Decimal(pre_opt_in["amount"]), Decimal("300"))
+        self.assertEqual(pre_opt_in["age_days"], 17)
+
+        post_opt_in = by_start["2026-05-22"]
+        self.assertEqual(Decimal(post_opt_in["amount"]), Decimal("75"))
+        self.assertEqual(post_opt_in["age_days"], 10)
 
     def test_projected_overall_multiplier_weights_all_lots(self):
         # Lot A: 100 RSC, age 25 — hits 30-day tier in 5 days


### PR DESCRIPTION
- Remove created_date as it's not used by the front end and we already have the effective start date