### PR TITLE
Allow notes to be read with note invitation

### DIFF
--- a/src/invite/services/note_invitation_service.py
+++ b/src/invite/services/note_invitation_service.py
@@ -27,6 +27,21 @@ class NoteInvitationService:
     Service for handling note invitations.
     """
 
+    def get_active_invite(self, key: str) -> NoteInvitation:
+        """
+        Get an active note invitation.
+
+        Raises:
+            NoteInvitationExpiredError: If the invitation has expired
+                or has already been accepted.
+        """
+        invite = NoteInvitation.objects.get(key=key)
+
+        if invite.is_expired() or invite.accepted:
+            raise NoteInvitationExpiredError()
+
+        return invite
+
     def accept_invite(self, key: str, user) -> NoteInvitation:
         """
         Accept a note invitation.

--- a/src/invite/services/note_invitation_service.py
+++ b/src/invite/services/note_invitation_service.py
@@ -57,10 +57,7 @@ class NoteInvitationService:
             NoteInvitationRecipientMismatchError: If the invitation recipient doesn't
                 match the user.
         """
-        invite = NoteInvitation.objects.get(key=key)
-
-        if invite.is_expired() or invite.accepted:
-            raise NoteInvitationExpiredError()
+        invite = self.get_active_invite(key)
 
         if invite.recipient and user != invite.recipient:
             raise NoteInvitationRecipientMismatchError()

--- a/src/invite/tests/test_views.py
+++ b/src/invite/tests/test_views.py
@@ -11,14 +11,14 @@ class OrganizationInvitationViewsTest(APITestCase):
     def setUp(self):
         # Create + auth user
         self.sender = get_user_model().objects.create_user(
-            username="user1@researchhub_test.com",
+            username="user1@researchhub.com",
             password=uuid.uuid4().hex,
-            email="user1@researchhub_test.com",
+            email="user1@researchhub.com",
         )
         self.recipient = get_user_model().objects.create_user(
-            username="user2@researchhub_test.com",
+            username="user2@researchhub.com",
             password=uuid.uuid4().hex,
-            email="user2@researchhub_test.com",
+            email="user2@researchhub.com",
         )
 
         # Create org

--- a/src/note/tests/test_note_by_invitation.py
+++ b/src/note/tests/test_note_by_invitation.py
@@ -1,0 +1,69 @@
+import uuid
+
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+
+from invite.models import NoteInvitation
+from note.tests.helpers import create_note
+
+
+class PublicNoteInvitationViewsTest(APITestCase):
+    """
+    Tests public note access through invitation links.
+    """
+
+    def setUp(self):
+        self.sender = get_user_model().objects.create_user(
+            username="sender@researchhub.com",
+            password=uuid.uuid4().hex,
+            email="sender@researchhub.com",
+        )
+        self.recipient = get_user_model().objects.create_user(
+            username="recipient@researchhub.com",
+            password=uuid.uuid4().hex,
+            email="recipient@researchhub.com",
+        )
+        self.note, _ = create_note(
+            self.sender,
+            None,
+            title="Shared note",
+            body="Readable note body",
+        )
+
+    def _create_note_invitation(self, expiration_time=1440):
+        return NoteInvitation.create(
+            expiration_time=expiration_time,
+            recipient=self.recipient,
+            recipient_email=self.recipient.email,
+            inviter_id=self.sender.id,
+            note_id=self.note.id,
+        )
+
+    def test_get_note_by_key_allows_unauthenticated_read_of_active_invite(self):
+        # Arrange
+        invite = self._create_note_invitation()
+        self.client.force_authenticate(user=None)
+
+        # Act
+        response = self.client.get(f"/api/note/{invite.key}/get_note_by_key/")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["note"]["id"], self.note.id)
+        self.assertEqual(response.data["note"]["title"], "Shared note")
+        self.assertEqual(
+            response.data["note"]["latest_version"]["plain_text"],
+            "Readable note body",
+        )
+
+    def test_get_note_by_key_rejects_expired_invite(self):
+        # Arrange
+        invite = self._create_note_invitation(expiration_time=-1)
+        self.client.force_authenticate(user=None)
+
+        # Act
+        response = self.client.get(f"/api/note/{invite.key}/get_note_by_key/")
+
+        # Assert
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data, {"data": "Invitation has expired"})

--- a/src/note/views/note_view.py
+++ b/src/note/views/note_view.py
@@ -13,6 +13,7 @@ from rest_framework.viewsets import ModelViewSet
 from hub.models import Hub
 from invite.models import NoteInvitation
 from invite.serializers import DynamicNoteInvitationSerializer
+from invite.services import NoteInvitationExpiredError, NoteInvitationService
 from note.models import Note, NoteContent
 from note.serializers import NoteContentSerializer, NoteSerializer
 from researchhub.pagination import MediumPageLimitPagination
@@ -242,7 +243,13 @@ class NoteViewSet(ModelViewSet):
 
     @action(detail=True, methods=["get"], permission_classes=[AllowAny])
     def get_note_by_key(self, request, pk=None):
-        invite = NoteInvitation.objects.get(key=pk)
+        service = NoteInvitationService()
+
+        try:
+            invite = service.get_active_invite(pk)
+        except NoteInvitationExpiredError:
+            return Response({"data": "Invitation has expired"}, status=403)
+
         serializer = DynamicNoteInvitationSerializer(
             invite,
             context={

--- a/src/note/views/note_view.py
+++ b/src/note/views/note_view.py
@@ -264,6 +264,16 @@ class NoteViewSet(ModelViewSet):
                         "organization",
                         "title",
                         "id",
+                        "latest_version",
+                    ]
+                },
+                "nte_dns_get_latest_version": {
+                    "_include_fields": [
+                        "created_date",
+                        "id",
+                        "json",
+                        "plain_text",
+                        "src",
                     ]
                 },
                 "nte_dns_get_organization": {


### PR DESCRIPTION
The previous implementation only returned note metadata for reading notes with invite links. This updates the view to return the latest version of the note with full content.