### PR TITLE
Add viewer-segment-aware caching to grant and funding feeds

### DIFF
--- a/src/feed/cache_segment.py
+++ b/src/feed/cache_segment.py
@@ -1,0 +1,34 @@
+from rest_framework.request import Request
+
+from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
+
+
+def get_feed_cache_segment(request: Request) -> tuple[str | None, bool]:
+    """Return (suffix, should_cache) for grant/funding feed page caching.
+
+    suffix is ``:public``, ``:viewer-{user_id}``, or ``None`` when caching is
+    disabled (moderators and hub editors always get a fresh response).
+    """
+    user = request.user
+
+    if user.is_authenticated and (
+        getattr(user, "moderator", False) or user.is_hub_editor()
+    ):
+        return None, False
+
+    if not user.is_authenticated:
+        return ":public", True
+
+    has_private_visibility = (
+        ResearchhubPost.objects.visible_to(user)
+        .filter(
+            unified_document__is_public=False,
+            unified_document__is_removed=False,
+        )
+        .exists()
+    )
+
+    if has_private_visibility:
+        return f":viewer-{user.id}", True
+
+    return ":public", True

--- a/src/feed/tests/test_cache_segment.py
+++ b/src/feed/tests/test_cache_segment.py
@@ -1,0 +1,135 @@
+from decimal import Decimal
+
+from django.utils import timezone
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from feed.cache_segment import get_feed_cache_segment
+from purchase.models import Grant, GrantApplication
+from purchase.related_models.constants.currency import USD
+from researchhub_document.helpers import create_post
+from researchhub_document.related_models.constants.document_type import (
+    GRANT,
+    PREREGISTRATION,
+)
+from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
+from researchhub_document.related_models.researchhub_unified_document_model import (
+    ResearchhubUnifiedDocument,
+)
+from user.tests.helpers import (
+    create_hub_editor,
+    create_random_authenticated_user,
+)
+from utils.test_helpers import AWSMockTestCase
+
+
+class FeedCacheSegmentTests(AWSMockTestCase):
+    def setUp(self):
+        super().setUp()
+        self.factory = APIRequestFactory()
+
+    def _request(self, user=None):
+        drf_request = Request(self.factory.get("/api/funding_feed/"))
+        if user is None:
+            from django.contrib.auth.models import AnonymousUser
+
+            drf_request.user = AnonymousUser()
+        else:
+            drf_request.user = user
+        return drf_request
+
+    def test_anonymous_returns_public_segment(self):
+        # Act
+        suffix, should_cache = get_feed_cache_segment(self._request())
+
+        # Assert
+        self.assertEqual(suffix, ":public")
+        self.assertTrue(should_cache)
+
+    def test_user_without_private_access_returns_public_segment(self):
+        # Arrange
+        user = create_random_authenticated_user("cache_seg_plain")
+
+        # Act
+        suffix, should_cache = get_feed_cache_segment(self._request(user))
+
+        # Assert
+        self.assertEqual(suffix, ":public")
+        self.assertTrue(should_cache)
+
+    def test_applicant_with_private_prereg_returns_viewer_segment(self):
+        # Arrange
+        applicant = create_random_authenticated_user("cache_seg_applicant")
+        private_doc = ResearchhubUnifiedDocument.objects.create(
+            document_type=PREREGISTRATION, is_public=False
+        )
+        ResearchhubPost.objects.create(
+            title="Private Preregistration",
+            created_by=applicant,
+            document_type=PREREGISTRATION,
+            renderable_text="Private proposal",
+            slug="private-prereg-cache-seg",
+            unified_document=private_doc,
+            created_date=timezone.now(),
+        )
+
+        # Act
+        suffix, should_cache = get_feed_cache_segment(self._request(applicant))
+
+        # Assert
+        self.assertEqual(suffix, f":viewer-{applicant.id}")
+        self.assertTrue(should_cache)
+
+    def test_grant_owner_with_private_application_returns_viewer_segment(self):
+        # Arrange
+        owner = create_random_authenticated_user("cache_seg_owner")
+        applicant = create_random_authenticated_user("cache_seg_app")
+        grant_post = create_post(created_by=owner, document_type=GRANT)
+        Grant.objects.create(
+            created_by=owner,
+            unified_document=grant_post.unified_document,
+            amount=Decimal("1000.00"),
+            currency=USD,
+            organization="Org",
+            description="desc",
+        )
+        private_post = create_post(
+            created_by=applicant, document_type=PREREGISTRATION, title="Private"
+        )
+        private_post.unified_document.is_public = False
+        private_post.unified_document.save()
+        GrantApplication.objects.create(
+            grant=Grant.objects.get(unified_document=grant_post.unified_document),
+            preregistration_post=private_post,
+            applicant=applicant,
+        )
+
+        # Act
+        suffix, should_cache = get_feed_cache_segment(self._request(owner))
+
+        # Assert
+        self.assertEqual(suffix, f":viewer-{owner.id}")
+        self.assertTrue(should_cache)
+
+    def test_moderator_disables_caching_even_with_private_posts(self):
+        # Arrange
+        moderator = create_random_authenticated_user("cache_seg_mod", moderator=True)
+        private_doc = ResearchhubUnifiedDocument.objects.create(
+            document_type=PREREGISTRATION, is_public=False
+        )
+        ResearchhubPost.objects.create(
+            title="Private Preregistration",
+            created_by=moderator,
+            document_type=PREREGISTRATION,
+            renderable_text="Private proposal",
+            slug="private-prereg-mod-cache-seg",
+            unified_document=private_doc,
+            created_date=timezone.now(),
+        )
+
+        # Act
+        suffix, should_cache = get_feed_cache_segment(self._request(moderator))
+
+        # Assert
+        self.assertIsNone(suffix)
+        self.assertFalse(should_cache)

