### PR TITLE
Add document-scoped expert email outreach history to search detail API

### DIFF
--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -165,9 +165,7 @@ class ExpertSerializer(serializers.Serializer):
         history = self._outreach_history_for(obj)
         if history is None:
             return []
-        return serialize_expert_outreach_history(history)[
-            "emailed_on_other_documents"
-        ]
+        return serialize_expert_outreach_history(history)["emailed_on_other_documents"]
 
     def get_display_name(self, obj):
         return ExpertDisplay.display_name_for(obj)

--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -18,6 +18,10 @@ from research_ai.models import (
     SearchExpert,
 )
 from research_ai.services.expert_display import ExpertDisplay
+from research_ai.services.expert_outreach_history_service import (
+    build_expert_outreach_history_map,
+    serialize_expert_outreach_history,
+)
 from research_ai.services.invited_experts_service import (
     EDITOR_SORT_FIELDS,
     default_overview_date_range,
@@ -140,7 +144,30 @@ class ExpertSerializer(serializers.Serializer):
     notes = serializers.CharField(allow_blank=True)
     sources = serializers.ListField(required=False, allow_null=True)
     last_email_sent_at = serializers.DateTimeField(allow_null=True)
+    emailed_for_current_document = serializers.SerializerMethodField()
+    emailed_on_other_documents = serializers.SerializerMethodField()
     display_name = serializers.SerializerMethodField()
+
+    def _outreach_history_for(self, obj):
+        by_email = self.context.get("expert_outreach_by_email") or {}
+        email = ExpertDisplay.normalize_email(getattr(obj, "email", "") or "")
+        return by_email.get(email)
+
+    def get_emailed_for_current_document(self, obj):
+        history = self._outreach_history_for(obj)
+        if history is None:
+            return None
+        return serialize_expert_outreach_history(history)[
+            "emailed_for_current_document"
+        ]
+
+    def get_emailed_on_other_documents(self, obj):
+        history = self._outreach_history_for(obj)
+        if history is None:
+            return []
+        return serialize_expert_outreach_history(history)[
+            "emailed_on_other_documents"
+        ]
 
     def get_display_name(self, obj):
         return ExpertDisplay.display_name_for(obj)
@@ -408,8 +435,19 @@ class ExpertSearchDetailSerializer(serializers.ModelSerializer):
             .order_by("-expert__is_manually_added", "position")
         )
         experts = [se.expert for se in qs]
+        outreach_by_email = build_expert_outreach_history_map(
+            expert_emails=[e.email for e in experts],
+            current_unified_document_id=obj.unified_document_id,
+        )
 
-        return ExpertSerializer(experts, many=True).data
+        return ExpertSerializer(
+            experts,
+            many=True,
+            context={
+                **self.context,
+                "expert_outreach_by_email": outreach_by_email,
+            },
+        ).data
 
     def get_report_urls(self, obj):
         out = {}

