### PR TITLE
Propagate viewer context into embedded note post serializer

### DIFF
--- a/src/note/serializers/note_serializer.py
+++ b/src/note/serializers/note_serializer.py
@@ -91,6 +91,9 @@ class NoteSerializer(ModelSerializer):
             return None
 
         context = {
+            # Propagate the request so DynamicPostSerializer can resolve the
+            # viewer and avoid redacting private posts they are allowed to see.
+            "request": self.context.get("request"),
             "doc_dps_get_authors": {
                 "_include_fields": [
                     "id",
@@ -243,6 +246,9 @@ class DynamicNoteSerializer(DynamicModelFieldSerializer):
             return None
 
         context = {
+            # Propagate the request so DynamicPostSerializer can resolve the
+            # viewer and avoid redacting private posts they are allowed to see.
+            "request": self.context.get("request"),
             "doc_dps_get_authors": {
                 "_include_fields": [
                     "id",

--- a/src/researchhub_document/serializers/researchhub_post_serializer.py
+++ b/src/researchhub_document/serializers/researchhub_post_serializer.py
@@ -145,7 +145,7 @@ class ResearchhubPostSerializer(ModelSerializer, GenericReactionSerializerMixin)
 
         note = instance.note
         if note:
-            return NoteSerializer(instance.note).data
+            return NoteSerializer(instance.note, context=self.context).data
         return None
 
     def get_unified_document_id(self, instance):

--- a/src/researchhub_document/tests/test_private_preregistration.py
+++ b/src/researchhub_document/tests/test_private_preregistration.py
@@ -811,9 +811,7 @@ class NotePostEmbedVisibilityTests(AWSMockTestCase):
         data = self._serialize_note(self.outsider)
 
         # Assert: redacted to the stub only
-        self.assertEqual(
-            data["post"], {"id": self.private_post.id, "is_public": False}
-        )
+        self.assertEqual(data["post"], {"id": self.private_post.id, "is_public": False})
 
     def test_post_endpoint_returns_full_embedded_post_for_author(self):
         """End-to-end: GET the post keeps the viewer through post -> note -> post."""

--- a/src/researchhub_document/tests/test_private_preregistration.py
+++ b/src/researchhub_document/tests/test_private_preregistration.py
@@ -10,6 +10,7 @@ from rest_framework.test import APIClient
 from feed.models import FeedEntry
 from feed.tasks import create_feed_entry
 from hub.models import Hub
+from note.models import Note
 from purchase.related_models.constants.currency import USD
 from purchase.related_models.grant_application_model import GrantApplication
 from purchase.related_models.grant_model import Grant
@@ -27,7 +28,7 @@ from researchhub_document.related_models.constants.document_type import (
 from researchhub_document.related_models.researchhub_post_model import (
     ResearchhubPost,
 )
-from user.models import Action
+from user.models import Action, Organization
 from user.tests.helpers import make_user_verified
 from utils.test_helpers import AWSMockTestCase
 
@@ -746,6 +747,88 @@ class DynamicPostSerializerRedactionTests(AWSMockTestCase):
             _include_fields=["id", "title"],
         ).data
         self.assertEqual(data["title"], "Open title")
+
+
+class NotePostEmbedVisibilityTests(AWSMockTestCase):
+    """A note embeds its published post via NoteSerializer.get_post, and the
+    post endpoint serializes that post -> note -> post chain. The requesting
+    viewer must be propagated all the way into the nested DynamicPostSerializer
+    so an authorized viewer sees the full post while an unauthorized one only
+    gets the redaction stub.
+
+    Regression: get_post built a fresh serializer context without the request,
+    so DynamicPostSerializer treated every viewer as anonymous and redacted the
+    embedded private post even for its own author.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.author = _make_user("author")
+        self.outsider = _make_user("outsider")
+        self.org = Organization.objects.create(
+            name=f"org-{uuid.uuid4().hex[:8]}",
+            slug=f"org-{uuid.uuid4().hex[:8]}",
+        )
+
+        self.private_post = create_post(
+            title="Secret title",
+            created_by=self.author,
+            document_type=PREREGISTRATION,
+        )
+        self.private_post.unified_document.is_public = False
+        self.private_post.unified_document.save()
+
+        # Link a note to the private post (mirrors a published note).
+        self.note = Note.objects.create(
+            created_by=self.author,
+            organization=self.org,
+            title="Note title",
+            unified_document=self.private_post.unified_document,
+        )
+        self.private_post.note = self.note
+        self.private_post.save()
+
+    def _serialize_note(self, user):
+        from rest_framework.test import APIRequestFactory
+
+        from note.serializers import NoteSerializer
+
+        request = APIRequestFactory().get("/")
+        request.user = user
+        return NoteSerializer(self.note, context={"request": request}).data
+
+    def test_author_sees_full_embedded_post(self):
+        # Arrange / Act
+        data = self._serialize_note(self.author)
+
+        # Assert: full payload, not the {id, is_public} stub
+        post_data = data["post"]
+        self.assertEqual(post_data["id"], self.private_post.id)
+        self.assertIn("document_type", post_data)
+
+    def test_outsider_gets_redacted_embedded_post(self):
+        # Arrange / Act
+        data = self._serialize_note(self.outsider)
+
+        # Assert: redacted to the stub only
+        self.assertEqual(
+            data["post"], {"id": self.private_post.id, "is_public": False}
+        )
+
+    def test_post_endpoint_returns_full_embedded_post_for_author(self):
+        """End-to-end: GET the post keeps the viewer through post -> note -> post."""
+        # Arrange
+        client = APIClient()
+        client.force_authenticate(self.author)
+
+        # Act
+        response = client.get(f"/api/researchhubpost/{self.private_post.id}/")
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        embedded = response.data["note"]["post"]
+        self.assertEqual(embedded["id"], self.private_post.id)
+        self.assertIn("document_type", embedded)
 
 
 class AuthorContributionsPrivacyTests(AWSMockTestCase):

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -305,7 +305,9 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
                     )
                     GrantCacheMixin.invalidate_grant_feed_cache()
 
-            response_data = ResearchhubPostSerializer(rh_post).data
+            response_data = ResearchhubPostSerializer(
+                rh_post, context={"request": request}
+            ).data
             response_data["fundraise"] = (
                 DynamicFundraiseSerializer(fundraise).data if fundraise else None
             )
@@ -413,7 +415,7 @@ class ResearchhubPostViewSet(ReactionViewActionMixin, ModelViewSet):
                 )
 
             serializer = ResearchhubPostSerializer(
-                rh_post, data=request.data, partial=True
+                rh_post, data=request.data, partial=True, context={"request": request}
             )
             serializer.is_valid(raise_exception=True)
             serializer.save()


### PR DESCRIPTION
- Fixed a bug that filtered post content for private notes even if you had access