### PR TITLE
New proposal draft endpoint

### DIFF
--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -15,6 +15,7 @@ from research_ai.models import (
     Expert,
     ExpertSearch,
     GeneratedEmail,
+    ProposalDraft,
     SearchExpert,
 )
 from research_ai.services.expert_display import ExpertDisplay
@@ -824,3 +825,36 @@ class EmailTemplateUpdateSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=255, required=False, allow_blank=False)
     email_subject = serializers.CharField(required=False, allow_blank=True)
     email_body = serializers.CharField(required=False, allow_blank=True)
+
+
+class ProposalDraftCreateSerializer(serializers.Serializer):
+    """
+    Request body for enqueueing a proposal-drafting job.
+    """
+
+    search_expert_id = serializers.IntegerField(min_value=1)
+
+
+class ProposalDraftSerializer(serializers.ModelSerializer):
+    """
+    Read-only job status/result payload for a `ProposalDraft`.
+    """
+
+    class Meta:
+        model = ProposalDraft
+        fields = [
+            "id",
+            "search_expert",
+            "created_by",
+            "note",
+            "status",
+            "step",
+            "rounds_used",
+            "final_scores",
+            "gate_report",
+            "error_message",
+            "processing_time",
+            "created_date",
+            "completed_at",
+        ]
+        read_only_fields = fields

