### PR TITLE
New feed signal on FundingActivity (BOUNTY_PAYOUT/TIP_REVIEW)

### DIFF
--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -610,6 +610,43 @@ class FundraiseContributionContentSerializer(serializers.Serializer):
         return None
 
 
+class FundingActivityRecipientSerializer(serializers.Serializer):
+    recipient_user = serializers.SerializerMethodField()
+    amount = serializers.DecimalField(max_digits=19, decimal_places=8)
+    amount_usd_cents = serializers.IntegerField()
+
+    def get_recipient_user(self, obj):
+        user = obj.recipient_user
+        if user and hasattr(user, "author_profile") and user.author_profile:
+            return SimpleAuthorSerializer(user.author_profile).data
+        return None
+
+
+class FundingActivityContentSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    source_type = serializers.CharField()
+    total_amount = serializers.DecimalField(max_digits=19, decimal_places=8)
+    total_usd_cents = serializers.IntegerField()
+    activity_date = serializers.DateTimeField()
+    funder = serializers.SerializerMethodField()
+    recipients = serializers.SerializerMethodField()
+
+    def get_funder(self, obj):
+        if (
+            obj.funder
+            and hasattr(obj.funder, "author_profile")
+            and obj.funder.author_profile
+        ):
+            return SimpleAuthorSerializer(obj.funder.author_profile).data
+        return None
+
+    def get_recipients(self, obj):
+        recipients = obj.recipients.select_related(
+            "recipient_user__author_profile"
+        ).all()
+        return FundingActivityRecipientSerializer(recipients, many=True).data
+
+
 class CommentSerializer(serializers.Serializer):
     author = serializers.SerializerMethodField()
     comment_content_json = serializers.JSONField()
@@ -922,6 +959,8 @@ def serialize_feed_item(feed_item, item_content_type):
             return CommentSerializer(feed_item).data
         case "purchase" | "usdfundraisecontribution":
             return FundraiseContributionContentSerializer(feed_item).data
+        case "fundingactivity":
+            return FundingActivityContentSerializer(feed_item).data
         case _:
             return None
 

--- a/src/feed/signals/__init__.py
+++ b/src/feed/signals/__init__.py
@@ -1,5 +1,6 @@
 from .bounty_signals import *  # noqa: F401, F403
 from .comment_signals import *  # noqa: F401, F403
+from .funding_activity_signals import *  # noqa: F401, F403
 from .document_signals import *  # noqa: F401, F403
 from .paper_signals import *  # noqa: F401, F403
 from .post_signals import *  # noqa: F401, F403

--- a/src/feed/signals/funding_activity_signals.py
+++ b/src/feed/signals/funding_activity_signals.py
@@ -1,0 +1,54 @@
+import logging
+
+from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from feed.models import FeedEntry
+from feed.tasks import create_feed_entry
+from user.related_models.funding_activity_model import FundingActivity
+
+logger = logging.getLogger(__name__)
+
+FINANCIAL_FEED_SOURCE_TYPES = (
+    FundingActivity.BOUNTY_PAYOUT,
+    FundingActivity.TIP_REVIEW,
+)
+
+
+@receiver(post_save, sender=FundingActivity)
+def handle_funding_activity_feed_entry(sender, instance, created, **kwargs):
+    """
+    Create a feed entry when a bounty payout or review tip FundingActivity
+    is created.
+    """
+    if not created:
+        return
+    if instance.source_type not in FINANCIAL_FEED_SOURCE_TYPES:
+        return
+
+    try:
+        if instance.unified_document_id:
+            hub_ids = list(instance.unified_document.hubs.values_list("id", flat=True))
+        else:
+            hub_ids = []
+
+        content_type = ContentType.objects.get_for_model(instance)
+        transaction.on_commit(
+            lambda: create_feed_entry.apply_async(
+                args=(
+                    instance.id,
+                    content_type.id,
+                    FeedEntry.PUBLISH,
+                    hub_ids,
+                    instance.funder_id,
+                ),
+                priority=1,
+            )
+        )
+    except Exception:
+        logger.exception(
+            "Error creating feed entry for FundingActivity %s",
+            instance.id,
+        )

