### PR TITLE
Fix withdrawal minimum check to allow amounts equal to the minimum

### DIFF
--- a/src/reputation/tests/test_withdrawal_view.py
+++ b/src/reputation/tests/test_withdrawal_view.py
@@ -661,10 +661,17 @@ class WithdrawalViewSetTests(APITestCase):
         create_deposit(user, amount="1000.0")
         self.client.force_authenticate(user)
 
-        with mock.patch.object(
-            WithdrawalViewSet,
-            "_prepare_withdrawal",
-            side_effect=Exception("Test exception"),
+        with (
+            mock.patch.object(
+                WithdrawalViewSet,
+                "_check_hotwallet_balance",
+                return_value=(True, None),
+            ),
+            mock.patch.object(
+                WithdrawalViewSet,
+                "_prepare_withdrawal",
+                side_effect=Exception("Test exception"),
+            ),
         ):
             response = self.client.post(
                 self.withdrawal_url,

--- a/src/reputation/tests/test_withdrawal_view.py
+++ b/src/reputation/tests/test_withdrawal_view.py
@@ -765,6 +765,15 @@ class WithdrawalViewSetTests(APITestCase):
         self.assertTrue(valid)
         self.assertIsNone(message)
 
+    def test_check_withdrawal_meets_minimum_exact(self):
+        """Withdrawals at exactly WITHDRAWAL_MINIMUM are allowed."""
+        amount = decimal.Decimal(WITHDRAWAL_MINIMUM)
+
+        valid, message = self.withdrawal_view._check_meets_withdrawal_minimum(amount)
+
+        self.assertTrue(valid)
+        self.assertIsNone(message)
+
     def test_check_withdrawal_meets_minimum_failure(self):
         """Test that _check_meets_withdrawal_minimum fails with insufficient amount."""
         # Set an amount below the minimum

--- a/src/reputation/views/withdrawal_view.py
+++ b/src/reputation/views/withdrawal_view.py
@@ -331,7 +331,7 @@ class WithdrawalViewSet(viewsets.ModelViewSet):
         """
         Reject withdrawals below the platform minimum (WITHDRAWAL_MINIMUM).
         """
-        if requested_amount > WITHDRAWAL_MINIMUM:
+        if requested_amount >= WITHDRAWAL_MINIMUM:
             return (True, None)
 
         if requested_amount == 0:


### PR DESCRIPTION
## What/Why?
- Withdrawals at exactly `WITHDRAWAL_MINIMUM` (e.g. 150 RSC) were rejected with “below the withdrawal minimum of 150” because the check used `>` instead of `>=`.
Sentry: https://researchhub.sentry.io/issues/7522476483/events/0f788ff7d42a4e0580744a6b37c3a54f/

## How?
- Change `_check_meets_withdrawal_minimum` in `withdrawal_view.py` to pass when `requested_amount >= WITHDRAWAL_MINIMUM`.