### PR TITLE
Hide Private Completed Proposals from Journal Feed

### DIFF
--- a/src/feed/tests/views/test_journal_v2_feed_view.py
+++ b/src/feed/tests/views/test_journal_v2_feed_view.py
@@ -54,6 +54,29 @@ class JournalV2FeedViewSetTests(APITestCase):
         self.assertIn(proposal.id, post_ids)
         self.assertNotIn(excluded_proposal.id, post_ids)
 
+    def test_list_excludes_private_proposal_journeys(self) -> None:
+        """Verify the feed excludes journeys whose funded proposal is private."""
+        # Arrange
+        public_proposal = self.create_completed_proposal("Public proposal")
+        private_proposal = self.create_completed_proposal(
+            "Private proposal",
+            is_public=False,
+        )
+        private_report = self.create_registered_report(
+            private_proposal,
+            "Private proposal report",
+        )
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        post_ids = self.get_response_post_ids(response.data)
+        self.assertIn(public_proposal.id, post_ids)
+        self.assertNotIn(private_proposal.id, post_ids)
+        self.assertNotIn(private_report.id, post_ids)
+
     def test_list_prefers_registered_reports(self) -> None:
         """Verify the feed shows the registered report when a journey has one."""
         # Arrange
@@ -289,6 +312,7 @@ class JournalV2FeedViewSetTests(APITestCase):
         include_in_journal: bool = True,
         amount_raised: Decimal = Decimal("0.00"),
         score: int = 0,
+        is_public: bool = True,
     ) -> ResearchhubPost:
         """Create an approved proposal with a completed fundraise and journey."""
         proposal = create_post(
@@ -296,6 +320,8 @@ class JournalV2FeedViewSetTests(APITestCase):
             document_type=PREREGISTRATION,
             title=title,
         )
+        proposal.unified_document.is_public = is_public
+        proposal.unified_document.save(update_fields=["is_public"])
         proposal.score = score
         proposal.save(update_fields=["score"])
         fundraise = Fundraise.objects.create(

--- a/src/feed/views/journal_v2_feed_view.py
+++ b/src/feed/views/journal_v2_feed_view.py
@@ -173,6 +173,7 @@ class JournalV2FeedViewSet(FeedViewMixin, ModelViewSet):
                 document_type__in=[PREREGISTRATION, REGISTERED_REPORT],
                 journey__is_in_journal=True,
                 journey_id__isnull=False,
+                journey__preregistration_post__unified_document__is_public=True,
             )
             .publicly_visible()
         )

--- a/src/notification/models.py
+++ b/src/notification/models.py
@@ -633,17 +633,21 @@ class Notification(models.Model):
         document = self.unified_document.get_document()
         doc_title = self._truncate_title(document.title)
         base_url = self._create_frontend_doc_link()
+        message = (
+            " is now in the ResearchHub Journal. Open it to create a "
+            "Registered Report."
+        )
+        if self.extra.get("is_private_proposal") == "True":
+            message = (
+                " is now in the ResearchHub Journal. When you are ready for it "
+                "to go public, you can create a Registered Report. Let us know and "
+                "we can help set you up."
+            )
 
         return [
             {"type": "text", "value": "Your funded proposal "},
             {"type": "link", "value": doc_title, "link": base_url, "extra": '["link"]'},
-            {
-                "type": "text",
-                "value": (
-                    " is now in the ResearchHub Journal. Open it to create a "
-                    "Registered Report."
-                ),
-            },
+            {"type": "text", "value": message},
         ], base_url
 
     def _format_registered_report_created(self) -> tuple[list, str | None]:

--- a/src/researchhub_document/services/journey_service.py
+++ b/src/researchhub_document/services/journey_service.py
@@ -218,7 +218,10 @@ class JourneyService:
             author=proposal.created_by,
             unified_document=proposal.unified_document,
             item=journey,
