### PR TITLE
Reduce server startup (ingestion clients cleanup)

### DIFF
--- a/src/paper/ingestion/clients/enrichment/bluesky.py
+++ b/src/paper/ingestion/clients/enrichment/bluesky.py
@@ -1,9 +1,14 @@
-import logging
+from __future__ import annotations
 
-from atproto import Client
+import logging
+from typing import TYPE_CHECKING
+
 from django.conf import settings
 
 from paper.ingestion.clients.base import RateLimiter
+
+if TYPE_CHECKING:
+    from atproto import Client
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +56,13 @@ class BlueskyClient:
         self.username = username or getattr(settings, "BLUESKY_USERNAME", "")
         self.password = password or getattr(settings, "BLUESKY_PASSWORD", "")
         self.rate_limiter = RateLimiter(rate_limit)
-        self.client = client or Client()
+
+        if client is None:
+            from atproto import Client  # delay until needed
+
+            client = Client()
+
+        self.client = client
         self.authenticated = False
         self._authenticate()
 
@@ -121,7 +132,10 @@ class BlueskyMetricsClient:
             bluesky_client: Bluesky API client.
                 If None, creates a BlueskyClient (which is a singleton).
         """
-        self.bluesky_client = bluesky_client or BlueskyClient()
+        if bluesky_client is None:
+            bluesky_client = BlueskyClient()
+
+        self.bluesky_client = bluesky_client
 
     def get_metrics(
         self, terms: list[str], limit: int = BlueskyClient.MAX_SEARCH_RESULTS

--- a/src/paper/ingestion/clients/enrichment/x.py
+++ b/src/paper/ingestion/clients/enrichment/x.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 from django.conf import settings
-from xdk import Client
 
 from paper.ingestion.clients.base import RateLimiter
 
 from .x_bot_accounts import X_BOT_ACCOUNTS
+
+if TYPE_CHECKING:
+    from xdk import Client
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +89,7 @@ class XClient:
     def __init__(
         self,
         bearer_token: str | None = None,
-        client=None,
+        client: Client | None = None,
         rate_limit: float = DEFAULT_RATE_LIMIT,
     ):
         """
@@ -118,6 +123,8 @@ class XClient:
             )
 
         if self._client is None:
+            from xdk import Client  # delay until needed
+
             self._client = Client(bearer_token=self.bearer_token)
 
     def search_posts(self, query: str, max_results: int = 10) -> dict | None:

--- a/src/paper/ingestion/pipeline.py
+++ b/src/paper/ingestion/pipeline.py
@@ -15,7 +15,7 @@ from paper.ingestion.clients.client_factory import ClientFactory
 from paper.ingestion.constants import IngestionSource
 from paper.ingestion.exceptions import FetchError, RetryExhaustedError
 from paper.ingestion.mappers import MapperFactory
-from paper.ingestion.services import PaperIngestionService
+from paper.ingestion.services.ingestion_service import PaperIngestionService
 from paper.models import PaperFetchLog
 from researchhub.celery import QUEUE_PULL_PAPERS, app
 from utils.sentry import log_error

--- a/src/paper/ingestion/services/__init__.py
+++ b/src/paper/ingestion/services/__init__.py
@@ -1,7 +1,0 @@
-from paper.ingestion.services.ingestion_service import PaperIngestionService
-from paper.ingestion.services.metrics_enrichment import PaperMetricsEnrichmentService
-
-__all__ = [
-    "PaperIngestionService",
-    "PaperMetricsEnrichmentService",
-]

--- a/src/paper/ingestion/services/metrics_enrichment.py
+++ b/src/paper/ingestion/services/metrics_enrichment.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
 import json
 import logging
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from django.utils import timezone
 
-from paper.ingestion.clients.enrichment.bluesky import BlueskyMetricsClient
-from paper.ingestion.clients.enrichment.github import GithubMetricsClient
-from paper.ingestion.clients.enrichment.x import XMetricsClient
 from paper.models import Paper
+
+if TYPE_CHECKING:
+    from paper.ingestion.clients.enrichment.bluesky import BlueskyMetricsClient
+    from paper.ingestion.clients.enrichment.github import GithubMetricsClient
+    from paper.ingestion.clients.enrichment.x import XMetricsClient
 
 logger = logging.getLogger(__name__)
 
