### PR TITLE
Add `view_as_user_id` query param for moderator feed inspection

### DIFF
--- a/src/feed/filtering.py
+++ b/src/feed/filtering.py
@@ -6,6 +6,7 @@ from rest_framework.filters import BaseFilterBackend
 
 from feed.feed_config import FEED_CONFIG
 from feed.models import FeedEntry
+from feed.views.feed_view_mixin import get_moderator_view_as_user_id
 from hub.models import Hub
 from personalize.config.settings import PERSONALIZE_CONFIG
 from personalize.services.feed_service import DEFAULT_NUM_RESULTS
@@ -170,7 +171,7 @@ class FeedFilteringBackend(BaseFilterBackend):
         if not request.user.is_authenticated:
             return queryset.none()
 
-        user_id = request.user.id
+        user_id = get_moderator_view_as_user_id(request) or request.user.id
 
         personalize_feed_service = getattr(view, "personalize_feed_service", None)
         if not personalize_feed_service:

--- a/src/feed/views/feed_view_mixin.py
+++ b/src/feed/views/feed_view_mixin.py
@@ -10,6 +10,24 @@ from paper.related_models.paper_model import Paper
 from researchhub_comment.related_models.rh_comment_model import RhCommentModel
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 
+VIEW_AS_USER_ID_QUERY_PARAM = "view_as_user_id"
+
+
+def get_moderator_view_as_user_id(request) -> int | None:
+    """
+    Return the user id from ``view_as_user_id`` when the requester is a moderator.
+
+    Returns None if view-as does not apply (caller should use ``request.user.id``).
+    """
+    view_as_user_id = request.query_params.get(VIEW_AS_USER_ID_QUERY_PARAM)
+    if (
+        request.user.is_authenticated
+        and getattr(request.user, "moderator", False)
+        and view_as_user_id
+    ):
+        return int(view_as_user_id)
+    return None
+
 
 class FeedViewMixin:
     """
@@ -167,6 +185,10 @@ class FeedViewMixin:
             target_user_id = request.user.id
         else:
             target_user_id = None
+
+        view_as_user_id = get_moderator_view_as_user_id(request)
+        if view_as_user_id is not None:
+            target_user_id = view_as_user_id
 
         page = request.query_params.get("page", "1")
         page_size = request.query_params.get(


### PR DESCRIPTION
## What?
- Adds optional query param `view_as_user_id` on `GET /api/feed/` so moderators can load another user's **For You** recommendations for debugging.
- Non-moderators: param is ignored; behavior stays the same as today