### PR TITLE
Add private RFPs and add RFP invite endpoint

### DIFF
--- a/src/feed/views/activity_feed_view.py
+++ b/src/feed/views/activity_feed_view.py
@@ -149,9 +149,11 @@ class ActivityFeedViewSet(FeedViewMixin, ModelViewSet):
         preregistration that has applied to any grant.
         Excludes PENDING and DECLINED grants (moderation-only).
         """
-        grant_ud_ids = Grant.objects.exclude(
-            status__in=[Grant.PENDING, Grant.DECLINED]
-        ).values_list("unified_document_id", flat=True)
+        grant_ud_ids = (
+            Grant.objects.exclude(status__in=[Grant.PENDING, Grant.DECLINED])
+            .filter(unified_document__is_public=True)
+            .values_list("unified_document_id", flat=True)
+        )
         prereg_ud_ids = GrantApplication.objects.values_list(
             "preregistration_post__unified_document_id",
             flat=True,
@@ -170,6 +172,7 @@ class ActivityFeedViewSet(FeedViewMixin, ModelViewSet):
         funder_grants = Grant.objects.filter(
             Q(created_by_id=funder_id) | Q(contacts__id=funder_id),
             status__in=[Grant.OPEN, Grant.COMPLETED],
+            unified_document__is_public=True,
         ).distinct()
 
         grant_ud_ids = funder_grants.values_list("unified_document_id", flat=True)

--- a/src/feed/views/grant_feed_view.py
+++ b/src/feed/views/grant_feed_view.py
@@ -97,7 +97,7 @@ class GrantFeedViewSet(GrantCacheMixin, FeedViewMixin, ModelViewSet):
         created_by = self.request.query_params.get("created_by")
 
         queryset = (
-            ResearchhubPost.objects.all()
+            ResearchhubPost.objects.filter(unified_document__is_public=True)
             .select_related(
                 "created_by",
                 "created_by__author_profile",

--- a/src/personalize/utils/related_data_fetcher.py
+++ b/src/personalize/utils/related_data_fetcher.py
@@ -104,7 +104,10 @@ class RelatedDataFetcher:
 
         open_grants = (
             ResearchhubUnifiedDocument.objects.filter(
-                id__in=doc_ids, document_type="GRANT", grants__status="OPEN"
+                id__in=doc_ids,
+                document_type="GRANT",
+                grants__status="OPEN",
+                is_public=True,
             )
             .filter(
                 Q(grants__end_date__isnull=True)

--- a/src/personalize/utils/related_data_fetcher.py
+++ b/src/personalize/utils/related_data_fetcher.py
@@ -61,6 +61,7 @@ class RelatedDataFetcher:
                 id__in=doc_ids,
                 document_type="PREREGISTRATION",
                 fundraises__status="OPEN",
+                is_public=True,
             )
             .filter(
                 Q(fundraises__end_date__isnull=True)
@@ -88,6 +89,7 @@ class RelatedDataFetcher:
                 id__in=doc_ids,
                 document_type="PREREGISTRATION",
                 fundraises__id__in=fundraise_ids_with_funders,
+                is_public=True,
             )
             .values_list("id", flat=True)
             .distinct()

--- a/src/purchase/views/grant_view.py
+++ b/src/purchase/views/grant_view.py
@@ -28,7 +28,8 @@ class GrantViewSet(viewsets.ModelViewSet):
         qs = super().get_queryset()
         # Restrict to grants whose unified_document has a post visible to the
         # current user. Reuses ResearchhubPost.visible_to so the rules
-        # (creator, Permission rows, applied-to-by-creator) stay in one place.
+        # (creator, Permission rows, applied-to-by-creator, mod/editor bypass)
+        # stay in one place.
         visible_post_ids = ResearchhubPost.objects.visible_to(self.request.user).values(
             "unified_document_id"
         )

--- a/src/purchase/views/grant_view.py
+++ b/src/purchase/views/grant_view.py
@@ -26,6 +26,13 @@ class GrantViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         qs = super().get_queryset()
+        # Restrict to grants whose unified_document has a post visible to the
+        # current user. Reuses ResearchhubPost.visible_to so the rules
+        # (creator, Permission rows, applied-to-by-creator) stay in one place.
+        visible_post_ids = ResearchhubPost.objects.visible_to(self.request.user).values(
+            "unified_document_id"
+        )
+        qs = qs.filter(unified_document_id__in=visible_post_ids)
         return qs.prefetch_related(
             Prefetch(
                 "proposal_reviews",

--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -611,6 +611,22 @@ class SendEmailRequestSerializer(serializers.Serializer):
     )
 
 
+class InviteRfpApplicantsSerializer(serializers.Serializer):
+    """Request for POST /expert-finder/rfp/<grant_id>/invite-applicants/."""
+
+    emails = serializers.ListField(
+        child=serializers.EmailField(),
+        min_length=1,
+        max_length=100,
+    )
+    reply_to = serializers.EmailField(required=False, allow_null=True)
+    cc = serializers.ListField(
+        child=serializers.EmailField(),
+        required=False,
+        default=list,
+    )
+
+
 class GeneratedEmailSerializer(serializers.ModelSerializer):
     created_by = serializers.SerializerMethodField()
     created_at = serializers.DateTimeField(source="created_date", read_only=True)

--- a/src/research_ai/services/invited_experts_service.py
+++ b/src/research_ai/services/invited_experts_service.py
@@ -10,7 +10,12 @@ from research_ai.models import Expert, ExpertSearch, GeneratedEmail, SearchExper
 from researchhub_access_group.constants import VIEWER
 from researchhub_access_group.models import Permission
 from researchhub_document.models import ResearchhubPost
-from researchhub_document.related_models.constants.document_type import PREREGISTRATION
+from researchhub_document.related_models.constants.document_type import (
+    GRANT,
+    PREREGISTRATION,
+)
+
+INVITE_ACCESS_DOC_TYPES = (PREREGISTRATION, GRANT)
 from researchhub_document.related_models.researchhub_unified_document_model import (
     ResearchhubUnifiedDocument,
 )
@@ -64,9 +69,9 @@ def link_experts_registered_user_for_signup(*, normalized_email: str, user) -> i
 
 def grant_invited_expert_access_for_signup(*, normalized_email: str, user) -> int:
     """
