### PR TITLE
Fixing backfill and signals to not include self deleted items

### DIFF
--- a/src/user/management/commands/backfill_risk_scores.py
+++ b/src/user/management/commands/backfill_risk_scores.py
@@ -20,13 +20,12 @@ from purchase.related_models.purchase_model import Purchase
 from reputation.related_models.bounty import BountySolution
 from research_ai.models import Expert
 from researchhub_comment.related_models.rh_comment_model import RhCommentModel
-from researchhub_document.related_models.researchhub_post_model import (
-    ResearchhubPost,
-)
 from review.models.review_model import Review
 from user.models import User
 from user.related_models.risk_score_model import RiskScoreEvent
 from user.related_models.user_verification_model import UserVerification
+from user.related_models.verdict_model import Verdict
+from user.services.censorship import resolve_censorship
 from user.services.risk_score_service import RiskScoreService
 
 EventType = RiskScoreEvent.EventType
@@ -40,15 +39,6 @@ def _grant_decision_date(grant):
     return grant.updated_date
 
 
-def _comment_removal_date(comment):
-    return comment.is_removed_date or comment.created_date
-
-
-def _document_removal_date(post):
-    unified_document = post.unified_document
-    return (unified_document and unified_document.is_removed_date) or post.created_date
-
-
 def _solution_award_date(solution):
     return solution.updated_date
 
@@ -60,18 +50,6 @@ def _review_assessment_date(review):
 HISTORICAL_SOURCES = [
     (Grant, {"status": Grant.OPEN}, EventType.WORK_APPROVED, _grant_decision_date),
     (Grant, {"status": Grant.DECLINED}, EventType.WORK_DECLINED, _grant_decision_date),
-    (
-        RhCommentModel,
-        {"is_removed": True},
-        EventType.CONTENT_CENSORED,
-        _comment_removal_date,
-    ),
-    (
-        ResearchhubPost,
-        {"unified_document__is_removed": True},
-        EventType.CONTENT_CENSORED,
-        _document_removal_date,
-    ),
     (
         BountySolution,
         {"status": BountySolution.Status.AWARDED},
@@ -137,8 +115,6 @@ class Command(BaseCommand):
             qs = manager.filter(
                 created_by_id__in=active_user_ids, **filters
             ).select_related("created_by")
-            if model is ResearchhubPost:
-                qs = qs.select_related("unified_document")
             for obj in qs:
                 self._record(
                     obj.created_by,
@@ -148,7 +124,25 @@ class Command(BaseCommand):
                     occurred_at=occurred_at(obj),
                 )
 
+        self._backfill_censorship_verdicts(active_user_ids, dry_run)
         self._backfill_foundation_tips(active_user_ids, dry_run)
+
+    def _backfill_censorship_verdicts(self, active_user_ids, dry_run):
+        """Backfill CONTENT_CENSORED for content a moderator removed via verdict."""
+        verdicts = Verdict.objects.filter(is_content_removed=True).select_related(
+            "flag__content_type"
+        )
+        for verdict in verdicts.iterator():
+            author, source = resolve_censorship(verdict)
+            if source is None or author is None or author.id not in active_user_ids:
+                continue
+            self._record(
+                author,
+                EventType.CONTENT_CENSORED,
+                dry_run,
+                source=source,
+                occurred_at=verdict.created_date,
+            )
 
     def _backfill_foundation_tips(self, active_user_ids, dry_run):
         """Backfill PEER_REVIEW_TIPPED for comments tipped by the foundation."""

--- a/src/user/services/censorship.py
+++ b/src/user/services/censorship.py
@@ -1,0 +1,41 @@
+"""Resolve the author and risk-score source behind a moderator removal verdict.
+
+Shared by the real-time risk-score signal and the backfill command so both
+attribute censorship identically.
+"""
+
+from paper.related_models.paper_model import Paper
+from researchhub_comment.related_models.rh_comment_model import RhCommentModel
+
+DECLINED_STATUS = "DECLINED"
+
+
+def _flagged_content(verdict):
+    model_class = verdict.flag.content_type.model_class()
+    if model_class is None:
+        return None
+    manager = getattr(model_class, "all_objects", model_class.objects)
+    return manager.filter(pk=verdict.flag.object_id).first()
+
+
+def resolve_censorship(verdict):
+    """Return (author, source) for the content a verdict removed, or (None, None)
+    when it shouldn't be scored as censorship.
+
+    Declined works are skipped: a decline already scores WORK_DECLINED, so
+    scoring it again as CONTENT_CENSORED would double-penalize the author.
+    `source` matches how the events API resolves detail: comments score against
+    themselves, documents against their unified_document.
+    """
+    content = _flagged_content(verdict)
+    if content is None or getattr(content, "status", None) == DECLINED_STATUS:
+        return None, None
+
+    if isinstance(content, RhCommentModel):
+        return content.created_by, content
+
+    if isinstance(content, Paper):
+        author = content.uploaded_by
+    else:
+        author = getattr(content, "created_by", None)
+    return author, getattr(content, "unified_document", None)

--- a/src/user/signals/risk_score_signals.py
+++ b/src/user/signals/risk_score_signals.py
@@ -12,11 +12,12 @@ from purchase.related_models.purchase_model import Purchase
 from reputation.related_models.bounty import BountySolution
 from research_ai.models import GeneratedEmail
 from researchhub_comment.related_models.rh_comment_model import RhCommentModel
-from researchhub_document.models import ResearchhubUnifiedDocument
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 from user.related_models.risk_score_model import RiskScoreEvent
 from user.related_models.user_model import User
 from user.related_models.user_verification_model import UserVerification
+from user.related_models.verdict_model import Verdict
+from user.services.censorship import resolve_censorship
 from user.services.risk_score_service import RiskScoreService
 
 logger = logging.getLogger(__name__)
@@ -97,34 +98,19 @@ def on_post_status_changed(sender, instance, **kwargs):
 
 @receiver(
     post_save,
-    sender=RhCommentModel,
-    dispatch_uid="risk_score_on_comment_censored",
+    sender=Verdict,
+    dispatch_uid="risk_score_on_content_censored",
 )
-def on_comment_censored(sender, instance, **kwargs):
-    if not instance.is_removed:
+def on_content_censored(sender, instance, created, **kwargs):
+    """Penalize an author only when a moderator verdict removes their content.
+    Self-deletions never create a verdict, so they are never scored."""
+    if not created or not instance.is_content_removed:
         return
 
     def record():
-        _service.record_event(
-            instance.created_by, EventType.CONTENT_CENSORED, source=instance
-        )
-
-    _run_after_commit(instance, record)
-
-
-@receiver(
-    post_save,
-    sender=ResearchhubUnifiedDocument,
-    dispatch_uid="risk_score_on_document_censored",
-)
-def on_document_censored(sender, instance, **kwargs):
-    if not instance.is_removed:
-        return
-
-    def record():
-        _service.record_event(
-            instance.created_by, EventType.CONTENT_CENSORED, source=instance
-        )
+        author, source = resolve_censorship(instance)
+        if author and source:
+            _service.record_event(author, EventType.CONTENT_CENSORED, source=source)
 
     _run_after_commit(instance, record)
 

--- a/src/user/tests/helpers.py
+++ b/src/user/tests/helpers.py
@@ -3,6 +3,8 @@ import random
 from django.contrib.contenttypes.models import ContentType
 from rest_framework.authtoken.models import Token
 
+from discussion.constants.flag_reasons import SPAM
+from discussion.models import Flag
 from hub.models import Hub
 from hub.tests.helpers import create_hub
 from reputation.related_models.score import Score
@@ -10,6 +12,7 @@ from researchhub_access_group.constants import ASSOCIATE_EDITOR
 from researchhub_access_group.models import Permission
 from user.models import Action, Author, University, User, UserVerification
 from user.related_models.organization_model import Organization
+from user.related_models.verdict_model import Verdict
 from utils.test_helpers import generate_password
 
 
@@ -115,6 +118,32 @@ def make_user_verified(user):
             "external_id": f"test-verified-{user.id}",
         },
     )