-            extra={"journey_id": str(journey.id)},
+            extra={
+                "is_private_proposal": str(not proposal.unified_document.is_public),
+                "journey_id": str(journey.id),
+            },
         )
 
     def notify_author_about_registered_report(

--- a/src/researchhub_document/tasks.py
+++ b/src/researchhub_document/tasks.py
@@ -23,6 +23,11 @@ logger = logging.getLogger(__name__)
 PROPOSAL_ENTERED_JOURNAL_EMAIL_SUBJECT = (
     "Your proposal is now in the ResearchHub Journal"
 )
+PRIVATE_PROPOSAL_REGISTERED_REPORT_CLAUSE = (
+    "\n\nYour proposal is currently private. When you are ready for it to go "
+    "public, you can create a Registered Report. Let us know and and we can "
+    "help set you up."
+)
 
 
 def build_proposal_entered_journal_email_context(
@@ -38,6 +43,8 @@ def build_proposal_entered_journal_email_context(
         f'Your funded proposal "{proposal_title}" is now in the ResearchHub Journal.'
         "\n\nThe next step is to create a Registered Report from your proposal."
     )
+    if not proposal.unified_document.is_public:
+        message += PRIVATE_PROPOSAL_REGISTERED_REPORT_CLAUSE
 
     return {
         **base_email_context,

--- a/src/researchhub_document/tests/test_journey_service.py
+++ b/src/researchhub_document/tests/test_journey_service.py
@@ -185,11 +185,39 @@ class JourneyServiceTests(TestCase):
         self.assertEqual(notification.unified_document, proposal.unified_document)
         self.assertEqual(notification.item, journey)
         self.assertEqual(notification.extra["journey_id"], str(journey.id))
+        self.assertEqual(notification.extra["is_private_proposal"], "False")
         self.assertIn("ResearchHub Journal", notification.body[2]["value"])
         self.assertEqual(
             notification.navigation_url,
             proposal.unified_document.frontend_view_link(),
         )
+
+    def test_notify_author_with_private_proposal_clause(self) -> None:
+        """Verify private proposal journal notifications explain public setup."""
+        # Arrange
+        proposal = self._create_post(PREREGISTRATION)
+        proposal.unified_document.is_public = False
+        proposal.unified_document.save(update_fields=["is_public"])
+        fundraise = Fundraise.objects.create(
+            created_by=self.user,
+            unified_document=proposal.unified_document,
+            goal_amount=Decimal("1000.00"),
+            goal_currency="USD",
+            status=Fundraise.COMPLETED,
+        )
+
+        # Act
+        journey = self.service.include_completed_fundraise_in_journal(fundraise)
+
+        # Assert
+        notification = Notification.objects.get(
+            notification_type=Notification.PROPOSAL_ENTERED_JOURNAL,
+            recipient=self.user,
+        )
+        self.assertEqual(notification.item, journey)
+        self.assertEqual(notification.extra["is_private_proposal"], "True")
+        self.assertIn("ready for it to go public", notification.body[2]["value"])
+        self.assertIn("set you up", notification.body[2]["value"])
 
     def test_skip_duplicate_journal_entry_notification(self) -> None:
         """Verify repeated journal inclusion does not duplicate notifications."""

--- a/src/researchhub_document/tests/test_tasks.py
+++ b/src/researchhub_document/tests/test_tasks.py
@@ -140,10 +140,31 @@ class SendProposalEnteredJournalEmailTests(TestCase):
             proposal.unified_document.frontend_view_link(),
         )
         self.assertIn(proposal.title, context["action"]["message"])
+        self.assertNotIn("ready for it to go public", context["action"]["message"])
         self.assertEqual(
             mock_send_email.call_args.kwargs["html_template"],
             "general_email_message.html",
         )
+
+    @patch("researchhub_document.tasks.send_email")
+    def test_sends_private_proposal_clause(
+        self, mock_send_email: Mock
+    ) -> None:
+        """Verify private proposal emails explain public setup for reports."""
+        # Arrange
+        proposal = self._create_proposal(is_public=False)
+        journey = self._create_journal_journey(proposal)
+        mock_send_email.return_value = {"success": [self.user.email], "failure": []}
+
+        # Act
+        result = send_proposal_entered_journal_email(journey.id)
+
+        # Assert
+        self.assertEqual(result, mock_send_email.return_value)
+        mock_send_email.assert_called_once()
+        context = mock_send_email.call_args[0][3]
+        self.assertIn("ready for it to go public", context["action"]["message"])
+        self.assertIn("set you up", context["action"]["message"])
 
     @patch("researchhub_document.tasks.send_email")
     def test_skips_email_for_missing_journey(self, mock_send_email: Mock) -> None:
@@ -177,13 +198,16 @@ class SendProposalEnteredJournalEmailTests(TestCase):
         self.assertIsNone(result)
         mock_send_email.assert_not_called()
 
-    def _create_proposal(self) -> ResearchhubPost:
+    def _create_proposal(self, is_public: bool = True) -> ResearchhubPost:
         """Create a preregistration post owned by the email recipient."""
-        return create_post(
+        proposal = create_post(
             title="Journal Email Proposal",
             created_by=self.user,
             document_type="PREREGISTRATION",
         )
+        proposal.unified_document.is_public = is_public
+        proposal.unified_document.save(update_fields=["is_public"])
+        return proposal
 
     def _create_journal_journey(self, proposal: ResearchhubPost) -> ResearchJourney:
         """Create an in-journal journey for the proposal."""


### PR DESCRIPTION
## Overview ##

This PR hides private proposals from the journal feed, and adds extra text in the notifications for private funded proposals before becoming registered reports.