-    Create VIEWER ``Permission`` rows on private preregistrations the user was
-    invited to via expert finder outreach, when a ``GeneratedEmail`` with
-    ``status=SENT`` exists in the link window.
+    Create VIEWER ``Permission`` rows on private preregistrations and private
+    grants the user was invited to via expert finder / RFP outreach, when a
+    ``GeneratedEmail`` with ``status=SENT`` exists in the link window.
     """
     email = (normalized_email or "").strip().lower()
     if not email:
@@ -92,7 +97,7 @@ def grant_invited_expert_access_for_signup(*, normalized_email: str, user) -> in
         ResearchhubUnifiedDocument.objects.filter(
             id__in=invited_doc_ids,
             is_public=False,
-            posts__document_type=PREREGISTRATION,
+            posts__document_type__in=INVITE_ACCESS_DOC_TYPES,
         )
         .values_list("id", flat=True)
         .distinct()
@@ -116,8 +121,8 @@ def grant_invited_expert_access_for_signup(*, normalized_email: str, user) -> in
 
 def grant_invited_expert_access_for_send(*, generated_email) -> bool:
     """
-    Grant VIEWER access on the invite's private preregistration when the
-    expert is already a registered user.
+    Grant VIEWER access on the invite's private preregistration or private
+    grant when the expert is already a registered user.
 
     Counterpart to ``grant_invited_expert_access_for_signup``: that function
     runs on signup and only covers users who created their account *after*
@@ -149,7 +154,7 @@ def grant_invited_expert_access_for_send(*, generated_email) -> bool:
     doc_qualifies = ResearchhubUnifiedDocument.objects.filter(
         id=expert_search.unified_document_id,
         is_public=False,
-        posts__document_type=PREREGISTRATION,
+        posts__document_type__in=INVITE_ACCESS_DOC_TYPES,
     ).exists()
     if not doc_qualifies:
         return False

--- a/src/research_ai/services/rfp_invite_service.py
+++ b/src/research_ai/services/rfp_invite_service.py
@@ -1,0 +1,123 @@
+import logging
+from dataclasses import dataclass
+
+from django.db import transaction
+from django.template.loader import render_to_string
+
+from research_ai.models import ExpertSearch, GeneratedEmail, SearchExpert
+from research_ai.services.expert_display import ExpertDisplay
+from research_ai.services.expert_persist import ExpertPersist
+from research_ai.services.rfp_email_context import build_rfp_context
+
+logger = logging.getLogger(__name__)
+
+INVITE_SEARCH_NAME = "RFP Applicant Invites"
+SUBJECT_TEMPLATE = "research_ai/email/rfp_applicant_invite_subject.txt"
+BODY_TEMPLATE = "research_ai/email/rfp_applicant_invite_body.html"
+
+
+@dataclass
+class InviteResult:
+    generated_email_ids: list[int]
+    skipped_existing: list[str]
+
+
+def _render_email(*, grant, inviter) -> tuple[str, str]:
+    rfp = build_rfp_context(grant)
+    full_name = getattr(inviter, "get_full_name", lambda: "")() or ""
+    inviter_name = full_name.strip() or "A ResearchHub editor"
+    context = {
+        "inviter_name": inviter_name,
+        "rfp_title": rfp.get("title") or "",
+        "rfp_amount": rfp.get("amount") or "",
+        "rfp_deadline": rfp.get("deadline") or "",
+        "rfp_url": rfp.get("url") or "",
+        "rfp_description": rfp.get("description_snippet") or "",
+        "rfp_organization": (grant.organization or "").strip(),
+    }
+    subject = render_to_string(SUBJECT_TEMPLATE, context).strip()
+    body = render_to_string(BODY_TEMPLATE, context)
+    return subject, body
+
+
+def _get_or_create_invite_search(*, grant, inviter) -> ExpertSearch:
+    """One ExpertSearch per (inviter, grant) so the existing access-grant flow
+    and per-editor analytics work without creating a new row per invite call.
+    """
+    search, _ = ExpertSearch.objects.get_or_create(
+        created_by=inviter,
+        unified_document=grant.unified_document,
+        name=INVITE_SEARCH_NAME,
+        defaults={
+            "query": INVITE_SEARCH_NAME,
+            "input_type": ExpertSearch.InputType.CUSTOM_QUERY,
+            "status": ExpertSearch.Status.COMPLETED,
+            "progress": 100,
+        },
+    )
+    return search
+
+
+def invite_applicants(*, grant, inviter, emails: list[str]) -> InviteResult:
+    """Create Expert + GeneratedEmail rows (status=SENDING) for each email.
+
+    The caller is expected to enqueue ``send_queued_emails_task`` with the
+    returned ids. ``skipped_existing`` lists emails that already have a SENT or
+    in-flight invite on this grant so we don't email anyone twice.
+    """
+    subject, body = _render_email(grant=grant, inviter=inviter)
+    search = _get_or_create_invite_search(grant=grant, inviter=inviter)
+
+    normalized_emails = []
+    seen = set()
+    for raw in emails:
+        em = ExpertDisplay.normalize_email(raw or "")
+        if em and em not in seen:
+            seen.add(em)
+            normalized_emails.append(em)
+
+    already_in_flight = set(
+        GeneratedEmail.objects.filter(
+            expert_search=search,
+            expert_email__in=normalized_emails,
+        )
+        .exclude(
+            status__in=[
+                GeneratedEmail.Status.FAILED,
+                GeneratedEmail.Status.SEND_FAILED,
+                GeneratedEmail.Status.CLOSED,
+            ]
+        )
+        .values_list("expert_email", flat=True)
+    )
+
+    created_ids: list[int] = []
+    with transaction.atomic():
+        for position, email in enumerate(normalized_emails):
+            if email in already_in_flight:
+                continue
+            expert = ExpertPersist.upsert_from_parsed_dict({"email": email})
+            ExpertPersist.tag_manual_source(expert, inviter)
+            SearchExpert.objects.get_or_create(
+                expert_search=search,
+                expert=expert,
+                defaults={"position": position},
+            )
+            ge = GeneratedEmail.objects.create(
+                created_by=inviter,
+                expert_search=search,
+                expert_email=email,
+                expert_name=ExpertDisplay.display_name_for(expert),
+                expert_title=expert.academic_title or "",
+                expert_affiliation=expert.affiliation or "",
+                email_subject=subject,
+                email_body=body,
+                template=None,
+                status=GeneratedEmail.Status.SENDING,
+            )
+            created_ids.append(ge.id)
+
+    return InviteResult(
+        generated_email_ids=created_ids,
+        skipped_existing=sorted(already_in_flight),
+    )

