### PR TITLE
Cleanup of RH doc app

### DIFF
--- a/src/paper/serializers/paper_serializers.py
+++ b/src/paper/serializers/paper_serializers.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 
 import requests
@@ -8,7 +9,6 @@ from django.db import IntegrityError, transaction
 from django.db.models import Case, IntegerField, Value, When
 from django.http import QueryDict
 
-import utils.sentry as sentry
 from discussion.models import Flag, Vote
 from discussion.serializers import (
     DynamicFlagSerializer,
@@ -52,6 +52,8 @@ from user.serializers import (
     UserSerializer,
 )
 from utils.http import check_url_contains_pdf, get_user_from_request
+
+logger = logging.getLogger(__name__)
 
 
 class BasePaperSerializer(serializers.ModelSerializer, GenericReactionSerializerMixin):
@@ -455,9 +457,7 @@ class PaperSerializer(BasePaperSerializer):
                     file = paper.file
                     self._add_file(paper, file)
                 except Exception as e:
-                    sentry.log_error(
-                        e,
-                    )
+                    logger.exception("Failed to add file to paper", exc_info=e)
 
                 paper.pdf_license = paper.get_license(save=False)
 
@@ -478,11 +478,11 @@ class PaperSerializer(BasePaperSerializer):
                 paper.save()
                 return paper
         except IntegrityError as e:
-            sentry.log_error(e)
+            logger.exception("Integrity error while creating paper")
             raise e
         except Exception as e:
             error = PaperSerializerError(e, "Failed to create paper")
-            sentry.log_error(error, base_error=error.trigger)
+            logger.exception("Failed to create paper")
             raise error
 
     def update(self, instance, validated_data):
@@ -549,7 +549,7 @@ class PaperSerializer(BasePaperSerializer):
                 return paper
         except Exception as e:
             error = PaperSerializerError(e, "Failed to update paper")
-            sentry.log_error(e, base_error=error.trigger)
+            logger.exception("Failed to update paper")
             raise error
 
     def _add_file(self, paper, file):

--- a/src/researchhub_document/utils.py
+++ b/src/researchhub_document/utils.py
@@ -1,42 +1,4 @@
-from datetime import datetime, timedelta
-
 from utils.sentry import log_error
-
-CACHE_DATE_RANGES = ("today", "week", "month", "year", "all")
-CACHE_DOCUMENT_TYPES = [
-    "all",
-    "paper",
-    "posts",
-]
-
-
-def get_doc_type_key(document):
-    doc_type = document.document_type.lower()
-    if doc_type == "discussion":
-        return "posts"
-
-    return doc_type
-
-
-def get_date_ranges_by_time_scope(time_scope):
-    end_date = datetime.now()
-    if time_scope == "all_time" or time_scope == "all":
-        start_date = datetime(year=2018, month=12, day=31, hour=0)
-    elif time_scope == "year":
-        start_date = datetime.now() - timedelta(days=365)
-    elif time_scope == "month":
-        start_date = datetime.now() - timedelta(days=30)
-    elif time_scope == "week":
-        start_date = datetime.now() - timedelta(days=7)
-    # Today
-    else:
-        # Given that our "today" results are minimal
-        # it makes sense to have a bit of an extra buffer
-        # for the forseeable future.
-        hours_buffer = 10
-        start_date = datetime.now() - timedelta(hours=(24 + hours_buffer))
-
-    return (start_date, end_date)
 
 
 def update_unified_document_to_paper(paper):

--- a/src/researchhub_document/utils.py
+++ b/src/researchhub_document/utils.py
@@ -1,4 +1,6 @@
-from utils.sentry import log_error
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def update_unified_document_to_paper(paper):
@@ -13,6 +15,5 @@ def update_unified_document_to_paper(paper):
             hubs = paper.hubs.all()
             rh_unified_doc.hubs.add(*hubs)
             rh_unified_doc.save()
-        except Exception as e:
-            print(e)
-            log_error(e)
+        except Exception:
+            logger.exception("Failed to update unified document to paper %s", paper.id)


### PR DESCRIPTION
Cleanup of the `researchhub_document` app:
- Replace Sentry with logging.
- Replace `print`s with logging.
- Remove unused utilities.