### PR TITLE
ExpertFinder: Raise output limit and cap experts per LLM round

### DIFF
--- a/src/research_ai/services/expert_finder_service.py
+++ b/src/research_ai/services/expert_finder_service.py
@@ -70,6 +70,7 @@ MAX_ERROR_MESSAGE_LENGTH = 10000
 EXPERT_FILL_MAX_ROUNDS = 6
 EXPERT_FILL_TOLERANCE_SHORT = 10
 EXPERT_FILL_EXCLUDED_NAMES_CAP = 250
+EXPERT_FILL_BATCH_MAX = 50
 
 PROMPT_EXPERT_HEADROOM_PCT = 10
 
@@ -189,7 +190,8 @@ def _extract_text_from_pdf_bytes(pdf_bytes: bytes) -> str:
 
 def _prompt_expert_count_for_round(remaining: int) -> int:
     need = max(1, remaining)
-    return (need * (100 + PROMPT_EXPERT_HEADROOM_PCT) + 99) // 100
+    with_headroom = (need * (100 + PROMPT_EXPERT_HEADROOM_PCT) + 99) // 100
+    return min(with_headroom, EXPERT_FILL_BATCH_MAX)
 
 
 def clear_expert_search_links(expert_search_id: int) -> None:

--- a/src/research_ai/services/openai_expert_finder_service.py
+++ b/src/research_ai/services/openai_expert_finder_service.py
@@ -23,7 +23,7 @@ class OpenAIExpertFinderService:
         system_prompt: str,
         user_prompt: str,
         *,
-        max_tokens: int = 8192,
+        max_tokens: int = 16_384,
         temperature: float = 0.0,
     ) -> str:
         """


### PR DESCRIPTION
## Why?
- Large expert searches (e.g. 100 experts) were failing when later fill rounds hit the 8k output token limit and returned truncated, unparseable JSON.
- Asking the model for ~100 experts in one round produced oversized responses and increased truncation risk.

## How?
- Increase OpenAI expert finder default `max_output_tokens` from 8192 to 16,384.
- Cap each fill round’s requested expert count at 50 (`EXPERT_FILL_BATCH_MAX`)