--- a/src/feed/tasks.py
+++ b/src/feed/tasks.py
@@ -67,7 +67,9 @@ def create_feed_entry(
     metrics = serialize_feed_metrics(item, item_content_type)
 
     action_date = item.created_date
-    if action == FeedEntry.PUBLISH and item_content_type.model == "paper":
+    if item_content_type.model == "fundingactivity":
+        action_date = item.activity_date
+    elif action == FeedEntry.PUBLISH and item_content_type.model == "paper":
         if item.paper_publish_date and item.paper_publish_date <= timezone.now():
             action_date = item.paper_publish_date
 
@@ -214,6 +216,8 @@ def _get_unified_document(
                 doc = None
         case "usdfundraisecontribution":
             doc = item.fundraise.unified_document
+        case "fundingactivity":
+            doc = item.unified_document
         case _:
             doc = None
 
@@ -251,6 +255,14 @@ def _get_authors_for_item(item: Any, item_content_type: ContentType) -> list[Aut
                 and item.user.author_profile
             ):
                 authors = [item.user.author_profile]
+        case "fundingactivity":
+            if (
+                hasattr(item, "funder")
+                and item.funder
+                and hasattr(item.funder, "author_profile")
+                and item.funder.author_profile
+            ):
+                authors = [item.funder.author_profile]
 
     return authors
 

--- a/src/feed/tests/signals/test_funding_activity_signals.py
+++ b/src/feed/tests/signals/test_funding_activity_signals.py
@@ -1,0 +1,205 @@
+from decimal import Decimal
+from unittest.mock import patch
+
+from django.contrib.contenttypes.models import ContentType
+from django.test import override_settings
+
+from feed.models import FeedEntry
+from feed.serializers import serialize_feed_item
+from feed.tasks import create_feed_entry
+from paper.tests.helpers import create_paper
+from purchase.models import Purchase
+from reputation.models import Bounty, Distribution
+from reputation.related_models.escrow import Escrow, EscrowRecipients
+from researchhub_comment.constants.rh_comment_thread_types import PEER_REVIEW
+from researchhub_comment.models import RhCommentModel, RhCommentThreadModel
+from user.related_models.funding_activity_model import (
+    FundingActivity,
+    FundingActivityRecipient,
+)
+from user.services.funding_activity_service import FundingActivityService
+from user.tasks.funding_activity_tasks import create_funding_activity_task
+from user.tests.helpers import create_user
+from utils.test_helpers import AWSMockTestCase
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True, CELERY_TASK_EAGER_PROPAGATES=True)
+class FundingActivityFeedSignalTests(AWSMockTestCase):
+    def setUp(self):
+        super().setUp()
+        self.funder = create_user(email="funder@test.com")
+        self.recipient = create_user(email="recipient@test.com")
+
+    @patch("feed.signals.funding_activity_signals.transaction")
+    @patch("user.signals.funding_activity_signals.transaction")
+    def test_bounty_payout_creates_feed_entry(
+        self, mock_user_transaction, mock_feed_transaction
+    ):
+        """
+        When a BOUNTY_PAYOUT FundingActivity is created, a feed entry is
+        created with the correct content type, unified document, and funder.
+        """
+        # Arrange
+        mock_user_transaction.on_commit = lambda func: func()
+        mock_feed_transaction.on_commit = lambda func: func()
+
+        def run_task_sync(source_type, source_id):
+            create_funding_activity_task(source_type, source_id)
+
+        with patch(
+            "user.signals.funding_activity_signals.create_funding_activity_task"
+        ) as mock_task:
+            mock_task.delay = run_task_sync
+
+            paper = create_paper(title="Bounty paper", uploaded_by=self.funder)
+            ct_paper = ContentType.objects.get_for_model(paper.__class__)
+            escrow = Escrow.objects.create(
+                hold_type=Escrow.BOUNTY,
+                status=Escrow.PENDING,
+                created_by=self.funder,
+                content_type=ct_paper,
+                object_id=paper.id,
+            )
+            Bounty.objects.create(
+                created_by=self.funder,
+                bounty_type=Bounty.Type.REVIEW,
+                unified_document=paper.unified_document,
+                item_content_type=ct_paper,
+                item_object_id=paper.id,
+                escrow=escrow,
+            )
+            rec = EscrowRecipients.objects.create(
+                escrow=escrow,
+                user=self.recipient,
+                amount=Decimal("25"),
+            )
+
+            # Act
+            escrow.status = Escrow.PAID
+            escrow.save()
+
+        # Assert
+        activity = FundingActivity.objects.get(
+            source_type=FundingActivity.BOUNTY_PAYOUT,
+            source_object_id=rec.pk,
+        )
+        fa_ct = ContentType.objects.get_for_model(FundingActivity)
+        feed_entry = FeedEntry.objects.get(
+            content_type=fa_ct,
+            object_id=activity.id,
+            action=FeedEntry.PUBLISH,
+        )
+        self.assertEqual(feed_entry.unified_document_id, paper.unified_document_id)
+        self.assertEqual(feed_entry.user_id, self.funder.id)
+        self.assertEqual(feed_entry.action_date, activity.activity_date)
+
+        content = serialize_feed_item(activity, fa_ct)
+        self.assertEqual(content["id"], activity.id)
+        self.assertEqual(content["source_type"], FundingActivity.BOUNTY_PAYOUT)
+        self.assertEqual(Decimal(str(content["total_amount"])), Decimal("25"))
+        self.assertEqual(content["funder"]["id"], self.funder.author_profile.id)
+        self.assertEqual(len(content["recipients"]), 1)
+        self.assertEqual(
+            content["recipients"][0]["recipient_user"]["id"],
+            self.recipient.author_profile.id,
+        )
+
+    @patch("feed.signals.funding_activity_signals.transaction")
+    def test_tip_review_creates_feed_entry(self, mock_feed_transaction):
+        """
+        When a TIP_REVIEW FundingActivity is created, a feed entry is created
+        with the correct content type, unified document, and funder.
+        """
+        # Arrange
+        mock_feed_transaction.on_commit = lambda func: func()
+
+        paper = create_paper(title="Review paper", uploaded_by=self.recipient)
+        thread = RhCommentThreadModel.objects.create(
+            content_object=paper,
+            created_by=self.recipient,
+            updated_by=self.recipient,
+        )
+        comment = RhCommentModel.objects.create(
+            thread=thread,
+            created_by=self.recipient,
+            updated_by=self.recipient,
+            comment_type=PEER_REVIEW,
+            comment_content_json={"ops": [{"insert": "Review comment"}]},
+        )
+        ct_comment = ContentType.objects.get_for_model(RhCommentModel)
+        proof_purchase = Purchase.objects.create(
+            user=self.funder,
+            content_type=ct_comment,
+            object_id=comment.id,
+            purchase_type=Purchase.BOOST,
+            paid_status=Purchase.PAID,
+            amount=Decimal("20"),
+            purchase_method=Purchase.OFF_CHAIN,
+        )
+        ct_purchase = ContentType.objects.get_for_model(Purchase)
+        distribution = Distribution.objects.create(
+            giver=self.funder,
+            recipient=self.recipient,
+            amount=Decimal("20"),
+            distribution_type="PURCHASE",
+            proof_item_content_type=ct_purchase,
+            proof_item_object_id=proof_purchase.id,
+        )
+
+        # Act
+        activity = FundingActivityService.create_funding_activity(
+            FundingActivity.TIP_REVIEW,
+            distribution,
+        )
+
+        # Assert
+        self.assertIsNotNone(activity)
+        fa_ct = ContentType.objects.get_for_model(FundingActivity)
+        feed_entry = FeedEntry.objects.get(
+            content_type=fa_ct,
+            object_id=activity.id,
+            action=FeedEntry.PUBLISH,
+        )
+        self.assertEqual(
+            feed_entry.unified_document_id,
+            paper.unified_document_id,
+        )
+        self.assertEqual(feed_entry.user_id, self.funder.id)
+
+        content = serialize_feed_item(activity, fa_ct)
+        self.assertEqual(content["source_type"], FundingActivity.TIP_REVIEW)
+        self.assertEqual(Decimal(str(content["total_amount"])), Decimal("20"))
+        self.assertEqual(content["funder"]["id"], self.funder.author_profile.id)
+        self.assertEqual(len(content["recipients"]), 1)
+
+    def test_create_feed_entry_task_uses_activity_date(self):
+        """create_feed_entry uses activity_date for FundingActivity rows."""
+        # Arrange
+        paper = create_paper(title="Task paper", uploaded_by=self.funder)
+        activity = FundingActivity.objects.create(
+            funder=self.funder,
+            source_type=FundingActivity.BOUNTY_PAYOUT,
+            total_amount=Decimal("10"),
+            unified_document=paper.unified_document,
+            activity_date=paper.created_date,
+            source_content_type=ContentType.objects.get_for_model(EscrowRecipients),
+            source_object_id=999_999,
+        )
+        FundingActivityRecipient.objects.create(
+            activity=activity,
+            recipient_user=self.recipient,
+            amount=Decimal("10"),
+        )
+        fa_ct = ContentType.objects.get_for_model(FundingActivity)
+
+        # Act
+        feed_entry = create_feed_entry(
+            activity.id,
+            fa_ct.id,
+            FeedEntry.PUBLISH,
+            [],
+            self.funder.id,
+        )
+
+        # Assert
+        self.assertEqual(feed_entry.action_date, activity.activity_date)

--- a/src/feed/tests/views/test_activity_feed_view.py
+++ b/src/feed/tests/views/test_activity_feed_view.py
@@ -38,6 +38,7 @@ from researchhub_document.related_models.researchhub_post_model import Researchh
 from researchhub_document.related_models.researchhub_unified_document_model import (
     ResearchhubUnifiedDocument,
 )
+from user.related_models.funding_activity_model import FundingActivity
 from user.related_models.user_model import AI_EXPERT_EMAIL
 from utils.test_helpers import AWSMockTestCase, create_test_user
 
@@ -982,6 +983,13 @@ class ActivityFeedFinancialScopeTests(AWSMockTestCase):
         self.user = create_test_user()
         self.client = APIClient()
 
+        RscExchangeRate.objects.create(
+            price_source=MORALIS,
+            rate=3.0,
+            real_rate=3.0,
+            target_currency=USD,
+        )
+
         self.proposal_doc = ResearchhubUnifiedDocument.objects.create(
             document_type=PREREGISTRATION,
         )
@@ -1085,6 +1093,59 @@ class ActivityFeedFinancialScopeTests(AWSMockTestCase):
             user=self.user,
         )
 
