### PR TITLE
Skip FundingActivityRecipient for Endaoment account on nonprofit fund…

### DIFF
--- a/src/user/management/commands/backfill_funding_activity.py
+++ b/src/user/management/commands/backfill_funding_activity.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 
 from user.related_models.funding_activity_model import FundingActivity
@@ -34,50 +35,50 @@ class Command(BaseCommand):
         total_created = 0
         total_skipped = 0
         total_errors = 0
-        total_would_process = 0
+        total_would_create = 0
 
         # 1. Fundraise payouts (Purchase FUNDRAISE_CONTRIBUTION, paid, escrow PAID)
-        created, skipped, errors, count = self._backfill_fundraise_payouts(
+        created, skipped, errors, would_create = self._backfill_fundraise_payouts(
             dry_run, log_freq
         )
         total_created += created
         total_skipped += skipped
         total_errors += errors
-        total_would_process += count if dry_run else 0
+        total_would_create += would_create
 
         # 2. Bounty payouts (EscrowRecipients, PAID escrow, REVIEW bounty)
-        c, s, e, n = self._backfill_bounty_payouts(dry_run, log_freq)
+        c, s, e, wc = self._backfill_bounty_payouts(dry_run, log_freq)
         total_created += c
         total_skipped += s
         total_errors += e
-        total_would_process += n if dry_run else 0
+        total_would_create += wc
 
         # 3. Document tips (Purchase BOOST on paper/post, paid)
-        c, s, e, n = self._backfill_document_tips(dry_run, log_freq)
+        c, s, e, wc = self._backfill_document_tips(dry_run, log_freq)
         total_created += c
         total_skipped += s
         total_errors += e
-        total_would_process += n if dry_run else 0
+        total_would_create += wc
 
         # 4. Review tips (Distribution PURCHASE for review comments)
-        c, s, e, n = self._backfill_review_tips(dry_run, log_freq)
+        c, s, e, wc = self._backfill_review_tips(dry_run, log_freq)
         total_created += c
         total_skipped += s
         total_errors += e
-        total_would_process += n if dry_run else 0
+        total_would_create += wc
 
         # 5. Fees (Distribution BOUNTY_DAO_FEE, BOUNTY_RH_FEE, SUPPORT_RH_FEE)
-        c, s, e, n = self._backfill_fees(dry_run, log_freq)
+        c, s, e, wc = self._backfill_fees(dry_run, log_freq)
         total_created += c
         total_skipped += s
         total_errors += e
-        total_would_process += n if dry_run else 0
+        total_would_create += wc
 
         if dry_run:
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"Dry run complete. Would process {total_would_process} "
-                    "source record(s)."
+                    f"Dry run complete. would_create={total_would_create} "
+                    f"skipped={total_skipped} errors={total_errors}"
                 )
             )
         else:
@@ -152,37 +153,83 @@ class Command(BaseCommand):
         log_freq,
     ):
         """Process a queryset of source objects; create FundingActivity per item."""
+        content_type = ContentType.objects.get_for_model(queryset.model)
+        existing_source_ids = set(
+            FundingActivity.objects.filter(
+                source_type=source_type,
+                source_content_type=content_type,
+            ).values_list("source_object_id", flat=True)
+        )
+
         created = 0
         skipped = 0
         errors = 0
+        would_create = 0
         total = queryset.count()
         self.stdout.write(f"Backfilling {label}: {total} source(s).")
 
         for i, obj in enumerate(queryset.iterator(), start=1):
-            if dry_run:
+            if obj.pk in existing_source_ids:
+                skipped += 1
                 if i % log_freq == 0:
-                    self.stdout.write(f"  {label}: {i}/{total} (dry-run)")
+                    self._log_backfill_progress(
+                        label, i, total, dry_run, created, skipped, errors, would_create
+                    )
                 continue
 
