### PR TITLE
fix: include creator in bounty notifications

### DIFF
--- a/src/reputation/tasks.py
+++ b/src/reputation/tasks.py
@@ -443,6 +443,7 @@ def find_qualified_users_and_notify(
                 notification_type=Notification.BOUNTY_FOR_YOU,
                 extra={
                     "bounty_id": bounty.id,
+                    "bounty_creator_id": bounty.created_by_id,
                     "amount": bounty.amount,
                     "bounty_type": bounty.bounty_type,
                     "bounty_expiration_date": bounty.expiration_date,
@@ -479,6 +480,7 @@ def find_bounties_for_user_and_notify(user_id) -> Notification | None:
                 notification_type=Notification.BOUNTY_FOR_YOU,
                 extra={
                     "bounty_id": bounty.id,
+                    "bounty_creator_id": bounty.created_by_id,
                     "amount": bounty.amount,
                     "bounty_type": bounty.bounty_type,
                     "bounty_expiration_date": bounty.expiration_date,

--- a/src/researchhub_comment/tests/test_comments.py
+++ b/src/researchhub_comment/tests/test_comments.py
@@ -394,6 +394,9 @@ class CommentViewTests(APITestCase):
         ).last()
 
         self.assertEqual(notification.notification_type, Notification.BOUNTY_FOR_YOU)
+        self.assertEqual(
+            notification.extra["bounty_creator_id"], str(self.foundation.id)
+        )
 
     def test_do_not_notify_unqualified_users_about_bounty(self):
 


### PR DESCRIPTION
## Summary

Expose the bounty creator ID in `BOUNTY_FOR_YOU` notification metadata so clients can distinguish ResearchHub Foundation bounties from user-created bounties.

Supports ResearchHub/issues#342 and ResearchHub/web#749.

## Changes

- Add `bounty_creator_id` to `find_qualified_users_and_notify`.
- Assert the persisted creator ID in the qualified-user notification regression test. Notification extras use HStore, so the stored ID is a string.
- Merge current main and preserve its removal of `find_bounties_for_user_and_notify` and `recalc_hot_score_for_open_bounties`; neither removed task is restored.

The resulting diff against main is one production line and three regression assertion lines.

## Testing

Validated locally on macOS ARM64 with Python 3.13 and an isolated PostgreSQL 17 instance, using dependencies from `uv sync --frozen --all-extras`.

- Ruff formatting and lint passed for both changed files.
- The qualified-user notification test and unqualified-user control passed.
- All 21 tests in `researchhub_comment.tests.test_comments.CommentViewTests` passed after running the repository's `collectstatic --noinput` setup step.
- `git diff --check` passed.

The first broader run lacked the generated email CSS; running `collectstatic` resolved that local setup failure without code changes. The full backend suite and CI's PostgreSQL 16 environment were not run locally. Remote checks are reported separately by GitHub.
