### PR TITLE
Improve server startup performance (part 1)

### DIFF
--- a/src/paper/ingestion/__init__.py
+++ b/src/paper/ingestion/__init__.py
@@ -5,16 +5,10 @@ This module provides a unified interface for ingesting papers from multiple
 preprint servers and academic repositories.
 """
 
-from .clients import (
-    ArXivClient,
-    ArXivConfig,
-    ArXivOAIClient,
-    ArXivOAIConfig,
-    BaseClient,
-    BioRxivClient,
-    BioRxivConfig,
-    ClientConfig,
-)
+from .clients.base import BaseClient, ClientConfig
+from .clients.preprints.arxiv import ArXivClient, ArXivConfig
+from .clients.preprints.arxiv_oai import ArXivOAIClient, ArXivOAIConfig
+from .clients.preprints.biorxiv import BioRxivClient, BioRxivConfig
 from .exceptions import (
     ClientError,
     FetchError,

--- a/src/paper/ingestion/clients/__init__.py
+++ b/src/paper/ingestion/clients/__init__.py
@@ -1,36 +1,3 @@
 """
 Client modules for fetching papers from various sources.
 """
-
-from .base import BaseClient, ClientConfig
-from .enrichment.bluesky import BlueskyClient, BlueskyMetricsClient
-from .enrichment.github import GithubClient, GithubMetricsClient
-from .enrichment.openalex import OpenAlexClient
-from .enrichment.x import XClient, XMetricsClient
-from .preprints.arxiv import ArXivClient, ArXivConfig
-from .preprints.arxiv_oai import ArXivOAIClient, ArXivOAIConfig
-from .preprints.biorxiv import BioRxivClient, BioRxivConfig
-from .preprints.chemrxiv import ChemRxivClient, ChemRxivConfig
-from .preprints.medrxiv import MedRxivClient, MedRxivConfig
-
-__all__ = [
-    "ArXivClient",
-    "ArXivConfig",
-    "ArXivOAIClient",
-    "ArXivOAIConfig",
-    "BaseClient",
-    "BioRxivClient",
-    "BioRxivConfig",
-    "BlueskyClient",
-    "BlueskyMetricsClient",
-    "ChemRxivClient",
-    "ChemRxivConfig",
-    "ClientConfig",
-    "GithubClient",
-    "GithubMetricsClient",
-    "MedRxivClient",
-    "MedRxivConfig",
-    "OpenAlexClient",
-    "XClient",
-    "XMetricsClient",
-]

--- a/src/paper/ingestion/services/metrics_enrichment.py
+++ b/src/paper/ingestion/services/metrics_enrichment.py
@@ -6,11 +6,9 @@ from typing import Any, Dict, List, Optional
 
 from django.utils import timezone
 
-from paper.ingestion.clients import (
-    BlueskyMetricsClient,
-    GithubMetricsClient,
-    XMetricsClient,
-)
+from paper.ingestion.clients.enrichment.bluesky import BlueskyMetricsClient
+from paper.ingestion.clients.enrichment.github import GithubMetricsClient
+from paper.ingestion.clients.enrichment.x import XMetricsClient
 from paper.models import Paper
 
 logger = logging.getLogger(__name__)

--- a/src/paper/ingestion/tasks.py
+++ b/src/paper/ingestion/tasks.py
@@ -4,13 +4,10 @@ from celery.exceptions import MaxRetriesExceededError
 from django.conf import settings
 from django.core.cache import cache
 
-from paper.ingestion.clients import (
-    BlueskyMetricsClient,
-    GithubClient,
-    GithubMetricsClient,
-    XMetricsClient,
-)
+from paper.ingestion.clients.enrichment.bluesky import BlueskyMetricsClient
+from paper.ingestion.clients.enrichment.github import GithubClient, GithubMetricsClient
 from paper.ingestion.clients.enrichment.openalex import OpenAlexClient
+from paper.ingestion.clients.enrichment.x import XMetricsClient
 from paper.ingestion.mappers import OpenAlexMapper
 from paper.ingestion.services.metrics_enrichment import PaperMetricsEnrichmentService
 from paper.ingestion.services.openalex_enrichment import PaperOpenAlexEnrichmentService


### PR DESCRIPTION
Remove the heaviest barrel export files and use concrete imports where needed.