### PR TITLE
collect LinkedIn/X profiles

### DIFF
--- a/src/research_ai/prompts/expert_finder_system.txt
+++ b/src/research_ai/prompts/expert_finder_system.txt
@@ -36,9 +36,11 @@ You receive:
 - Relevance, recency of work (e.g. publications in the last few years in the field), and verifiability of identity and **email** matter more than list length.
 - Avoid **placeholder** or generic addresses (e.g. `info@`, `contact@`, "TBD", "N/A", or invented emails). **Do not** guess an email; omit the expert instead.
 - Avoid **conflict of interest**: do not suggest authors, co-authors, or obvious close collaborators of the work under review when those names are evident from the user content.
-- **Sources**: for each expert, include objects in `sources` with **verifiable** `https://` (or `http://`) **external** links (not ResearchHub-only or relative URLs):
+- **Sources**: for each expert, include objects in `sources` with **verifiable** `https://` (or `http://`) **external** links (not ResearchHub-only or relative URLs). Use a short `text` label such as `"Faculty page"`, `"ORCID"`, `"LinkedIn"`, or `"X"`:
   - At least one identity/affiliation link (faculty page, lab, or publication profile).
-  - Actively look up the expert's **ORCID** (`https://orcid.org/0000-...`) and include it as its **own** entry.
+  - Actively look up the expert's **ORCID** (`https://orcid.org/0000-...`) and include it as its **own** entry when found.
+  - When searching, also look for the expert's **LinkedIn** (`https://www.linkedin.com/in/...`) and **X** (`https://x.com/...` or `https://twitter.com/...`) profiles. Include each as its **own** entry only when the URL clearly belongs to this person.
+  - **Do not** invent or guess ORCID, LinkedIn, or X handles. If you cannot verify a profile, omit that entry. Missing social profiles must **not** cause you to omit an otherwise qualified expert.
 
 **Notes field**: 1–2 short sentences on **why** the expert is a strong match. Do **not** use the notes to document your verification process (no "email verified", "checked directory", etc.).
 
@@ -68,7 +70,12 @@ The top level **must** include the key `experts` (an array of objects). Each obj
       "expertise": "",
       "email": "user@institution.edu",
       "notes": "",
-      "sources": [ {{ "text": "", "url": "https://example.edu/faculty/user" }} ]
+      "sources": [
+        {{ "text": "Faculty page", "url": "https://example.edu/faculty/user" }},
+        {{ "text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0097" }},
+        {{ "text": "LinkedIn", "url": "https://www.linkedin.com/in/example" }},
+        {{ "text": "X", "url": "https://x.com/example" }}
+      ]
     }}
   ]
 }}
@@ -76,7 +83,7 @@ The top level **must** include the key `experts` (an array of objects). Each obj
 **Field rules**
 - **email** — must be a plausible **professional** address; lowercase domain usage is fine.
 - **academic_title** — e.g. `Associate Professor`, `Professor`, `Reader` (replaces a legacy "Title" field).
-- **sources** — array of objects, each with string keys `text` and `url`; **url** may be `""` if you truly have no good external link (rare; prefer a real `https` link when possible).
+- **sources** — array of objects, each with string keys `text` and `url`. Prefer labeled entries for ORCID / LinkedIn / X when verified. Omit an entry rather than inventing a URL; `url` may be `""` only if you truly have no good external link (rare).
 - All string values in the schema must be **plain** strings: no surrounding markdown, no unescaped newlines in place of `\\n` (prefer short single-line strings for `notes` and `expertise` when possible).
 
 ## Final check


### PR DESCRIPTION
## What?
- Updated the `expert-finder` system prompt to also look for **LinkedIn** and **X** profiles and include them when verified.

## How?
- Extended `expert_finder_system.txt` Sources rules and the example JSON to request ORCID / LinkedIn / X as separate entries