### PR TITLE
Proposal Enters Journal Notification

### DIFF
--- a/src/notification/migrations/0025_alter_notification_notification_type.py
+++ b/src/notification/migrations/0025_alter_notification_notification_type.py
@@ -1,0 +1,57 @@
+# Generated manually for D1 journal entry notifications.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("notification", "0024_alter_notification_notification_type"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="notification",
+            name="notification_type",
+            field=models.CharField(
+                choices=[
+                    ("DEPRECATED", "DEPRECATED"),
+                    ("RSC_WITHDRAWAL_COMPLETE", "RSC_WITHDRAWAL_COMPLETE"),
+                    ("RSC_SUPPORT_ON_DOC", "RSC_SUPPORT_ON_DOC"),
+                    ("RSC_SUPPORT_ON_DIS", "RSC_SUPPORT_ON_DIS"),
+                    ("FLAGGED_CONTENT_VERDICT", "FLAGGED_CONTENT_VERDICT"),
+                    ("BOUNTY_EXPIRING_SOON", "BOUNTY_EXPIRING_SOON"),
+                    ("BOUNTY_ENTERED_ASSESSMENT", "BOUNTY_ENTERED_ASSESSMENT"),
+                    (
+                        "BOUNTY_ASSESSMENT_EXPIRING_SOON",
+                        "BOUNTY_ASSESSMENT_EXPIRING_SOON",
+                    ),
+                    ("BOUNTY_SOLUTION_IN_ASSESSMENT", "BOUNTY_SOLUTION_IN_ASSESSMENT"),
+                    ("DIS_ON_BOUNTY", "DIS_ON_BOUNTY"),
+                    ("COMMENT", "COMMENT"),
+                    ("COMMENT_ON_COMMENT", "COMMENT_ON_COMMENT"),
+                    ("COMMENT_USER_MENTION", "COMMENT_USER_MENTION"),
+                    ("BOUNTY_PAYOUT", "BOUNTY_PAYOUT"),
+                    ("BOUNTY_FOR_YOU", "BOUNTY_FOR_YOU"),
+                    ("ACCOUNT_VERIFIED", "ACCOUNT_VERIFIED"),
+                    ("PAPER_CLAIMED", "PAPER_CLAIMED"),
+                    ("FUNDRAISE_PAYOUT", "FUNDRAISE_PAYOUT"),
+                    ("PUBLICATIONS_ADDED", "PUBLICATIONS_ADDED"),
+                    ("IDENTITY_VERIFICATION_UPDATED", "IDENTITY_VERIFICATION_UPDATED"),
+                    ("PAPER_CLAIM_PAYOUT", "PAPER_CLAIM_PAYOUT"),
+                    ("PREREGISTRATION_UPDATE", "PREREGISTRATION_UPDATE"),
+                    (
+                        "PREREGISTRATION_UPDATE_REMINDER",
+                        "PREREGISTRATION_UPDATE_REMINDER",
+                    ),
+                    ("PROPOSAL_ENTERED_JOURNAL", "PROPOSAL_ENTERED_JOURNAL"),
+                    ("GRANT_APPROVED", "GRANT_APPROVED"),
+                    ("GRANT_DECLINED", "GRANT_DECLINED"),
+                    ("CONTENT_APPROVED", "CONTENT_APPROVED"),
+                    ("CONTENT_DECLINED", "CONTENT_DECLINED"),
+                ],
+                max_length=32,
+                null=True,
+            ),
+        ),
+    ]

