### PR TITLE
New endpoint that returns all notes accessible by the authenticated user

### DIFF
--- a/src/note/tests/test_note_api.py
+++ b/src/note/tests/test_note_api.py
@@ -13,14 +13,14 @@ from user.tests.helpers import make_user_verified
 
 
 class NoteTests(APITestCase):
-    organization_content_type = None
-    unified_doc_content_type = None
+    organization_ct = None
+    unified_doc_ct = None
 
     def setUp(self):
-        self.unified_doc_content_type = ContentType.objects.get_for_model(
+        self.unified_doc_ct = ContentType.objects.get_for_model(
             ResearchhubUnifiedDocument
         )
-        self.organization_content_type = ContentType.objects.get_for_model(Organization)
+        self.organization_ct = ContentType.objects.get_for_model(Organization)
 
         # Create + auth user
         username = "test@researchhub_test.com"
@@ -99,7 +99,7 @@ class NoteTests(APITestCase):
 
         Permission.objects.create(
             access_type="MEMBER",
-            content_type=self.organization_content_type,
+            content_type=self.organization_ct,
             object_id=self.org["id"],
             user=member_user,
         )
@@ -133,7 +133,7 @@ class NoteTests(APITestCase):
 
         Permission.objects.create(
             access_type="VIEWER",
-            content_type=self.unified_doc_content_type,
+            content_type=self.unified_doc_ct,
             object_id=note["unified_document"]["id"],
             user=viewer_user,
         )
@@ -223,7 +223,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="EDITOR",
-            content_type=self.unified_doc_content_type,
+            content_type=self.unified_doc_ct,
             object_id=note["unified_document"]["id"],
             user=editor_user,
         )
@@ -264,7 +264,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="EDITOR",
-            content_type=self.unified_doc_content_type,
+            content_type=self.unified_doc_ct,
             object_id=note["unified_document"]["id"],
             user=editor_user,
         )
@@ -316,7 +316,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="VIEWER",
-            content_type=self.unified_doc_content_type,
+            content_type=self.unified_doc_ct,
             object_id=note["unified_document"]["id"],
             user=viewer_user,
         )
@@ -373,7 +373,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="VIEWER",
-            content_type=self.unified_doc_content_type,
+            content_type=self.unified_doc_ct,
             object_id=note["unified_document"]["id"],
             user=invited_viewer,
         )
@@ -414,7 +414,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="ADMIN",
-            content_type=self.unified_doc_content_type,
+            content_type=self.unified_doc_ct,
             object_id=note["unified_document"]["id"],
             user=invited_note_admin,
         )
@@ -458,7 +458,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="ADMIN",
-            content_type=self.unified_doc_content_type,
+            content_type=self.unified_doc_ct,
             object_id=note["unified_document"]["id"],
             user=invited_note_admin,
         )
@@ -588,7 +588,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="VIEWER",
-            content_type=self.unified_doc_content_type,
+            content_type=self.unified_doc_ct,
             object_id=note["unified_document"]["id"],
             user=viewer_user,
         )
@@ -596,7 +596,7 @@ class NoteTests(APITestCase):
         # Upgrade user to org member
         Permission.objects.create(
             access_type="MEMBER",
-            content_type=self.organization_content_type,
+            content_type=self.organization_ct,
             object_id=self.org["id"],
             user=viewer_user,
         )
@@ -633,7 +633,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="ADMIN",
-            content_type=self.unified_doc_content_type,
+            content_type=self.unified_doc_ct,
             object_id=note["unified_document"]["id"],
             user=admin_user,
         )
@@ -672,7 +672,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="EDITOR",
-            content_type=self.unified_doc_content_type,
+            content_type=self.unified_doc_ct,
             object_id=note["unified_document"]["id"],
             user=editor_user,
         )
@@ -706,7 +706,7 @@ class NoteTests(APITestCase):
         # Add second user
         Permission.objects.create(
             access_type="MEMBER",
-            content_type=self.organization_content_type,
+            content_type=self.organization_ct,
             object_id=self.org["id"],
             user=member_user,
         )