+
+
+def remove_content_via_verdict(content, moderator=None, removed_at=None):
+    """Flag `content` and resolve it with a content-removing verdict, mimicking a
+    moderator takedown. Returns the created Verdict."""
+    content_type = ContentType.objects.get_for_model(content)
+    if moderator is None:
+        moderator = create_user(
+            email=f"verdict-mod-{random.random()}@test.com",
+            moderator=True,
+        )
+    flag = Flag.objects.create(
+        created_by=moderator,
+        content_type=content_type,
+        object_id=content.pk,
+    )
+    verdict = Verdict.objects.create(
+        created_by=moderator,
+        flag=flag,
+        verdict_choice=SPAM,
+        is_content_removed=True,
+    )
+    if removed_at is not None:
+        Verdict.objects.filter(pk=verdict.pk).update(created_date=removed_at)
+        verdict.refresh_from_db()
+    return verdict
 
 
 def create_random_authenticated_user_with_reputation(unique_value, reputation):

--- a/src/user/tests/helpers.py
+++ b/src/user/tests/helpers.py
@@ -1,4 +1,5 @@
 import random
+import uuid
 
 from django.contrib.contenttypes.models import ContentType
 from rest_framework.authtoken.models import Token
@@ -126,7 +127,7 @@ def remove_content_via_verdict(content, moderator=None, removed_at=None):
     content_type = ContentType.objects.get_for_model(content)
     if moderator is None:
         moderator = create_user(
-            email=f"verdict-mod-{random.random()}@test.com",
+            email=f"verdict-mod-{uuid.uuid4().hex}@test.com",
             moderator=True,
         )
     flag = Flag.objects.create(

--- a/src/user/tests/test_risk_score_backfill.py
+++ b/src/user/tests/test_risk_score_backfill.py
@@ -22,7 +22,7 @@ from user.models import UserVerification
 from user.related_models.risk_score_model import RiskScoreEvent
 from user.related_models.user_model import FOUNDATION_EMAIL
 from user.services.risk_score_service import RiskScoreService
-from user.tests.helpers import create_user
+from user.tests.helpers import create_user, remove_content_via_verdict
 
 EventType = RiskScoreEvent.EventType
 DELTAS = RiskScoreEvent.DELTAS
@@ -275,6 +275,14 @@ class BackfillHistoricalActionsTests(BackfillCommandMixin, TestCase):
         self.user = create_user(email="historical@test.com")
         self.post = create_post(created_by=self.user)
 
+    def _create_comment(self):
+        thread = RhCommentThreadModel.objects.create(
+            content_type=ContentType.objects.get_for_model(self.post),
+            object_id=self.post.id,
+            created_by=self.user,
+        )
+        return RhCommentModel.objects.create(thread=thread, created_by=self.user)
+
     def test_approved_grant_creates_work_approved_event(self):
         # Arrange
         grant = Grant.objects.create(
@@ -315,18 +323,10 @@ class BackfillHistoricalActionsTests(BackfillCommandMixin, TestCase):
         self.assertEqual(event.delta, DELTAS[EventType.WORK_DECLINED])
         self.assertEqual(event.source_content_id, grant.pk)
 
-    def test_censored_comment_creates_content_censored_event(self):
+    def test_moderator_verdict_creates_content_censored_event(self):
         # Arrange
-        thread = RhCommentThreadModel.objects.create(
-            content_type=ContentType.objects.get_for_model(self.post),
-            object_id=self.post.id,
-            created_by=self.user,
-        )
-        comment = RhCommentModel.objects.create(
-            thread=thread,
-            created_by=self.user,
-            is_removed=True,
-        )
+        comment = self._create_comment()
+        remove_content_via_verdict(comment)
 
         # Act
         self._call()
@@ -337,6 +337,47 @@ class BackfillHistoricalActionsTests(BackfillCommandMixin, TestCase):
         )
         self.assertEqual(event.delta, DELTAS[EventType.CONTENT_CENSORED])
         self.assertEqual(event.source_content_id, comment.pk)
+
+    def test_self_deleted_comment_creates_no_content_censored_event(self):
+        # Arrange
+        comment = self._create_comment()
+        comment.delete(soft=True)
+
+        # Act
+        self._call()
+
+        # Assert
+        self.assertFalse(
+            RiskScoreEvent.objects.filter(
+                user=self.user, event_type=EventType.CONTENT_CENSORED
+            ).exists()
+        )
+
+    def test_declined_grant_verdict_does_not_add_content_censored(self):
+        # Arrange - a declined grant is scored as WORK_DECLINED, not censored
+        grant = Grant.objects.create(
+            created_by=self.user,
+            unified_document=self.post.unified_document,
+            amount=1000,
+            description="Test",
+            status=Grant.DECLINED,
+        )
+        remove_content_via_verdict(grant)
+
+        # Act
+        self._call()
+
+        # Assert
+        self.assertTrue(
+            RiskScoreEvent.objects.filter(
+                user=self.user, event_type=EventType.WORK_DECLINED
+            ).exists()
+        )
+        self.assertFalse(
+            RiskScoreEvent.objects.filter(
+                user=self.user, event_type=EventType.CONTENT_CENSORED
+            ).exists()
+        )
 
     def test_grant_event_dated_to_decision_not_run_time(self):
         # Arrange
@@ -359,20 +400,11 @@ class BackfillHistoricalActionsTests(BackfillCommandMixin, TestCase):
         )
         self.assertEqual(event.action_date, decided_at)
 