--- a/src/feed/tests/test_funding_feed_cache_invalidation.py
+++ b/src/feed/tests/test_funding_feed_cache_invalidation.py
@@ -54,7 +54,7 @@ class FundingFeedCacheInvalidationTests(TestCase):
         req.user = MagicMock()
         req.user.is_authenticated = False
         req.user.id = None
-        k = view.get_cache_key(req, "funding")
+        k = view.get_cache_key(req, "funding") + ":public"
         cache.set(k, {"cached": True}, timeout=3600)
         self.assertIsNotNone(cache.get(k))
         FundingCacheMixin.invalidate_funding_feed_cache()

--- a/src/feed/tests/views/test_funding_feed_view.py
+++ b/src/feed/tests/views/test_funding_feed_view.py
@@ -330,7 +330,8 @@ class FundingFeedViewSetTests(AWSMockTestCase):
             self.assertNotIn("user_vote", item)
 
     def test_get_cache_key(self):
-        """Test cache key generation logic"""
+        """Base cache key from get_cache_key(); list() appends viewer segment suffix."""
+        from feed.cache_segment import get_feed_cache_segment
         from feed.views.funding_feed_view import FundingFeedViewSet
 
         # Create viewset instance and configure it
@@ -356,6 +357,14 @@ class FundingFeedViewSetTests(AWSMockTestCase):
 
         cache_key = viewset.get_cache_key(request, "funding")
         self.assertEqual(cache_key, "funding_feed:popular:all:all:none:1-20")
+
+        suffix, should_cache = get_feed_cache_segment(request)
+        self.assertEqual(suffix, ":public")
+        self.assertTrue(should_cache)
+        self.assertEqual(
+            cache_key + suffix,
+            "funding_feed:popular:all:all:none:1-20:public",
+        )
 
         # Authenticated user
         request = request_factory.get("/api/funding_feed/")

--- a/src/feed/tests/views/test_grant_feed_view.py
+++ b/src/feed/tests/views/test_grant_feed_view.py
@@ -702,12 +702,16 @@ class GrantFeedViewTests(APITestCase):
 
         view = GrantFeedViewSet()
         factory = APIRequestFactory()