@@ -741,7 +741,7 @@ class NoteTests(APITestCase):
         # Add user
         Permission.objects.create(
             access_type="MEMBER",
-            content_type=self.organization_content_type,
+            content_type=self.organization_ct,
             object_id=self.org["id"],
             user=member_user,
         )

--- a/src/note/tests/test_note_api.py
+++ b/src/note/tests/test_note_api.py
@@ -11,12 +11,17 @@ from researchhub_document.models import ResearchhubUnifiedDocument
 from user.models import Organization
 from user.tests.helpers import make_user_verified
 
-unified_doc_content_type = ContentType.objects.get_for_model(ResearchhubUnifiedDocument)
-organization_content_type = ContentType.objects.get_for_model(Organization)
-
 
 class NoteTests(APITestCase):
+    organization_content_type = None
+    unified_doc_content_type = None
+
     def setUp(self):
+        self.unified_doc_content_type = ContentType.objects.get_for_model(
+            ResearchhubUnifiedDocument
+        )
+        self.organization_content_type = ContentType.objects.get_for_model(Organization)
+
         # Create + auth user
         username = "test@researchhub_test.com"
         password = uuid.uuid4().hex
@@ -94,7 +99,7 @@ class NoteTests(APITestCase):
 
         Permission.objects.create(
             access_type="MEMBER",
-            content_type=organization_content_type,
+            content_type=self.organization_content_type,
             object_id=self.org["id"],
             user=member_user,
         )
@@ -128,7 +133,7 @@ class NoteTests(APITestCase):
 
         Permission.objects.create(
             access_type="VIEWER",
-            content_type=unified_doc_content_type,
+            content_type=self.unified_doc_content_type,
             object_id=note["unified_document"]["id"],
             user=viewer_user,
         )
@@ -218,7 +223,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="EDITOR",
-            content_type=unified_doc_content_type,
+            content_type=self.unified_doc_content_type,
             object_id=note["unified_document"]["id"],
             user=editor_user,
         )
@@ -259,7 +264,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="EDITOR",
-            content_type=unified_doc_content_type,
+            content_type=self.unified_doc_content_type,
             object_id=note["unified_document"]["id"],
             user=editor_user,
         )
@@ -311,7 +316,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="VIEWER",
-            content_type=unified_doc_content_type,
+            content_type=self.unified_doc_content_type,
             object_id=note["unified_document"]["id"],
             user=viewer_user,
         )
@@ -368,7 +373,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="VIEWER",
-            content_type=unified_doc_content_type,
+            content_type=self.unified_doc_content_type,
             object_id=note["unified_document"]["id"],
             user=invited_viewer,
         )
@@ -409,7 +414,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="ADMIN",
-            content_type=unified_doc_content_type,
+            content_type=self.unified_doc_content_type,
             object_id=note["unified_document"]["id"],
             user=invited_note_admin,
         )
@@ -453,7 +458,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="ADMIN",
-            content_type=unified_doc_content_type,
+            content_type=self.unified_doc_content_type,
             object_id=note["unified_document"]["id"],
             user=invited_note_admin,
         )
@@ -583,7 +588,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="VIEWER",
-            content_type=unified_doc_content_type,
+            content_type=self.unified_doc_content_type,
             object_id=note["unified_document"]["id"],
             user=viewer_user,
         )
@@ -591,7 +596,7 @@ class NoteTests(APITestCase):
         # Upgrade user to org member
         Permission.objects.create(
             access_type="MEMBER",
-            content_type=organization_content_type,
+            content_type=self.organization_content_type,
             object_id=self.org["id"],
             user=viewer_user,
         )
@@ -628,7 +633,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="ADMIN",
-            content_type=unified_doc_content_type,
+            content_type=self.unified_doc_content_type,
             object_id=note["unified_document"]["id"],
             user=admin_user,
         )
