### PR TITLE
Remove chat-based expert finder fallback

### DIFF
--- a/src/research_ai/services/openai_expert_finder_service.py
+++ b/src/research_ai/services/openai_expert_finder_service.py
@@ -25,7 +25,12 @@ class OpenAIExpertFinderService:
         temperature: float = 0.0,
     ) -> str:
         """
-        Run expert discovery via the Responses API with web search, when available.
+        Run expert discovery via the Responses API with web search.
+
+        Note that web search must yield results, otherwise the search fails.
+        This is deliberate: the expert emails in the output are used for email-based
+        outreach, so results must only come from a call where the model can verify
+        addresses via web search.
 
         Returns:
             The model's assistant message as plain text. Callers should treat this as
@@ -48,21 +53,8 @@ class OpenAIExpertFinderService:
                 temperature=temperature,
             )
         except Exception as e:
-            logger.warning(
-                "OpenAI Responses API with web_search failed, falling back to chat "
-                "completions: %s",
-                e,
-            )
-            try:
-                return self._invoke_chat_completions(
-                    system_prompt=system_prompt,
-                    user_prompt=user_prompt,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                )
-            except Exception as e2:
-                logger.exception("OpenAI expert finder failed")
-                raise RuntimeError(f"OpenAI expert finder failed: {e2}") from e2
+            logger.exception("OpenAI expert finder failed")
+            raise RuntimeError(f"OpenAI expert finder failed: {e}") from e
 
     def _invoke_with_web_search(
         self,
@@ -84,28 +76,3 @@ class OpenAIExpertFinderService:
         if not text:
             logger.warning("OpenAI Responses returned empty output_text")
         return text
-
-    def _invoke_chat_completions(
-        self,
-        *,
-        system_prompt: str,
-        user_prompt: str,
-        max_tokens: int,
-        temperature: float,
-    ) -> str:
-        """
-        Fallback path when web_search fails.
-        Uses Chat Completions without web search, so results may be less grounded.
-        """
-        completion = self._client.chat.completions.create(
-            model=self.model_id,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            max_completion_tokens=max_tokens,
-            temperature=temperature,
-        )
-        choice = completion.choices[0].message
-        content = choice.content or ""
-        return content.strip()

--- a/src/research_ai/tests/test_openai_expert_finder_service.py
+++ b/src/research_ai/tests/test_openai_expert_finder_service.py
@@ -11,7 +11,7 @@ from research_ai.services.openai_expert_finder_service import (
 
 
 class OpenAIExpertFinderServiceTests(TestCase):
-    """Cover invoke paths: missing key, Responses API, chat fallback, failures."""
+    """Cover invoke paths: missing key, Responses API with web search, failures."""
 
     def test_missing_api_key_raises_before_any_client_call(self):
         with override_settings(OPENAI_API_KEY=""):
@@ -56,37 +56,6 @@ class OpenAIExpertFinderServiceTests(TestCase):
 
     @override_settings(OPENAI_API_KEY="sk-test")
     @patch("research_ai.services.openai_expert_finder_service.OpenAI")
-    def test_invoke_falls_back_to_chat_when_responses_raises(self, mock_openai_cls):
-        mock_client = MagicMock()
-        mock_openai_cls.return_value = mock_client
-        mock_client.responses.create.side_effect = ValueError("responses unavailable")
-
-        completion = MagicMock()
-        completion.choices = [MagicMock()]
-        completion.choices[0].message.content = "  fallback text  "
-        mock_client.chat.completions.create.return_value = completion
-
-        svc = OpenAIExpertFinderService()
-        out = svc.invoke("sys", "user", max_tokens=100, temperature=0.0)
-
-        self.assertEqual(out, "fallback text")
-        mock_client.responses.create.assert_called_once()
-        mock_client.chat.completions.create.assert_called_once()
-        cc_kwargs = mock_client.chat.completions.create.call_args.kwargs
-        self.assertEqual(cc_kwargs["model"], OPENAI_EXPERT_FINDER_MODEL)
-        self.assertEqual(
-            cc_kwargs["messages"],
-            [
-                {"role": "system", "content": "sys"},
-                {"role": "user", "content": "user"},
-            ],
-        )
-        self.assertEqual(cc_kwargs["max_completion_tokens"], 100)
-        self.assertNotIn("max_tokens", cc_kwargs)
-        self.assertEqual(cc_kwargs["temperature"], 0.0)
-
-    @override_settings(OPENAI_API_KEY="sk-test")
-    @patch("research_ai.services.openai_expert_finder_service.OpenAI")
     def test_invoke_returns_empty_string_when_output_text_empty(self, mock_openai_cls):
         mock_client = MagicMock()
         mock_openai_cls.return_value = mock_client
@@ -98,34 +67,24 @@ class OpenAIExpertFinderServiceTests(TestCase):
         self.assertEqual(svc.invoke("s", "u"), "")
 
     @override_settings(OPENAI_API_KEY="sk-test")
-    @patch("research_ai.services.openai_expert_finder_service.OpenAI")
-    def test_invoke_chat_completion_null_content_returns_empty(self, mock_openai_cls):
-        mock_client = MagicMock()
-        mock_openai_cls.return_value = mock_client
-        mock_client.responses.create.side_effect = RuntimeError("no responses")
-
-        completion = MagicMock()
-        completion.choices = [MagicMock()]
-        completion.choices[0].message.content = None
-        mock_client.chat.completions.create.return_value = completion
-
-        svc = OpenAIExpertFinderService()
-        self.assertEqual(svc.invoke("s", "u"), "")
-
-    @override_settings(OPENAI_API_KEY="sk-test")
     @patch("research_ai.services.openai_expert_finder_service.logger")
     @patch("research_ai.services.openai_expert_finder_service.OpenAI")
-    def test_invoke_raises_when_both_paths_fail(self, mock_openai_cls, mock_logger):
+    def test_invoke_raises_without_ungrounded_fallback_when_responses_fails(
+        self, mock_openai_cls, mock_logger
+    ):
+        # Arrange
         mock_client = MagicMock()
         mock_openai_cls.return_value = mock_client
         mock_client.responses.create.side_effect = ValueError("responses failed")
-        mock_client.chat.completions.create.side_effect = ConnectionError(
-            "network down"
-        )
 
+        # Act
         svc = OpenAIExpertFinderService()
         with self.assertRaises(RuntimeError) as ctx:
             svc.invoke("s", "u")
+
+        # Assert
         self.assertIn("OpenAI expert finder failed", str(ctx.exception))
-        self.assertIsInstance(ctx.exception.__cause__, ConnectionError)
+        self.assertIsInstance(ctx.exception.__cause__, ValueError)
         mock_logger.exception.assert_called_once()
+        # No silent fallback to an ungrounded completion.
+        mock_client.chat.completions.create.assert_not_called()


### PR DESCRIPTION
Since expert emails in the output are used for email-based outreach, this change removes the chat-based LLM fallback to avoid using hallucinated email addresses.