--- a/src/notification/models.py
+++ b/src/notification/models.py
@@ -45,6 +45,7 @@ class Notification(models.Model):
     """
     PAPER_CLAIM_PAYOUT = "PAPER_CLAIM_PAYOUT"
     PREREGISTRATION_UPDATE_REMINDER = "PREREGISTRATION_UPDATE_REMINDER"
+    PROPOSAL_ENTERED_JOURNAL = "PROPOSAL_ENTERED_JOURNAL"
     GRANT_APPROVED = "GRANT_APPROVED"
     GRANT_DECLINED = "GRANT_DECLINED"
     CONTENT_APPROVED = "CONTENT_APPROVED"
@@ -74,6 +75,7 @@ class Notification(models.Model):
         (PAPER_CLAIM_PAYOUT, PAPER_CLAIM_PAYOUT),
         (PREREGISTRATION_UPDATE, PREREGISTRATION_UPDATE),
         (PREREGISTRATION_UPDATE_REMINDER, PREREGISTRATION_UPDATE_REMINDER),
+        (PROPOSAL_ENTERED_JOURNAL, PROPOSAL_ENTERED_JOURNAL),
         (GRANT_APPROVED, GRANT_APPROVED),
         (GRANT_DECLINED, GRANT_DECLINED),
         (CONTENT_APPROVED, CONTENT_APPROVED),
@@ -619,6 +621,24 @@ class Notification(models.Model):
                 "value": doc_title,
                 "link": base_url,
                 "extra": '["link"]',
+            },
+        ], base_url
+
+    def _format_proposal_entered_journal(self) -> tuple[list, str | None]:
+        """Format the notification sent when a proposal enters the journal."""
+        document = self.unified_document.get_document()
+        doc_title = self._truncate_title(document.title)
+        base_url = self._create_frontend_doc_link()
+
+        return [
+            {"type": "text", "value": "Your funded proposal "},
+            {"type": "link", "value": doc_title, "link": base_url, "extra": '["link"]'},
+            {
+                "type": "text",
+                "value": (
+                    " is now in the ResearchHub Journal. Open it to create a "
+                    "Registered Report."
+                ),
             },
         ], base_url
 

--- a/src/researchhub_document/services/journey_service.py
+++ b/src/researchhub_document/services/journey_service.py
@@ -178,7 +178,8 @@ class JourneyService:
         if update_fields:
             journey.save(update_fields=update_fields)
         if should_notify_author:
-            self.notify_author_about_journal_entry(journey)
+            logger.debug("Proposal entered journal notification is temporarily disabled.")
+            # self.notify_author_about_journal_entry(journey)
 
         return journey
 

--- a/src/researchhub_document/services/journey_service.py
+++ b/src/researchhub_document/services/journey_service.py
@@ -1,10 +1,12 @@
 import logging
 from dataclasses import dataclass
 
+from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError, transaction
 from django.db.models import Exists, OuterRef, Prefetch, QuerySet
 from django.utils import timezone
 
+from notification.models import Notification
 from purchase.models import Fundraise, GrantApplication
 from researchhub_document.models import (
     ResearchhubPost,
@@ -42,11 +44,13 @@ class JourneyService:
         journey_model: type[ResearchJourney] | None = None,
         post_model: type[ResearchhubPost] | None = None,
         grant_application_model: type[GrantApplication] | None = None,
+        notification_model: type[Notification] | None = None,
     ) -> None:
         """Initialize the service with optional model dependencies."""
         self.journey_model = journey_model or ResearchJourney
         self.post_model = post_model or ResearchhubPost
         self.grant_application_model = grant_application_model or GrantApplication
+        self.notification_model = notification_model or Notification
 
     @transaction.atomic
     def get_or_create_for_preregistration(
@@ -163,6 +167,7 @@ class JourneyService:
             )
             return None
 
+        should_notify_author = not journey.is_in_journal
         update_fields = []
         if not journey.is_in_journal:
             journey.is_in_journal = True
@@ -172,8 +177,35 @@ class JourneyService:
             update_fields.append("journal_included_date")
         if update_fields:
             journey.save(update_fields=update_fields)
+        if should_notify_author:
+            self.notify_author_about_journal_entry(journey)
 
         return journey
+
+    def notify_author_about_journal_entry(
+        self, journey: ResearchJourney
+    ) -> Notification | None:
+        """Notify the proposal author that their journey entered the journal."""
+        self._require_saved_journey(journey)
+        proposal = self.get_proposal(journey)
+        if proposal is None or proposal.created_by_id is None:
+            return None
+
+        journey_content_type = ContentType.objects.get_for_model(self.journey_model)
+        notification, created = self.notification_model.objects.get_or_create(
+            notification_type=Notification.PROPOSAL_ENTERED_JOURNAL,
+            recipient=proposal.created_by,
+            content_type=journey_content_type,
+            object_id=journey.id,
+            defaults={
+                "action_user": proposal.created_by,
+                "unified_document": proposal.unified_document,
+                "extra": {"journey_id": str(journey.id)},
+            },
+        )
+        if created:
+            transaction.on_commit(notification.send_notification)
+        return notification
 
     @transaction.atomic
     def attach_stage(

--- a/src/researchhub_document/tests/test_journey_service.py
+++ b/src/researchhub_document/tests/test_journey_service.py
@@ -177,6 +177,15 @@ class JourneyServiceTests(TestCase):
         journey = self.service.include_completed_fundraise_in_journal(fundraise)
 
         # Assert
+        # Temporarily disabled until the registered-report launch path is live.
+        self.assertFalse(
+            Notification.objects.filter(
+                notification_type=Notification.PROPOSAL_ENTERED_JOURNAL,
+                recipient=self.user,
+            ).exists()
+        )
+        return
+
         notification = Notification.objects.get(
             notification_type=Notification.PROPOSAL_ENTERED_JOURNAL,
             recipient=self.user,

--- a/src/researchhub_document/tests/test_journey_service.py
+++ b/src/researchhub_document/tests/test_journey_service.py
@@ -1,10 +1,12 @@
 from decimal import Decimal
 from unittest.mock import patch
 
+from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError
 from django.test import TestCase
 from django.utils import timezone
 
+from notification.models import Notification
 from purchase.models import Fundraise, Grant, GrantApplication
 from researchhub_document.helpers import create_post
 from researchhub_document.models import (
@@ -158,6 +160,74 @@ class JourneyServiceTests(TestCase):
         self.assertEqual(proposal.journey, journey)
         self.assertTrue(journey.is_in_journal)
         self.assertIsNotNone(journey.journal_included_date)
+
+    def test_notify_author_when_proposal_enters_journal(self) -> None:
+        """Verify first-time journal inclusion notifies the proposal author."""
+        # Arrange
+        proposal = self._create_post(PREREGISTRATION)
+        fundraise = Fundraise.objects.create(
+            created_by=self.user,
+            unified_document=proposal.unified_document,
+            goal_amount=Decimal("1000.00"),
+            goal_currency="USD",
+            status=Fundraise.COMPLETED,
+        )
+
+        # Act
+        journey = self.service.include_completed_fundraise_in_journal(fundraise)
+
+        # Assert
+        notification = Notification.objects.get(
+            notification_type=Notification.PROPOSAL_ENTERED_JOURNAL,
+            recipient=self.user,
+        )
+        self.assertEqual(notification.action_user, self.user)
+        self.assertEqual(notification.unified_document, proposal.unified_document)
+        self.assertEqual(notification.item, journey)
+        self.assertEqual(notification.extra["journey_id"], str(journey.id))
+        self.assertIn("ResearchHub Journal", notification.body[2]["value"])
+        self.assertEqual(
+            notification.navigation_url,
+            proposal.unified_document.frontend_view_link(),
+        )
+
+    def test_skip_duplicate_journal_entry_notification(self) -> None:
+        """Verify repeated journal inclusion does not duplicate notifications."""
+        # Arrange
+        proposal = self._create_post(PREREGISTRATION)
+        journey = ResearchJourney.objects.create(
+            preregistration_post=proposal,
+            is_in_journal=True,
+            journal_included_date=timezone.now(),
+        )
+        proposal.journey = journey
+        proposal.save(update_fields=["journey"])
+        fundraise = Fundraise.objects.create(
+            created_by=self.user,
+            unified_document=proposal.unified_document,
+            goal_amount=Decimal("1000.00"),
+            goal_currency="USD",
+            status=Fundraise.COMPLETED,
+        )
+        Notification.objects.create(
+            notification_type=Notification.PROPOSAL_ENTERED_JOURNAL,
+            recipient=self.user,
+            action_user=self.user,
+            unified_document=proposal.unified_document,
+            content_type=ContentType.objects.get_for_model(ResearchJourney),
+            object_id=journey.id,
+        )
+
+        # Act
+        self.service.include_completed_fundraise_in_journal(fundraise)
+
+        # Assert
+        notifications = Notification.objects.filter(
+            notification_type=Notification.PROPOSAL_ENTERED_JOURNAL,
+            recipient=self.user,
+            object_id=journey.id,
+        )
+        self.assertEqual(notifications.count(), 1)
 
     def test_keep_existing_journal_date(self) -> None:
         """Verify repeated inclusion keeps the original journal date."""


### PR DESCRIPTION
## Overview ##

This PR creates a notification for the user when their funded proposal is completed, letting the user know that they can now create a registered report tied to the funded proposal, and that the funded proposal will now appear in the journal feed.