--- a/src/research_ai/services/proposal_draft/runner.py
+++ b/src/research_ai/services/proposal_draft/runner.py
@@ -348,6 +348,7 @@ def _needs_profile(profile) -> bool:
 def run_proposal_draft(
     search_expert_id,
     *,
+    draft_id=None,
     progress_callback=None,
     provider=None,
     panel: ProposalJudgePanel | None = None,
@@ -356,10 +357,12 @@ def run_proposal_draft(
 ) -> dict:
     """Run a headless proposal-drafting job for one ``SearchExpert``.
 
-    Creates a ``ProposalDraft``, builds the agent, runs the bounded
-    draft -> critique -> verify -> revise loop with a deterministic gate before
-    stop, and writes the verified proposal as a ``Note``. Returns a result dict
-    carrying the final status, the gate report, and (on success) the note id.
+    Creates a ``ProposalDraft`` (or, when ``draft_id`` is given, resumes a
+    pre-created ``PENDING`` record), builds the agent, runs the bounded draft
+    -> critique -> verify -> revise loop with a deterministic gate before stop,
+    and writes the verified proposal as a ``Note``.
+    Returns a result dict carrying the final status, the gate report, and (on success)
+    the note id.
 
     ``provider`` / ``panel`` / ``oa_client`` / ``web_search_client`` are
     injectable for tests; in production they default to the real Bedrock
@@ -368,11 +371,14 @@ def run_proposal_draft(
     search_expert = SearchExpert.objects.select_related(
         "expert", "expert_search", "expert_search__unified_document"
     ).get(id=search_expert_id)
-    draft = ProposalDraft.objects.create(
-        search_expert=search_expert,
-        status=ProposalDraft.Status.PENDING,
-        step=ProposalDraft.Step.QUEUED,
-    )
+    if draft_id is not None:
+        draft = ProposalDraft.objects.get(id=draft_id)
+    else:
+        draft = ProposalDraft.objects.create(
+            search_expert=search_expert,
+            status=ProposalDraft.Status.PENDING,
+            step=ProposalDraft.Step.QUEUED,
+        )
     runner = _ProposalDraftRunner(
         search_expert,
         draft,

--- a/src/research_ai/tasks.py
+++ b/src/research_ai/tasks.py
@@ -4,7 +4,7 @@ from functools import partial
 from django.utils import timezone
 
 from research_ai.constants import VALID_EMAIL_TEMPLATE_KEYS
-from research_ai.models import ExpertSearch, GeneratedEmail
+from research_ai.models import ExpertSearch, GeneratedEmail, ProposalDraft
 from research_ai.services import expert_finder_service as expert_finder_service_mod
 from research_ai.services.email_generator_service import generate_expert_email
 from research_ai.services.email_sending_service import send_plain_email
@@ -14,6 +14,7 @@ from research_ai.services.invited_experts_service import (
     grant_invited_expert_access_for_send,
     link_experts_for_new_user,
 )
+from research_ai.services.proposal_draft import run_proposal_draft
 from research_ai.services.rfp_email_context import get_expert_for_search_by_email
 from researchhub.celery import app
 from user.models import User
@@ -228,6 +229,41 @@ def run_expert_finder_search(
             error_message=err,
         )
         raise
+
+
+@app.task
+def run_proposal_draft_task(draft_id: int):
+    """
+    Background task to run one headless proposal-drafting job.
+    """
+    try:
+        draft = ProposalDraft.objects.get(id=draft_id)
+    except ProposalDraft.DoesNotExist:
+        logger.warning("Proposal draft not found", extra={"draft_id": draft_id})
+        return {"status": "not_found", "draft_id": draft_id}
+
+    logger.info("Starting proposal draft", extra={"draft_id": draft_id})
+    start_time = timezone.now()
+    try:
+        result = run_proposal_draft(draft.search_expert_id, draft_id=draft.id)
+    except Exception as e:
+        logger.exception("Proposal draft task failed", extra={"draft_id": draft_id})
+        ProposalDraft.objects.filter(id=draft_id).update(
+            status=ProposalDraft.Status.FAILED,
+            error_message=str(e)[:10000],
+        )
+        raise
+    processing_time = (timezone.now() - start_time).total_seconds()
+    ProposalDraft.objects.filter(id=draft_id).update(processing_time=processing_time)
+    logger.info(
+        "Proposal draft finished",
+        extra={
+            "draft_id": draft_id,
+            "status": result.get("status"),
+            "processing_time": processing_time,
+        },
+    )
+    return result
 
 
 def _normalize_template_for_bulk(template: str | None) -> tuple[str | None, str | None]:

--- a/src/research_ai/tests/proposal_draft/test_proposal_draft_service.py
+++ b/src/research_ai/tests/proposal_draft/test_proposal_draft_service.py
@@ -287,6 +287,33 @@ class ProposalDraftServiceTests(TestCase):
             "https://doi.org/10.1/a",
         )
 
+    def test_run_with_pre_created_draft_reuses_row(self):
+        # Arrange
+        draft = ProposalDraft.objects.create(
+            search_expert=self.search_expert,
+            created_by=self.user,
+            status=ProposalDraft.Status.PENDING,
+            step=ProposalDraft.Step.QUEUED,
+        )
+        provider = _ScriptedProvider([_submit_turn(_clean_payload())])
+        panel = _FakePanel(overall=5)
+
+        # Act
+        result = run_proposal_draft(
+            self.search_expert.id,
+            draft_id=draft.id,
+            provider=provider,
+            panel=panel,
+            oa_client=_FakeOpenAlex(),
+        )
+
+        # Assert
+        self.assertEqual(result["proposal_draft_id"], draft.id)
+        self.assertEqual(ProposalDraft.objects.count(), 1)
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, ProposalDraft.Status.COMPLETED)
+        self.assertEqual(draft.created_by, self.user)
+
     # -- a major_fabrication submit is blocked, gaps fed back -------------
 
     def test_major_fabrication_submit_is_blocked_and_loop_continues(self):

--- a/src/research_ai/tests/proposal_draft/test_proposal_draft_views.py
+++ b/src/research_ai/tests/proposal_draft/test_proposal_draft_views.py
@@ -1,0 +1,167 @@
+"""API tests for the proposal-draft endpoints.
+
+The Celery task is patched at the view boundary; running the actual
+drafting loop is covered by ``test_proposal_draft_service``.
+"""
+
+from unittest.mock import patch
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from research_ai.models import Expert, ExpertSearch, ProposalDraft, SearchExpert
+from user.tests.helpers import create_random_authenticated_user
+
+BASE_URL = "/api/research_ai/expert-finder/proposal-drafts/"
+
+
+class ProposalDraftCreateViewTests(APITestCase):
+    def setUp(self):
+        self.moderator = create_random_authenticated_user("mod", moderator=True)
+        self.user = create_random_authenticated_user("user", moderator=False)
+        self.expert = Expert.objects.create(email="jane@example.edu")
+        self.expert_search = ExpertSearch.objects.create(
+            created_by=self.moderator,
+            query="protein folding",
+        )
+        self.search_expert = SearchExpert.objects.create(
+            expert_search=self.expert_search,
+            expert=self.expert,
+        )
+
+    def test_create_requires_editor_or_moderator(self):
+        # Arrange
+        self.client.force_authenticate(self.user)
+
+        # Act
+        response = self.client.post(
+            BASE_URL, {"search_expert_id": self.search_expert.id}, format="json"
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @patch("research_ai.views.proposal_draft_views.run_proposal_draft_task.delay")
+    def test_create_returns_201_and_enqueues_task(self, mock_delay):
+        # Arrange
+        self.client.force_authenticate(self.moderator)
+
+        # Act
+        response = self.client.post(
+            BASE_URL, {"search_expert_id": self.search_expert.id}, format="json"
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+        draft = ProposalDraft.objects.get(id=data["id"])
+        self.assertEqual(draft.search_expert_id, self.search_expert.id)
+        self.assertEqual(draft.created_by, self.moderator)
+        self.assertEqual(draft.status, ProposalDraft.Status.PENDING)
+        self.assertEqual(draft.step, ProposalDraft.Step.QUEUED)
+        self.assertEqual(data["status"], ProposalDraft.Status.PENDING)
+        mock_delay.assert_called_once_with(draft.id)
+
+    def test_create_without_search_expert_id_returns_400(self):
+        # Arrange
+        self.client.force_authenticate(self.moderator)
+
+        # Act
+        response = self.client.post(BASE_URL, {}, format="json")
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_unknown_search_expert_returns_404(self):
+        # Arrange
+        self.client.force_authenticate(self.moderator)
+
+        # Act
+        response = self.client.post(
+            BASE_URL, {"search_expert_id": 999999}, format="json"
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch("research_ai.views.proposal_draft_views.run_proposal_draft_task.delay")
+    def test_create_with_active_draft_returns_409(self, mock_delay):
+        # Arrange
+        draft = ProposalDraft.objects.create(
+            search_expert=self.search_expert,
+            status=ProposalDraft.Status.PROCESSING,
+        )
+        self.client.force_authenticate(self.moderator)
+
+        # Act
+        response = self.client.post(
+            BASE_URL, {"search_expert_id": self.search_expert.id}, format="json"
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(ProposalDraft.objects.count(), 1)
+        mock_delay.assert_not_called()
+        self.assertEqual(response.json()["proposal_draft_id"], draft.id)
+
+
+class ProposalDraftDetailViewTests(APITestCase):
+    def setUp(self):
+        # Arrange
+        self.moderator = create_random_authenticated_user("mod", moderator=True)
+        self.user = create_random_authenticated_user("user", moderator=False)
+        self.expert = Expert.objects.create(email="jane@example.edu")
+        self.expert_search = ExpertSearch.objects.create(
+            created_by=self.moderator,
+            query="protein folding",
+        )
+        self.search_expert = SearchExpert.objects.create(
+            expert_search=self.expert_search,
+            expert=self.expert,
+        )
+        self.draft = ProposalDraft.objects.create(
+            search_expert=self.search_expert,
+            created_by=self.moderator,
+            status=ProposalDraft.Status.FAILED,
+            step=ProposalDraft.Step.DRAFTING,
+            rounds_used=2,
+            error_message="gates not cleared within 2 rounds",
+        )
+
+    def test_detail_requires_editor_or_moderator(self):
+        # Arrange
+        self.client.force_authenticate(self.user)
+
+        # Act
+        response = self.client.get(f"{BASE_URL}{self.draft.id}/")
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_detail_returns_job_state(self):
+        # Arrange
+        self.client.force_authenticate(self.moderator)
+
+        # Act
+        response = self.client.get(f"{BASE_URL}{self.draft.id}/")
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["id"], self.draft.id)
+        self.assertEqual(data["search_expert"], self.search_expert.id)
+        self.assertEqual(data["status"], ProposalDraft.Status.FAILED)
+        self.assertEqual(data["step"], ProposalDraft.Step.DRAFTING)
+        self.assertEqual(data["rounds_used"], 2)
+        self.assertEqual(data["error_message"], "gates not cleared within 2 rounds")
+        self.assertIsNone(data["note"])
+
+    def test_detail_not_found_returns_404(self):
+        # Arrange
+        self.client.force_authenticate(self.moderator)
+
+        # Act
+        response = self.client.get(f"{BASE_URL}999999/")
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/src/research_ai/tests/test_tasks.py
+++ b/src/research_ai/tests/test_tasks.py
@@ -4,10 +4,17 @@ from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 
-from research_ai.models import Expert, ExpertSearch, GeneratedEmail
+from research_ai.models import (
+    Expert,
+    ExpertSearch,
+    GeneratedEmail,
+    ProposalDraft,
+    SearchExpert,
+)
 from research_ai.tasks import (
     _update_search_progress,
     process_bulk_generate_emails_task,
+    run_proposal_draft_task,
     send_queued_emails_task,
 )
 from user.tests.helpers import create_random_authenticated_user
@@ -305,3 +312,58 @@ class SendQueuedEmailsTaskTests(TestCase):
         self.assertIsNotNone(ex.last_email_sent_at)
         if before:
             self.assertGreaterEqual(ex.last_email_sent_at, before)
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+class RunProposalDraftTaskTests(TestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("draft_user")
+        self.expert = Expert.objects.create(email="draft-expert@example.edu")
+        self.expert_search = ExpertSearch.objects.create(
+            created_by=self.user,
+            query="protein folding",
+        )
+        self.search_expert = SearchExpert.objects.create(
+            expert_search=self.expert_search,
+            expert=self.expert,
+        )
+        self.draft = ProposalDraft.objects.create(
+            search_expert=self.search_expert,
+            created_by=self.user,
+        )
+
+    @patch("research_ai.tasks.run_proposal_draft")
+    def test_runs_service(self, mock_run):
+        # Arrange
+        mock_run.return_value = {
+            "status": ProposalDraft.Status.COMPLETED,
+            "proposal_draft_id": self.draft.id,
+        }
+
+        # Act
+        result = run_proposal_draft_task.apply(args=[self.draft.id]).get()
+
+        # Assert
+        mock_run.assert_called_once_with(self.search_expert.id, draft_id=self.draft.id)
+        self.assertEqual(result["status"], ProposalDraft.Status.COMPLETED)
+        self.draft.refresh_from_db()
+        self.assertIsNotNone(self.draft.processing_time)
+
+    @patch("research_ai.tasks.run_proposal_draft")
+    def test_unexpected_error_marks_draft_failed(self, mock_run):
+        # Arrange
+        mock_run.side_effect = SearchExpert.DoesNotExist("SearchExpert gone")
+
+        # Act & Assert
+        with self.assertRaises(SearchExpert.DoesNotExist):
+            run_proposal_draft_task.apply(args=[self.draft.id]).get()
+        self.draft.refresh_from_db()
+        self.assertEqual(self.draft.status, ProposalDraft.Status.FAILED)
+        self.assertIn("SearchExpert gone", self.draft.error_message)
+
+    def test_missing_draft_returns_not_found(self):
+        # Act
+        result = run_proposal_draft_task.apply(args=[999999]).get()
+
+        # Assert
+        self.assertEqual(result, {"status": "not_found", "draft_id": 999999})

--- a/src/research_ai/urls.py
+++ b/src/research_ai/urls.py
@@ -20,6 +20,10 @@ from research_ai.views.expert_finder_views import (
     InvitedExpertEditorsOverviewView,
     InvitedExpertOverviewView,
 )
+from research_ai.views.proposal_draft_views import (
+    ProposalDraftCreateView,
+    ProposalDraftDetailView,
+)
 from research_ai.views.template_views import TemplateDetailView, TemplateListView
 
 urlpatterns = [
@@ -85,5 +89,13 @@ urlpatterns = [
     path(
         "expert-finder/rfp/<int:grant_id>/invite-applicants/",
         InviteRfpApplicantsView.as_view(),
+    ),
+    path(
+        "expert-finder/proposal-drafts/",
+        ProposalDraftCreateView.as_view(),
+    ),
+    path(
+        "expert-finder/proposal-drafts/<int:draft_id>/",
+        ProposalDraftDetailView.as_view(),
     ),
 ]

--- a/src/research_ai/views/proposal_draft_views.py
+++ b/src/research_ai/views/proposal_draft_views.py
@@ -1,0 +1,90 @@
+import logging
+
+from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from research_ai.models import ProposalDraft, SearchExpert
+from research_ai.permissions import ResearchAIPermission
+from research_ai.serializers import (
+    ProposalDraftCreateSerializer,
+    ProposalDraftSerializer,
+)
+from research_ai.tasks import run_proposal_draft_task
+from user.permissions import IsModerator, UserIsEditor
+
+logger = logging.getLogger(__name__)
+
+
+class ProposalDraftCreateView(APIView):
+    """
+    View for creating proposal draft jobs.
+    """
+
+    permission_classes = [
+        IsAuthenticated,
+        ResearchAIPermission,
+        UserIsEditor | IsModerator,
+    ]
+
+    def post(self, request):
+        """
+        Create a new proposal draft job for a given search expert.
+        If a draft is already in progress for that expert,
+        return a 409 Conflict with the existing draft ID.
+        """
+        serializer = ProposalDraftCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        search_expert_id = serializer.validated_data["search_expert_id"]
+
+        search_expert = get_object_or_404(SearchExpert, id=search_expert_id)
+
+        active = ProposalDraft.objects.filter(
+            search_expert=search_expert,
+            status__in=[
+                ProposalDraft.Status.PENDING,
+                ProposalDraft.Status.PROCESSING,
+            ],
+        ).first()
+        if active is not None:
+            return Response(
+                {
+                    "detail": (
+                        "A proposal draft is already in progress for this expert"
+                    ),
+                    "proposal_draft_id": active.id,
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        draft = ProposalDraft.objects.create(
+            search_expert=search_expert,
+            created_by=request.user,
+            status=ProposalDraft.Status.PENDING,
+            step=ProposalDraft.Step.QUEUED,
+        )
+        run_proposal_draft_task.delay(draft.id)
+
+        return Response(
+            ProposalDraftSerializer(draft).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+
+class ProposalDraftDetailView(APIView):
+    """
+    View for polling the status of a proposal draft job.
+    """
+
+    permission_classes = [
+        IsAuthenticated,
+        ResearchAIPermission,
+        UserIsEditor | IsModerator,
+    ]
+
+    def get(self, request, draft_id):
+        draft = get_object_or_404(ProposalDraft, id=draft_id)
+
+        return Response(ProposalDraftSerializer(draft).data)


### PR DESCRIPTION
Add a new endpoint to allow callers to trigger and run new proposal draft runs and check their status.