-            try:
-                activity = FundingActivityService.create_funding_activity(
-                    source_type=source_type,
-                    source_object=obj,
-                )
-                if activity is not None:
-                    created += 1
-                else:
-                    skipped += 1
-            except Exception as e:
-                errors += 1
-                self.stdout.write(
-                    self.style.WARNING(f"  {label} pk={getattr(obj, 'pk', '?')}: {e}")
-                )
+            if dry_run:
+                would_create += 1
+            else:
+                try:
+                    activity = FundingActivityService.create_funding_activity(
+                        source_type=source_type,
+                        source_object=obj,
+                    )
+                    if activity is not None:
+                        created += 1
+                    else:
+                        skipped += 1
+                except Exception as e:
+                    errors += 1
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"  {label} pk={getattr(obj, 'pk', '?')}: {e}"
+                        )
+                    )
 
             if i % log_freq == 0:
-                self.stdout.write(
-                    f"  {label}: {i}/{total} (created={created} skipped={skipped} "
-                    f"errors={errors})"
+                self._log_backfill_progress(
+                    label, i, total, dry_run, created, skipped, errors, would_create
                 )
 
-        return created, skipped, errors, total
+        self._log_backfill_phase_summary(
+            label, dry_run, created, skipped, errors, would_create
+        )
+        return created, skipped, errors, would_create
+
+    def _log_backfill_progress(
+        self, label, i, total, dry_run, created, skipped, errors, would_create
+    ):
+        if dry_run:
+            self.stdout.write(
+                f"  {label}: {i}/{total} "
+                f"(would_create={would_create} skipped={skipped} errors={errors})"
+            )
+        else:
+            self.stdout.write(
+                f"  {label}: {i}/{total} "
+                f"(created={created} skipped={skipped} errors={errors})"
+            )
+
+    def _log_backfill_phase_summary(
+        self, label, dry_run, created, skipped, errors, would_create
+    ):
+        if dry_run:
+            self.stdout.write(
+                f"  {label}: would_create={would_create} "
+                f"skipped={skipped} errors={errors}"
+            )
+        else:
+            self.stdout.write(
+                f"  {label}: created={created} skipped={skipped} errors={errors}"
+            )

--- a/src/user/management/commands/backfill_funding_activity_amounts.py
+++ b/src/user/management/commands/backfill_funding_activity_amounts.py
@@ -98,7 +98,7 @@ class Command(BaseCommand):
         activity_batch = []
         recipient_batch = []
 
-        for i, activity in enumerate(qs.iterator(), start=1):
+        for i, activity in enumerate(qs.iterator(chunk_size=BATCH_SIZE), start=1):
             try:
                 recipients = list(activity.recipients.all())
                 populated = self._populate_amounts_for_activity(activity, recipients)

--- a/src/user/services/funding_activity_service.py
+++ b/src/user/services/funding_activity_service.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from typing import Optional
 
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 from django.db.models import Q, Sum
@@ -66,6 +67,14 @@ class FundingActivityService:
     @classmethod
     def _get_content_type(cls, model):
         return ContentType.objects.get_for_model(model)
+
+    @classmethod
+    def _should_record_funding_recipient(cls, recipient_user) -> bool:
+        """Skip recipient rows for the Endaoment holding account (not a real earner)."""
+        endaoment_id = settings.ENDAOMENT_ACCOUNT_ID
+        if not endaoment_id:
+            return True
+        return recipient_user.id != int(endaoment_id)
 
     # -------------------------------------------------------------------------
     # Query methods
@@ -279,17 +288,22 @@ class FundingActivityService:
             source_content_type=cls._get_content_type(Purchase),
             source_object_id=purchase.pk,
         )
-        recipient = FundingActivityRecipient(
-            recipient_user=recipient_user,
-            amount=amount,
-        )
+        recipients = []
+        if cls._should_record_funding_recipient(recipient_user):
+            recipients.append(
+                FundingActivityRecipient(
+                    recipient_user=recipient_user,
+                    amount=amount,
+                )
+            )
         rate = FundingActivityAmountsService.resolve_rate_for_purchase(purchase)
         FundingActivityAmountsService.populate_dual_amounts_on_recipients(
-            activity, [recipient], rate
+            activity, recipients, rate
         )
         activity.save()
-        recipient.activity = activity
-        recipient.save()
+        for recipient in recipients:
+            recipient.activity = activity
+            recipient.save()
         return activity
 
     @classmethod