-    def test_censored_comment_event_dated_to_removal(self):
+    def test_content_censored_event_dated_to_verdict(self):
         # Arrange
         removed_at = timezone.now() - timedelta(days=30)
-        thread = RhCommentThreadModel.objects.create(
-            content_type=ContentType.objects.get_for_model(self.post),
-            object_id=self.post.id,
-            created_by=self.user,
-        )
-        RhCommentModel.objects.create(
-            thread=thread,
-            created_by=self.user,
-            is_removed=True,
-            is_removed_date=removed_at,
-        )
+        comment = self._create_comment()
+        remove_content_via_verdict(comment, removed_at=removed_at)
 
         # Act
         self._call()

--- a/src/user/tests/test_risk_score_signals.py
+++ b/src/user/tests/test_risk_score_signals.py
@@ -4,6 +4,8 @@ from allauth.socialaccount.models import SocialAccount
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
+from discussion.constants.flag_reasons import SPAM
+from discussion.models import Flag
 from purchase.related_models.grant_model import Grant
 from purchase.related_models.purchase_model import Purchase
 from reputation.related_models.bounty import Bounty, BountySolution
@@ -17,8 +19,9 @@ from researchhub_document.helpers import create_post
 from review.models.review_model import Review
 from user.models import User, UserVerification
 from user.related_models.risk_score_model import RiskScoreEvent
