### PR TITLE
Removing Editor ability to view Risk Score Data

### DIFF
--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -92,6 +92,14 @@ class ModeratorUserSerializer(ModelSerializer):
             "risk_score",
         ]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Risk score is moderator-only: drop the field entirely for hub editors
+        # and others so it's never computed or exposed to them.
+        requester = getattr(self.context.get("request"), "user", None)
+        if not (requester and getattr(requester, "moderator", False)):
+            self.fields.pop("risk_score", None)
+
     def get_verification(self, user):
         try:
             user_verification = user.userverification

--- a/src/user/tests/test_moderator_view.py
+++ b/src/user/tests/test_moderator_view.py
@@ -2,6 +2,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from user.tests.helpers import (
+    create_hub_editor,
     create_user,
 )
 
@@ -20,6 +21,44 @@ class ModeratorTests(APITestCase):
         url = f"/api/moderator/{self.user.id}/user_details/"
         response = self.client.get(url, {})
         self.assertIn("id", response.data)
+
+    def test_moderator_details_include_risk_score(self):
+        # Arrange
+        moderator = create_user(email="mod@example.com", moderator=True)
+        self.client.force_authenticate(user=moderator)
+
+        # Act
+        response = self.client.get(f"/api/moderator/{moderator.id}/user_details/")
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("risk_score", response.data)
+
+    def test_hub_editor_can_view_details_without_risk_score(self):
+        # Arrange
+        editor, _ = create_hub_editor("modview_editor", "Editor Hub")
+        target = create_user(email="target@example.com")
+        self.client.force_authenticate(user=editor)
+
+        # Act
+        response = self.client.get(f"/api/moderator/{target.id}/user_details/")
+
+        # Assert: editors keep access to basic moderator info, but not risk score
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("id", response.data)
+        self.assertNotIn("risk_score", response.data)
+
+    def test_hub_editor_cannot_view_risk_score_events(self):
+        # Arrange
+        editor, _ = create_hub_editor("modview_editor_events", "Editor Hub")
+        target = create_user(email="target@example.com")
+        self.client.force_authenticate(user=editor)
+
+        # Act
+        response = self.client.get(f"/api/moderator/{target.id}/risk_score_events/")
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_non_moderator_cannot_view_details(self):
         self.user = create_user(

--- a/src/user/views/moderator_view.py
+++ b/src/user/views/moderator_view.py
@@ -25,7 +25,7 @@ class ModeratorView(ModelViewSet):
     def user_details(self, request, pk=None, **kwargs):
         return super().retrieve(request, pk, **kwargs)
 
-    @action(detail=True, methods=["get"])
+    @action(detail=True, methods=["get"], permission_classes=[IsModerator])
     def risk_score_events(self, request, pk=None, **kwargs):
         user = self.get_object()
         events = RiskScoreEvent.objects.filter(user=user).select_related(


### PR DESCRIPTION
## Overview ## 

This PR removes the ability for an Editor to view Moderator only Risk Score Data.