### PR TITLE
Optimize get review details method on the RH document model

### DIFF
--- a/src/researchhub_document/related_models/researchhub_unified_document_model.py
+++ b/src/researchhub_document/related_models/researchhub_unified_document_model.py
@@ -2,7 +2,16 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.db.models import Avg, Count, DecimalField, Q, QuerySet, Sum
+from django.db.models import (
+    Avg,
+    Count,
+    DecimalField,
+    Exists,
+    OuterRef,
+    Q,
+    QuerySet,
+    Sum,
+)
 from django.db.models.functions import Cast
 from django.utils.functional import cached_property
 
@@ -271,22 +280,19 @@ class ResearchhubUnifiedDocument(SoftDeletableModel, HotScoreMixin, DefaultModel
 
         comment_content_type = ContentType.objects.get_for_model(RhCommentModel)
 
-        active_comment_ids = RhCommentModel.objects.filter(is_removed=False).values(
-            "id"
+        # query comments that have not been removed
+        active_comment = RhCommentModel.objects.filter(
+            id=OuterRef("object_id"), is_removed=False
         )
 
         reviews = self.reviews.filter(
             is_removed=False,
             is_assessed=True,
             content_type=comment_content_type,
-            object_id__in=active_comment_ids,
-        )
+        ).filter(Exists(active_comment))
 
-        if reviews.exists():
-            details = reviews.aggregate(avg=Avg("score"), count=Count("id"))
-        else:
-            details = {"avg": 0, "count": 0}
-        return details
+        details = reviews.aggregate(avg=Avg("score"), count=Count("id"))
+        return {"avg": details["avg"] or 0, "count": details["count"]}
 
     def frontend_view_link(self):
         doc = self.get_document()

--- a/src/researchhub_document/tests/test_models.py
+++ b/src/researchhub_document/tests/test_models.py
@@ -125,3 +125,33 @@ class ModelTests(TestCase):
         # Assert
         self.assertEqual(details["count"], 0)
         self.assertEqual(details["avg"], 0)
+
+    def test_get_review_details_excludes_removed_comments(self):
+        """Reviews referencing a soft-deleted comment are not counted."""
+        # Arrange
+        post = create_post(created_by=self.user)
+        unified_doc = post.unified_document
+        comment_ct = ContentType.objects.get_for_model(RhCommentModel)
+
+        active_comment = create_rh_comment(post=post, created_by=self.user)
+        removed_comment = create_rh_comment(post=post, created_by=self.user)
+        removed_comment.is_removed = True
+        removed_comment.save()
+
+        for comment, score in [(active_comment, 6), (removed_comment, 2)]:
+            Review.objects.create(
+                created_by=self.user,
+                content_type=comment_ct,
+                object_id=comment.id,
+                unified_document=unified_doc,
+                score=score,
+                is_assessed=True,
+            )
+
+        # Act
+        details = unified_doc.get_review_details()
+
+        # Assert
+        # only the review on the active comment is counted
+        self.assertEqual(details["count"], 1)
+        self.assertEqual(details["avg"], 6.0)


### PR DESCRIPTION
- Replaces an object_id IN (all non-removed comments) subquery with a correlated `Exists` on the comment's primary key.
- Drops the now-redundant `.exists()` check.