+from user.related_models.verdict_model import Verdict
 from user.signals.risk_score_signals import on_post_status_changed
-from user.tests.helpers import create_user
+from user.tests.helpers import create_user, remove_content_via_verdict
 
 EventType = RiskScoreEvent.EventType
 
@@ -129,13 +132,13 @@ class ContentCensoredSignalTests(RiskScoreSignalTestCase):
         self.user = create_user(email="censor@test.com")
         self.post = create_post(created_by=self.user)
 
-    def test_comment_censored_records_event(self):
+    def test_moderator_verdict_on_comment_records_event(self):
         # Arrange
         comment = self._create_comment(self.post, self.user)
 
         # Act
         with self.captureOnCommitCallbacks(execute=True):
-            comment.delete(soft=True)
+            remove_content_via_verdict(comment)
 
         # Assert
         self._assert_has_event(
@@ -145,37 +148,77 @@ class ContentCensoredSignalTests(RiskScoreSignalTestCase):
             source_id=comment.pk,
         )
 
-    def test_comment_not_removed_does_not_record(self):
+    def test_moderator_verdict_on_document_records_event(self):
         # Act
-        self._create_comment(self.post, self.user)
+        with self.captureOnCommitCallbacks(execute=True):
+            remove_content_via_verdict(self.post)
+
+        # Assert
+        self._assert_has_event(
+            self.user,
+            EventType.CONTENT_CENSORED,
+            source_id=self.post.unified_document.pk,
+        )
+
+    def test_self_deleted_comment_does_not_record(self):
+        # Arrange
+        comment = self._create_comment(self.post, self.user)
+
+        # Act
+        with self.captureOnCommitCallbacks(execute=True):
+            comment.delete(soft=True)
 
         # Assert
         self._assert_no_events(self.user)
 
-    def test_document_censored_records_event(self):
-        # Arrange
-        document = self.post.unified_document
-
-        # Act
-        document.is_removed = True
-        with self.captureOnCommitCallbacks(execute=True):
-            document.save()
-
-        # Assert
-        self._assert_has_event(
-            self.user, EventType.CONTENT_CENSORED, source_id=document.pk
+    def test_declined_work_verdict_does_not_record(self):
+        # Arrange - a declined work is already scored as WORK_DECLINED
+        grant = Grant.objects.create(
+            created_by=self.user,
+            unified_document=self.post.unified_document,
+            amount=1000,
+            description="Test",
+            status=Grant.DECLINED,
         )
 
-    def test_document_censored_is_idempotent(self):
-        # Arrange
-        document = self.post.unified_document
-        document.is_removed = True
+        # Act
         with self.captureOnCommitCallbacks(execute=True):
-            document.save()
+            remove_content_via_verdict(grant)
+
+        # Assert
+        self._assert_no_events(self.user, EventType.CONTENT_CENSORED)
+
+    def test_dismissed_verdict_does_not_record(self):
+        # Arrange
+        comment = self._create_comment(self.post, self.user)
+        moderator = create_user(email="dismiss-mod@test.com", moderator=True)
+        flag = Flag.objects.create(
+            created_by=moderator,
+            content_type=ContentType.objects.get_for_model(comment),
+            object_id=comment.pk,
+        )
 
         # Act
         with self.captureOnCommitCallbacks(execute=True):
-            document.save()
+            Verdict.objects.create(
+                created_by=moderator,
+                flag=flag,
+                verdict_choice=SPAM,
+                is_content_removed=False,
+            )
+
+        # Assert
+        self._assert_no_events(self.user)
+
+    def test_repeated_verdicts_are_idempotent(self):
+        # Arrange
+        comment = self._create_comment(self.post, self.user)
+
+        # Act
+        with self.captureOnCommitCallbacks(execute=True):
+            remove_content_via_verdict(comment)
+        with self.captureOnCommitCallbacks(execute=True):
+            remove_content_via_verdict(comment)
 
         # Assert
         self._assert_event_count(self.user, EventType.CONTENT_CENSORED, 1)


### PR DESCRIPTION
## Overview ## 

This PR updates the backfill and signals to not include user deleted items for negative risk score updates.