### PR TITLE
Fix OpenAI chat fallback for GPT-5 models using max_completion_tokens

### DIFF
--- a/src/ai_peer_review/services/openai_web_context_service.py
+++ b/src/ai_peer_review/services/openai_web_context_service.py
@@ -119,7 +119,7 @@ class OpenAIReviewContextService:
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt},
             ],
-            max_tokens=max_tokens,
+            max_completion_tokens=max_tokens,
             temperature=temperature,
         )
         choice = completion.choices[0].message

--- a/src/ai_peer_review/tests/test_llm_services.py
+++ b/src/ai_peer_review/tests/test_llm_services.py
@@ -114,3 +114,6 @@ class OpenAIReviewContextServiceTests(SimpleTestCase):
         svc = OpenAIReviewContextService()
         self.assertEqual(svc.invoke("s", "u"), "fallback")
         mock_client.chat.completions.create.assert_called_once()
+        cc_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        self.assertEqual(cc_kwargs["max_completion_tokens"], 2048)
+        self.assertNotIn("max_tokens", cc_kwargs)

--- a/src/research_ai/services/openai_expert_finder_service.py
+++ b/src/research_ai/services/openai_expert_finder_service.py
@@ -106,7 +106,7 @@ class OpenAIExpertFinderService:
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt},
             ],
-            max_tokens=max_tokens,
+            max_completion_tokens=max_tokens,
             temperature=temperature,
         )
         choice = completion.choices[0].message

--- a/src/research_ai/tests/test_openai_expert_finder_service.py
+++ b/src/research_ai/tests/test_openai_expert_finder_service.py
@@ -81,7 +81,8 @@ class OpenAIExpertFinderServiceTests(TestCase):
                 {"role": "user", "content": "user"},
             ],
         )
-        self.assertEqual(cc_kwargs["max_tokens"], 100)
+        self.assertEqual(cc_kwargs["max_completion_tokens"], 100)
+        self.assertNotIn("max_tokens", cc_kwargs)
         self.assertEqual(cc_kwargs["temperature"], 0.0)
 
     @override_settings(OPENAI_API_KEY="sk-test")


### PR DESCRIPTION
## What/Why?
- Chat Completions fallback for web context and expert finder failed with `400 unsupported_parameter` when using `gpt-5.4-mini`, because GPT-5 models reject `max_tokens` and require `max_completion_tokens`.
- When the Responses API + `web_search` path failed, the fallback threw a misleading second error instead of attempting a valid chat completion call.

## How?
- Updated `_invoke_chat_completions` to pass `max_completion_tokens` instead of `max_tokens`.