--- a/src/research_ai/templates/research_ai/email/rfp_applicant_invite_body.html
+++ b/src/research_ai/templates/research_ai/email/rfp_applicant_invite_body.html
@@ -1,0 +1,34 @@
+{% autoescape on %}<p>Hello,</p>
+
+<p>
+  {{ inviter_name }} has invited you to apply to the following request for
+  proposals on ResearchHub:
+</p>
+
+<p>
+  <strong>{{ rfp_title }}</strong>{% if rfp_organization %} &mdash; {{ rfp_organization }}{% endif %}
+</p>
+
+<ul>
+  {% if rfp_amount %}<li><strong>Amount:</strong> {{ rfp_amount }}</li>{% endif %}
+  {% if rfp_deadline %}<li><strong>Application deadline:</strong> {{ rfp_deadline }}</li>{% endif %}
+</ul>
+
+{% if rfp_description %}<p>{{ rfp_description }}</p>{% endif %}
+
+{% if rfp_url %}
+<p>
+  <a href="{{ rfp_url }}">View the RFP and submit your application</a>
+</p>
+{% endif %}
+
+<p>
+  If you don&rsquo;t already have a ResearchHub account, you can sign up with this
+  email address and your invitation will be linked automatically.
+</p>
+
+<p>
+  Thanks,<br />
+  The ResearchHub team
+</p>
+{% endautoescape %}

--- a/src/research_ai/templates/research_ai/email/rfp_applicant_invite_subject.txt
+++ b/src/research_ai/templates/research_ai/email/rfp_applicant_invite_subject.txt
@@ -1,0 +1,1 @@
+Invitation to apply: {{ rfp_title }}