@@ -667,7 +672,7 @@ class NoteTests(APITestCase):
         # Add permission to user
         Permission.objects.create(
             access_type="EDITOR",
-            content_type=unified_doc_content_type,
+            content_type=self.unified_doc_content_type,
             object_id=note["unified_document"]["id"],
             user=editor_user,
         )
@@ -701,7 +706,7 @@ class NoteTests(APITestCase):
         # Add second user
         Permission.objects.create(
             access_type="MEMBER",
-            content_type=organization_content_type,
+            content_type=self.organization_content_type,
             object_id=self.org["id"],
             user=member_user,
         )
@@ -736,7 +741,7 @@ class NoteTests(APITestCase):
         # Add user
         Permission.objects.create(
             access_type="MEMBER",
-            content_type=organization_content_type,
+            content_type=self.organization_content_type,
             object_id=self.org["id"],
             user=member_user,
         )

--- a/src/note/tests/test_note_api.py
+++ b/src/note/tests/test_note_api.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from rest_framework.test import APITestCase
 
+from invite.related_models.note_invitation import NoteInvitation
 from note.models import Note
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
 from researchhub_access_group.models import Permission
@@ -1532,4 +1533,211 @@ class NoteTests(APITestCase):
         self.assertEqual(application["applicant"]["id"], applicant.author_profile.id)
         self.assertEqual(
             application["preregistration_post_id"], preregistration_response.data["id"]
+        )
+
+
+class AccessibleNoteTests(APITestCase):
+    organization_ct = None
+
+    def setUp(self):
+        self.organization_ct = ContentType.objects.get_for_model(Organization)
+
+        username = "test@researchhub_test.com"
+        password = uuid.uuid4().hex
+        self.user = get_user_model().objects.create_user(
+            username=username, password=password, email=username, moderator=True
+        )
+        make_user_verified(self.user)
+        self.client.force_authenticate(self.user)
+
+        response = self.client.post("/api/organization/", {"name": "some org"})
+        self.org = response.data
+
+        RscExchangeRate.objects.create(rate=4.99014625)
+
+    def test_accessible_notes_returns_all_notes_user_can_access(self):
+        # Arrange
+        own_response = self.client.post(
+            "/api/note/",
+            {
+                "grouping": "PRIVATE",
+                "organization_slug": self.org["slug"],
+                "title": "Own private note",
+            },
+        )
+        self.assertEqual(own_response.status_code, 200)
+
+        org_member = get_user_model().objects.create_user(
+            username="org-member@researchhub.com",
+            password=uuid.uuid4().hex,
+            email="org-member@researchhub.com",
+        )
+        Permission.objects.create(
+            access_type="MEMBER",
+            content_type=self.organization_ct,
+            object_id=self.org["id"],
+            user=org_member,
+        )
+        self.client.force_authenticate(org_member)
+        org_note_response = self.client.post(
+            "/api/note/",
+            {
+                "grouping": "WORKSPACE",
+                "organization_slug": self.org["slug"],
+                "title": "Workspace note from member",
+            },
+        )
+        self.assertEqual(org_note_response.status_code, 200)
+
+        inviter = get_user_model().objects.create_user(
+            username="inviter@researchhub.com",
+            password=uuid.uuid4().hex,
+            email="inviter@researchhub.com",
+        )
+        self.client.force_authenticate(inviter)
+        invited_note_response = self.client.post(
+            "/api/note/",
+            {
+                "grouping": "PRIVATE",
+                "organization_slug": inviter.organization.slug,
+                "title": "Accepted invite note",
+            },
+        )
+        self.assertEqual(invited_note_response.status_code, 200)
+        invite = NoteInvitation.create(
+            expiration_time=1440,
+            recipient=None,
+            recipient_email=self.user.email,
+            inviter_id=inviter.id,
+            note_id=invited_note_response.data["id"],
+            invite_type="EDITOR",
+        )
+
+        unrelated_user = get_user_model().objects.create_user(
+            username="unrelated@researchhub.com",
+            password=uuid.uuid4().hex,
+            email="unrelated@researchhub.com",
+        )
+        self.client.force_authenticate(unrelated_user)
+        unrelated_response = self.client.post(
+            "/api/note/",
+            {
+                "grouping": "PRIVATE",
+                "organization_slug": unrelated_user.organization.slug,
+                "title": "Unrelated note",
+            },
+        )
+        self.assertEqual(unrelated_response.status_code, 200)
+
+        self.client.force_authenticate(self.user)
+        accept_response = self.client.post(
+            f"/api/invite/note/{invite.key}/accept_invite/"
+        )
+        self.assertEqual(accept_response.status_code, 200)
+        removed_response = self.client.post(
+            "/api/note/",
+            {
+                "grouping": "PRIVATE",
+                "organization_slug": self.org["slug"],
+                "title": "Removed note",
+            },
+        )
+        self.assertEqual(removed_response.status_code, 200)
+        delete_response = self.client.post(
+            f"/api/note/{removed_response.data['id']}/delete/"
+        )
+        self.assertEqual(delete_response.status_code, 200)
+
+        # Act
+        response = self.client.get("/api/note/accessible/")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        titles = {note["title"] for note in response.data["results"]}
+        self.assertEqual(
+            titles,
+            {
+                "Accepted invite note",
+                "Own private note",
+                "Workspace note from member",
+            },
+        )
+        self.assertNotIn("Unrelated note", titles)
+        self.assertNotIn("Removed note", titles)
+        self.assertNotIn("latest_version", response.data["results"][0])
+
+    def test_accessible_notes_supports_status_and_type_filters(self):
+        # Arrange
+        draft_grant_response = self.client.post(
+            "/api/note/",
+            {
+                "grouping": "WORKSPACE",
+                "organization_slug": self.org["slug"],
+                "title": "Draft grant",
+                "document_type": "GRANT",
+            },
+        )
+        self.assertEqual(draft_grant_response.status_code, 200)
+
+        published_grant_response = self.client.post(
+            "/api/note/",
+            {
+                "grouping": "WORKSPACE",
+                "organization_slug": self.org["slug"],
+                "title": "Published grant",
+                "document_type": "GRANT",
+            },
+        )
+        self.assertEqual(published_grant_response.status_code, 200)
+
+        draft_preregistration_response = self.client.post(
+            "/api/note/",
+            {
+                "grouping": "WORKSPACE",
+                "organization_slug": self.org["slug"],
+                "title": "Draft preregistration",
+                "document_type": "PREREGISTRATION",
+            },
+        )
+        self.assertEqual(draft_preregistration_response.status_code, 200)
+
+        post_response = self.client.post(
+            "/api/researchhubpost/",
+            {
+                "document_type": "GRANT",
+                "created_by": self.user.id,
+                "full_src": "Grant post content",
+                "is_public": True,
+                "note_id": published_grant_response.data["id"],
+                "renderable_text": (
+                    "Grant post content that is sufficiently long for validation"
+                ),
+                "title": "Grant post title that is sufficiently long",
+                "hubs": [],
+                "grant_amount": 50000,
+                "grant_currency": "USD",
+                "grant_organization": "Test Foundation",
+                "grant_description": "Test grant description",
+            },
+        )
+        self.assertEqual(post_response.status_code, 200)
+
+        # Act
+        draft_response = self.client.get(
+            "/api/note/accessible/?status=DRAFT&type=GRANT"
+        )
+        published_response = self.client.get(
+            "/api/note/accessible/?status=PUBLISHED&type=GRANT"
+        )
+
+        # Assert
+        self.assertEqual(draft_response.status_code, 200)
+        self.assertEqual(draft_response.data["count"], 1)
+        self.assertEqual(draft_response.data["results"][0]["title"], "Draft grant")
+        self.assertEqual(draft_response.data["results"][0]["document_type"], "GRANT")
+
+        self.assertEqual(published_response.status_code, 200)
+        self.assertEqual(published_response.data["count"], 1)
+        self.assertEqual(
+            published_response.data["results"][0]["title"], "Published grant"
         )

