### PR TITLE
Remove unused paper endpoints

### DIFF
--- a/src/paper/tests/test_views.py
+++ b/src/paper/tests/test_views.py
@@ -1,10 +1,8 @@
 import json
-import random
 from pathlib import Path
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 from django.conf import settings
-from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -21,11 +19,7 @@ from user.tests.helpers import (
     make_user_verified,
 )
 from utils.openalex import OpenAlex
-from utils.test_helpers import (
-    create_test_user,
-    get_authenticated_get_response,
-    get_authenticated_post_response,
-)
+from utils.test_helpers import create_test_user
 
 fixtures_dir = Path(__file__).parent / "fixtures"
 
@@ -810,54 +804,6 @@ class PaperApiTests(APITestCase):
         # Both versions should link back to the same original paper
         self.assertEqual(paper_version_v2.original_paper_id, paper_v1_id)
         self.assertEqual(paper_version_v1.original_paper_id, paper_v1_id)
-
-
-class PaperViewsTests(TestCase):
-    def setUp(self):
-        SEED = "paper"
-        self.random_generator = random.Random(SEED)
-        self.base_url = "/api/paper/"
-        self.paper = create_paper()
-        self.user = create_random_authenticated_user("paper_views_user")
-        self.trouble_maker = create_random_authenticated_user("trouble_maker")
-
-    @patch("paper.views.paper_views.check_url_contains_pdf")
-    def test_check_url_is_true_if_url_has_pdf(self, mock_check_url):
-        mock_check_url.return_value = True
-        url = self.base_url + "check_url/"
-        data = {"url": "https://bitcoin.org/bitcoin.pdf"}
-        response = get_authenticated_post_response(self.user, url, data)
-        self.assertContains(response, "true", status_code=200)
-
-    @patch("paper.views.paper_views.check_url_contains_pdf")
-    def test_check_url_is_false_if_url_does_NOT_have_pdf(self, mock_check_url):
-        mock_check_url.return_value = False
-        url = self.base_url + "check_url/"
-        data = {"url": "https://bitcoin.org/en/"}
-        response = get_authenticated_post_response(self.user, url, data)
-        self.assertContains(response, "false", status_code=200)
-
-    @patch("paper.views.paper_views.check_url_contains_pdf")
-    def test_check_url_is_false_for_malformed_url(self, mock_check_url):
-        mock_check_url.return_value = False
-        url = self.base_url + "check_url/"
-        data = {"url": "bitcoin.org/bitcoin.pdf/"}
-        response = get_authenticated_post_response(self.user, url, data)
-        self.assertContains(response, "false", status_code=200)
-
-        data = {"url": "bitcoin"}
-        response = get_authenticated_post_response(self.user, url, data)
-        self.assertContains(response, "false", status_code=200)
-
-    @patch.object(Paper, "paper_rewards", new_callable=PropertyMock)
-    def test_eligible_reward_summary(self, mock_get_paper_reward):
-        url = self.base_url + f"{self.paper.id}/eligible_reward_summary/"
-        mock_get_paper_reward.return_value = 100
-        response = get_authenticated_get_response(self.user, url, {})
-
-        self.assertEqual(response.status_code, 200)
-        result = response.data
-        self.assertEqual(result["base_rewards"], 100)
 
 
 class PaperDOITests(APITestCase):

--- a/src/paper/views/paper_views.py
+++ b/src/paper/views/paper_views.py
@@ -37,17 +37,11 @@ from paper.serializers import (
     PaperSubmissionSerializer,
 )
 from paper.utils import get_cache_key
-from reputation.related_models.paper_reward import (
-    OPEN_ACCESS_MULTIPLIER,
-    OPEN_DATA_MULTIPLIER,
-    PREREGISTERED_MULTIPLIER,
-)
 from researchhub.permissions import IsObjectOwnerOrModerator
 from user.permissions import IsVerifiedUser
 from user.related_models.author_model import Author
 from user.views.follow_view_mixins import FollowViewActionMixin
 from utils.doi import DOI
-from utils.http import POST, check_url_contains_pdf
 from utils.openalex import OpenAlex
 from utils.permissions import CreateOrUpdateIfAllowed, PostOnly
 from utils.sentry import log_error
@@ -786,55 +780,6 @@ class PaperViewSet(
             return Response(vote_id, status=200)
         except Exception as e:
             return Response(f"Failed to delete vote: {e}", status=400)
-
-    @action(detail=False, methods=[POST])
-    def check_url(self, request):
-        url = request.data.get("url", None)
-        url_is_pdf = check_url_contains_pdf(url)
-        data = {"found_file": url_is_pdf}
-        return Response(data, status=status.HTTP_200_OK)
-
-    @action(
-        detail=True,
-        methods=["get"],
-    )
-    def eligible_reward_summary(self, request, pk=None):
-        """
-        Provides information about rewards for which this paper is eligible for
-        """
-        paper_id = pk
-        if not paper_id:
-            return Response("paper_id is required", status=400)
-
-        paper = Paper.objects.get(id=paper_id)
-        if not paper:
-            return Response("Paper not found", status=404)
-
-        try:
-            paper_rewards = paper.paper_rewards
-        except Exception:
-            return Response("Failed to get paper reward", status=500)
-
-        summary = {
-            "base_rewards": paper_rewards,
-            "open_access_multiplier": OPEN_ACCESS_MULTIPLIER,
-            "open_data_multiplier": OPEN_DATA_MULTIPLIER,
-            "preregistration_multiplier": PREREGISTERED_MULTIPLIER,
-        }
-        return Response(summary, status=200)
-
-    @action(detail=False, methods=["get"], permission_classes=[AllowAny])
-    def doi_search_via_openalex(self, request):
-        doi_string = request.query_params.get("doi", None)
-        if doi_string is None:
-            return Response(status=400)
-        try:
-            open_alex = OpenAlex()
-            open_alex_json = open_alex.get_data_from_doi(doi_string)
-        except Exception:
-            return Response(status=404)
-
-        return Response(open_alex_json, status=200)
 
     @action(detail=False, methods=["get"], permission_classes=[IsAuthenticated])
     def fetch_publications_by_doi(self, request):


### PR DESCRIPTION
Remove the following unused endpoints:
- `check_url`
- `doi_search_via_openalex`
- `eligible_reward_summary`