### PR TITLE
Add paginated expert-finder experts list endpoint

### DIFF
--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -460,6 +460,17 @@ class InvitedExpertOverviewQuerySerializer(InvitedExpertStatsFilterSerializer):
     editor_id = serializers.IntegerField(required=False, allow_null=True, min_value=1)
 
 
+class ExpertFinderExpertsListQuerySerializer(InvitedExpertOverviewQuerySerializer):
+    """Query params for GET expert-finder experts/."""
+
+    registered = serializers.BooleanField(required=False, default=False)
+    limit = serializers.IntegerField(required=False, default=20, min_value=1)
+    offset = serializers.IntegerField(required=False, default=0, min_value=0)
+
+    def validate_limit(self, value):
+        return min(100, max(1, value if value is not None else 20))
+
+
 class InvitedExpertEditorsOverviewQuerySerializer(InvitedExpertStatsFilterSerializer):
     """Query params for GET expert-finder editors-overview."""
 
@@ -535,6 +546,15 @@ class InvitedExpertEditorsOverviewSerializer(serializers.Serializer):
     offset = serializers.IntegerField(read_only=True)
     sort_by = serializers.CharField(read_only=True)
     sort_order = serializers.CharField(read_only=True)
+
+
+class ExpertFinderListItemSerializer(ExpertSerializer):
+    """Expert row for GET expert-finder experts/ with registered RH user as author."""
+
+    registered_user = serializers.SerializerMethodField()
+
+    def get_registered_user(self, obj):
+        return _get_user_with_author_payload(obj.registered_user)
 
 
 class ExpertSearchSubmitResponseSerializer(serializers.Serializer):

--- a/src/research_ai/services/invited_experts_service.py
+++ b/src/research_ai/services/invited_experts_service.py
@@ -619,3 +619,52 @@ def load_editor_users(user_ids: list[int]) -> dict[int, User]:
         return {}
     users = User.objects.filter(id__in=user_ids).select_related("author_profile")
     return {user.id: user for user in users}
+
+
+@dataclass(frozen=True)
+class ExpertFinderExpertsListResult:
+    items: list[Expert] = field(default_factory=list)
+    total: int = 0
+    limit: int = 20
+    offset: int = 0
+
+
+def get_expert_finder_experts_list(
+    *,
+    unified_document_id: int | None,
+    start: datetime | None,
+    end: datetime | None,
+    editor_id: int | None = None,
+    registered: bool = False,
+    limit: int = 20,
+    offset: int = 0,
+) -> ExpertFinderExpertsListResult:
+    """
+    Paginated distinct experts linked to expert searches in the filter window.
+    """
+    filtered_searches = _filtered_expert_searches(
+        unified_document_id=unified_document_id,
+        start=start,
+        end=end,
+        editor_id=editor_id,
+    )
+    experts_qs = (
+        Expert.objects.filter(search_experts__expert_search__in=filtered_searches)
+        .distinct()
+        .select_related("registered_user__author_profile")
+    )
+    if registered:
+        experts_qs = experts_qs.filter(registered_user__isnull=False)
+
+    total = experts_qs.count()
+    limit = min(100, max(1, limit))
+    offset = max(0, offset)
+    items = list(
+        experts_qs.order_by("-last_email_sent_at", "-id")[offset : offset + limit]
+    )
+    return ExpertFinderExpertsListResult(
+        items=items,
+        total=total,
+        limit=limit,
+        offset=offset,
+    )

--- a/src/research_ai/tests/test_invited_experts_stats_service.py
+++ b/src/research_ai/tests/test_invited_experts_stats_service.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from research_ai.models import Expert, ExpertSearch, GeneratedEmail, SearchExpert
 from research_ai.services.invited_experts_service import (
     _safe_rate,
+    get_expert_finder_experts_list,
     get_invited_expert_editors_overview,
     get_invited_expert_overview,
 )
@@ -117,3 +118,59 @@ class InvitedExpertsStatsServiceTests(TestCase):
                 prereg_b.unified_document_id: 1,
             },
         )