+        self.bounty_fa = FundingActivity.objects.create(
+            funder=self.user,
+            source_type=FundingActivity.BOUNTY_PAYOUT,
+            total_amount=Decimal("25"),
+            total_usd_cents=500,
+            unified_document=self.proposal_doc,
+            activity_date=timezone.now(),
+            source_content_type=ContentType.objects.get_for_model(Purchase),
+            source_object_id=self.rsc_contribution.id,
+        )
+        self.bounty_fa_entry = _make_feed_entry(
+            FundingActivity,
+            self.bounty_fa.id,
+            self.proposal_doc,
+            user=self.user,
+        )
+
+        self.tip_review_fa = FundingActivity.objects.create(
+            funder=self.user,
+            source_type=FundingActivity.TIP_REVIEW,
+            total_amount=Decimal("20"),
+            total_usd_cents=400,
+            unified_document=self.proposal_doc,
+            activity_date=timezone.now(),
+            source_content_type=ContentType.objects.get_for_model(
+                UsdFundraiseContribution
+            ),
+            source_object_id=self.usd_contribution.id,
+        )
+        self.tip_review_fa_entry = _make_feed_entry(
+            FundingActivity,
+            self.tip_review_fa.id,
+            self.proposal_doc,
+            user=self.user,
+        )
+
+        self.tip_document_fa = FundingActivity.objects.create(
+            funder=self.user,
+            source_type=FundingActivity.TIP_DOCUMENT,
+            total_amount=Decimal("10"),
+            total_usd_cents=200,
+            unified_document=self.unrelated_doc,
+            activity_date=timezone.now(),
+            source_content_type=ContentType.objects.get_for_model(Purchase),
+            source_object_id=self.boost_purchase.id,
+        )
+        self.tip_document_fa_entry = _make_feed_entry(
+            FundingActivity,
+            self.tip_document_fa.id,
+            self.unrelated_doc,
+            user=self.user,
+        )
+
     def test_scope_financial_includes_rsc_and_usd_contributions(self):
         # Act
         resp = self.client.get(ACTIVITY_LIST_URL, {"scope": "financial"})
