### PR TITLE
Fix search index operation with `django-opensearch-dsl`

### DIFF
--- a/src/search/documents/hub.py
+++ b/src/search/documents/hub.py
@@ -58,11 +58,14 @@ class HubDocument(BaseDocument):
         count=None,
         alias=None,
     ) -> QuerySet:
-        return (
+        qs = (
             super()
-            .get_queryset(filter_=filter_, exclude=exclude, count=count, alias=alias)
+            .get_queryset(filter_=filter_, exclude=exclude, alias=alias)
             .exclude(namespace="journal")
         )
+        if count is not None:
+            qs = qs[:count]
+        return qs
 
     # Used specifically for "autocomplete" style suggest feature
     def prepare_name_suggest(self, instance) -> dict[str, Any]:

--- a/src/search/documents/hub.py
+++ b/src/search/documents/hub.py
@@ -2,7 +2,7 @@ import logging
 import re
 from typing import Any, override
 
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django_opensearch_dsl import fields as es_fields
 from django_opensearch_dsl.registries import registry
 from opensearchpy import analyzer, token_filter
@@ -53,10 +53,10 @@ class HubDocument(BaseDocument):
     @override
     def get_queryset(
         self,
-        filter_=None,
-        exclude=None,
-        count=None,
-        alias=None,
+        filter_: Q | None = None,
+        exclude: Q | None = None,
+        count: int = None,
+        alias: str = None,
     ) -> QuerySet:
         qs = (
             super()

--- a/src/search/documents/hub.py
+++ b/src/search/documents/hub.py
@@ -51,10 +51,16 @@ class HubDocument(BaseDocument):
         ]
 
     @override
-    def get_queryset(self, filter_=None, exclude=None, count=None) -> QuerySet:
+    def get_queryset(
+        self,
+        filter_=None,
+        exclude=None,
+        count=None,
+        alias=None,
+    ) -> QuerySet:
         return (
             super()
-            .get_queryset(filter_=filter_, exclude=exclude, count=count)
+            .get_queryset(filter_=filter_, exclude=exclude, count=count, alias=alias)
             .exclude(namespace="journal")
         )
 

--- a/src/search/documents/journal.py
+++ b/src/search/documents/journal.py
@@ -55,8 +55,8 @@ class JournalDocument(BaseDocument):
         self,
         filter_: Q | None = None,
         exclude: Q | None = None,
-        count: int = None,  # type: ignore[override]
-        alias=None,
+        count: int = None,
+        alias: str = None,
     ) -> QuerySet:
         qs = (
             super()

--- a/src/search/documents/journal.py
+++ b/src/search/documents/journal.py
@@ -56,10 +56,11 @@ class JournalDocument(BaseDocument):
         filter_: Q | None = None,
         exclude: Q | None = None,
         count: int = None,  # type: ignore[override]
+        alias=None,
     ) -> QuerySet:
         return (
             super()
-            .get_queryset(filter_=filter_, exclude=exclude, count=count)
+            .get_queryset(filter_=filter_, exclude=exclude, count=count, alias=alias)
             .filter(namespace="journal")
         )
 

--- a/src/search/documents/journal.py
+++ b/src/search/documents/journal.py
@@ -58,11 +58,14 @@ class JournalDocument(BaseDocument):
         count: int = None,  # type: ignore[override]
         alias=None,
     ) -> QuerySet:
