### PR TITLE
Count only assessed reviews toward Peer Reviewer achievement

### DIFF
--- a/src/user/related_models/user_model.py
+++ b/src/user/related_models/user_model.py
@@ -423,10 +423,16 @@ class User(AbstractUser):
     def peer_review_count(self):
         from researchhub_comment.related_models.rh_comment_model import RhCommentModel
 
-        peer_review_count = RhCommentModel.objects.filter(
-            created_by=self,
-            comment_type="REVIEW",
-            is_removed=False,
-        ).aggregate(count=Count("id"))["count"]
+        peer_review_count = (
+            RhCommentModel.objects.filter(
+                created_by=self,
+                comment_type="REVIEW",
+                is_removed=False,
+                reviews__is_assessed=True,
+                reviews__is_removed=False,
+            )
+            .distinct()
+            .aggregate(count=Count("id"))["count"]
+        )
 
         return peer_review_count

--- a/src/user/tests/test_models.py
+++ b/src/user/tests/test_models.py
@@ -10,6 +10,8 @@ from paper.related_models.authorship_model import Authorship
 from paper.related_models.paper_model import Paper
 from purchase.related_models.balance_model import Balance
 from reputation.related_models.distribution import Distribution
+from researchhub_comment.models import RhCommentModel, RhCommentThreadModel
+from review.models import Review
 from user.related_models.follow_model import Follow
 from user.related_models.user_model import User
 from user.tests.helpers import create_user
@@ -49,6 +51,50 @@ class AuthorModelsTests(TestCase):
 
     def test_achievements(self):
         self.assertIn("CITED_AUTHOR", self.user.author_profile.achievements)
+
+    def test_peer_review_count_only_includes_assessed_reviews(self):
+        paper = Paper.objects.create(title="review paper")
+        thread = RhCommentThreadModel.objects.create(
+            object_id=paper.id,
+            content_type=ContentType.objects.get_for_model(Paper),
+            created_by=self.user,
+        )
+        comment_content_type = ContentType.objects.get_for_model(RhCommentModel)
+
+        assessed_comment = RhCommentModel.objects.create(
+            created_by=self.user,
+            comment_type="REVIEW",
+            is_removed=False,
+            thread=thread,
+        )
+        Review.objects.create(
+            created_by=self.user,
+            content_type=comment_content_type,
+            object_id=assessed_comment.id,
+            is_assessed=True,
+        )
+
+        unassessed_comment = RhCommentModel.objects.create(
+            created_by=self.user,
+            comment_type="REVIEW",
+            is_removed=False,
+            thread=thread,
+        )
+        Review.objects.create(
+            created_by=self.user,
+            content_type=comment_content_type,
+            object_id=unassessed_comment.id,
+            is_assessed=False,
+        )
+
+        RhCommentModel.objects.create(
+            created_by=self.user,
+            comment_type="REVIEW",
+            is_removed=False,
+            thread=thread,
+        )
+
+        self.assertEqual(self.user.peer_review_count, 1)
 
     def test_is_orcid_connected_false_when_no_account(self):
         # Act

--- a/src/user/tests/test_serializers.py
+++ b/src/user/tests/test_serializers.py
@@ -16,6 +16,7 @@ from reputation.distributions import Distribution as Dist
 from reputation.distributor import Distributor
 from reputation.models import Distribution, Score, Withdrawal
 from researchhub_comment.models import RhCommentModel, RhCommentThreadModel
+from review.models import Review
 from user.models import UserVerification
 from user.serializers import (
     AuthorSerializer,
@@ -64,11 +65,17 @@ class UserSerializersTests(TestCase):
                 created_by=self.user,
             )
 
-            RhCommentModel.objects.create(
+            comment = RhCommentModel.objects.create(
                 created_by=self.user,
                 comment_type="REVIEW",
                 is_removed=False,
                 thread_id=thread.id,
+            )
+            Review.objects.create(
+                created_by=self.user,
+                content_type=ContentType.objects.get_for_model(RhCommentModel),
+                object_id=comment.id,
+                is_assessed=True,
             )
 
     def test_author_serializer_succeeds_without_user_or_university(self):


### PR DESCRIPTION
## What?
- Fixes the Peer Reviewer (`EXPERT_PEER_REVIEWER`) achievement so it no longer counts reviews that were merely opened/created
- Prevents spammers from earning the badge by creating review comments without Foundation assessment

## How?
- Updated `User.peer_review_count` to count only `RhCommentModel` review comments that have an associated `Review` with `is_assessed=True` and `is_removed=False`
