### PR TITLE
unified_document prefetch  in ActivityFeedViewSet

### DIFF
--- a/src/feed/related_work.py
+++ b/src/feed/related_work.py
@@ -62,6 +62,11 @@ def _serialize_slim_fundraise_for_related_work(fundraise):
     }
 
 
+def _first_prefetched(relation):
+    items = list(relation.all())
+    return items[0] if items else None
+
+
 def _serialize_grant_nested(grant):
     from feed.feed_list_dto import _grant_amount
 
@@ -129,10 +134,7 @@ def _build_common_fields_from_paper(paper, unified_document):
     return data
 
 
-def serialize_related_work(unified_document, context=None):
-    if unified_document is None:
-        return None
-
+def _serialize_related_work_impl(unified_document):
     document_type = unified_document.document_type
 
     if document_type == PAPER:
@@ -142,7 +144,9 @@ def serialize_related_work(unified_document, context=None):
         return _build_common_fields_from_paper(paper, unified_document)
 
     post = (
-        unified_document.posts.first() if hasattr(unified_document, "posts") else None
+        _first_prefetched(unified_document.posts)
+        if hasattr(unified_document, "posts")
+        else None
     )
     if not post:
         return None
@@ -150,15 +154,36 @@ def serialize_related_work(unified_document, context=None):
     data = _build_common_fields_from_post(post, unified_document)
 
     if document_type == GRANT:
-        if hasattr(unified_document, "grants") and unified_document.grants.exists():
-            grant = unified_document.grants.first()
+        grant = (
+            _first_prefetched(unified_document.grants)
+            if hasattr(unified_document, "grants")
+            else None
+        )
+        if grant:
             data["grant"] = _serialize_grant_nested(grant)
     elif document_type == PREREGISTRATION:
-        if (
-            hasattr(unified_document, "fundraises")
-            and unified_document.fundraises.exists()
-        ):
-            fundraise = unified_document.fundraises.first()
+        fundraise = (
+            _first_prefetched(unified_document.fundraises)
+            if hasattr(unified_document, "fundraises")
+            else None
+        )
+        if fundraise:
             data["fundraise"] = _serialize_slim_fundraise_for_related_work(fundraise)
 
     return data
+
+
+def serialize_related_work(unified_document, context=None):
+    if unified_document is None:
+        return None
+
+    if context is not None:
+        cache = context.setdefault("related_work_cache", {})
+        cache_key = unified_document.id
+        if cache_key in cache:
+            return cache[cache_key]
+        result = _serialize_related_work_impl(unified_document)
+        cache[cache_key] = result
+        return result
+
+    return _serialize_related_work_impl(unified_document)

--- a/src/feed/tests/views/test_activity_feed_view.py
+++ b/src/feed/tests/views/test_activity_feed_view.py
@@ -2,7 +2,9 @@ from decimal import Decimal
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.db import connection
 from django.test import override_settings
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
@@ -10,9 +12,12 @@ from rest_framework.test import APIClient, APITestCase
 
 from feed.models import FeedEntry
 from purchase.models import Fundraise
+from purchase.related_models.constants.currency import USD
+from purchase.related_models.constants.rsc_exchange_currency import MORALIS
 from purchase.related_models.grant_application_model import GrantApplication
 from purchase.related_models.grant_model import Grant
 from purchase.related_models.purchase_model import Purchase
+from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
 from purchase.related_models.usd_fundraise_contribution_model import (
     UsdFundraiseContribution,
 )
@@ -124,6 +129,13 @@ class ActivityFeedRelatedWorkTests(ActivityFeedBaseTests):
     def setUp(self):
         super().setUp()
 