@@ -43,9 +47,9 @@ class PaperMetricsEnrichmentService:
 
     def __init__(
         self,
-        bluesky_metrics_client: BlueskyMetricsClient,
-        github_metrics_client: GithubMetricsClient,
-        x_metrics_client: XMetricsClient,
+        bluesky_metrics_client: BlueskyMetricsClient | None = None,
+        github_metrics_client: GithubMetricsClient | None = None,
+        x_metrics_client: XMetricsClient | None = None,
     ):
         """
         Constructor.

--- a/src/paper/ingestion/services/metrics_enrichment.py
+++ b/src/paper/ingestion/services/metrics_enrichment.py
@@ -63,7 +63,8 @@ class PaperMetricsEnrichmentService:
         self.bluesky_metrics_client = bluesky_metrics_client
         self.x_metrics_client = x_metrics_client
 
-    def get_recent_papers_with_dois(self, days: int) -> list[int]:
+    @staticmethod
+    def get_recent_papers_with_dois(days: int) -> list[int]:
         """
         Query papers published in the last N days that have DOIs.
 

--- a/src/paper/ingestion/services/tests/test_ingestion_service.py
+++ b/src/paper/ingestion/services/tests/test_ingestion_service.py
@@ -79,7 +79,9 @@ class TestPaperIngestionService(TestCase):
         self.assertEqual(failures[0]["error"], "Validation failed")
         self.assertEqual(failures[0]["id"], "test123")
 
-    @patch("paper.ingestion.services.PaperIngestionService._save_paper")
+    @patch(
+        "paper.ingestion.services.ingestion_service.PaperIngestionService._save_paper"
+    )
     def test_ingest_papers_with_save(self, mock_save_paper):
         """Test ingestion with database save."""
         mock_paper = Mock(spec=Paper)
@@ -132,7 +134,7 @@ class TestPaperIngestionService(TestCase):
         self.assertEqual(failures[0]["id"], "test123")
 
     @patch(
-        "paper.ingestion.services.PaperIngestionService._trigger_pdf_download_if_needed"
+        "paper.ingestion.services.ingestion_service.PaperIngestionService._trigger_pdf_download_if_needed"
     )
     @patch("paper.models.Paper.objects.filter")
     def test_save_paper_new(self, mock_filter, mock_trigger_pdf):
@@ -153,9 +155,11 @@ class TestPaperIngestionService(TestCase):
         mock_trigger_pdf.assert_called_once_with(mock_paper, pdf_url_changed=True)
 
     @patch(
-        "paper.ingestion.services.PaperIngestionService._trigger_pdf_download_if_needed"
+        "paper.ingestion.services.ingestion_service.PaperIngestionService._trigger_pdf_download_if_needed"
     )
