### PR TITLE
Update notes on testing in `CLAUDE.md`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ uv add --dev <package_name>
 - Run the relevant tests before committing.
 
 ## Testing
-- Prefer `django.test.TestCase` or DRF `APITestCase`.
+- If possible, use `unittest.TestCase` when there is no dependency on Django, otherwise use `django.test.TestCase` or DRF `APITestCase`.
 - Mock external services instead of calling real integrations in unit tests.
 - For AWS-dependent code, inherit from `AWSMockTestCase` in `src/utils/test_helpers.py`.
 - Use `AWSMockTransactionTestCase` when the code under test relies on `transaction.on_commit()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ uv add --dev <package_name>
 - For AWS-dependent code, inherit from `AWSMockTestCase` in `src/utils/test_helpers.py`.
 - Use `AWSMockTransactionTestCase` when the code under test relies on `transaction.on_commit()`.
 - Test behavior, not implementation details.
+- Add Arrange/Act/Assert (AAA) comment markers to tests.
 
 ## CI Reference
 CI runs from `src/` and performs:


### PR DESCRIPTION
- Prefer plain `unittest.TestCase` if there are no Django dependencies.
- Use AAA markers, also see: https://xp123.com/3a-arrange-act-assert/