+        RscExchangeRate.objects.create(
+            price_source=MORALIS,
+            rate=3.0,
+            real_rate=3.0,
+            target_currency=USD,
+        )
+
         self.grant = Grant.objects.create(
             created_by=self.user,
             unified_document=self.grant_doc,
@@ -205,6 +217,57 @@ class ActivityFeedRelatedWorkTests(ActivityFeedBaseTests):
         self.assertEqual(related_work["title"], "Grant Post")
         self.assertEqual(related_work["id"], self.grant_post.id)
         self.assertIn("grant", related_work)
+
+
+class ActivityFeedRelatedWorkPrefetchTests(ActivityFeedRelatedWorkTests):
+    """Ensure related_work serialization avoids N+1 queries."""
+
+    def setUp(self):
+        super().setUp()
+        # Arrange: multiple entries on the same unified documents
+        self.shared_grant_comment_2 = _make_feed_entry(
+            RhCommentModel,
+            object_id=10003,
+            unified_document=self.grant_doc,
+            user=self.user,
+        )
+        self.shared_grant_comment_3 = _make_feed_entry(
+            RhCommentModel,
+            object_id=10004,
+            unified_document=self.grant_doc,
+            user=self.user,
+        )
+        self.shared_prereg_comment_2 = _make_feed_entry(
+            RhCommentModel,
+            object_id=10005,
+            unified_document=self.prereg_doc,
+            user=self.user,
+        )
+
+    def _activity_feed_query_count(self):
+        with CaptureQueriesContext(connection) as context:
+            resp = self.client.get(ACTIVITY_LIST_URL)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        return len(context.captured_queries)
+
+    def test_related_work_prefetch_does_not_scale_with_shared_documents(self):
+        # Arrange
+        baseline_query_count = self._activity_feed_query_count()
+
+        for object_id in (10006, 10007, 10008):
+            _make_feed_entry(
+                RhCommentModel,
+                object_id=object_id,
+                unified_document=self.grant_doc,
+                user=self.user,
+            )
+
+        # Act
+        expanded_query_count = self._activity_feed_query_count()
+
+        # Assert: extra rows on the same unified document should not re-fetch
+        # related_work relations (only generic FK lookups for new content rows).
+        self.assertLessEqual(expanded_query_count - baseline_query_count, 4)
 
 
 class ActivityFeedListTests(ActivityFeedBaseTests):

--- a/src/feed/views/activity_feed_view.py
+++ b/src/feed/views/activity_feed_view.py
@@ -1,5 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Q
+from django.db.models import Count, Prefetch, Q
 from rest_framework.viewsets import ModelViewSet
 
 from feed.models import FeedEntry
@@ -7,6 +7,7 @@ from feed.serializers import ActivityFeedEntrySerializer
 from feed.views.common import FeedPagination
 from feed.views.feed_view_mixin import FeedViewMixin
 from paper.related_models.paper_model import Paper
+from purchase.models import Fundraise
 from purchase.related_models.grant_application_model import GrantApplication
 from purchase.related_models.grant_model import Grant
 from purchase.related_models.purchase_model import Purchase
@@ -21,6 +22,7 @@ from researchhub_comment.related_models.rh_comment_model import RhCommentModel
 from researchhub_comment.related_models.rh_comment_thread_model import (
     hidden_comment_ids,
 )
+from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
 from user.related_models.user_model import AI_EXPERT_EMAIL
 
 
@@ -65,13 +67,38 @@ class ActivityFeedViewSet(FeedViewMixin, ModelViewSet):
         return response
 
     def get_queryset(self):
-        queryset = FeedEntry.objects.select_related(
-            "content_type",
-            "unified_document",
-            "user",
-            "user__author_profile",
-            "user__userverification",
-        ).order_by("-action_date")
+        queryset = (
+            FeedEntry.objects.select_related(
+                "content_type",
+                "unified_document",
+                "user",
+                "user__author_profile",
+                "user__userverification",
+                "unified_document__paper__uploaded_by__author_profile",
+            )
+            .prefetch_related(
+                Prefetch(
+                    "unified_document__posts",
+                    queryset=ResearchhubPost.objects.select_related(
+                        "created_by__author_profile"
+                    ),
+                ),
+                Prefetch(
+                    "unified_document__grants",
+                    queryset=Grant.objects.annotate(
+                        num_applicants=Count("applications", distinct=True),
+                    ),
+                ),
+                Prefetch(
+                    "unified_document__fundraises",
+                    queryset=Fundraise.objects.select_related(
+                        "created_by__author_profile"
+                    ),
+                ),
+                "unified_document__paper__authors",
+            )
+            .order_by("-action_date")
+        )
 
         # Exclude paper publications
         paper_ct = ContentType.objects.get_for_model(Paper)


### PR DESCRIPTION
## What?

- Add a `prefetch_related` chain on `ActivityFeedViewSet.get_queryset()` so `related_work` can be built from cached unified-document relations in a single page load:
  - Posts (`unified_document__posts` + `created_by__author_profile`)
  - Grants (`unified_document__grants`, annotated with `num_applicants`)
  - Fundraises (`unified_document__fundraises` + `created_by__author_profile`)
  - Papers (`unified_document__paper`, authors)
- Update `serialize_related_work()` to read from prefetched relations.

## Why?

- Prefetching unified-document relations up front keeps pagination performant and predictable.