+
+    def test_experts_list_matches_overview_totals(self):
+        from paper.tests.helpers import create_paper
+
+        user = create_random_authenticated_user("list_svc", moderator=True)
+        paper = create_paper(
+            title="List paper",
+            paper_publish_date="2021-01-01",
+        )
+        ud_id = paper.unified_document_id
+        search = ExpertSearch.objects.create(
+            created_by=user,
+            unified_document_id=ud_id,
+            query="List",
+            status=ExpertSearch.Status.COMPLETED,
+        )
+        registered_expert = Expert.objects.create(
+            email="registered@example.com",
+            registered_user=user,
+        )
+        other_expert = Expert.objects.create(email="other@example.com")
+        SearchExpert.objects.create(
+            expert_search=search, expert=registered_expert, position=0
+        )
+        SearchExpert.objects.create(
+            expert_search=search, expert=other_expert, position=1
+        )
+        GeneratedEmail.objects.create(
+            created_by=user,
+            expert_search=search,
+            expert_email="registered@example.com",
+            status=GeneratedEmail.Status.SENT,
+        )
+
+        start = timezone.now() - timedelta(days=1)
+        end = timezone.now()
+        overview = get_invited_expert_overview(
+            unified_document_id=ud_id,
+            start=start,
+            end=end,
+        )
+        all_experts = get_expert_finder_experts_list(
+            unified_document_id=ud_id,
+            start=start,
+            end=end,
+        )
+        registered_only = get_expert_finder_experts_list(
+            unified_document_id=ud_id,
+            start=start,
+            end=end,
+            registered=True,
+        )
+
+        self.assertEqual(all_experts.total, overview.counts.experts_total)
+        self.assertEqual(registered_only.total, overview.counts.experts_signed_up)
+        self.assertEqual(len(all_experts.items), 2)

