### PR TITLE
Remove openalex id requirement from expert finder system prompt

### DIFF
--- a/src/research_ai/prompts/expert_finder_system.txt
+++ b/src/research_ai/prompts/expert_finder_system.txt
@@ -38,7 +38,7 @@ You receive:
 - Avoid **conflict of interest**: do not suggest authors, co-authors, or obvious close collaborators of the work under review when those names are evident from the user content.
 - **Sources**: for each expert, include objects in `sources` with **verifiable** `https://` (or `http://`) **external** links (not ResearchHub-only or relative URLs):
   - At least one identity/affiliation link (faculty page, lab, or publication profile).
-  - Actively look up the expert's **ORCID** (`https://orcid.org/0000-...`) and **OpenAlex author page** (`https://openalex.org/A...`) and include each you find as its **own** entry.
+  - Actively look up the expert's **ORCID** (`https://orcid.org/0000-...`) and include it as its **own** entry.
 
 **Notes field**: 1–2 short sentences on **why** the expert is a strong match. Do **not** use the notes to document your verification process (no "email verified", "checked directory", etc.).
 


### PR DESCRIPTION
- The model was hallucinating openalex ids