--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -19,8 +19,8 @@ from research_ai.models import (
 )
 from research_ai.services.expert_display import ExpertDisplay
 from research_ai.services.expert_outreach_history_service import (
+    ExpertOutreachHistory,
     build_expert_outreach_history_map,
-    serialize_expert_outreach_history,
 )
 from research_ai.services.invited_experts_service import (
     EDITOR_SORT_FIELDS,
@@ -130,6 +130,37 @@ class ExpertSearchCreateSerializer(serializers.Serializer):
         return attrs
 
 
+class ExpertCurrentDocumentOutreachSerializer(serializers.Serializer):
+    sent_at = serializers.CharField()
+    search_id = serializers.IntegerField()
+
+
+class ExpertOutreachDocumentRefSerializer(serializers.Serializer):
+    unified_document_id = serializers.IntegerField()
+    document_type = serializers.CharField()
+    title = serializers.CharField()
+    slug = serializers.CharField()
+    id = serializers.IntegerField()
+    sent_at = serializers.CharField()
+    search_id = serializers.IntegerField()
+
+
+class ExpertOutreachHistorySerializer(serializers.Serializer):
+    emailed_for_current_document = ExpertCurrentDocumentOutreachSerializer(
+        allow_null=True,
+        required=False,
+    )
+    emailed_on_other_documents = ExpertOutreachDocumentRefSerializer(many=True)
+
+    def to_representation(self, instance: ExpertOutreachHistory | None):
+        if instance is None:
+            return {
+                "emailed_for_current_document": None,
+                "emailed_on_other_documents": [],
+            }
+        return super().to_representation(instance)
+
+
 class ExpertSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     honorific = serializers.CharField(allow_blank=True)
@@ -157,15 +188,18 @@ class ExpertSerializer(serializers.Serializer):
         history = self._outreach_history_for(obj)
         if history is None:
             return None
-        return serialize_expert_outreach_history(history)[
-            "emailed_for_current_document"
-        ]
+        return ExpertCurrentDocumentOutreachSerializer(
+            history.emailed_for_current_document
+        ).data
 
     def get_emailed_on_other_documents(self, obj):
         history = self._outreach_history_for(obj)
         if history is None:
             return []
-        return serialize_expert_outreach_history(history)["emailed_on_other_documents"]
+        return ExpertOutreachDocumentRefSerializer(
+            history.emailed_on_other_documents,
+            many=True,
+        ).data
 
     def get_display_name(self, obj):
         return ExpertDisplay.display_name_for(obj)

--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -186,7 +186,7 @@ class ExpertSerializer(serializers.Serializer):
 
     def get_emailed_for_current_document(self, obj):
         history = self._outreach_history_for(obj)
-        if history is None:
+        if history is None or history.emailed_for_current_document is None:
             return None
         return ExpertCurrentDocumentOutreachSerializer(
             history.emailed_for_current_document

--- a/src/research_ai/services/expert_outreach_history_service.py
+++ b/src/research_ai/services/expert_outreach_history_service.py
@@ -1,11 +1,19 @@
 from dataclasses import dataclass
-from typing import Any
 
 from research_ai.models import GeneratedEmail
 from research_ai.services.expert_display import ExpertDisplay
 from researchhub_document.related_models.researchhub_unified_document_model import (
     ResearchhubUnifiedDocument,
 )
+
+
+@dataclass(frozen=True)
+class DocumentOutreachMeta:
+    unified_document_id: int
+    document_type: str
+    title: str
+    slug: str
+    id: int
 
 
 @dataclass(frozen=True)
@@ -31,74 +39,22 @@ class ExpertOutreachHistory:
     emailed_on_other_documents: list[ExpertOutreachDocumentRef]
 
 
-def _document_title_from_doc(doc) -> str:
-    if hasattr(doc, "display_title"):
-        return (doc.display_title or "").strip()[:512]
-    if hasattr(doc, "title"):
-        return (str(doc.title or "")).strip()[:512]
-    return ""
-
-
-def _document_ref_from_unified_doc(
+def _document_meta_from_unified_doc(
     unified_doc: ResearchhubUnifiedDocument,
-) -> dict[str, Any] | None:
+) -> DocumentOutreachMeta | None:
     try:
         doc = unified_doc.get_document()
         if doc is None:
             return None
-        doc_type = (unified_doc.document_type or "").strip()
-        if not doc_type:
-            return None
-        return {
-            "unified_document_id": unified_doc.id,
-            "document_type": doc_type,
-            "title": _document_title_from_doc(doc),
-            "slug": getattr(doc, "slug", "") or "",
-            "id": doc.id,
-        }
+        return DocumentOutreachMeta(
+            unified_document_id=unified_doc.id,
+            document_type=unified_doc.document_type,
+            title=unified_doc.get_display_title(),
+            slug=unified_doc.get_document_slug(),
+            id=doc.id,
+        )
     except Exception:
         return None
-
-
-def _serialize_current_outreach(
-    entry: ExpertCurrentDocumentOutreach | None,
-) -> dict[str, Any] | None:
-    if entry is None:
-        return None
-    return {
-        "sent_at": entry.sent_at,
-        "search_id": entry.search_id,
-    }
-
-
-def _serialize_document_ref(ref: ExpertOutreachDocumentRef) -> dict[str, Any]:
-    return {
-        "unified_document_id": ref.unified_document_id,
-        "document_type": ref.document_type,
-        "title": ref.title,
-        "slug": ref.slug,
-        "id": ref.id,
-        "sent_at": ref.sent_at,
-        "search_id": ref.search_id,
-    }
-
-
-def serialize_expert_outreach_history(
-    history: ExpertOutreachHistory | None,
-) -> dict[str, Any]:
-    if history is None:
-        return {
-            "emailed_for_current_document": None,
-            "emailed_on_other_documents": [],
-        }
-    return {
-        "emailed_for_current_document": _serialize_current_outreach(
-            history.emailed_for_current_document
-        ),
-        "emailed_on_other_documents": [
-            _serialize_document_ref(ref) for ref in history.emailed_on_other_documents
-        ],
-    }
 
 
 def build_expert_outreach_history_map(
@@ -135,7 +91,7 @@ def build_expert_outreach_history_map(
 
     current_by_email: dict[str, ExpertCurrentDocumentOutreach] = {}
     other_by_email_doc: dict[str, dict[int, ExpertOutreachDocumentRef]] = {}
-    doc_meta_cache: dict[int, dict[str, Any] | None] = {}
+    doc_meta_cache: dict[int, DocumentOutreachMeta | None] = {}
 
     for row in rows:
         email = ExpertDisplay.normalize_email(row.expert_email or "")
@@ -163,7 +119,9 @@ def build_expert_outreach_history_map(
             continue
 
         if unified_doc_id not in doc_meta_cache:
-            doc_meta_cache[unified_doc_id] = _document_ref_from_unified_doc(unified_doc)
+            doc_meta_cache[unified_doc_id] = _document_meta_from_unified_doc(
+                unified_doc
+            )
         meta = doc_meta_cache[unified_doc_id]
         if meta is None:
             continue
@@ -173,11 +131,11 @@ def build_expert_outreach_history_map(
             continue
 
         per_email[unified_doc_id] = ExpertOutreachDocumentRef(
-            unified_document_id=meta["unified_document_id"],
-            document_type=meta["document_type"],
-            title=meta["title"],
-            slug=meta["slug"],
-            id=meta["id"],
+            unified_document_id=meta.unified_document_id,
+            document_type=meta.document_type,
+            title=meta.title,
+            slug=meta.slug,
+            id=meta.id,
             sent_at=sent_at,
             search_id=search_id,
         )

--- a/src/research_ai/services/expert_outreach_history_service.py
+++ b/src/research_ai/services/expert_outreach_history_service.py
@@ -186,8 +186,6 @@ def build_expert_outreach_history_map(
     for email in normalized:
         out[email] = ExpertOutreachHistory(
             emailed_for_current_document=current_by_email.get(email),
-            emailed_on_other_documents=list(
-                other_by_email_doc.get(email, {}).values()
-            ),
+            emailed_on_other_documents=list(other_by_email_doc.get(email, {}).values()),
         )
     return out

--- a/src/research_ai/services/expert_outreach_history_service.py
+++ b/src/research_ai/services/expert_outreach_history_service.py
@@ -1,0 +1,193 @@
+from dataclasses import dataclass
+from typing import Any
+
+from research_ai.models import GeneratedEmail
+from research_ai.services.expert_display import ExpertDisplay
+from researchhub_document.related_models.researchhub_unified_document_model import (
+    ResearchhubUnifiedDocument,
+)
+
+
+@dataclass(frozen=True)
+class ExpertOutreachDocumentRef:
+    unified_document_id: int
+    document_type: str
+    title: str
+    slug: str
+    id: int
+    sent_at: str
+    search_id: int
+
+
+@dataclass(frozen=True)
+class ExpertCurrentDocumentOutreach:
+    sent_at: str
+    search_id: int
+
+
+@dataclass(frozen=True)
+class ExpertOutreachHistory:
+    emailed_for_current_document: ExpertCurrentDocumentOutreach | None
+    emailed_on_other_documents: list[ExpertOutreachDocumentRef]
+
+
+def _document_title_from_doc(doc) -> str:
+    if hasattr(doc, "display_title"):
+        return (doc.display_title or "").strip()[:512]
+    if hasattr(doc, "title"):
+        return (str(doc.title or "")).strip()[:512]
+    return ""
+
+
+def _document_ref_from_unified_doc(
+    unified_doc: ResearchhubUnifiedDocument,
+) -> dict[str, Any] | None:
+    try:
+        doc = unified_doc.get_document()
+        if doc is None:
+            return None
+        doc_type = (unified_doc.document_type or "").strip()
+        if not doc_type:
+            return None
+        return {
+            "unified_document_id": unified_doc.id,
+            "document_type": doc_type,
+            "title": _document_title_from_doc(doc),
+            "slug": getattr(doc, "slug", "") or "",
+            "id": doc.id,
+        }
+    except Exception:
+        return None
+
+
+def _serialize_current_outreach(
+    entry: ExpertCurrentDocumentOutreach | None,
+) -> dict[str, Any] | None:
+    if entry is None:
+        return None
+    return {
+        "sent_at": entry.sent_at,
+        "search_id": entry.search_id,
+    }
+
+
+def _serialize_document_ref(ref: ExpertOutreachDocumentRef) -> dict[str, Any]:
+    return {
+        "unified_document_id": ref.unified_document_id,
+        "document_type": ref.document_type,
+        "title": ref.title,
+        "slug": ref.slug,
+        "id": ref.id,
+        "sent_at": ref.sent_at,
+        "search_id": ref.search_id,
+    }
+
+
+def serialize_expert_outreach_history(
+    history: ExpertOutreachHistory | None,
+) -> dict[str, Any]:
+    if history is None:
+        return {
+            "emailed_for_current_document": None,
+            "emailed_on_other_documents": [],
+        }
+    return {
+        "emailed_for_current_document": _serialize_current_outreach(
+            history.emailed_for_current_document
+        ),
+        "emailed_on_other_documents": [
+            _serialize_document_ref(ref) for ref in history.emailed_on_other_documents
+        ],
+    }
+
+
+def build_expert_outreach_history_map(
+    *,
+    expert_emails: list[str],
+    current_unified_document_id: int | None,
+) -> dict[str, ExpertOutreachHistory]:
+    """
+    Return per-email outreach history from sent ``GeneratedEmail`` rows.
+
+    ``emailed_for_current_document`` is scoped to ``current_unified_document_id``.
+    ``emailed_on_other_documents`` lists the latest send per other linked document.
+    """
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in expert_emails:
+        email = ExpertDisplay.normalize_email(raw)
+        if email and email not in seen:
+            seen.add(email)
+            normalized.append(email)
+
+    if not normalized:
+        return {}
+
+    rows = (
+        GeneratedEmail.objects.filter(
+            expert_email__in=normalized,
+            status=GeneratedEmail.Status.SENT,
+            expert_search__isnull=False,
+        )
+        .select_related("expert_search__unified_document")
+        .order_by("-updated_date", "-id")
+    )
+
+    current_by_email: dict[str, ExpertCurrentDocumentOutreach] = {}
+    other_by_email_doc: dict[str, dict[int, ExpertOutreachDocumentRef]] = {}
+    doc_meta_cache: dict[int, dict[str, Any] | None] = {}
+
+    for row in rows:
+        email = ExpertDisplay.normalize_email(row.expert_email or "")
+        if not email:
+            continue
+
+        expert_search = row.expert_search
+        unified_doc = getattr(expert_search, "unified_document", None)
+        unified_doc_id = getattr(unified_doc, "id", None)
+        sent_at = row.updated_date.isoformat() if row.updated_date else ""
+        search_id = expert_search.id
+
+        if unified_doc_id is None:
+            continue
+
+        if (
+            current_unified_document_id is not None
+            and unified_doc_id == current_unified_document_id
+        ):
+            if email not in current_by_email:
+                current_by_email[email] = ExpertCurrentDocumentOutreach(
+                    sent_at=sent_at,
+                    search_id=search_id,
+                )
+            continue
+
+        if unified_doc_id not in doc_meta_cache:
+            doc_meta_cache[unified_doc_id] = _document_ref_from_unified_doc(unified_doc)
+        meta = doc_meta_cache[unified_doc_id]
+        if meta is None:
+            continue
+
+        per_email = other_by_email_doc.setdefault(email, {})
+        if unified_doc_id in per_email:
+            continue
+
+        per_email[unified_doc_id] = ExpertOutreachDocumentRef(
+            unified_document_id=meta["unified_document_id"],
+            document_type=meta["document_type"],
+            title=meta["title"],
+            slug=meta["slug"],
+            id=meta["id"],
+            sent_at=sent_at,
+            search_id=search_id,
+        )
+
+    out: dict[str, ExpertOutreachHistory] = {}
+    for email in normalized:
+        out[email] = ExpertOutreachHistory(
+            emailed_for_current_document=current_by_email.get(email),
+            emailed_on_other_documents=list(
+                other_by_email_doc.get(email, {}).values()
+            ),
+        )
+    return out

--- a/src/research_ai/tests/test_serializers.py
+++ b/src/research_ai/tests/test_serializers.py
@@ -147,6 +147,8 @@ class ExpertSearchDetailSerializerTests(TestCase):
         self.assertEqual(ser.data["experts"][0]["email"], "v2@x.edu")
         self.assertIn("last_email_sent_at", ser.data["experts"][0])
         self.assertIsNone(ser.data["experts"][0]["last_email_sent_at"])
+        self.assertIsNone(ser.data["experts"][0]["emailed_for_current_document"])
+        self.assertEqual(ser.data["experts"][0]["emailed_on_other_documents"], [])
 
     def test_manually_added_experts_returned_first(self):
         # Existing setUp seeded a non-manual expert at position 0.
@@ -285,6 +287,90 @@ class ExpertSearchDetailSerializerWorkTests(TestCase):
         self.assertEqual(work["slug"], paper.slug)
         self.assertIn("file", work)
         self.assertIn("pdf_url", work)
+
+
+class ExpertSearchDetailSerializerOutreachTests(TestCase):
+    def setUp(self):
+        from paper.tests.helpers import create_paper
+
+        self.user = create_random_authenticated_user("outreach")
+        self.paper_a = create_paper(
+            title="RFP A",
+            paper_publish_date="2020-01-01",
+        )
+        self.paper_b = create_paper(
+            title="RFP B Paper Title",
+            paper_publish_date="2020-01-02",
+        )
+        self.search_a = ExpertSearch.objects.create(
+            created_by=self.user,
+            unified_document=self.paper_a.unified_document,
+            query="Search A",
+            status=ExpertSearch.Status.COMPLETED,
+        )
+        self.search_b = ExpertSearch.objects.create(
+            created_by=self.user,
+            unified_document=self.paper_b.unified_document,
+            query="Search B",
+            status=ExpertSearch.Status.COMPLETED,
+        )
+        self.expert = Expert.objects.create(
+            email="scoped@uni.edu",
+            first_name="Scoped",
+            last_name="Expert",
+        )
+        SearchExpert.objects.create(
+            expert_search=self.search_a, expert=self.expert, position=0
+        )
+
+    def test_emailed_for_current_document_when_sent_on_same_unified_doc(self):
+        GeneratedEmail.objects.create(
+            created_by=self.user,
+            expert_search=self.search_a,
+            expert_email="scoped@uni.edu",
+            status=GeneratedEmail.Status.SENT,
+        )
+        ser = ExpertSearchDetailSerializer(self.search_a)
+        expert = ser.data["experts"][0]
+        self.assertIsNotNone(expert["emailed_for_current_document"])
+        self.assertEqual(
+            expert["emailed_for_current_document"]["search_id"], self.search_a.id
+        )
+        self.assertEqual(expert["emailed_on_other_documents"], [])
+
+    def test_other_document_email_does_not_set_current_document_flag(self):
+        GeneratedEmail.objects.create(
+            created_by=self.user,
+            expert_search=self.search_b,
+            expert_email="scoped@uni.edu",
+            status=GeneratedEmail.Status.SENT,
+        )
+        ser = ExpertSearchDetailSerializer(self.search_a)
+        expert = ser.data["experts"][0]
+        self.assertIsNone(expert["emailed_for_current_document"])
+        self.assertEqual(len(expert["emailed_on_other_documents"]), 1)
+        other = expert["emailed_on_other_documents"][0]
+        self.assertEqual(
+            other["unified_document_id"], self.paper_b.unified_document_id
+        )
+        self.assertEqual(other["document_type"], "PAPER")
+        self.assertEqual(other["title"], "RFP B Paper Title")
+        self.assertEqual(other["slug"], self.paper_b.slug)
+        self.assertEqual(other["id"], self.paper_b.id)
+        self.assertEqual(other["search_id"], self.search_b.id)
+        self.assertIn("sent_at", other)
+
+    def test_draft_email_is_excluded(self):
+        GeneratedEmail.objects.create(
+            created_by=self.user,
+            expert_search=self.search_a,
+            expert_email="scoped@uni.edu",
+            status=GeneratedEmail.Status.DRAFT,
+        )
+        ser = ExpertSearchDetailSerializer(self.search_a)
+        expert = ser.data["experts"][0]
+        self.assertIsNone(expert["emailed_for_current_document"])
+        self.assertEqual(expert["emailed_on_other_documents"], [])
 
 
 class ExpertSearchListItemSerializerTests(TestCase):

--- a/src/research_ai/tests/test_serializers.py
+++ b/src/research_ai/tests/test_serializers.py
@@ -350,9 +350,7 @@ class ExpertSearchDetailSerializerOutreachTests(TestCase):
         self.assertIsNone(expert["emailed_for_current_document"])
         self.assertEqual(len(expert["emailed_on_other_documents"]), 1)
         other = expert["emailed_on_other_documents"][0]
-        self.assertEqual(
-            other["unified_document_id"], self.paper_b.unified_document_id
-        )
+        self.assertEqual(other["unified_document_id"], self.paper_b.unified_document_id)
         self.assertEqual(other["document_type"], "PAPER")
         self.assertEqual(other["title"], "RFP B Paper Title")
         self.assertEqual(other["slug"], self.paper_b.slug)

--- a/src/research_ai/views/expert_finder_views.py
+++ b/src/research_ai/views/expert_finder_views.py
@@ -55,21 +55,6 @@ def _get_sse_url(request, search_id):
     return base + "/api/research_ai/expert-finder/progress/" + search_id + "/"
 
 
-def _get_document_title(unified_doc):
-    """Return a display title for the document (paper or post), max 512 chars."""
-    try:
-        doc = unified_doc.get_document()
-        if doc is None:
-            return ""
-        if hasattr(doc, "display_title"):
-            return (doc.display_title or "")[:512]
-        if hasattr(doc, "title"):
-            return (str(doc.title or ""))[:512]
-        return ""
-    except Exception:
-        return ""
-
-
 def _search_prefetch():
     return Prefetch(
         "search_experts",
@@ -155,7 +140,7 @@ class ExpertSearchListCreateView(APIView):
         effective_input_type = content_type
         is_pdf = content_type == ExpertSearch.InputType.PDF
         if not search_name:
-            search_name = _get_document_title(unified_doc)
+            search_name = unified_doc.get_display_title()
 
         expert_search = ExpertSearch.objects.create(
             created_by=request.user,

--- a/src/researchhub_document/related_models/researchhub_unified_document_model.py
+++ b/src/researchhub_document/related_models/researchhub_unified_document_model.py
@@ -297,6 +297,25 @@ class ResearchhubUnifiedDocument(
         else:
             raise Exception(f"Unrecognized document_type: {self.document_type}")
 
+    def get_display_title(self, *, max_length: int = 512) -> str:
+        """Return the user-facing title of the underlying document."""
+        doc = self.get_document()
+        if doc is None:
+            return ""
+        if hasattr(doc, "display_title"):
+            title = (doc.display_title or "").strip()
+        elif hasattr(doc, "title"):
+            title = (str(doc.title or "")).strip()
+        else:
+            title = ""
+        return title[:max_length]
+
+    def get_document_slug(self) -> str:
+        doc = self.get_document()
+        if doc is None:
+            return ""
+        return getattr(doc, "slug", "") or ""
+
     @cached_property
     def fe_document_type(self):
         document_type = self.document_type

--- a/src/researchhub_document/tests/test_models.py
+++ b/src/researchhub_document/tests/test_models.py
@@ -159,6 +159,50 @@ class ModelTests(TestCase):
         self.assertEqual(details["count"], 1)
         self.assertEqual(details["avg"], 6.0)
 
+    def test_get_display_title_for_paper(self):
+        # Arrange
+        self.paper.title = "Short title"
+        self.paper.paper_title = "Full paper title"
+        self.paper.save()
+
+        # Act
+        title = self.paper.unified_document.get_display_title()
+
+        # Assert
+        self.assertEqual(title, "Short title")
+
+    def test_get_display_title_for_paper_falls_back_to_paper_title(self):
+        # Arrange
+        self.paper.title = ""
+        self.paper.paper_title = "Full paper title"
+        self.paper.save()
+
+        # Act
+        title = self.paper.unified_document.get_display_title()
+
+        # Assert
+        self.assertEqual(title, "Full paper title")
+
+    def test_get_display_title_for_post(self):
+        # Arrange
+        post = create_post(title="Post title", created_by=self.user)
+
+        # Act
+        title = post.unified_document.get_display_title()
+
+        # Assert
+        self.assertEqual(title, "Post title")
+
+    def test_get_document_slug(self):
+        # Arrange
+        post = create_post(title="Post title", created_by=self.user)
+
+        # Act
+        slug = post.unified_document.get_document_slug()
+
+        # Assert
+        self.assertEqual(slug, post.slug)
+
 
 class ResearchhubPostStatusTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## What?
- Adds per-expert outreach history to `GET /api/research_ai/expert-finder/searches/<search_id>/`

## How?
- Builds outreach history from sent `GeneratedEmail` rows linked to `ExpertSearch.unified_document`
- Adds `emailed_for_current_document` and `emailed_on_other_documents` 
Example
```
{
  "id": 42,
  "email": "expert@uni.edu",
  "display_name": "Dr. Jane Doe",
  "last_email_sent_at": "2025-11-01T12:00:00Z",
  "emailed_for_current_document": null,
  "emailed_on_other_documents": [
    {
      "unified_document_id": 999,
      "document_type": "GRANT",
      "title": "Novel Therapies RFP",
      "slug": "novel-therapies-rfp",
      "id": 123,
      "sent_at": "2025-10-01T08:00:00Z",
      "search_id": 55
    }
  ]
}
```