--- a/src/research_ai/tests/test_rfp_invite_view.py
+++ b/src/research_ai/tests/test_rfp_invite_view.py
@@ -1,0 +1,154 @@
+from datetime import timedelta
+from decimal import Decimal
+from unittest.mock import patch
+
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from purchase.models import Grant
+from research_ai.models import Expert, ExpertSearch, GeneratedEmail, SearchExpert
+from researchhub_document.helpers import create_post
+from researchhub_document.related_models.constants.document_type import GRANT
+from user.tests.helpers import create_random_authenticated_user
+
+
+def _make_grant(*, created_by, contacts=None):
+    post = create_post(created_by=created_by, document_type=GRANT)
+    grant = Grant.objects.create(
+        created_by=created_by,
+        unified_document=post.unified_document,
+        amount=Decimal("50000.00"),
+        currency="USD",
+        organization="National Science Foundation",
+        short_title="AI Healthcare RFP",
+        description="Research grant for AI applications in healthcare",
+        status=Grant.OPEN,
+        end_date=timezone.now() + timedelta(days=30),
+    )
+    if contacts:
+        grant.contacts.set(contacts)
+    return grant
+
+
+class InviteRfpApplicantsViewTests(APITestCase):
+    def setUp(self):
+        self.creator = create_random_authenticated_user("creator", moderator=False)
+        self.contact = create_random_authenticated_user("contact", moderator=False)
+        self.other = create_random_authenticated_user("other", moderator=False)
+        self.moderator = create_random_authenticated_user("mod", moderator=True)
+        self.grant = _make_grant(created_by=self.creator, contacts=[self.contact])
+        self.url = (
+            f"/api/research_ai/expert-finder/rfp/{self.grant.id}/invite-applicants/"
+        )
+
+    def _post(self, body=None):
+        return self.client.post(
+            self.url, body or {"emails": ["a@example.com"]}, format="json"
+        )
+
+    def test_requires_authentication(self):
+        self.assertEqual(self._post().status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_rejects_unrelated_user(self):
+        self.client.force_authenticate(self.other)
+        self.assertEqual(self._post().status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_returns_404_for_missing_grant(self):
+        self.client.force_authenticate(self.creator)
+        url = "/api/research_ai/expert-finder/rfp/999999/invite-applicants/"
+        resp = self.client.post(url, {"emails": ["a@example.com"]}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_emails_payload_required(self):
+        self.client.force_authenticate(self.creator)
+        resp = self.client.post(self.url, {}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_invalid_email_returns_400(self):
+        self.client.force_authenticate(self.creator)
+        resp = self.client.post(self.url, {"emails": ["nope"]}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch("research_ai.views.email_views.send_queued_emails_task.delay")
+    def test_creator_can_invite_and_queues_send(self, mock_delay):
+        self.client.force_authenticate(self.creator)
+        resp = self._post(
+            {"emails": ["jane@example.com", "JOHN@example.com", "jane@example.com"]}
+        )
+        self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED)
+        data = resp.json()
+        self.assertEqual(data["queued"], 2)
+        self.assertEqual(data["skipped_existing"], [])
+        self.assertEqual(len(data["generated_email_ids"]), 2)
+
+        emails = GeneratedEmail.objects.order_by("id")
+        self.assertEqual(emails.count(), 2)
+        self.assertEqual(
+            set(emails.values_list("expert_email", flat=True)),
+            {"jane@example.com", "john@example.com"},
+        )
+        for ge in emails:
+            self.assertEqual(ge.status, GeneratedEmail.Status.SENDING)
+            self.assertIn("AI Healthcare RFP", ge.email_subject)
+            self.assertEqual(ge.created_by, self.creator)
+            self.assertIsNotNone(ge.expert_search_id)
+            self.assertEqual(
+                ge.expert_search.unified_document_id, self.grant.unified_document_id
+            )
+
+        self.assertEqual(Expert.objects.count(), 2)
+        self.assertEqual(SearchExpert.objects.count(), 2)
+        search = ExpertSearch.objects.get()
+        self.assertEqual(search.created_by, self.creator)
+        self.assertEqual(search.unified_document_id, self.grant.unified_document_id)
+
+        mock_delay.assert_called_once()
+        kwargs = mock_delay.call_args.kwargs
+        self.assertEqual(
+            sorted(kwargs["generated_email_ids"]),
+            sorted(data["generated_email_ids"]),
+        )
+
+    @patch("research_ai.views.email_views.send_queued_emails_task.delay")
+    def test_grant_contact_can_invite(self, mock_delay):
+        self.client.force_authenticate(self.contact)
+        resp = self._post()
+        self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(resp.json()["queued"], 1)
+        mock_delay.assert_called_once()
+
+    @patch("research_ai.views.email_views.send_queued_emails_task.delay")
+    def test_moderator_can_invite(self, mock_delay):
+        self.client.force_authenticate(self.moderator)
+        resp = self._post()
+        self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(resp.json()["queued"], 1)
+        mock_delay.assert_called_once()
+
+    @patch("research_ai.views.email_views.send_queued_emails_task.delay")
+    def test_skips_already_invited_emails(self, mock_delay):
+        self.client.force_authenticate(self.creator)
+        first = self._post({"emails": ["dup@example.com"]})
+        self.assertEqual(first.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(first.json()["queued"], 1)
+
+        second = self._post({"emails": ["dup@example.com", "new@example.com"]})
+        self.assertEqual(second.status_code, status.HTTP_202_ACCEPTED)
+        body = second.json()
+        self.assertEqual(body["queued"], 1)
+        self.assertEqual(body["skipped_existing"], ["dup@example.com"])
+        self.assertEqual(GeneratedEmail.objects.count(), 2)
+
+        # First call + second call each queue once (second skipped only the dup).
+        self.assertEqual(mock_delay.call_count, 2)
+
+    @patch("research_ai.views.email_views.send_queued_emails_task.delay")
+    def test_no_send_when_all_skipped(self, mock_delay):
+        self.client.force_authenticate(self.creator)
+        self.assertEqual(self._post().status_code, status.HTTP_202_ACCEPTED)
+        mock_delay.reset_mock()
+        resp = self._post()
+        self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(resp.json()["queued"], 0)
+        mock_delay.assert_not_called()

--- a/src/research_ai/tests/test_rfp_invite_view.py
+++ b/src/research_ai/tests/test_rfp_invite_view.py
@@ -152,3 +152,20 @@ class InviteRfpApplicantsViewTests(APITestCase):
         self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED)
         self.assertEqual(resp.json()["queued"], 0)
         mock_delay.assert_not_called()
+
+    @patch("research_ai.views.email_views.send_queued_emails_task.delay")
+    def test_rejects_non_open_grant(self, mock_delay):
+        for blocked_status in (
+            Grant.PENDING,
+            Grant.CLOSED,
+            Grant.COMPLETED,
+            Grant.DECLINED,
+        ):
+            with self.subTest(status=blocked_status):
+                self.grant.status = blocked_status
+                self.grant.save(update_fields=["status"])
+                self.client.force_authenticate(self.creator)
+                resp = self._post()
+                self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assertEqual(GeneratedEmail.objects.count(), 0)
+                mock_delay.assert_not_called()

--- a/src/research_ai/urls.py
+++ b/src/research_ai/urls.py
@@ -5,6 +5,7 @@ from research_ai.views.email_views import (
     GeneratedEmailDetailView,
     GeneratedEmailListView,
     GenerateEmailView,
+    InviteRfpApplicantsView,
     PreviewEmailView,
     SendEmailView,
 )
@@ -75,5 +76,9 @@ urlpatterns = [
     path(
         "expert-finder/templates/<int:template_id>/",
         TemplateDetailView.as_view(),
+    ),
+    path(
+        "expert-finder/rfp/<int:grant_id>/invite-applicants/",
+        InviteRfpApplicantsView.as_view(),
     ),
 ]

--- a/src/research_ai/views/email_views.py
+++ b/src/research_ai/views/email_views.py
@@ -15,6 +15,7 @@ from research_ai.serializers import (
     GeneratedEmailCreateUpdateSerializer,
     GeneratedEmailSerializer,
     GenerateEmailRequestSerializer,
+    InviteRfpApplicantsSerializer,
     PreviewEmailRequestSerializer,
     SendEmailRequestSerializer,
 )
@@ -24,6 +25,7 @@ from research_ai.services.email_template_variables import format_expert_name_fro
 from research_ai.services.expert_display import ExpertDisplay
 from research_ai.services.expert_persist import ExpertPersist
 from research_ai.services.rfp_email_context import get_expert_for_search_by_email
+from research_ai.services.rfp_invite_service import invite_applicants
 from research_ai.tasks import process_bulk_generate_emails_task, send_queued_emails_task
 from user.permissions import IsModerator, UserIsEditor
 
@@ -449,3 +451,81 @@ class GeneratedEmailDetailView(APIView):
             return err
         email.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class InviteRfpApplicantsView(APIView):
+    """POST /api/research_ai/expert-finder/rfp/<grant_id>/invite-applicants/.
+
+    Send a fixed-template invitation to each email address inviting them to
+    apply to the RFP. Authorized for the grant creator, listed grant contacts,
+    and moderators.
+    """
+
+    permission_classes = [IsAuthenticated, ResearchAIPermission]
+
+    def _get_grant_or_404(self, grant_id):
+        from purchase.related_models.grant_model import Grant
+
+        return Grant.objects.filter(id=grant_id).first()
+
+    def _is_authorized(self, user, grant) -> bool:
+        if getattr(user, "moderator", False):
+            return True
+        if grant.created_by_id == user.id:
+            return True
+        return grant.contacts.filter(id=user.id).exists()
+
+    def post(self, request, grant_id):
+        grant = self._get_grant_or_404(grant_id)
+        if grant is None:
+            return Response(
+                {"detail": "Grant not found."}, status=status.HTTP_404_NOT_FOUND
+            )
+        if not self._is_authorized(request.user, grant):
+            return Response(
+                {"detail": "Not allowed to invite applicants to this RFP."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        ser = InviteRfpApplicantsSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        data = ser.validated_data
+
+        try:
+            result = invite_applicants(
+                grant=grant,
+                inviter=request.user,
+                emails=data["emails"],
+            )
+        except Exception as e:
+            logger.exception("RFP applicant invite failed for grant=%s", grant.id)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )
+
+        reply_to = (data.get("reply_to") or request.user.email or "").strip() or None
+        cc_list = list(data.get("cc") or [])
+        get_full_name = getattr(request.user, "get_full_name", None)
+        display_name = (
+            (get_full_name() if callable(get_full_name) else "") or ""
+        ).strip() or "ResearchHub"
+        from_email = (
+            f"{display_name} via ResearchHub <{settings.EXPERT_FINDER_FROM_EMAIL}>"
+        )
+
+        if result.generated_email_ids:
+            send_queued_emails_task.delay(
+                generated_email_ids=result.generated_email_ids,
+                reply_to=reply_to,
+                cc=cc_list,
+                from_email=from_email,
+            )
+
+        return Response(
+            {
+                "queued": len(result.generated_email_ids),
+                "skipped_existing": result.skipped_existing,
+                "generated_email_ids": result.generated_email_ids,
+            },
+            status=status.HTTP_202_ACCEPTED,
+        )

--- a/src/research_ai/views/email_views.py
+++ b/src/research_ai/views/email_views.py
@@ -486,6 +486,12 @@ class InviteRfpApplicantsView(APIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
+        if grant.status != Grant.OPEN:
+            return Response(
+                {"detail": "Grant must be approved and open to invite applicants."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         ser = InviteRfpApplicantsSerializer(data=request.data)
         ser.is_valid(raise_exception=True)
         data = ser.validated_data

--- a/src/research_ai/views/email_views.py
+++ b/src/research_ai/views/email_views.py
@@ -7,6 +7,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from purchase.related_models.grant_model import Grant
 from research_ai.constants import DEFAULT_EMAIL_TEMPLATE_KEY, VALID_EMAIL_TEMPLATE_KEYS
 from research_ai.models import ExpertSearch, GeneratedEmail
 from research_ai.permissions import ResearchAIPermission
@@ -464,8 +465,6 @@ class InviteRfpApplicantsView(APIView):
     permission_classes = [IsAuthenticated, ResearchAIPermission]
 
     def _get_grant_or_404(self, grant_id):
-        from purchase.related_models.grant_model import Grant
-
         return Grant.objects.filter(id=grant_id).first()
 
     def _is_authorized(self, user, grant) -> bool:

--- a/src/researchhub_document/related_models/researchhub_post_model.py
+++ b/src/researchhub_document/related_models/researchhub_post_model.py
@@ -28,15 +28,20 @@ class ResearchhubPostQuerySet(models.QuerySet):
         """Restrict to posts the given user is allowed to see.
 
         Public posts (unified_document.is_public=True) are visible to anyone.
-        Private posts are visible only to their author, to the creator of
-        any grant the post has applied to (via GrantApplication), and to
-        users with a non-revoked Permission on the post's unified document
-        (e.g. invited experts). A NO_ACCESS Permission row revokes access even
-        when other (e.g. stale VIEWER) rows exist for the same user/document.
+        Private posts are visible to: the author, the creator of any grant the
+        post has applied to (via GrantApplication), users with a non-revoked
+        Permission on the post's unified document (e.g. invited experts), and
+        site moderators / hub editors who need to see private grants and
+        preregistrations to moderate them. A NO_ACCESS Permission row revokes
+        access even when other (e.g. stale VIEWER) rows exist for the same
+        user/document.
         """
         public = Q(unified_document__is_public=True)
         if user is None or not getattr(user, "is_authenticated", False):
             return self.filter(public)
+
+        if getattr(user, "moderator", False) or user.is_hub_editor():
+            return self
 
         ud_ct = ContentType.objects.get_for_model(ResearchhubUnifiedDocument)
         user_perms = Permission.objects.filter(

--- a/src/researchhub_document/tests/test_private_grant.py
+++ b/src/researchhub_document/tests/test_private_grant.py
@@ -1,0 +1,252 @@
+from datetime import timedelta
+from decimal import Decimal
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+from django.utils import timezone
+from rest_framework.test import APITestCase
+
+from hub.tests.helpers import create_hub
+from purchase.models import Grant, GrantApplication
+from research_ai.models import ExpertSearch, GeneratedEmail
+from research_ai.services.invited_experts_service import (
+    grant_invited_expert_access_for_signup,
+)
+from researchhub_access_group.constants import VIEWER
+from researchhub_access_group.models import Permission
+from researchhub_document.helpers import create_post
+from researchhub_document.models import ResearchhubUnifiedDocument
+from researchhub_document.related_models.constants.document_type import GRANT
+from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
+from user.tests.helpers import (
+    create_random_authenticated_user,
+    create_random_default_user,
+    make_user_verified,
+)
+
+
+def _grant_post_body(*, is_public=None, **overrides):
+    body = {
+        "document_type": "GRANT",
+        "full_src": "body",
+        "renderable_text": (
+            "sufficiently long body. sufficiently long body. "
+            "sufficiently long body. sufficiently long body. "
+            "sufficiently long body"
+        ),
+        "title": "sufficiently long title. sufficiently long title.",
+        "grant_amount": 50000,
+        "grant_currency": "USD",
+        "grant_organization": "Test Foundation",
+        "grant_description": "Test grant for research",
+    }
+    if is_public is not None:
+        body["is_public"] = is_public
+    body.update(overrides)
+    return body
+
+
+class CreatePrivateGrantTests(APITestCase):
+    def setUp(self):
+        cache.clear()
+        self.author = create_random_default_user("private_grant_author", moderator=True)
+        make_user_verified(self.author)
+        self.hub = create_hub()
+
+    def test_grant_defaults_to_public(self):
+        self.client.force_authenticate(self.author)
+        resp = self.client.post(
+            "/api/researchhubpost/",
+            _grant_post_body(hubs=[self.hub.id]),
+        )
+        self.assertEqual(resp.status_code, 200)
+        post_id = resp.data["id"]
+        post = ResearchhubPost.objects.get(id=post_id)
+        self.assertTrue(post.unified_document.is_public)
+
+    def test_grant_can_be_created_private(self):
+        self.client.force_authenticate(self.author)
+        resp = self.client.post(
+            "/api/researchhubpost/",
+            _grant_post_body(is_public=False, hubs=[self.hub.id]),
+        )
+        self.assertEqual(resp.status_code, 200)
+        post_id = resp.data["id"]
+        post = ResearchhubPost.objects.get(id=post_id)
+        self.assertFalse(post.unified_document.is_public)
+        self.assertEqual(post.unified_document.grants.count(), 1)
+
+
+class PrivateGrantVisibilityTests(APITestCase):
+    """Private grants must be hidden from users without permission across
+    the post-detail, grant feed, and GrantViewSet surfaces."""
+
+    def setUp(self):
+        cache.clear()
+        GrantApplication.objects.all().delete()
+        Grant.objects.all().delete()
+        ResearchhubPost.objects.filter(document_type=GRANT).delete()
+
+        self.owner = create_random_authenticated_user("priv_grant_owner")
+        self.other = create_random_authenticated_user("priv_grant_other")
+        self.invitee = create_random_authenticated_user("priv_grant_invitee")
+        self.moderator = create_random_authenticated_user(
+            "priv_grant_mod", moderator=True
+        )
+
+        self.public_post = create_post(
+            created_by=self.owner, document_type=GRANT, title="Public Grant"
+        )
+        self.public_grant = Grant.objects.create(
+            created_by=self.owner,
+            unified_document=self.public_post.unified_document,
+            amount=Decimal("10000.00"),
+            currency="USD",
+            organization="OrgPub",
+            description="public",
+            status=Grant.OPEN,
+            end_date=timezone.now() + timedelta(days=30),
+        )
+
+        self.private_post = create_post(
+            created_by=self.owner, document_type=GRANT, title="Private Grant"
+        )
+        self.private_post.unified_document.is_public = False
+        self.private_post.unified_document.save(update_fields=["is_public"])
+        self.private_grant = Grant.objects.create(
+            created_by=self.owner,
+            unified_document=self.private_post.unified_document,
+            amount=Decimal("20000.00"),
+            currency="USD",
+            organization="OrgPriv",
+            description="private",
+            status=Grant.OPEN,
+            end_date=timezone.now() + timedelta(days=30),
+        )
+
+        ud_ct = ContentType.objects.get_for_model(ResearchhubUnifiedDocument)
+        Permission.objects.create(
+            content_type=ud_ct,
+            object_id=self.private_post.unified_document_id,
+            user=self.invitee,
+            access_type=VIEWER,
+        )
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_grant_feed_hides_private_from_unrelated_user(self):
+        self.client.force_authenticate(self.other)
+        resp = self.client.get("/api/grant_feed/")
+        self.assertEqual(resp.status_code, 200)
+        titles = [r["content_object"]["title"] for r in resp.data["results"]]
+        self.assertIn("Public Grant", titles)
+        self.assertNotIn("Private Grant", titles)
+
+    def test_grant_feed_hides_private_from_anonymous(self):
+        cache.clear()
+        resp = self.client.get("/api/grant_feed/")
+        self.assertEqual(resp.status_code, 200)
+        titles = [r["content_object"]["title"] for r in resp.data["results"]]
+        self.assertIn("Public Grant", titles)
+        self.assertNotIn("Private Grant", titles)
+
+    def test_grant_feed_hides_private_from_owner(self):
+        """Private grants are excluded from the feed for everyone, including
+        the owner. The owner accesses them via the direct post/grant URL."""
+        self.client.force_authenticate(self.owner)
+        resp = self.client.get("/api/grant_feed/")
+        self.assertEqual(resp.status_code, 200)
+        titles = [r["content_object"]["title"] for r in resp.data["results"]]
+        self.assertIn("Public Grant", titles)
+        self.assertNotIn("Private Grant", titles)
+
+    def test_grant_feed_hides_private_from_permitted_user(self):
+        """Permission rows grant detail-page access but do not surface private
+        grants in the shared feed (which is cached across all users)."""
+        self.client.force_authenticate(self.invitee)
+        resp = self.client.get("/api/grant_feed/")
+        self.assertEqual(resp.status_code, 200)
+        titles = [r["content_object"]["title"] for r in resp.data["results"]]
+        self.assertIn("Public Grant", titles)
+        self.assertNotIn("Private Grant", titles)
+
+    def test_grant_viewset_hides_private_from_unrelated_user(self):
+        self.client.force_authenticate(self.other)
+        resp = self.client.get(f"/api/grant/{self.private_grant.id}/")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_grant_viewset_shows_private_to_owner(self):
+        self.client.force_authenticate(self.owner)
+        resp = self.client.get(f"/api/grant/{self.private_grant.id}/")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_grant_viewset_shows_private_to_permitted_user(self):
+        self.client.force_authenticate(self.invitee)
+        resp = self.client.get(f"/api/grant/{self.private_grant.id}/")
+        self.assertEqual(resp.status_code, 200)
+
+
+class InviteAccessGrantForPrivateGrantTests(APITestCase):
+    """grant_invited_expert_access_for_signup must now create a Permission on
+    a private GRANT (previously only on PREREGISTRATIONs)."""
+
+    def setUp(self):
+        cache.clear()
+        self.owner = create_random_authenticated_user("invite_owner")
+        self.invitee_email = "applicant@example.com"
+
+        post = create_post(created_by=self.owner, document_type=GRANT)
+        post.unified_document.is_public = False
+        post.unified_document.save(update_fields=["is_public"])
+        Grant.objects.create(
+            created_by=self.owner,
+            unified_document=post.unified_document,
+            amount=Decimal("30000.00"),
+            currency="USD",
+            organization="OrgX",
+            description="d",
+            status=Grant.OPEN,
+            end_date=timezone.now() + timedelta(days=30),
+        )
+
+        search = ExpertSearch.objects.create(
+            created_by=self.owner,
+            unified_document=post.unified_document,
+            name="RFP Applicant Invites",
+            query="x",
+            input_type=ExpertSearch.InputType.CUSTOM_QUERY,
+            status=ExpertSearch.Status.COMPLETED,
+            progress=100,
+        )
+        GeneratedEmail.objects.create(
+            created_by=self.owner,
+            expert_search=search,
+            expert_email=self.invitee_email,
+            email_subject="s",
+            email_body="b",
+            status=GeneratedEmail.Status.SENT,
+        )
+        self.unified_doc = post.unified_document
+
+    def test_signup_grants_viewer_permission_on_private_grant(self):
+        new_user = create_random_authenticated_user("late_signup")
+        # Move signup into the window relative to the invite's created_date.
+        new_user.email = self.invitee_email
+        new_user.date_joined = timezone.now()
+        new_user.save(update_fields=["email", "date_joined"])
+
+        granted = grant_invited_expert_access_for_signup(
+            normalized_email=self.invitee_email, user=new_user
+        )
+        self.assertEqual(granted, 1)
+
+        ud_ct = ContentType.objects.get_for_model(ResearchhubUnifiedDocument)
+        self.assertTrue(
+            Permission.objects.filter(
+                content_type=ud_ct,
+                object_id=self.unified_doc.id,
+                user=new_user,
+                access_type=VIEWER,
+            ).exists()
+        )

--- a/src/researchhub_document/tests/test_private_grant.py
+++ b/src/researchhub_document/tests/test_private_grant.py
@@ -16,9 +16,13 @@ from researchhub_access_group.constants import VIEWER
 from researchhub_access_group.models import Permission
 from researchhub_document.helpers import create_post
 from researchhub_document.models import ResearchhubUnifiedDocument
-from researchhub_document.related_models.constants.document_type import GRANT
+from researchhub_document.related_models.constants.document_type import (
+    GRANT,
+    PREREGISTRATION,
+)
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 from user.tests.helpers import (
+    create_hub_editor,
     create_random_authenticated_user,
     create_random_default_user,
     make_user_verified,
@@ -181,9 +185,76 @@ class PrivateGrantVisibilityTests(APITestCase):
         resp = self.client.get(f"/api/grant/{self.private_grant.id}/")
         self.assertEqual(resp.status_code, 200)
 
+    def test_grant_viewset_shows_private_to_moderator(self):
+        self.client.force_authenticate(self.moderator)
+        resp = self.client.get(f"/api/grant/{self.private_grant.id}/")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_grant_viewset_shows_private_to_hub_editor(self):
+        editor, _ = create_hub_editor("priv_grant_editor", "priv_grant_hub")
+        self.client.force_authenticate(editor)
+        resp = self.client.get(f"/api/grant/{self.private_grant.id}/")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_post_detail_shows_private_grant_to_moderator(self):
+        self.client.force_authenticate(self.moderator)
+        resp = self.client.get(f"/api/researchhubpost/{self.private_post.id}/")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_post_detail_shows_private_grant_to_hub_editor(self):
+        editor, _ = create_hub_editor("priv_grant_editor_post", "priv_grant_hub_post")
+        self.client.force_authenticate(editor)
+        resp = self.client.get(f"/api/researchhubpost/{self.private_post.id}/")
+        self.assertEqual(resp.status_code, 200)
+
     def test_grant_viewset_shows_private_to_permitted_user(self):
         self.client.force_authenticate(self.invitee)
         resp = self.client.get(f"/api/grant/{self.private_grant.id}/")
+        self.assertEqual(resp.status_code, 200)
+
+
+class PrivatePreregistrationVisibilityTests(APITestCase):
+    """Moderators and hub editors must be able to view private preregistration
+    posts so they can moderate them; unrelated users still get a 404."""
+
+    def setUp(self):
+        cache.clear()
+        self.owner = create_random_authenticated_user("priv_prereg_owner")
+        self.other = create_random_authenticated_user("priv_prereg_other")
+        self.moderator = create_random_authenticated_user(
+            "priv_prereg_mod", moderator=True
+        )
+
+        self.private_post = create_post(
+            created_by=self.owner,
+            document_type=PREREGISTRATION,
+            title="Private Prereg",
+        )
+        self.private_post.unified_document.is_public = False
+        self.private_post.unified_document.save(update_fields=["is_public"])
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_post_detail_hides_private_prereg_from_unrelated_user(self):
+        self.client.force_authenticate(self.other)
+        resp = self.client.get(f"/api/researchhubpost/{self.private_post.id}/")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_post_detail_shows_private_prereg_to_owner(self):
+        self.client.force_authenticate(self.owner)
+        resp = self.client.get(f"/api/researchhubpost/{self.private_post.id}/")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_post_detail_shows_private_prereg_to_moderator(self):
+        self.client.force_authenticate(self.moderator)
+        resp = self.client.get(f"/api/researchhubpost/{self.private_post.id}/")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_post_detail_shows_private_prereg_to_hub_editor(self):
+        editor, _ = create_hub_editor("priv_prereg_editor", "priv_prereg_hub")
+        self.client.force_authenticate(editor)
+        resp = self.client.get(f"/api/researchhubpost/{self.private_post.id}/")
         self.assertEqual(resp.status_code, 200)
 
 

--- a/src/researchhub_document/tests/test_private_preregistration.py
+++ b/src/researchhub_document/tests/test_private_preregistration.py
@@ -27,9 +27,6 @@ from researchhub_document.related_models.constants.document_type import (
 from researchhub_document.related_models.researchhub_post_model import (
     ResearchhubPost,
 )
-from researchhub_document.related_models.researchhub_unified_document_model import (
-    ResearchhubUnifiedDocument,
-)
 from user.models import Action
 from user.tests.helpers import make_user_verified
 from utils.test_helpers import AWSMockTestCase
@@ -160,9 +157,10 @@ class VisibleToQuerySetTests(AWSMockTestCase):
         self.private_post.unified_document.save()
 
         # Grant owned by `grant_owner`; the private post applies to it.
-        self.grant_doc = ResearchhubUnifiedDocument.objects.create(
-            document_type="GRANT"
+        self.grant_post = create_post(
+            created_by=self.grant_owner, document_type="GRANT", title="Grant"
         )
+        self.grant_doc = self.grant_post.unified_document
         self.grant = Grant.objects.create(
             created_by=self.grant_owner,
             unified_document=self.grant_doc,
@@ -278,9 +276,10 @@ class PostViewSetVisibilityTests(AWSMockTestCase):
         self.private_post.unified_document.is_public = False
         self.private_post.unified_document.save()
 
-        self.grant_doc = ResearchhubUnifiedDocument.objects.create(
-            document_type="GRANT"
+        self.grant_post = create_post(
+            created_by=self.grant_owner, document_type="GRANT", title="Grant"
         )
+        self.grant_doc = self.grant_post.unified_document
         self.grant = Grant.objects.create(
             created_by=self.grant_owner,
             unified_document=self.grant_doc,
@@ -344,9 +343,10 @@ class FundingFeedPrivacyTests(AWSMockTestCase):
         self.private_post.unified_document.is_public = False
         self.private_post.unified_document.save()
 
-        self.grant_doc = ResearchhubUnifiedDocument.objects.create(
-            document_type="GRANT"
+        self.grant_post = create_post(
+            created_by=self.grant_owner, document_type="GRANT", title="Grant"
         )
+        self.grant_doc = self.grant_post.unified_document
         self.grant = Grant.objects.create(
             created_by=self.grant_owner,
             unified_document=self.grant_doc,
@@ -525,10 +525,16 @@ class GrantEnforcedApplicationVisibilityTests(AWSMockTestCase):
         self.client.force_authenticate(self.author)
 
     def _make_grant(self, application_visibility):
-        ud = ResearchhubUnifiedDocument.objects.create(document_type="GRANT")
+        # Every grant has an associated post in production; mirror that here
+        # so visibility filters (GrantViewSet.get_queryset) behave realistically.
+        post = create_post(
+            created_by=self.grant_owner,
+            document_type="GRANT",
+            title=f"Grant {uuid.uuid4().hex[:8]}",
+        )
         return Grant.objects.create(
             created_by=self.grant_owner,
-            unified_document=ud,
+            unified_document=post.unified_document,
             amount=1000,
             currency=USD,
             organization="Org",

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -26,6 +26,7 @@ from researchhub_document.permissions import HasDocumentEditingPermission
 from researchhub_document.related_models.constants.document_type import (
     FILTER_BOUNTY_OPEN,
     FILTER_HAS_BOUNTY,
+    GRANT,
     PREREGISTRATION,
     RESEARCHHUB_POST_DOCUMENT_TYPES,
     SORT_BOUNTY_EXPIRATION_DATE,
@@ -571,15 +572,15 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
             hubs = Hub.objects.filter(id__in=request_data.get("hubs", [])).all()
             document_type = request_data.get("document_type")
             is_public = True
-            # Only PREREGISTRATION posts may be created as private today.
-            if document_type == PREREGISTRATION:
+            # PREREGISTRATION and GRANT posts may be created as private.
+            if document_type in (PREREGISTRATION, GRANT):
                 explicit_is_public = "is_public" in request_data
                 if explicit_is_public:
                     is_public = serializers.BooleanField().run_validation(
                         request_data["is_public"]
                     )
 
-                if target_grant is not None:
+                if document_type == PREREGISTRATION and target_grant is not None:
                     required = target_grant.application_visibility
                     # An explicit is_public that conflicts with the grant's
                     # requirement is treated as a client error. When is_public


### PR DESCRIPTION
- Add private RFPs as well as an invite endpoint
- POST /api/research_ai/expert-finder/rfp/<grant_id>/invite-applicants/ with body {"emails": ["a@x.com", "b@x.com"], "reply_to": "...", "cc": ["..."]}
  - Specify a list of emails to send invite to
- Add mod and editor access to private RFPs and Grants


Follow up PR will be preregistration invites