--- a/src/note/views/note_view.py
+++ b/src/note/views/note_view.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 from django.shortcuts import get_object_or_404
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -14,7 +14,11 @@ from invite.models import NoteInvitation
 from invite.serializers import DynamicNoteInvitationSerializer
 from invite.services import NoteInvitationExpiredError, NoteInvitationService
 from note.models import Note, NoteContent
-from note.serializers import NoteContentSerializer, NoteSerializer
+from note.serializers import (
+    DynamicNoteSerializer,
+    NoteContentSerializer,
+    NoteSerializer,
+)
 from researchhub.pagination import MediumPageLimitPagination
 from researchhub.settings import TESTING
 from researchhub_access_group.constants import (
@@ -57,6 +61,88 @@ class NoteViewSet(ModelViewSet):
             .distinct()
             .order_by("-created_date")
         )
+
+    @action(detail=False, methods=["get"], permission_classes=[IsAuthenticated])
+    def accessible(self, request):
+        """
+        Endpoint to retrieve all notes that the current user has access to, including
+        those associated with organizations they belong to, and those they have explicit
+        permissions for (e.g., by invitation).
+        The notes are filtered based on the user's access rights and the status of the
+        notes (draft or published).
+        This endpoint mirrors the behavior and shape of the `get_organization_notes`
+        endpoint.
+        """
+        notes = self._get_accessible_notes(request.user)
+        notes = self._filter_accessible_notes(notes, request)
+        notes = notes.select_related(
+            "organization",
+            "unified_document",
+        ).prefetch_related(
+            "unified_document__permissions",
+        )
+
+        page = self.paginate_queryset(notes)
+        serializer_data = DynamicNoteSerializer(
+            page,
+            _include_fields=[
+                "access",
+                "created_date",
+                "document_type",
+                "id",
+                "organization",
+                "title",
+                "updated_date",
+            ],
+            context=self._get_accessible_notes_context(),
+            many=True,
+        ).data
+        return self.get_paginated_response(serializer_data)
+
+    def _get_accessible_notes(self, user) -> QuerySet[Note]:
+        return (
+            self.queryset.filter(
+                (
+                    Q(unified_document__permissions__user=user)
+                    & ~Q(unified_document__permissions__access_type=NO_ACCESS)
+                )
+                | (
+                    Q(
+                        unified_document__permissions__organization__permissions__user=user
+                    )
+                    & ~Q(unified_document__permissions__access_type=NO_ACCESS)
+                )
+            )
+            .distinct()
+            .order_by("-created_date")
+        )
+
+    def _filter_accessible_notes(
+        self, notes: QuerySet[Note], request
+    ) -> QuerySet[Note]:
+        status = request.query_params.get("status", "").upper()
+        if status == "DRAFT":
+            notes = notes.filter(post__isnull=True)
+        elif status == "PUBLISHED":
+            notes = notes.filter(post__isnull=False)
+
+        note_type = request.query_params.get("type", "").upper()
+        if note_type:
+            notes = notes.filter(document_type=note_type)
+
+        return notes
+
+    def _get_accessible_notes_context(self) -> dict:
+        return {
+            "nte_dns_get_organization": {
+                "_include_fields": [
+                    "cover_image",
+                    "id",
+                    "name",
+                    "slug",
+                ]
+            }
+        }
 
     def create(self, request, *args, **kwargs):
         user = request.user


### PR DESCRIPTION
Add a new endpoint that mirrors the shape and behavior (query parameters) of the existing `get_organization_notes`. Instead of just returning the notes of the current organization, it returns all notes the user has access to (including notes by invitation and notes from other organizations).