-    @patch("paper.ingestion.services.PaperIngestionService._update_paper")
+    @patch(
+        "paper.ingestion.services.ingestion_service.PaperIngestionService._update_paper"
+    )
     @patch("paper.models.Paper.objects.filter")
     def test_save_paper_existing_no_update(
         self, mock_filter, mock_update, mock_trigger_pdf
@@ -183,9 +187,11 @@ class TestPaperIngestionService(TestCase):
         mock_trigger_pdf.assert_called_once_with(existing_paper, pdf_url_changed=False)
 
     @patch(
-        "paper.ingestion.services.PaperIngestionService._trigger_pdf_download_if_needed"
+        "paper.ingestion.services.ingestion_service.PaperIngestionService._trigger_pdf_download_if_needed"
     )
-    @patch("paper.ingestion.services.PaperIngestionService._update_paper")
+    @patch(
+        "paper.ingestion.services.ingestion_service.PaperIngestionService._update_paper"
+    )
     @patch("paper.models.Paper.objects.filter")
     def test_save_paper_existing_with_update(
         self, mock_filter, mock_update, mock_trigger_pdf
@@ -210,9 +216,11 @@ class TestPaperIngestionService(TestCase):
         mock_trigger_pdf.assert_called_once_with(updated_paper, pdf_url_changed=True)
 
     @patch(
-        "paper.ingestion.services.PaperIngestionService._trigger_pdf_download_if_needed"
+        "paper.ingestion.services.ingestion_service.PaperIngestionService._trigger_pdf_download_if_needed"
     )
-    @patch("paper.ingestion.services.PaperIngestionService._update_paper")
+    @patch(
+        "paper.ingestion.services.ingestion_service.PaperIngestionService._update_paper"
+    )
     @patch("paper.models.Paper.objects.filter")
     def test_save_paper_existing_by_url_when_doi_not_found(
         self, mock_filter, mock_update, mock_trigger_pdf
@@ -333,7 +341,9 @@ class TestPaperIngestionService(TestCase):
         existing_paper.save.assert_called_once()
         self.assertEqual(result, existing_paper)
 
-    @patch("paper.ingestion.services.PaperIngestionService.ingest_papers")
+    @patch(
+        "paper.ingestion.services.ingestion_service.PaperIngestionService.ingest_papers"
+    )
     def test_ingest_single_paper_success(self, mock_ingest_papers):
         """Test ingesting a single paper successfully."""
         mock_paper = Mock(spec=Paper)
@@ -347,7 +357,9 @@ class TestPaperIngestionService(TestCase):
             [raw_record], IngestionSource.ARXIV, validate=True
         )
 
-    @patch("paper.ingestion.services.PaperIngestionService.ingest_papers")
+    @patch(
+        "paper.ingestion.services.ingestion_service.PaperIngestionService.ingest_papers"
+    )
     def test_ingest_single_paper_failure(self, mock_ingest_papers):
         """Test handling failure when ingesting a single paper."""
         mock_ingest_papers.return_value = (

--- a/src/paper/ingestion/services/tests/test_ingestion_service.py
+++ b/src/paper/ingestion/services/tests/test_ingestion_service.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 
 from institution.models import Institution
 from paper.ingestion.constants import IngestionSource
-from paper.ingestion.services import PaperIngestionService
+from paper.ingestion.services.ingestion_service import PaperIngestionService
 from paper.models import Paper
 from paper.related_models.authorship_model import Authorship
 from user.related_models.author_model import Author

--- a/src/paper/ingestion/services/tests/test_ingestion_service.py
+++ b/src/paper/ingestion/services/tests/test_ingestion_service.py
@@ -79,9 +79,7 @@ class TestPaperIngestionService(TestCase):
         self.assertEqual(failures[0]["error"], "Validation failed")
         self.assertEqual(failures[0]["id"], "test123")
 
-    @patch(
-        "paper.ingestion.services.ingestion_service.PaperIngestionService._save_paper"
-    )
+    @patch.object(PaperIngestionService, "_save_paper")
     def test_ingest_papers_with_save(self, mock_save_paper):
         """Test ingestion with database save."""
         mock_paper = Mock(spec=Paper)
@@ -133,9 +131,7 @@ class TestPaperIngestionService(TestCase):
         self.assertEqual(failures[0]["error"], "Mapping error")
         self.assertEqual(failures[0]["id"], "test123")
 
-    @patch(
-        "paper.ingestion.services.ingestion_service.PaperIngestionService._trigger_pdf_download_if_needed"
-    )
+    @patch.object(PaperIngestionService, "_trigger_pdf_download_if_needed")
     @patch("paper.models.Paper.objects.filter")
     def test_save_paper_new(self, mock_filter, mock_trigger_pdf):
         """Test saving a new paper."""
@@ -154,12 +150,8 @@ class TestPaperIngestionService(TestCase):
         # PDF download should be triggered for new papers
         mock_trigger_pdf.assert_called_once_with(mock_paper, pdf_url_changed=True)
 
-    @patch(
-        "paper.ingestion.services.ingestion_service.PaperIngestionService._trigger_pdf_download_if_needed"
-    )
-    @patch(
-        "paper.ingestion.services.ingestion_service.PaperIngestionService._update_paper"
-    )
+    @patch.object(PaperIngestionService, "_trigger_pdf_download_if_needed")
+    @patch.object(PaperIngestionService, "_update_paper")
     @patch("paper.models.Paper.objects.filter")
     def test_save_paper_existing_no_update(
         self, mock_filter, mock_update, mock_trigger_pdf
@@ -186,12 +178,8 @@ class TestPaperIngestionService(TestCase):
         # PDF download triggered with pdf_url_changed=False
         mock_trigger_pdf.assert_called_once_with(existing_paper, pdf_url_changed=False)
 
-    @patch(
-        "paper.ingestion.services.ingestion_service.PaperIngestionService._trigger_pdf_download_if_needed"
-    )
-    @patch(
-        "paper.ingestion.services.ingestion_service.PaperIngestionService._update_paper"
-    )
+    @patch.object(PaperIngestionService, "_trigger_pdf_download_if_needed")
+    @patch.object(PaperIngestionService, "_update_paper")
     @patch("paper.models.Paper.objects.filter")
     def test_save_paper_existing_with_update(
         self, mock_filter, mock_update, mock_trigger_pdf
@@ -215,12 +203,8 @@ class TestPaperIngestionService(TestCase):
         # PDF download triggered with pdf_url_changed=True
         mock_trigger_pdf.assert_called_once_with(updated_paper, pdf_url_changed=True)
 
-    @patch(
-        "paper.ingestion.services.ingestion_service.PaperIngestionService._trigger_pdf_download_if_needed"
-    )
-    @patch(
-        "paper.ingestion.services.ingestion_service.PaperIngestionService._update_paper"
-    )
+    @patch.object(PaperIngestionService, "_trigger_pdf_download_if_needed")
+    @patch.object(PaperIngestionService, "_update_paper")
     @patch("paper.models.Paper.objects.filter")
     def test_save_paper_existing_by_url_when_doi_not_found(
         self, mock_filter, mock_update, mock_trigger_pdf
@@ -341,9 +325,7 @@ class TestPaperIngestionService(TestCase):
         existing_paper.save.assert_called_once()
         self.assertEqual(result, existing_paper)
 
-    @patch(
-        "paper.ingestion.services.ingestion_service.PaperIngestionService.ingest_papers"
-    )
+    @patch.object(PaperIngestionService, "ingest_papers")
     def test_ingest_single_paper_success(self, mock_ingest_papers):
         """Test ingesting a single paper successfully."""
         mock_paper = Mock(spec=Paper)
@@ -357,9 +339,7 @@ class TestPaperIngestionService(TestCase):
             [raw_record], IngestionSource.ARXIV, validate=True
         )
 
-    @patch(
-        "paper.ingestion.services.ingestion_service.PaperIngestionService.ingest_papers"
-    )
+    @patch.object(PaperIngestionService, "ingest_papers")
     def test_ingest_single_paper_failure(self, mock_ingest_papers):
         """Test handling failure when ingesting a single paper."""
         mock_ingest_papers.return_value = (

--- a/src/paper/ingestion/services/tests/test_metrics_enrichment.py
+++ b/src/paper/ingestion/services/tests/test_metrics_enrichment.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 from django.test import TestCase
 from django.utils import timezone
 
-from paper.ingestion.services import PaperMetricsEnrichmentService
+from paper.ingestion.services.metrics_enrichment import PaperMetricsEnrichmentService
 from paper.models import Paper
 
 

--- a/src/paper/ingestion/tasks.py
+++ b/src/paper/ingestion/tasks.py
@@ -87,14 +87,7 @@ def update_recent_papers_with_github_metrics(days: int = 7):
     """
     logger.info(f"Starting GitHub metrics update for papers (last {days} days)")
 
-    github_metrics_client = _create_github_metrics_client()
-    service = PaperMetricsEnrichmentService(
-        bluesky_metrics_client=None,
-        github_metrics_client=github_metrics_client,
-        x_metrics_client=None,
-    )
-
-    papers = service.get_recent_papers_with_dois(days)
+    papers = PaperMetricsEnrichmentService.get_recent_papers_with_dois(days)
 
     total_papers = len(papers)
     logger.info(f"Found {total_papers} papers to update with GitHub metrics")
@@ -221,13 +214,7 @@ def update_recent_papers_with_bluesky_metrics(days: int = 7):
     """
     logger.info(f"Starting Bluesky metrics update for papers (last {days} days)")
 
-    service = PaperMetricsEnrichmentService(
-        bluesky_metrics_client=BlueskyMetricsClient(),
-        github_metrics_client=None,
-        x_metrics_client=None,
-    )
-
-    papers = service.get_recent_papers_with_dois(days)
+    papers = PaperMetricsEnrichmentService.get_recent_papers_with_dois(days)
 
     total_papers = len(papers)
     logger.info(f"Found {total_papers} papers to update with Bluesky metrics")
@@ -357,13 +344,7 @@ def update_recent_papers_with_x_metrics(days: int = 7):
 
     logger.info(f"Starting X metrics update for papers (last {days} days)")
 
-    service = PaperMetricsEnrichmentService(
-        bluesky_metrics_client=None,
-        github_metrics_client=None,
-        x_metrics_client=XMetricsClient(),
-    )
-
-    papers = service.get_recent_papers_with_dois(days)
+    papers = PaperMetricsEnrichmentService.get_recent_papers_with_dois(days)
 
     total_papers = len(papers)
     logger.info(f"Found {total_papers} papers to update with X metrics")


### PR DESCRIPTION
- Lazy-load the atproto SDK (Bluesky) and xdk SDK (X) so importing ingestion tasks no longer imports the SDK during server startup.
- Remove ingestion service barrel exports.
- Make `PaperMetricsEnrichmentService` avoid runtime imports of metric clients by moving those imports behind `TYPE_CHECKING`.
- Make the recent-paper query static so dispatcher tasks can enqueue paper-related tasks without constructing actual clients.
- Keep metric client construction in the per-paper enrichment tasks where the external API clients are needed.