--- a/src/research_ai/tests/test_views.py
+++ b/src/research_ai/tests/test_views.py
@@ -393,6 +393,92 @@ class InvitedExpertOverviewViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
+class ExpertListViewTests(APITestCase):
+    URL = "/api/research_ai/expert-finder/experts/"
+
+    def setUp(self):
+        self.moderator = create_random_authenticated_user("mod_experts", moderator=True)
+        self.user = create_random_authenticated_user("user_experts", moderator=False)
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_experts_list_requires_moderator(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(self.URL)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_experts_list_returns_expert_rows_with_registered_user(self):
+        from paper.tests.helpers import create_paper
+
+        paper = create_paper(
+            title="Experts list paper",
+            paper_publish_date="2021-01-01",
+        )
+        ud_id = paper.unified_document_id
+        search = ExpertSearch.objects.create(
+            created_by=self.moderator,
+            unified_document_id=ud_id,
+            query="Experts list",
+            status=ExpertSearch.Status.COMPLETED,
+        )
+        expert = Expert.objects.create(
+            email="listed@example.com",
+            first_name="List",
+            last_name="Ed",
+            registered_user=self.moderator,
+        )
+        SearchExpert.objects.create(expert_search=search, expert=expert, position=0)
+        GeneratedEmail.objects.create(
+            created_by=self.moderator,
+            expert_search=search,
+            expert_email="listed@example.com",
+            status=GeneratedEmail.Status.SENT,
+            opened_at=timezone.now(),
+            open_count=1,
+        )
+
+        self.client.force_authenticate(self.moderator)
+        response = self.client.get(self.URL, {"unified_document_id": ud_id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["total"], 1)
+        self.assertEqual(len(data["items"]), 1)
+        row = data["items"][0]
+        self.assertEqual(row["email"], "listed@example.com")
+        self.assertEqual(row["display_name"], "List Ed")
+        self.assertIsNotNone(row["registered_user"])
+        self.assertEqual(row["registered_user"]["user_id"], self.moderator.id)
+        self.assertIn("author", row["registered_user"])
+        self.assertNotIn("outreach", row)
+        self.assertNotIn("meta", data)
+
+    def test_experts_list_registered_filter(self):
+        search = ExpertSearch.objects.create(
+            created_by=self.moderator,
+            query="Registered filter",
+            status=ExpertSearch.Status.COMPLETED,
+        )
+        registered = Expert.objects.create(
+            email="reg@example.com",
+            registered_user=self.moderator,
+        )
+        unregistered = Expert.objects.create(email="unreg@example.com")
+        SearchExpert.objects.create(expert_search=search, expert=registered, position=0)
+        SearchExpert.objects.create(
+            expert_search=search, expert=unregistered, position=1
+        )
+
+        self.client.force_authenticate(self.moderator)
+        response = self.client.get(self.URL, {"registered": "true"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["total"], 1)
+        self.assertEqual(data["items"][0]["email"], "reg@example.com")
+        self.assertNotIn("meta", data)
+
+
 class InvitedExpertEditorsOverviewViewTests(APITestCase):
     URL = "/api/research_ai/expert-finder/editors-overview/"
 

--- a/src/research_ai/urls.py
+++ b/src/research_ai/urls.py
@@ -10,6 +10,7 @@ from research_ai.views.email_views import (
 )
 from research_ai.views.expert_finder_views import (
     ExpertDetailView,
+    ExpertListView,
     ExpertSearchAddExpertView,
     ExpertSearchDetailView,
     ExpertSearchListCreateView,
@@ -29,6 +30,10 @@ urlpatterns = [
     path(
         "expert-finder/searches/<int:search_id>/experts/",
         ExpertSearchAddExpertView.as_view(),
+    ),
+    path(
+        "expert-finder/experts/",
+        ExpertListView.as_view(),
     ),
     path(
         "expert-finder/experts/<int:expert_id>/",

--- a/src/research_ai/views/expert_finder_views.py
+++ b/src/research_ai/views/expert_finder_views.py
@@ -15,6 +15,8 @@ from research_ai.constants import ExpertiseLevel, Gender, Region
 from research_ai.models import Expert, ExpertSearch, SearchExpert
 from research_ai.permissions import ResearchAIPermission
 from research_ai.serializers import (
+    ExpertFinderExpertsListQuerySerializer,
+    ExpertFinderListItemSerializer,
     ExpertSearchCreateSerializer,
     ExpertSearchDetailSerializer,
     ExpertSearchListItemSerializer,
@@ -32,6 +34,7 @@ from research_ai.serializers import (
 from research_ai.services.expert_finder_service import get_document_content
 from research_ai.services.expert_persist import ExpertPersist
 from research_ai.services.invited_experts_service import (
+    get_expert_finder_experts_list,
     get_invited_expert_editors_overview,
     get_invited_expert_overview,
     invited_stats_cache_key,
@@ -483,6 +486,63 @@ class InvitedExpertEditorsOverviewView(InvitedExpertStatsMixin, APIView):
                         end=end,
                     ),
                 },
+            }
+
+        return self._get_cached_or_build(
+            cache_key=cache_key, build_payload=build_payload
+        )
+
+
+class ExpertListView(InvitedExpertStatsMixin, APIView):
+    """
+    GET ``/expert-finder/experts/`` — paginated experts for filtered expert searches.
+    """
+
+    cache_prefix = "experts_list"
+
+    def get(self, request):
+        qser = ExpertFinderExpertsListQuerySerializer(data=request.query_params)
+        qser.is_valid(raise_exception=True)
+        params = qser.validated_data
+        unified_document_id = params.get("unified_document_id")
+        start = params.get("start")
+        end = params.get("end")
+        editor_id = params.get("editor_id")
+        registered = params.get("registered", False)
+        limit = params.get("limit", 20)
+        offset = params.get("offset", 0)
+
+        cache_key = invited_stats_cache_key(
+            self.cache_prefix,
+            ud=(
+                str(int(unified_document_id))
+                if unified_document_id is not None
+                else "none"
+            ),
+            start=start.isoformat() if start is not None else "none",
+            end=end.isoformat() if end is not None else "none",
+            editor_id=editor_id if editor_id is not None else "none",
+            registered=str(bool(registered)),
+            limit=limit,
+            offset=offset,
+        )
+
+        def build_payload():
+            result = get_expert_finder_experts_list(
+                unified_document_id=unified_document_id,
+                start=start,
+                end=end,
+                editor_id=editor_id,
+                registered=registered,
+                limit=limit,
+                offset=offset,
+            )
+            items_data = ExpertFinderListItemSerializer(result.items, many=True).data
+            return {
+                "items": items_data,
+                "total": result.total,
+                "limit": result.limit,
+                "offset": result.offset,
             }
 
         return self._get_cached_or_build(


### PR DESCRIPTION
## What?
- Add `GET /api/research_ai/expert-finder/experts/` to return paginated experts
- Support the same filters as overview: document, date range, editor, and optional `registered=true`

```
Example
{
  "items": [
    {
      "id": 42,
      "honorific": "Dr",
      "first_name": "Jane",
      "middle_name": "",
      "last_name": "Smith",
      "name_suffix": "PhD",
      "academic_title": "Associate Professor",
      "affiliation": "MIT",
      "expertise": "Machine learning",
      "email": "jane.smith@mit.edu",
      "notes": "",
      "sources": [],
      "last_email_sent_at": "2026-05-20T14:30:00Z",
      "display_name": "Dr. Jane Smith, PhD",
      "registered_user": {
        "user_id": 1001,
        "author": {
          "id": 501,
          "first_name": "Jane",
          "last_name": "Smith",
          "profile_image": "https://...",
          "headline": "ML researcher"
        }
      }
    },
    {
      "id": 43,
      "honorific": "",
      "first_name": "John",
      "middle_name": "",
      "last_name": "Doe",
      "name_suffix": "",
      "academic_title": "Research Scientist",
      "affiliation": "Stanford",
      "expertise": "Neuroscience",
      "email": "john.doe@stanford.edu",
      "notes": "",
      "sources": [],
      "last_email_sent_at": null,
      "display_name": "John Doe",
      "registered_user": null
    }
  ],
  "total": 2,
  "limit": 20,
  "offset": 0
}
```