### PR TITLE
New Journal Feed

### DIFF
--- a/src/feed/tests/views/test_journal_v2_feed_view.py
+++ b/src/feed/tests/views/test_journal_v2_feed_view.py
@@ -1,0 +1,117 @@
+from decimal import Decimal
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from purchase.models import Fundraise
+from researchhub_document.helpers import create_post
+from researchhub_document.models import ResearchhubPost
+from researchhub_document.related_models.constants.document_type import (
+    PREREGISTRATION,
+    REGISTERED_REPORT,
+)
+from researchhub_document.services.journey_service import JourneyService
+from user.tests.helpers import create_random_default_user
+
+
+class JournalV2FeedViewSetTests(APITestCase):
+    def setUp(self) -> None:
+        """Create the user, client, and service used by journal feed tests."""
+        self.user = create_random_default_user("journal_v2_user")
+        self.service = JourneyService()
+        self.url = reverse("journal_v2_feed-list")
+        self.client.force_authenticate(self.user)
+
+    def test_list_includes_journal_proposals(self) -> None:
+        """Verify the feed includes proposals from journeys in the journal."""
+        # Arrange
+        proposal = self.create_completed_proposal("Included proposal")
+        excluded_proposal = self.create_completed_proposal(
+            "Excluded proposal",
+            include_in_journal=False,
+        )
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        post_ids = self.get_response_post_ids(response.data)
+        self.assertIn(proposal.id, post_ids)
+        self.assertNotIn(excluded_proposal.id, post_ids)
+
+    def test_list_prefers_registered_reports(self) -> None:
+        """Verify the feed shows the registered report when a journey has one."""
+        # Arrange
+        proposal = self.create_completed_proposal("Reported proposal")
+        report = self.create_registered_report(proposal, "Registered report")
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        post_ids = self.get_response_post_ids(response.data)
+        self.assertIn(report.id, post_ids)
+        self.assertNotIn(proposal.id, post_ids)
+
+    def test_list_returns_one_card_per_journey(self) -> None:
+        """Verify each journal journey contributes only its latest stage card."""
+        # Arrange
+        proposal = self.create_completed_proposal("Proposal only")
+        reported_proposal = self.create_completed_proposal("Proposal with report")
+        report = self.create_registered_report(reported_proposal, "Latest report")
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        post_ids = self.get_response_post_ids(response.data)
+        self.assertEqual(post_ids.count(proposal.id), 1)
+        self.assertEqual(post_ids.count(report.id), 1)
+        self.assertNotIn(reported_proposal.id, post_ids)
+        self.assertEqual(len(post_ids), 2)
+
+    def create_completed_proposal(
+        self, title: str, include_in_journal: bool = True
+    ) -> ResearchhubPost:
+        """Create an approved proposal with a completed fundraise and journey."""
+        proposal = create_post(
+            created_by=self.user,
+            document_type=PREREGISTRATION,
+            title=title,
+        )
+        fundraise = Fundraise.objects.create(
+            created_by=self.user,
+            unified_document=proposal.unified_document,
+            goal_amount=Decimal("1000.00"),
+            goal_currency="USD",
+            status=Fundraise.COMPLETED,
+        )
+
+        if include_in_journal:
+            self.service.include_completed_fundraise_in_journal(fundraise)
+        else:
+            self.service.ensure_approved_preregistration_has_journey(proposal)
+
+        proposal.refresh_from_db()
+        return proposal
+
+    def create_registered_report(
+        self, proposal: ResearchhubPost, title: str
+    ) -> ResearchhubPost:
+        """Create and attach a registered report to a proposal journey."""
+        report = create_post(
+            created_by=self.user,
+            document_type=REGISTERED_REPORT,
+            title=title,
+        )
+        self.service.attach_stage(proposal.journey, report)
+        return report
+
+    @staticmethod
+    def get_response_post_ids(data: dict) -> list[int]:
+        """Return post ids from a paginated journal feed response."""
+        return [item["content_object"]["id"] for item in data["results"]]

--- a/src/feed/views/__init__.py
+++ b/src/feed/views/__init__.py
@@ -7,6 +7,7 @@ from .feed_view import FeedViewSet
 from .funding_feed_view import FundingFeedViewSet
 from .grant_feed_view import GrantFeedViewSet
 from .journal_feed_view import JournalFeedViewSet
