### PR TITLE
Fix leaking AWS client mock across tests

### DIFF
--- a/src/utils/test_helpers.py
+++ b/src/utils/test_helpers.py
@@ -67,10 +67,7 @@ class AWSMockMixin:
         )
         self.mock_boto3_client = self.aws_patcher.start()
 
-    def tearDown(self):
-        if hasattr(self, "aws_patcher"):
-            self.aws_patcher.stop()
-        super().tearDown()
+        self.addCleanup(self.aws_patcher.stop)
 
 
 # Convenience classes for common use cases


### PR DESCRIPTION
`AWSMockMixin` started a boto3.Session.client patch in `setUp` but only stopped it in its own tearDown. A subclass that overrides `tearDown` without calling `super()` left the patch active for the rest of the test process, so unrelated tests such received a `MagicMock` instead of a real client and failed depending on test ordering.

Register stop patching with `addCleanup` in `setUp` so it always runs regardless of how a subclass handles `tearDown`.