@@ -323,19 +337,24 @@ class FundingActivityService:
             source_content_type=cls._get_content_type(UsdFundraiseContribution),
             source_object_id=contribution.pk,
         )
-        recipient = FundingActivityRecipient(
-            recipient_user=recipient_user,
-            amount=Decimal("0"),
-        )
+        recipients = []
+        if cls._should_record_funding_recipient(recipient_user):
+            recipients.append(
+                FundingActivityRecipient(
+                    recipient_user=recipient_user,
+                    amount=Decimal("0"),
+                )
+            )
         rate = FundingActivityAmountsService.get_historical_rsc_usd_rate(
             contribution.created_date
         )
         FundingActivityAmountsService.populate_usd_native_dual_amounts_on_recipients(
-            activity, [recipient], native_usd_cents, rate
+            activity, recipients, native_usd_cents, rate
         )
         activity.save()
-        recipient.activity = activity
-        recipient.save()
+        for recipient in recipients:
+            recipient.activity = activity
+            recipient.save()
         return activity
 
     @classmethod

--- a/src/user/tests/test_funding_activity_service.py
+++ b/src/user/tests/test_funding_activity_service.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from paper.tests.helpers import create_paper
@@ -235,6 +235,55 @@ class FundingActivityServiceTests(TestCase):
         self.assertEqual(len(recipients), 1)
         self.assertEqual(recipients[0].recipient_user_id, self.other_user.id)
         self.assertEqual(recipients[0].amount, Decimal("100"))
+
+    @override_settings(ENDAOMENT_ACCOUNT_ID=888888)
+    def test_create_fundraise_payout_skips_recipient_for_endaoment(self):
+        """Nonprofit Endaoment recipient: activity for funder, no recipient row."""
+        # Arrange
+        endaoment_user = User.objects.create(
+            id=888888,
+            username="endaoment_test",
+            email="endaoment@test.com",
+        )
+        uni_doc = ResearchhubUnifiedDocument.objects.create(
+            document_type="PREREGISTRATION",
+        )
+        ct_fundraise = ContentType.objects.get_for_model(Fundraise)
+        fundraise = Fundraise.objects.create(
+            created_by=self.other_user,
+            status=Fundraise.CLOSED,
+            unified_document=uni_doc,
+        )
+        escrow = Escrow.objects.create(
+            hold_type=Escrow.FUNDRAISE,
+            status=Escrow.PAID,
+            created_by=self.user,
+            content_type=ct_fundraise,
+            object_id=fundraise.id,
+        )
+        fundraise.escrow = escrow
+        fundraise.save()
+        purchase = Purchase.objects.create(
+            user=self.user,
+            content_type=ct_fundraise,
+            object_id=fundraise.id,
+            purchase_type=Purchase.FUNDRAISE_CONTRIBUTION,
+            paid_status=Purchase.PAID,
+            amount="100",
+            purchase_method=Purchase.OFF_CHAIN,
+        )
+
+        # Act
+        with patch.object(Fundraise, "get_recipient", return_value=endaoment_user):
+            activity = FundingActivityService.create_funding_activity(
+                FundingActivity.FUNDRAISE_PAYOUT, purchase
+            )
+
+        # Assert
+        self.assertIsNotNone(activity)
+        self.assertEqual(activity.funder_id, self.user.id)
+        self.assertEqual(activity.total_amount, Decimal("100"))
+        self.assertEqual(activity.recipients.count(), 0)
 
     def test_fundraise_payout_total_amount_full_when_user_used_locked_and_regular(
         self,


### PR DESCRIPTION
## What/Why?

- Nonprofit fundraise payouts route RSC through escrow to the Endaoment holding user (`ENDAOMENT_ACCOUNT_ID`).
- When escrow becomes `PAID`, we correctly create `FundingActivity` rows with the **contributor** as `funder_id`, but we also created `FundingActivityRecipient` rows for the Endaoment system user.
- That made the Endaoment account look like it **earned** money in `earning_overview`, even though it is only a passthrough holding account.

## How?

- Add `_should_record_funding_recipient()` in `FundingActivityService` 
- returns `False` when `recipient_user.id == ENDAOMENT_ACCOUNT_ID`.

