### PR TITLE
Bug: Proposal AI reviews were failing for some proposals

### DIFF
--- a/src/ai_peer_review/services/bedrock_llm_service.py
+++ b/src/ai_peer_review/services/bedrock_llm_service.py
@@ -6,12 +6,12 @@ from utils.aws import bedrock_runtime_client
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 BEDROCK_MODEL_ID = getattr(
     settings,
     "AI_PEER_REVIEW_BEDROCK_MODEL_ID",
-    _DEFAULT_MODEL,
+    DEFAULT_BEDROCK_MODEL_ID,
 )
 
 _BEDROCK_OMIT_TEMPERATURE_SUBSTRINGS: tuple[str, ...] = ("opus-4-7",)
@@ -30,9 +30,9 @@ def _converse_inference_config(
 class BedrockLLMService:
     """Invoke Bedrock for structured proposal review JSON (and related tasks)."""
 
-    def __init__(self):
+    def __init__(self, model_id: str | None = None):
         self.bedrock_client = bedrock_runtime_client()
-        self.model_id = BEDROCK_MODEL_ID
+        self.model_id = model_id or BEDROCK_MODEL_ID
 
     def invoke(
         self,

--- a/src/ai_peer_review/services/proposal_review_service.py
+++ b/src/ai_peer_review/services/proposal_review_service.py
@@ -9,7 +9,10 @@ from ai_peer_review.prompts.proposal_review_prompts import (
     build_proposal_review_user_prompt,
     get_proposal_review_system_prompt,
 )
-from ai_peer_review.services.bedrock_llm_service import BedrockLLMService
+from ai_peer_review.services.bedrock_llm_service import (
+    DEFAULT_BEDROCK_MODEL_ID,
+    BedrockLLMService,
+)
 from ai_peer_review.services.openai_web_context_service import (
     fetch_proposal_review_web_context,
 )
@@ -130,6 +133,20 @@ def run_proposal_review(review_id: int) -> None:
             max_tokens=PROPOSAL_REVIEW_MAX_OUTPUT_TOKENS,
             temperature=0.0,
         )
+        if not (raw or "").strip() and llm.model_id != DEFAULT_BEDROCK_MODEL_ID:
+            logger.warning(
+                "Proposal review %s: %s returned no text; retrying with %s",
+                review_id,
+                llm.model_id,
+                DEFAULT_BEDROCK_MODEL_ID,
+            )
+            llm = BedrockLLMService(model_id=DEFAULT_BEDROCK_MODEL_ID)
+            raw = llm.invoke(
+                system,
+                user,
+                max_tokens=PROPOSAL_REVIEW_MAX_OUTPUT_TOKENS,
+                temperature=0.0,
+            )
         review.progress = 70
         review.current_step = "Normalizing scores"
         review.save(update_fields=["progress", "current_step", "updated_date"])

--- a/src/researchhub_document/related_models/researchhub_post_model.py
+++ b/src/researchhub_document/related_models/researchhub_post_model.py
@@ -14,6 +14,7 @@ from researchhub_comment.models import RhCommentThreadModel
 from researchhub_document.related_models.constants.document_type import (
     DISCUSSION,
     DOCUMENT_TYPES,
+    RESEARCHHUB_POST_DOCUMENT_TYPES,
 )
 from researchhub_document.related_models.constants.editor_type import (
     CK_EDITOR,
@@ -262,7 +263,7 @@ class ResearchhubPost(AbstractGenericReactionModel):
 
     def get_full_markdown(self):
         try:
-            if self.document_type == DISCUSSION:
+            if self.document_type in RESEARCHHUB_POST_DOCUMENT_TYPES:
                 byte_string = self.discussion_src.read()
             else:
                 byte_string = self.eln_src.read()

--- a/src/researchhub_document/tests/test_models.py
+++ b/src/researchhub_document/tests/test_models.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.core.files.base import ContentFile
 from django.test import TestCase
 
 from hub.models import Hub
@@ -10,6 +11,10 @@ from paper.tests.helpers import create_paper
 from researchhub_comment.related_models.rh_comment_model import RhCommentModel
 from researchhub_comment.tests.helpers import create_rh_comment
 from researchhub_document.helpers import create_post
+from researchhub_document.related_models.constants.document_type import (
+    NOTE,
+    PREREGISTRATION,
+)
 from researchhub_document.related_models.researchhub_unified_document_model import (
     ResearchhubUnifiedDocument,
 )


### PR DESCRIPTION
## What/Why?
- two separate cases:
  - **_Wrong file field for proposal text._** preregistrations store full markdown in `discussion_src`, but `get_full_markdown()` only read `discussion_src` for `DISCUSSION` posts. That caused `eln_src` errors.
  - **_Bedrock Opus content filtering_**. with `AI_PEER_REVIEW_BEDROCK_MODEL_ID` set to Opus, sensitive biology/antiviral proposals get `content_filtered` and an empty model response. That looked like a JSON parse failure, but the model never produced output.

## How?
- `ResearchhubPost.get_full_markdown()`. read `discussion_src` for all `RESEARCHHUB_POST_DOCUMENT_TYPES` _(not only `DISCUSSION`)_
- `run_proposal_review()`. try the configured primary model first(OPUS); if the response is empty and primary != DEFAULT, log a warning and retry once with `DEFAULT_BEDROCK_MODEL_ID`