-        unfiltered_key = view.get_cache_key(
-            Request(factory.get("/api/grant_feed/")), "grants"
+        unfiltered_key = (
+            view.get_cache_key(Request(factory.get("/api/grant_feed/")), "grants")
+            + ":public"
         )
-        filtered_key = view.get_cache_key(
-            Request(factory.get("/api/grant_feed/", {"created_by": str(user1.id)})),
-            "grants",
+        filtered_key = (
+            view.get_cache_key(
+                Request(factory.get("/api/grant_feed/", {"created_by": str(user1.id)})),
+                "grants",
+            )
+            + ":public"
         )
         self.assertIsNotNone(cache.get(unfiltered_key))
         self.assertIsNotNone(cache.get(filtered_key))
@@ -819,8 +823,11 @@ class GrantFeedViewTests(APITestCase):
         )
         self.client.force_authenticate(self.user)
         self.client.get("/api/grant_feed/")
-        cache_key = GrantFeedViewSet().get_cache_key(
-            Request(APIRequestFactory().get("/api/grant_feed/")), "grants"
+        cache_key = (
+            GrantFeedViewSet().get_cache_key(
+                Request(APIRequestFactory().get("/api/grant_feed/")), "grants"
+            )
+            + ":public"
         )
         self.assertIsNotNone(cache.get(cache_key))
 
@@ -831,3 +838,91 @@ class GrantFeedViewTests(APITestCase):
         # Act + Assert — grant-linked doc clears cache
         GrantCacheMixin.invalidate_if_grant_linked(proposal.unified_document)
         self.assertIsNone(cache.get(cache_key))
+
+    def test_viewer_segment_cache_isolates_private_applications(self):
+        """Grant owner populates :viewer-{id} cache; anonymous :public has no leak."""
+        from django.contrib.auth.models import AnonymousUser
+
+        from feed.cache_segment import get_feed_cache_segment
+
+        # Arrange
+        grant_owner = create_random_authenticated_user("cache_iso_owner")
+        applicant = create_random_authenticated_user("cache_iso_applicant")
+        grant_post = create_post(
+            created_by=grant_owner, document_type=GRANT, title="Cache Iso Grant"
+        )
+        grant = Grant.objects.create(
+            created_by=grant_owner,
+            unified_document=grant_post.unified_document,
+            amount=Decimal("5000.00"),
+            currency="USD",
+            organization="NSF",
+            description="Grant for cache test",
+            status=Grant.OPEN,
+            end_date=datetime.now(pytz.UTC) + timedelta(days=30),
+        )
+        public_post = create_post(
+            created_by=applicant, document_type=PREREGISTRATION, title="Public App"
+        )
+        private_post = create_post(
+            created_by=applicant, document_type=PREREGISTRATION, title="Private App"
+        )
+        private_post.unified_document.is_public = False
+        private_post.unified_document.save()
+        GrantApplication.objects.create(
+            grant=grant, preregistration_post=public_post, applicant=applicant
+        )
+        GrantApplication.objects.create(
+            grant=grant, preregistration_post=private_post, applicant=applicant
+        )
+        cache.clear()
+
+        # Act — grant owner hits feed first (viewer segment)
+        self.client.force_authenticate(grant_owner)
+        owner_response = self.client.get("/api/grant_feed/")
+
+        # Assert — owner sees both applications
+        self.assertEqual(owner_response.status_code, 200)
+        grant_entry = next(
+            e
+            for e in owner_response.data["results"]
+            if e["content_object"]["id"] == grant_post.id
+        )
+        owner_app_ids = {
+            app["preregistration_post_id"]
+            for app in grant_entry["content_object"]["grant"]["applications"]
+        }
+        self.assertIn(public_post.id, owner_app_ids)
+        self.assertIn(private_post.id, owner_app_ids)
+
+        view = GrantFeedViewSet()
+        factory = APIRequestFactory()
+        owner_request = Request(factory.get("/api/grant_feed/"))
+        owner_request.user = grant_owner
+        owner_suffix, _ = get_feed_cache_segment(owner_request)
+        viewer_key = view.get_cache_key(owner_request, "grants") + owner_suffix
+        self.assertIsNotNone(cache.get(viewer_key))
+
+        anon_request = Request(factory.get("/api/grant_feed/"))
+        anon_request.user = AnonymousUser()
+        public_suffix, _ = get_feed_cache_segment(anon_request)
+        public_key = view.get_cache_key(anon_request, "grants") + public_suffix
+        self.assertNotEqual(viewer_key, public_key)
+
+        # Act — anonymous uses separate public cache entry
+        self.client.logout()
+        anon_response = self.client.get("/api/grant_feed/")
+
+        # Assert — anonymous does not see private application
+        self.assertEqual(anon_response.status_code, 200)
+        anon_grant_entry = next(
+            e
+            for e in anon_response.data["results"]
+            if e["content_object"]["id"] == grant_post.id
+        )
+        anon_app_ids = {
+            app["preregistration_post_id"]
+            for app in anon_grant_entry["content_object"]["grant"]["applications"]
+        }
+        self.assertIn(public_post.id, anon_app_ids)
+        self.assertNotIn(private_post.id, anon_app_ids)

--- a/src/feed/views/funding_cache_mixin.py
+++ b/src/feed/views/funding_cache_mixin.py
@@ -39,9 +39,11 @@ class FundingCacheMixin:
         """
         Delete cached funding-feed list responses (pages 1–``FUNDING_FEED_MAX_CACHED_PAGE``).
 
-        Only keys that can be written when ``FundingFeedViewSet.list`` uses the cache
-        branch are targeted. Hub-specific ``?hub_slug=`` keys (other than default) are
-        not enumerated; they expire via TTL.
+        Only ``:public`` segment keys that can be written when
+        ``FundingFeedViewSet.list`` uses the cache branch are targeted.
+        Per-viewer ``:viewer-{user_id}`` entries are left to TTL.
+        Hub-specific ``?hub_slug=`` keys (other than default) are not enumerated;
+        they expire via TTL.
         """
         # Local import avoids circular import: funding_feed_view loads this module first.
         from feed.views.funding_feed_view import FundingFeedViewSet
@@ -73,5 +75,7 @@ class FundingCacheMixin:
                                     if include_ended != "true":
                                         params["include_ended"] = include_ended
                                     req = _funding_invalidation_request(params)
-                                    keys.append(view.get_cache_key(req, "funding"))
+                                    keys.append(
+                                        view.get_cache_key(req, "funding") + ":public"
+                                    )
         cache.delete_many(list(dict.fromkeys(keys)))

--- a/src/feed/views/funding_feed_view.py
+++ b/src/feed/views/funding_feed_view.py
@@ -14,6 +14,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
+from feed.cache_segment import get_feed_cache_segment
 from feed.feed_list_dto import (
     FundingFeedListEntrySerializer,
     serialize_fund_feed_metrics,
@@ -54,15 +55,19 @@ class FundingFeedViewSet(FundingCacheMixin, FeedViewMixin, ModelViewSet):
         grant_id = request.query_params.get("grant_id", None)
         created_by = request.query_params.get("created_by", None)
         funded_by = request.query_params.get("funded_by", None)
-        cache_key = self.get_cache_key(request, "funding")
+        suffix, should_cache = get_feed_cache_segment(request)
         use_cache = (
-            page_num <= FUNDING_FEED_MAX_CACHED_PAGE
+            should_cache
+            and page_num <= FUNDING_FEED_MAX_CACHED_PAGE
             and grant_id is None
             and created_by is None
             and funded_by is None
         )
+        cache_key = (
+            (self.get_cache_key(request, "funding") + suffix) if use_cache else None
+        )
 
-        if use_cache:
+        if cache_key:
             cached_response = cache.get(cache_key)
             if cached_response:
                 if request.user.is_authenticated:
@@ -94,7 +99,7 @@ class FundingFeedViewSet(FundingCacheMixin, FeedViewMixin, ModelViewSet):
         )
         response_data = self.get_paginated_response(serializer.data).data
 
-        if use_cache:
+        if cache_key:
             cache.set(cache_key, response_data, timeout=self.DEFAULT_CACHE_TIMEOUT)
 
         if request.user.is_authenticated:

--- a/src/feed/views/grant_cache_mixin.py
+++ b/src/feed/views/grant_cache_mixin.py
@@ -46,7 +46,7 @@ class GrantCacheMixin:
                                 f"{page}-{page_size}{sort_part}:{status}:"
                                 f"{created_by}:{include_key_insights}"
                             )
-                            cache.delete(cache_key)
+                            cache.delete(cache_key + ":public")
 
     @staticmethod
     def invalidate_if_grant_linked(unified_document):

--- a/src/feed/views/grant_feed_view.py
+++ b/src/feed/views/grant_feed_view.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from ai_peer_review.models import ProposalReview
+from feed.cache_segment import get_feed_cache_segment
 from feed.feed_list_dto import GrantFeedListEntrySerializer
 from feed.filters import FundOrderingFilter
 from feed.models import FeedEntry
@@ -54,10 +55,13 @@ class GrantFeedViewSet(GrantCacheMixin, FeedViewMixin, ModelViewSet):
     def list(self, request, *args, **kwargs):
         page = request.query_params.get("page", "1")
         page_num = int(page)
-        cache_key = self.get_cache_key(request, "grants")
-        use_cache = page_num <= GRANT_FEED_MAX_CACHED_PAGE
+        suffix, should_cache = get_feed_cache_segment(request)
+        use_cache = should_cache and page_num <= GRANT_FEED_MAX_CACHED_PAGE
+        cache_key = (
+            (self.get_cache_key(request, "grants") + suffix) if use_cache else None
+        )
 
-        if use_cache:
+        if cache_key:
             cached_response = cache.get(cache_key)
             if cached_response:
                 return Response(cached_response)
@@ -84,7 +88,7 @@ class GrantFeedViewSet(GrantCacheMixin, FeedViewMixin, ModelViewSet):
         )
         response_data = self.get_paginated_response(serializer.data).data
 
-        if use_cache:
+        if cache_key:
             cache.set(cache_key, response_data, timeout=self.DEFAULT_CACHE_TIMEOUT)
 
         return Response(response_data)


### PR DESCRIPTION
## What?
- Introduce viewer-segment-aware cache keys so public discovery traffic stays on a shared cache;
- Users with private visibility get per-user cache entries;
- Moderators/hub editors always receive fresh responses.

## WHy?
- Prepares both feeds for serving private content correctly later without one global cached payload for everyone.

## How?
- Add `get_feed_cache_segment()` to resolve the viewer segment:

  - `:public` => anonymous users, or logged-in users with no private post visibility
  - `:viewer-{user_id}` => users who can see private posts via `ResearchhubPost.visible_to()`
  - **No cache** =>  moderators and hub editors