### PR TITLE
Allow invites without recipient user

### DIFF
--- a/src/invite/services/note_invitation_service.py
+++ b/src/invite/services/note_invitation_service.py
@@ -62,6 +62,9 @@ class NoteInvitationService:
         if invite.recipient and user != invite.recipient:
             raise NoteInvitationRecipientMismatchError()
 
+        if not invite.recipient:
+            self._claim_recipientless_invite(invite, user)
+
         note = invite.note
         invite_type = invite.invite_type
         unified_document = note.unified_document
@@ -79,3 +82,28 @@ class NoteInvitationService:
         invite.accept()
 
         return invite
+
+    def _claim_recipientless_invite(self, invite: NoteInvitation, user) -> None:
+        """
+        Claim a recipientless invite for a user if the user's email matches the invite's
+        email.
+
+        Args:
+            invite: The note invitation to claim.
+            user: The user claiming the invitation.
+        Raises:
+            NoteInvitationRecipientMismatchError: If the user's email doesn't match the
+                invite's email.
+        """
+        user_email = (getattr(user, "email", "") or "").strip().lower()
+        invite_email = (invite.recipient_email or "").strip().lower()
+
+        if (
+            not getattr(user, "is_authenticated", False)
+            or not user_email
+            or not invite_email
+            or user_email != invite_email
+        ):
+            raise NoteInvitationRecipientMismatchError()
+
+        invite.recipient = user

--- a/src/invite/tests/test_note_invitation_service.py
+++ b/src/invite/tests/test_note_invitation_service.py
@@ -29,13 +29,20 @@ class NoteInvitationServiceTest(TestCase):
         )
 
     def _create_note_invitation(
-        self, recipient=None, expiration_time=1440, invite_type=VIEWER
+        self,
+        recipient=None,
+        recipient_email=None,
+        expiration_time=1440,
+        invite_type=VIEWER,
     ):
-        recipient = recipient or self.recipient
+        if recipient_email is None:
+            recipient = recipient or self.recipient
+            recipient_email = recipient.email
+
         return NoteInvitation.create(
             expiration_time=expiration_time,
             recipient=recipient,
-            recipient_email=recipient.email,
+            recipient_email=recipient_email,
             inviter_id=self.sender.id,
             note_id=self.note.id,
             invite_type=invite_type,
@@ -56,6 +63,48 @@ class NoteInvitationServiceTest(TestCase):
 
         permission = self.note.unified_document.permissions.get(user=self.recipient)
         self.assertEqual(permission.access_type, EDITOR)
+
+    def test_accept_invite_claims_recipientless_invite(self):
+        # Arrange
+        invite = self._create_note_invitation(
+            recipient=None,
+            recipient_email="new-recipient@researchhub.com",
+            invite_type=EDITOR,
+        )
+        new_recipient = self._create_user("new-recipient")
+
+        # Act
+        accepted_invite = self.service.accept_invite(invite.key, new_recipient)
+
+        # Assert
+        self.assertEqual(accepted_invite.id, invite.id)
+
+        invite.refresh_from_db()
+        self.assertTrue(invite.accepted)
+        self.assertEqual(invite.recipient, new_recipient)
+
+        permission = self.note.unified_document.permissions.get(user=new_recipient)
+        self.assertEqual(permission.access_type, EDITOR)
+
+    def test_accept_invite_rejects_recipientless_invite_with_different_emails(self):
+        # Arrange
+        invite = self._create_note_invitation(
+            recipient=None,
+            recipient_email="invited@researchhub.com",
+        )
+        other_user = self._create_user("other")
+
+        # Act
+        with self.assertRaises(NoteInvitationRecipientMismatchError):
+            self.service.accept_invite(invite.key, other_user)
+
+        # Assert
+        invite.refresh_from_db()
+        self.assertFalse(invite.accepted)
+        self.assertIsNone(invite.recipient)
+        self.assertFalse(
+            self.note.unified_document.permissions.filter(user=other_user).exists()
+        )
 
     def test_accept_invite_raises_for_expired_invite(self):
         # Arrange

--- a/src/invite/tests/test_views.py
+++ b/src/invite/tests/test_views.py
@@ -6,6 +6,7 @@ from rest_framework.test import APITestCase
 from invite.related_models.note_invitation import NoteInvitation
 from invite.related_models.organization_invitation import OrganizationInvitation
 from note.tests.helpers import create_note
+from researchhub_access_group.constants import EDITOR
 
 
 class OrganizationInvitationViewsTest(APITestCase):
@@ -114,6 +115,38 @@ class NoteInvitationAcceptViewsTest(APITestCase):
             email="sender@researchhub.com",
         )
         self.note, _ = create_note(self.sender, None, title="Test note")
+
+    def test_accept_invite_claims_recipientless_invite(self):
+        # Arrange
+        recipient_email = "new-recipient@researchhub.com"
+        invite = NoteInvitation.create(
+            expiration_time=1440,
+            recipient=None,
+            recipient_email=recipient_email,
+            inviter_id=self.sender.id,
+            note_id=self.note.id,
+            invite_type=EDITOR,
+        )
+        new_recipient = get_user_model().objects.create_user(
+            username=recipient_email,
+            password=uuid.uuid4().hex,
+            email=recipient_email,
+        )
+        self.client.force_authenticate(user=new_recipient)
+
+        # Act
+        response = self.client.post(f"/api/invite/note/{invite.key}/accept_invite/")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["data"], "User has accepted invitation")
+
+        invite.refresh_from_db()
+        self.assertTrue(invite.accepted)
+        self.assertEqual(invite.recipient, new_recipient)
+
+        permission = self.note.unified_document.permissions.get(user=new_recipient)
+        self.assertEqual(permission.access_type, EDITOR)
 
     def test_accept_invite_requires_authentication(self):
         # Arrange


### PR DESCRIPTION
Allow note invites without a targeted recipient user to be claimed by an authenticated user whose email matches the invite recipient's email. This allows invites to be sent by email when the user does not yet exist in the system. Once the user creates an account, they can claim the invite and get access.