@@ -1106,6 +1167,42 @@ class ActivityFeedFinancialScopeTests(AWSMockTestCase):
         ids = {entry["id"] for entry in resp.data["results"]}
         self.assertIn(self.grant_entry.id, ids)
         self.assertNotIn(self.unrelated_entry.id, ids)
+
+    def test_scope_financial_includes_bounty_and_tip_review_funding_activities(self):
+        # Act
+        resp = self.client.get(ACTIVITY_LIST_URL, {"scope": "financial"})
+
+        # Assert
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        ids = {entry["id"] for entry in resp.data["results"]}
+        self.assertIn(self.bounty_fa_entry.id, ids)
+        self.assertIn(self.tip_review_fa_entry.id, ids)
+        self.assertNotIn(self.tip_document_fa_entry.id, ids)
+
+    def test_scope_financial_funding_activity_has_related_work(self):
+        # Act
+        resp = self.client.get(ACTIVITY_LIST_URL, {"scope": "financial"})
+
+        # Assert
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        bounty_result = next(
+            entry
+            for entry in resp.data["results"]
+            if entry["id"] == self.bounty_fa_entry.id
+        )
+        self.assertIsNotNone(bounty_result["related_work"])
+        self.assertEqual(
+            bounty_result["related_work"]["document_type"],
+            PREREGISTRATION,
+        )
+        self.assertEqual(
+            bounty_result["related_work"]["unified_document_id"],
+            self.proposal_doc.id,
+        )
+        self.assertEqual(
+            bounty_result["related_work"]["title"],
+            self.proposal_post.title,
+        )
 
 
 class ActivityFeedFunderFilterTests(APITestCase):

