### PR TITLE
Fix UP017: Use `datetime.UTC`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ extend-select = [
     "E",    # pycodestyle errors
     "W",    # pycodestyle warnings
     "I",    # isort
+    "UP017",  # datetime-timezone-utc
     "T20",  # flake8-print: forbid print statements
     "TID251",  # flake8-tidy-imports
 ]


### PR DESCRIPTION
See: https://docs.astral.sh/ruff/rules/datetime-timezone-utc/#datetime-timezone-utc-up017