-        return (
+        qs = (
             super()
-            .get_queryset(filter_=filter_, exclude=exclude, count=count, alias=alias)
+            .get_queryset(filter_=filter_, exclude=exclude, alias=alias)
             .filter(namespace="journal")
         )
+        if count is not None:
+            qs = qs[:count]
+        return qs
 
     # Used specifically for "autocomplete" style suggest feature
     def prepare_name_suggest(self, instance) -> dict[str, Any]:

--- a/src/search/documents/paper.py
+++ b/src/search/documents/paper.py
@@ -1,14 +1,14 @@
-import io
 import logging
 import math
 import sys
 import time
 from collections.abc import Iterable
-from typing import Any, override
+from typing import Any, TextIO, override
 
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q, QuerySet
 from django_opensearch_dsl import fields as es_fields
+from django_opensearch_dsl.enums import CommandAction
 from django_opensearch_dsl.registries import registry
 
 from feed.models import FeedEntry
@@ -258,10 +258,10 @@ class PaperDocument(BaseDocument):
         verbose: bool = False,
         filter_: Q | None = None,
         exclude: Q | None = None,
-        alias=None,
+        alias: str = None,
         count: int = None,
-        action: str = "Index",
-        stdout: io.FileIO = sys.stdout,
+        action: CommandAction = CommandAction.INDEX,
+        stdout: TextIO = sys.stdout,
     ) -> Iterable:
         """
         Divide the queryset into chunks. Overwrite django_opensearch_dsl default

--- a/src/search/documents/paper.py
+++ b/src/search/documents/paper.py
@@ -68,8 +68,8 @@ class PaperDocument(BaseDocument):
         self,
         filter_: Q | None = None,
         exclude: Q | None = None,
-        count: int = None,  # type: ignore[override]
-        alias=None,
+        count: int = None,
+        alias: str = None,
     ) -> QuerySet:
         """
         Override get_queryset to include prefetching of relationsships.

--- a/src/search/documents/paper.py
+++ b/src/search/documents/paper.py
@@ -74,9 +74,9 @@ class PaperDocument(BaseDocument):
         """
         Override get_queryset to include prefetching of relationsships.
         """
-        return (
+        qs = (
             super()
-            .get_queryset(filter_=filter_, exclude=exclude, count=count, alias=alias)
+            .get_queryset(filter_=filter_, exclude=exclude, alias=alias)
             .select_related(
                 "unified_document",
             )
@@ -84,6 +84,9 @@ class PaperDocument(BaseDocument):
                 "unified_document__hubs",
             )
         )
+        if count is not None:
+            qs = qs[:count]
+        return qs
 
     @override
     def should_index_object(self, obj) -> bool:  # type: ignore[override]

--- a/src/search/documents/paper.py
+++ b/src/search/documents/paper.py
@@ -69,13 +69,14 @@ class PaperDocument(BaseDocument):
         filter_: Q | None = None,
         exclude: Q | None = None,
         count: int = None,  # type: ignore[override]
+        alias=None,
     ) -> QuerySet:
         """
         Override get_queryset to include prefetching of relationsships.
         """
         return (
             super()
-            .get_queryset(filter_=filter_, exclude=exclude, count=count)
+            .get_queryset(filter_=filter_, exclude=exclude, count=count, alias=alias)
             .select_related(
                 "unified_document",
             )
@@ -254,6 +255,7 @@ class PaperDocument(BaseDocument):
         verbose: bool = False,
         filter_: Q | None = None,
         exclude: Q | None = None,
+        alias=None,
         count: int = None,
         action: str = "Index",
         stdout: io.FileIO = sys.stdout,
@@ -263,7 +265,12 @@ class PaperDocument(BaseDocument):
         because it uses offsets instead of filtering by greater than pk.
         """
         chunk_size = self.django.queryset_pagination
-        qs = self.get_queryset(filter_=filter_, exclude=exclude, count=count)
+        qs = self.get_queryset(
+            filter_=filter_,
+            exclude=exclude,
+            count=count,
+            alias=alias,
+        )
         qs = qs.order_by("pk") if not qs.query.is_sliced else qs
         count = qs.count()
         model = self.django.model.__name__


### PR DESCRIPTION
- Add optional `alias` argument to overridden `get_queryset` methods (introduced with `django-opensearch-dsl` 0.8.0.
- Apply count after queryset creation to properly limit the final document queryset, aligning the implementation with django-opensearch-dsl.
- Add/update type annotations.