--- a/src/feed/views/activity_feed_view.py
+++ b/src/feed/views/activity_feed_view.py
@@ -1,5 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Count, Prefetch, Q
+from django.db.models import Count, Exists, OuterRef, Prefetch, Q
 from rest_framework.viewsets import ModelViewSet
 
 from feed.models import FeedEntry
@@ -24,6 +24,7 @@ from researchhub_comment.related_models.rh_comment_thread_model import (
 )
 from researchhub_document.related_models.constants.document_type import GRANT
 from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
+from user.related_models.funding_activity_model import FundingActivity
 from user.related_models.user_model import AI_EXPERT_EMAIL
 
 
@@ -37,8 +38,8 @@ class ActivityFeedViewSet(FeedViewMixin, ModelViewSet):
         every preregistration that applied to any grant.
         "peer_reviews" returns only peer review comments.
         "financial" returns fundraise contribution activity
-        (RSC and USD contributions) and approved grant post
-        feed entries.
+        (RSC and USD contributions), approved grant post
+        feed entries, bounty payouts, and review tips.
       - document_type: PREREGISTRATION, GRANT, etc.
       - grant_id: all activity on a grant and its applied preregistrations
       - funder_id: all activity on OPEN/COMPLETED grants where this user is
@@ -235,17 +236,25 @@ class ActivityFeedViewSet(FeedViewMixin, ModelViewSet):
     @staticmethod
     def _filter_financial_activities(queryset):
         """
-        Return feed entries for fundraise contributions and grant post
-        publications.
+        Return feed entries for fundraise contributions, grant post
+        publications, bounty payouts, and review tips.
         """
         purchase_type = ContentType.objects.get_for_model(Purchase)
         usd_contribution_type = ContentType.objects.get_for_model(
             UsdFundraiseContribution
         )
         post_ct = ContentType.objects.get_for_model(ResearchhubPost)
+        fa_ct = ContentType.objects.get_for_model(FundingActivity)
         contribution_purchase_ids = Purchase.objects.filter(
             purchase_type=Purchase.FUNDRAISE_CONTRIBUTION
         ).values_list("id", flat=True)
+        financial_funding_activity = FundingActivity.objects.filter(
+            id=OuterRef("object_id"),
+            source_type__in=[
+                FundingActivity.BOUNTY_PAYOUT,
+                FundingActivity.TIP_REVIEW,
+            ],
+        )
 
         return queryset.filter(
             Q(
@@ -257,6 +266,7 @@ class ActivityFeedViewSet(FeedViewMixin, ModelViewSet):
                 content_type=post_ct,
                 unified_document__document_type=GRANT,
             )
+            | (Q(content_type=fa_ct) & Q(Exists(financial_funding_activity)))
         )
 
     @staticmethod


### PR DESCRIPTION
## What?

- Add a feed signal that creates `FeedEntry` rows when `FundingActivity` is created for `BOUNTY_PAYOUT` or `TIP_REVIEW` 
- Add `FundingActivityContentSerializer` and wire it into `serialize_feed_item()` so activity feed entries expose funder, recipients, amounts, and `activity_date`
- Extend `?scope=financial` on `/api/activity_feed/` to include bounty payout and review tip feed entries

## Why?

- The activity feed already surfaces fundraise contributions and grant posts under `?scope=financial`, but bounty payouts and review tips only existed as `FundingActivity` records