+from .journal_v2_feed_view import JournalV2FeedViewSet
 from .moderator_feed_view import ModeratorFeedViewSet
 
 __all__ = [
@@ -15,5 +16,6 @@ __all__ = [
     "FundingFeedViewSet",
     "GrantFeedViewSet",
     "JournalFeedViewSet",
+    "JournalV2FeedViewSet",
     "ModeratorFeedViewSet",
 ]

--- a/src/feed/views/journal_v2_feed_view.py
+++ b/src/feed/views/journal_v2_feed_view.py
@@ -1,0 +1,166 @@
+"""
+Post-based journal feed for funded proposal journeys.
+
+This feed renders one card per journal journey. The card is the registered
+report when a journey has one, otherwise it is the funded proposal.
+"""
+
+from django.db.models import (
+    Count,
+    F,
+    IntegerField,
+    OuterRef,
+    Prefetch,
+    Q,
+    QuerySet,
+    Subquery,
+)
+from django.db.models.functions import Coalesce
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.viewsets import ModelViewSet
+
+from feed.feed_list_dto import (
+    FundingFeedListEntrySerializer,
+    serialize_fund_feed_metrics,
+)
+from feed.views.feed_view_mixin import FeedViewMixin
+from purchase.models import Grant, GrantApplication
+from purchase.related_models.grant_application_model import approved_proposal_filters
+from reputation.related_models.bounty import Bounty
+from researchhub_document.related_models.constants.document_type import (
+    PREREGISTRATION,
+    REGISTERED_REPORT,
+)
+from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
+from review.models import Review
+
+from .common import FeedPagination
+
+
+class JournalV2FeedViewSet(FeedViewMixin, ModelViewSet):
+    """ViewSet for the post-based ResearchHub journal feed."""
+
+    serializer_class = FundingFeedListEntrySerializer
+    permission_classes = []
+    pagination_class = FeedPagination
+
+    def get_serializer_context(self) -> dict:
+        """Return serializer context shared with other feed viewsets."""
+        context = super().get_serializer_context()
+        context.update(self.get_common_serializer_context())
+        return context
+
+    def list(self, request: Request, *args: object, **kwargs: object) -> Response:
+        """Return journal journey feed entries built from latest stage posts."""
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+
+        feed_entries = []
+        for post in page:
+            feed_entry = self.build_unsaved_feed_entry(
+                post, self._post_content_type, post.created_by
+            )
+            feed_entry.metrics = serialize_fund_feed_metrics(
+                post, self._post_content_type
+            )
+            feed_entries.append(feed_entry)
+
+        serializer = self.get_serializer(feed_entries, many=True)
+        response_data = self.get_paginated_response(serializer.data).data
+
+        if request.user.is_authenticated:
+            self.add_user_votes_to_response(request.user, response_data)
+
+        return Response(response_data)
+
+    def get_queryset(self) -> QuerySet[ResearchhubPost]:
+        """Return one public latest-stage post for each journal journey."""
+        registered_report_id = self._build_stage_id_subquery(REGISTERED_REPORT)
+        proposal_id = self._build_stage_id_subquery(PREREGISTRATION)
+
+        return (
+            self._build_base_queryset()
+            .annotate(
+                latest_stage_id=Coalesce(
+                    registered_report_id,
+                    proposal_id,
+                    output_field=IntegerField(),
+                )
+            )
+            .filter(id=F("latest_stage_id"))
+            .order_by("-created_date", "-id")
+        )
+
+    @staticmethod
+    def _build_stage_id_subquery(document_type: str) -> Subquery:
+        """Build a post-id subquery for one stage in the outer post's journey."""
+        stage_ids = (
+            ResearchhubPost.objects.filter(
+                journey_id=OuterRef("journey_id"),
+                document_type=document_type,
+            )
+            .order_by("id")
+            .values("id")[:1]
+        )
+        return Subquery(stage_ids, output_field=IntegerField())
+
+    @staticmethod
+    def _build_base_queryset() -> QuerySet[ResearchhubPost]:
+        """Build the visible journal-stage post queryset with card prefetches."""
+        application_lookup = "applications"
+        annotated_grants = Grant.objects.annotate(
+            num_applicants=Count(
+                application_lookup,
+                distinct=True,
+                filter=Q(**approved_proposal_filters(application_lookup)),
+            )
+        ).prefetch_related("unified_document__posts")
+
+        grant_applications_prefetch = Prefetch(
+            "grant_applications",
+            queryset=GrantApplication.objects.prefetch_related(
+                Prefetch("grant", queryset=annotated_grants)
+            ),
+        )
+
+        return (
+            ResearchhubPost.objects.select_related(
+                "created_by",
+                "created_by__author_profile",
+                "journey",
+                "unified_document",
+            )
+            .prefetch_related(
+                "authors",
+                "unified_document__hubs",
+                "unified_document__fundraises",
+                "unified_document__fundraises__nonprofit_links__nonprofit",
+                Prefetch(
+                    "unified_document__reviews",
+                    queryset=Review.objects.filter(is_removed=False).select_related(
+                        "created_by__author_profile"
+                    ),
+                ),
+                Prefetch(
+                    "unified_document__related_bounties",
+                    queryset=Bounty.objects.filter(parent__isnull=True)
+                    .select_related("created_by")
+                    .prefetch_related(
+                        Prefetch(
+                            "children",
+                            queryset=Bounty.objects.select_related(
+                                "created_by__author_profile"
+                            ),
+                        )
+                    ),
+                ),
+                grant_applications_prefetch,
+            )
+            .filter(
+                document_type__in=[PREREGISTRATION, REGISTERED_REPORT],
+                journey__is_in_journal=True,
+                journey_id__isnull=False,
+            )
+            .publicly_visible()
+        )

--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -38,6 +38,7 @@ from feed.views import (
     FundingFeedViewSet,
     GrantFeedViewSet,
     JournalFeedViewSet,
+    JournalV2FeedViewSet,
     ModeratorFeedViewSet,
 )
 from orcid.views import OrcidCallbackView, OrcidConnectView, OrcidFetchView
@@ -196,6 +197,8 @@ router.register(r"funding_feed", FundingFeedViewSet, basename="funding_feed")
 router.register(r"grant_feed", GrantFeedViewSet, basename="grant_feed")
 
 router.register(r"journal_feed", JournalFeedViewSet, basename="journal_feed")
+
+router.register(r"journal_v2_feed", JournalV2FeedViewSet, basename="journal_v2_feed")
 
 urlpatterns = [
     # Health check


### PR DESCRIPTION
## Overview ##

This is the first part of the new journal feed, that pulls completed proposals and registered reports. It filters to show only one of the type for a matched document (aka if the proposal has a registered report, it will only show the registered report, rather than both the proposal and its attached registered report) for better filtering.