### PR TITLE
Temporarily disable expert-finder outreach via SES kill switch

### DIFF
--- a/src/research_ai/services/email_sending_service.py
+++ b/src/research_ai/services/email_sending_service.py
@@ -7,6 +7,10 @@ from django.utils.html import strip_tags
 logger = logging.getLogger(__name__)
 
 
+class ExpertFinderOutreachDisabledError(Exception):
+    """Raised when expert-finder outreach sending is disabled via killswitch."""
+
+
 def send_plain_email(
     to_email: str,
     subject: str,
@@ -21,6 +25,15 @@ def send_plain_email(
 
     Returns the SES Message ID when the email was sent via SES, or None otherwise.
     """
+    if not settings.EXPERT_FINDER_OUTREACH_ENABLED:
+        logger.warning(
+            "Expert finder outreach disabled; refusing send to %s",
+            to_email,
+        )
+        raise ExpertFinderOutreachDisabledError(
+            "Expert finder outreach is temporarily disabled."
+        )
+
     subject = (subject or "").replace("\n", "").replace("\r", "")
     if not settings.PRODUCTION:
         subject = "[Staging] " + subject

--- a/src/research_ai/tests/test_email_views.py
+++ b/src/research_ai/tests/test_email_views.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from django.conf import settings
+from django.test import override_settings
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -802,6 +803,7 @@ class BulkGenerateEmailViewTests(APITestCase):
         mock_task.delay.assert_not_called()
 
 
+@override_settings(EXPERT_FINDER_OUTREACH_ENABLED=True)
 class SendPlainEmailTests(APITestCase):
     """Unit tests for send_plain_email service."""
 

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -847,6 +847,9 @@ if STAGING or PRODUCTION:
 
 # Killswitch Variables
 SERIALIZER_SWITCH = os.environ.get("SERIALIZER_SWITCH", True)
+EXPERT_FINDER_OUTREACH_ENABLED = (
+    os.environ.get("EXPERT_FINDER_OUTREACH_ENABLED", "false").lower() == "true"
+)
 
 # Crossref
 CROSSREF_DOI_RSC_FEE = 5


### PR DESCRIPTION
## What?
- Adds a temporary kill switch to block all expert-finder email sends (preview, outreach, and RFP invites) while AWS SES is unavailable
- Introduces `EXPERT_FINDER_OUTREACH_ENABLED` (defaults to `false` when the env var is unset)

## How?
- Added `EXPERT_FINDER_OUTREACH_ENABLED` in `settings.py` under the existing killswitch section
- Added an early guard in `send_plain_email()` that raises `ExpertFinderOutreachDisabledError` before any SES call when the flag is off
