### PR TITLE
Persist proposal draft agent histories

### DIFF
--- a/src/research_ai/services/agent/loop.py
+++ b/src/research_ai/services/agent/loop.py
@@ -23,6 +23,7 @@ from research_ai.services.agent.providers.base import LLMProvider
 from research_ai.services.agent.recorder import AgentRecorder
 from research_ai.services.agent.tools import Toolset
 from research_ai.services.agent.types import (
+    AssistantTurn,
     Message,
     StopReason,
     TextBlock,
@@ -120,8 +121,7 @@ class Agent:
     def run(self, user_prompt: str) -> AgentResult:
         """Drive a fresh conversation from ``user_prompt`` to completion."""
         seed = Message(role="user", content=[TextBlock(text=user_prompt)])
-        self._record("record_message", seed)
-        return self._drive([seed])
+        return self._drive([seed], new_message=seed)
 
     def continue_conversation(
         self,
@@ -135,20 +135,33 @@ class Agent:
         recorded by the runs that produced it.
         """
         appended = Message(role="user", content=[TextBlock(text=user_message)])
-        self._record("record_message", appended)
-        return self._drive(list(messages) + [appended])
+        return self._drive(list(messages) + [appended], new_message=appended)
 
-    def _record(self, hook: str, *args, **kwargs) -> None:
-        """Invoke a recorder hook; a raising recorder never breaks the run.
+    def _record_message(
+        self, message: Message, *, turn: AssistantTurn | None = None
+    ) -> None:
+        """Persist an appended message before the run advances.
 
-        The transcript is observability -- persistence failing must not kill
-        the run it observes (same contract as ``progress_callback``).
+        Ordinary observers remain best-effort. A recorder may opt into required
+        message persistence with ``requires_durable_messages``; the database
+        recorder uses that contract while isolating its optional trace writes.
         """
         if self.recorder is None:
             return
         try:
-            getattr(self.recorder, hook)(*args, **kwargs)
-        except Exception:  # noqa: BLE001 - recording must not break the run
+            self.recorder.record_message(message, turn=turn)
+        except Exception:  # noqa: BLE001 - observer failures are best-effort
+            if getattr(self.recorder, "requires_durable_messages", False):
+                raise
+            logger.warning("agent recorder record_message failed", exc_info=True)
+
+    def _record_terminal(self, hook: str, *args) -> None:
+        """Best-effort terminal observation must not mask the run outcome."""
+        if self.recorder is None:
+            return
+        try:
+            getattr(self.recorder, hook)(*args)
+        except Exception:  # noqa: BLE001 - preserve the original run outcome
             logger.warning("agent recorder %s failed", hook, exc_info=True)
 
     def _complete_turn(self, messages, rendered_tools, iteration):
@@ -165,6 +178,10 @@ class Agent:
             # conversation resumable via ``continue_conversation``.
             exc.messages = messages
             exc.iterations = iteration - 1
+            raise
+        except InterruptedError:
+            # Preserve an explicit interruption so persistence can distinguish
+            # it from an ordinary provider failure.
             raise
         except Exception as exc:
             # A provider that leaks a foreign exception still surfaces as
@@ -202,15 +219,16 @@ class Agent:
             )
         return result_blocks, stop
 
-    def _drive(self, messages: list[Message]) -> AgentResult:
+    def _drive(self, messages: list[Message], *, new_message: Message) -> AgentResult:
         try:
+            self._record_message(new_message)
             result = self._loop(messages)
-        except AgentRunError as error:
+        except Exception as error:
             # Every message up to the failure was already recorded as it was
             # appended; this only marks the terminal outcome.
-            self._record("on_run_failed", error)
+            self._record_terminal("on_run_failed", error)
             raise
-        self._record("on_run_finished", result)
+        self._record_terminal("on_run_finished", result)
         return result
 
     def _loop(self, messages: list[Message]) -> AgentResult:
@@ -228,7 +246,7 @@ class Agent:
                 content=[*turn.text_blocks, *turn.tool_calls],
             )
             messages.append(assistant_message)
-            self._record("record_message", assistant_message, turn=turn)
+            self._record_message(assistant_message, turn=turn)
 
             # The assistant's text on a tool-calling turn is its stated reason for
             # the calls -- log it so the trace shows *why* a tool was picked.
@@ -256,7 +274,7 @@ class Agent:
             result_blocks, stop = self._dispatch_tool_calls(turn.tool_calls, iteration)
             tool_result_message = Message(role="user", content=result_blocks)
             messages.append(tool_result_message)
-            self._record("record_message", tool_result_message)
+            self._record_message(tool_result_message)
 
             if stop:
                 logger.info("iter %d stop_tool: terminal tool ended the run", iteration)

--- a/src/research_ai/services/agent/providers/bedrock.py
+++ b/src/research_ai/services/agent/providers/bedrock.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 # Default generator model. Bedrock requires the cross-region inference profile
 # (the ``us.`` prefix); the bare ``anthropic.claude-opus-4-8`` is provisioned-
 # throughput only. Override per environment via RESEARCH_AI_GENERATOR_MODEL_ID.
-_DEFAULT_MODEL_ID = "us.anthropic.claude-opus-4-8"
+DEFAULT_MODEL_ID = "us.anthropic.claude-opus-4-8"
 
 # Opus 4.7+ and Fable reject sampling params (temperature/top_p/top_k) with a
 # 400 ("`temperature` is deprecated for this model"). Match by substring so the
@@ -57,10 +57,14 @@ _STOP_REASONS = {
 class BedrockProvider(LLMProvider):
     """Adapts the neutral agent types to the Bedrock Converse API."""
 
+    default_model_id = DEFAULT_MODEL_ID
+
     def __init__(self, *, client: Any = None, model_id: str | None = None):
         self._client = client or bedrock_runtime_client()
-        self.model_id = model_id or getattr(
-            settings, "RESEARCH_AI_GENERATOR_MODEL_ID", _DEFAULT_MODEL_ID
+        self.model_id = (
+            model_id
+            or getattr(settings, "RESEARCH_AI_GENERATOR_MODEL_ID", None)
+            or DEFAULT_MODEL_ID
         )
         # Prompt caching is the dominant cost lever for this uncached, ever-growing
         # tool loop: the tools+system prefix is byte-identical every turn and the

--- a/src/research_ai/services/agent/recorder.py
+++ b/src/research_ai/services/agent/recorder.py
@@ -6,10 +6,10 @@ An ``AgentRecorder`` observes a run as it happens: the loop calls
 one of ``on_run_finished`` / ``on_run_failed`` when the run ends.
 
 This module defines only the protocol -- implementations live outside the
-``agent`` package (e.g. a Django recorder persisting ``AgentMessage`` rows) and
-are injected by callers, keeping the core Django-free. The loop wraps every
-recorder call: a raising recorder is logged and ignored, never fatal to the
-run (a transcript is observability, same contract as ``progress_callback``).
+``agent`` package and are injected by callers, keeping the core Django-free.
+Message-hook failures are best-effort unless an implementation opts into the
+``requires_durable_messages`` contract; terminal-hook failures are logged
+without masking the original run outcome.
 """
 
 from __future__ import annotations
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Protocol
 from research_ai.services.agent.types import AssistantTurn, Message
 
 if TYPE_CHECKING:
-    from research_ai.services.agent.errors import AgentRunError
     from research_ai.services.agent.loop import AgentResult
 
 
@@ -32,7 +31,9 @@ class AgentRecorder(Protocol):
         """Record one appended message.
 
         ``turn`` is set only for assistant messages, carrying the per-turn
-        metadata (usage, latency, stop reason) alongside the content.
+        metadata (usage, latency, stop reason) alongside the content. A recorder
+        that sets ``requires_durable_messages`` may propagate required-write
+        failures; optional writes should be isolated by the implementation.
         """
         ...
 
@@ -40,6 +41,6 @@ class AgentRecorder(Protocol):
         """The run completed; every message was already recorded."""
         ...
 
-    def on_run_failed(self, error: AgentRunError) -> None:
+    def on_run_failed(self, error: Exception) -> None:
         """The run failed; every message up to the failure was recorded."""
         ...

--- a/src/research_ai/services/agent_persistence/__init__.py
+++ b/src/research_ai/services/agent_persistence/__init__.py
@@ -1,5 +1,6 @@
-"""Serialization and persistence services for the provider-neutral agent core."""
+"""Django persistence and read services for the provider-neutral agent core."""
 
+from .chat_service import AgentChatService, PreparedAgentExecution
 from .context_service import AgentContextService
 from .conversation_service import (
     AgentConversationService,
@@ -11,6 +12,7 @@ from .retention_service import AgentRetentionService
 from .run_details_service import AgentRunDetailsService
 
 __all__ = [
+    "AgentChatService",
     "AgentContextService",
     "AgentConversationBusyError",
     "AgentConversationService",
@@ -19,4 +21,5 @@ __all__ = [
     "AgentRunDetailsService",
     "DatabaseAgentRecorder",
     "NoteAgentConversationService",
+    "PreparedAgentExecution",
 ]

--- a/src/research_ai/services/agent_persistence/__init__.py
+++ b/src/research_ai/services/agent_persistence/__init__.py
@@ -1,10 +1,22 @@
 """Serialization and persistence services for the provider-neutral agent core."""
 
+from .context_service import AgentContextService
+from .conversation_service import (
+    AgentConversationService,
+    NoteAgentConversationService,
+)
 from .execution_service import AgentConversationBusyError, AgentExecutionService
 from .recorder import DatabaseAgentRecorder
+from .retention_service import AgentRetentionService
+from .run_details_service import AgentRunDetailsService
 
 __all__ = [
+    "AgentContextService",
     "AgentConversationBusyError",
+    "AgentConversationService",
     "AgentExecutionService",
+    "AgentRetentionService",
+    "AgentRunDetailsService",
     "DatabaseAgentRecorder",
+    "NoteAgentConversationService",
 ]

--- a/src/research_ai/services/agent_persistence/__init__.py
+++ b/src/research_ai/services/agent_persistence/__init__.py
@@ -1,1 +1,10 @@
 """Serialization and persistence services for the provider-neutral agent core."""
+
+from .execution_service import AgentConversationBusyError, AgentExecutionService
+from .recorder import DatabaseAgentRecorder
+
+__all__ = [
+    "AgentConversationBusyError",
+    "AgentExecutionService",
+    "DatabaseAgentRecorder",
+]

--- a/src/research_ai/services/agent_persistence/chat_service.py
+++ b/src/research_ai/services/agent_persistence/chat_service.py
@@ -1,0 +1,232 @@
+"""User-facing chat preparation and representation services."""
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from django.db import transaction
+
+from research_ai.models import (
+    AgentConversation,
+    AgentConversationMessage,
+    AgentExecution,
+    AgentExecutionMessage,
+)
+from research_ai.services.agent.types import Message
+from research_ai.services.agent_persistence.context_service import AgentContextService
+from research_ai.services.agent_persistence.conversation_service import (
+    AgentConversationService,
+)
+from research_ai.services.agent_persistence.execution_service import (
+    AgentExecutionService,
+)
+from research_ai.services.agent_persistence.recorder import DatabaseAgentRecorder
+
+logger = logging.getLogger(__name__)
+
+RecorderFactory = Callable[..., DatabaseAgentRecorder]
+
+
+@dataclass(frozen=True)
+class PreparedAgentExecution:
+    execution: AgentExecution
+    recorder: DatabaseAgentRecorder
+    human_message: AgentConversationMessage | None
+    context: list[Message]
+
+
+class AgentChatService:
+    def __init__(
+        self,
+        *,
+        conversation_service: AgentConversationService | None = None,
+        execution_service: AgentExecutionService | None = None,
+        context_service: AgentContextService | None = None,
+        recorder_factory: RecorderFactory | None = None,
+    ):
+        self.conversations = (
+            AgentConversationService()
+            if conversation_service is None
+            else conversation_service
+        )
+        self.executions = (
+            AgentExecutionService(recorder_factory=recorder_factory)
+            if execution_service is None
+            else execution_service
+        )
+        self.contexts = (
+            AgentContextService() if context_service is None else context_service
+        )
+        self.recorder_factory = (
+            getattr(self.executions, "recorder_factory", DatabaseAgentRecorder)
+            if recorder_factory is None
+            else recorder_factory
+        )
+
+    def prepare_turn(
+        self,
+        conversation: AgentConversation,
+        human_content: str,
+        *,
+        provider: str = "",
+        model: str = "",
+        configuration: dict | None = None,
+        system_prompt: str = "",
+        prompt_is_backend_composed: bool = False,
+    ) -> PreparedAgentExecution:
+        with transaction.atomic():
+            locked = AgentConversation.objects.select_for_update().get(
+                id=conversation.id
+            )
+            parent = (
+                locked.executions.filter(status=AgentExecution.Status.SUCCEEDED)
+                .order_by("-attempt")
+                .first()
+            )
+            context = self.contexts.reconstruct(parent) if parent else []
+            human_message = self.conversations.add_human_message(locked, human_content)
+            recorder = self.executions.start(
+                locked,
+                provider=provider,
+                model=model,
+                configuration=configuration,
+                system_prompt=system_prompt,
+                trigger_message=human_message,
+                context_parent=parent,
+                initial_prompt_provenance=(
+                    AgentExecutionMessage.Provenance.BACKEND
+                    if prompt_is_backend_composed
+                    else AgentExecutionMessage.Provenance.HUMAN
+                ),
+                publish_assistant_message=True,
+            )
+        return PreparedAgentExecution(
+            recorder.execution, recorder, human_message, context
+        )
+
+    @staticmethod
+    def _retry_provenance(execution: AgentExecution) -> str:
+        provenance = (
+            execution.messages.order_by("execution_sequence")
+            .values_list("provenance", flat=True)
+            .first()
+        )
+        if provenance in AgentExecutionMessage.Provenance.values:
+            return provenance
+        if execution.trigger_message_id:
+            return AgentExecutionMessage.Provenance.HUMAN
+        return AgentExecutionMessage.Provenance.BACKEND
+
+    def prepare_retry(
+        self,
+        execution: AgentExecution,
+        *,
+        configuration: dict | None = None,
+        system_prompt: str | None = None,
+        regenerate: bool = False,
+        initial_prompt_provenance: str | None = None,
+    ) -> PreparedAgentExecution:
+        context = (
+            self.contexts.reconstruct(execution.context_parent)
+            if execution.context_parent
+            else []
+        )
+        recorder = self.executions.start(
+            execution.conversation,
+            provider=execution.provider,
+            model=execution.model,
+            configuration=(
+                execution.configuration if configuration is None else configuration
+            ),
+            system_prompt=(
+                execution.system_prompt if system_prompt is None else system_prompt
+            ),
+            trigger_message=execution.trigger_message,
+            context_parent=execution.context_parent,
+            retry_of=execution,
+            initial_prompt_provenance=(
+                self._retry_provenance(execution)
+                if initial_prompt_provenance is None
+                else initial_prompt_provenance
+            ),
+            publish_assistant_message=True,
+            replaces_output_of=execution if regenerate else None,
+        )
+        return PreparedAgentExecution(
+            recorder.execution, recorder, execution.trigger_message, context
+        )
+
+    @staticmethod
+    def _public_error(execution: AgentExecution) -> dict[str, str] | None:
+        if not execution.error_type:
+            return None
+        if execution.status == AgentExecution.Status.INTERRUPTED:
+            return {
+                "code": "agent_interrupted",
+                "message": "The agent request was interrupted.",
+            }
+        return {
+            "code": "agent_failed",
+            "message": "The agent could not complete this request.",
+        }
+
+    def representation(self, conversation: AgentConversation) -> dict:
+        """Repair pending publication and return user-safe chat lifecycle data."""
+        self.repair_pending_outputs(conversation)
+        messages = [
+            {
+                "id": message.id,
+                "sequence": message.sequence,
+                "role": message.role.lower(),
+                "content": message.content,
+                "execution_id": message.generated_by_execution_id,
+            }
+            for message in conversation.chat_messages.filter(is_active=True).order_by(
+                "sequence"
+            )
+        ]
+        executions = [
+            {
+                "id": execution.id,
+                "attempt": execution.attempt,
+                "status": execution.status,
+                "trigger_message_id": execution.trigger_message_id,
+                "retry_of_id": execution.retry_of_id,
+                "context_parent_id": execution.context_parent_id,
+                "stop_reason": execution.stop_reason,
+                "assistant_message_pending": (
+                    execution.status == AgentExecution.Status.SUCCEEDED
+                    and execution.publish_output_to_chat
+                    and not hasattr(execution, "generated_chat_message")
+                ),
+                "error": self._public_error(execution),
+            }
+            for execution in conversation.executions.select_related(
+                "generated_chat_message"
+            ).order_by("attempt")
+        ]
+        return {
+            "conversation_id": conversation.id,
+            "messages": messages,
+            "executions": executions,
+        }
+
+    def repair_pending_outputs(self, conversation: AgentConversation) -> int:
+        """Retry any successful chat publication that previously failed."""
+        repaired = 0
+        pending = conversation.executions.filter(
+            status=AgentExecution.Status.SUCCEEDED,
+            publish_output_to_chat=True,
+            generated_chat_message__isnull=True,
+        ).order_by("attempt")
+        for execution in pending:
+            try:
+                repaired += int(
+                    self.recorder_factory(execution).publish_assistant_output()
+                )
+            except Exception:  # noqa: BLE001 - reads still expose pending state
+                logger.warning(
+                    "failed to repair agent response publication",
+                    exc_info=True,
+                )
+        return repaired

--- a/src/research_ai/services/agent_persistence/context_service.py
+++ b/src/research_ai/services/agent_persistence/context_service.py
@@ -1,0 +1,44 @@
+"""Durable model-context reconstruction services."""
+
+from research_ai.models import AgentConversation, AgentExecution
+from research_ai.services.agent.types import Message, deserialize_messages
+
+
+class AgentContextService:
+    def reconstruct(self, execution: AgentExecution) -> list[Message]:
+        """Rebuild the durable, explicitly compacted context lineage."""
+        lineage: list[AgentExecution] = []
+        seen: set[int] = set()
+        current = execution
+        while current is not None:
+            if (
+                current.id in seen
+                or current.conversation_id != execution.conversation_id
+            ):
+                raise ValueError("invalid agent execution context lineage")
+            seen.add(current.id)
+            lineage.append(current)
+            current = current.context_parent
+        lineage.reverse()
+
+        serialized_messages = []
+        for item in lineage:
+            serialized_messages.extend(
+                item.context_messages.order_by("sequence").values("role", "content")
+            )
+        return deserialize_messages(serialized_messages)
+
+    def for_continuation(
+        self, conversation: AgentConversation, *, include_partial: bool = False
+    ) -> list[Message]:
+        statuses = [AgentExecution.Status.SUCCEEDED]
+        if include_partial:
+            statuses.extend(
+                [AgentExecution.Status.FAILED, AgentExecution.Status.INTERRUPTED]
+            )
+        execution = (
+            conversation.executions.filter(status__in=statuses)
+            .order_by("-attempt")
+            .first()
+        )
+        return self.reconstruct(execution) if execution else []

--- a/src/research_ai/services/agent_persistence/conversation_service.py
+++ b/src/research_ai/services/agent_persistence/conversation_service.py
@@ -1,0 +1,63 @@
+"""Conversation and notebook-association services."""
+
+from django.db import transaction
+from django.db.models import Q
+
+from research_ai.models import (
+    AgentConversation,
+    AgentConversationMessage,
+    NoteAgentConversation,
+)
+
+
+class AgentConversationService:
+    def create(
+        self,
+        *,
+        user=None,
+        workflow: str = "",
+    ) -> AgentConversation:
+        return AgentConversation.objects.create(
+            user=user,
+            workflow=workflow,
+        )
+
+    def add_human_message(
+        self, conversation: AgentConversation, content: str
+    ) -> AgentConversationMessage:
+        with transaction.atomic():
+            locked = AgentConversation.objects.select_for_update().get(
+                id=conversation.id
+            )
+            message = AgentConversationMessage.objects.create(
+                conversation=locked,
+                sequence=locked.next_chat_sequence,
+                role=AgentConversationMessage.Role.USER,
+                content=content,
+            )
+            locked.next_chat_sequence += 1
+            locked.save(update_fields=["next_chat_sequence", "updated_date"])
+        return message
+
+
+class NoteAgentConversationService:
+    """Manage notebook-to-conversation associations."""
+
+    def attach(self, conversation: AgentConversation, note) -> NoteAgentConversation:
+        with transaction.atomic():
+            link, _created = NoteAgentConversation.objects.get_or_create(
+                note=note,
+                conversation=conversation,
+            )
+        return link
+
+    def for_note(self, note):
+        # The proposal relation is a deterministic recovery path if the
+        # best-effort join-table write failed after the proposal was completed.
+        return (
+            AgentConversation.objects.filter(
+                Q(note_links__note=note) | Q(proposal_draft__note=note)
+            )
+            .distinct()
+            .order_by("-updated_date", "-id")
+        )

--- a/src/research_ai/services/agent_persistence/execution_service.py
+++ b/src/research_ai/services/agent_persistence/execution_service.py
@@ -1,0 +1,206 @@
+"""Execution creation and atomic claim services."""
+
+from collections.abc import Callable
+
+from django.db import transaction
+from django.db.models import Max
+from django.utils import timezone
+
+from research_ai.models import (
+    AgentConversation,
+    AgentConversationMessage,
+    AgentExecution,
+    AgentExecutionMessage,
+)
+from research_ai.services.agent_persistence.recorder import DatabaseAgentRecorder
+
+RecorderFactory = Callable[..., DatabaseAgentRecorder]
+
+
+class AgentConversationBusyError(RuntimeError):
+    """Raised when a linear conversation already has an active execution."""
+
+
+class AgentExecutionService:
+    def __init__(self, *, recorder_factory: RecorderFactory | None = None):
+        self.recorder_factory = (
+            DatabaseAgentRecorder if recorder_factory is None else recorder_factory
+        )
+
+    @staticmethod
+    def _validate_relationships(
+        conversation: AgentConversation,
+        *,
+        trigger_message: AgentConversationMessage | None,
+        context_parent: AgentExecution | None,
+        retry_of: AgentExecution | None,
+        replaces_output_of: AgentExecution | None,
+    ) -> None:
+        related = [context_parent, retry_of, replaces_output_of]
+        if any(
+            item is not None and item.conversation_id != conversation.id
+            for item in related
+        ):
+            raise ValueError("agent execution relationships cross conversations")
+        if (
+            trigger_message is not None
+            and trigger_message.conversation_id != conversation.id
+        ):
+            raise ValueError("trigger message belongs to another conversation")
+
+    @staticmethod
+    def _ensure_no_active_execution(conversation: AgentConversation) -> None:
+        if conversation.executions.filter(
+            status__in=[
+                AgentExecution.Status.PENDING,
+                AgentExecution.Status.RUNNING,
+            ]
+        ).exists():
+            raise AgentConversationBusyError(
+                "agent conversation already has an active execution"
+            )
+
+    def _create_execution(
+        self,
+        conversation: AgentConversation,
+        *,
+        status: str,
+        provider: str,
+        model: str,
+        configuration: dict | None,
+        system_prompt: str,
+        trigger_message: AgentConversationMessage | None,
+        context_parent: AgentExecution | None,
+        retry_of: AgentExecution | None,
+        publish_assistant_message: bool,
+        replaces_output_of: AgentExecution | None,
+    ) -> AgentExecution:
+        self._validate_relationships(
+            conversation,
+            trigger_message=trigger_message,
+            context_parent=context_parent,
+            retry_of=retry_of,
+            replaces_output_of=replaces_output_of,
+        )
+        now = timezone.now()
+        with transaction.atomic():
+            locked = AgentConversation.objects.select_for_update().get(
+                id=conversation.id
+            )
+            self._ensure_no_active_execution(locked)
+            max_attempt = (
+                AgentExecution.objects.filter(conversation=locked).aggregate(
+                    value=Max("attempt")
+                )["value"]
+                or 0
+            )
+            timestamps = (
+                {"started_at": now, "last_activity_at": now}
+                if status == AgentExecution.Status.RUNNING
+                else {}
+            )
+            return AgentExecution.objects.create(
+                conversation=locked,
+                status=status,
+                attempt=max_attempt + 1,
+                context_parent=context_parent,
+                retry_of=retry_of,
+                replaces_output_of=replaces_output_of,
+                trigger_message=trigger_message,
+                provider=provider,
+                model=model,
+                configuration=configuration if configuration is not None else {},
+                system_prompt=system_prompt,
+                publish_output_to_chat=publish_assistant_message,
+                **timestamps,
+            )
+
+    def start(
+        self,
+        conversation: AgentConversation,
+        *,
+        provider: str = "",
+        model: str = "",
+        configuration: dict | None = None,
+        system_prompt: str = "",
+        trigger_message: AgentConversationMessage | None = None,
+        context_parent: AgentExecution | None = None,
+        retry_of: AgentExecution | None = None,
+        initial_prompt_provenance: str = AgentExecutionMessage.Provenance.BACKEND,
+        publish_assistant_message: bool = False,
+        replaces_output_of: AgentExecution | None = None,
+    ) -> DatabaseAgentRecorder:
+        execution = self._create_execution(
+            conversation,
+            status=AgentExecution.Status.RUNNING,
+            provider=provider,
+            model=model,
+            configuration=configuration,
+            system_prompt=system_prompt,
+            trigger_message=trigger_message,
+            context_parent=context_parent,
+            retry_of=retry_of,
+            publish_assistant_message=publish_assistant_message,
+            replaces_output_of=replaces_output_of,
+        )
+        return self.recorder_factory(
+            execution,
+            initial_prompt_provenance=initial_prompt_provenance,
+            publish_assistant_message=publish_assistant_message,
+        )
+
+    def create_pending(
+        self,
+        conversation: AgentConversation,
+        *,
+        provider: str = "",
+        model: str = "",
+        configuration: dict | None = None,
+        system_prompt: str = "",
+        trigger_message: AgentConversationMessage | None = None,
+        context_parent: AgentExecution | None = None,
+        retry_of: AgentExecution | None = None,
+        publish_assistant_message: bool = False,
+    ) -> AgentExecution:
+        """Create a queued attempt that a worker can claim later."""
+        return self._create_execution(
+            conversation,
+            status=AgentExecution.Status.PENDING,
+            provider=provider,
+            model=model,
+            configuration=configuration,
+            system_prompt=system_prompt,
+            trigger_message=trigger_message,
+            context_parent=context_parent,
+            retry_of=retry_of,
+            publish_assistant_message=publish_assistant_message,
+            replaces_output_of=None,
+        )
+
+    def claim_pending(
+        self,
+        execution: AgentExecution,
+        *,
+        initial_prompt_provenance: str = AgentExecutionMessage.Provenance.BACKEND,
+        publish_assistant_message: bool | None = None,
+    ) -> DatabaseAgentRecorder | None:
+        """Atomically claim a queued attempt; return ``None`` if already claimed."""
+        now = timezone.now()
+        updates = {
+            "status": AgentExecution.Status.RUNNING,
+            "started_at": now,
+            "last_activity_at": now,
+        }
+        if publish_assistant_message is not None:
+            updates["publish_output_to_chat"] = publish_assistant_message
+        claimed = AgentExecution.objects.filter(
+            id=execution.id, status=AgentExecution.Status.PENDING
+        ).update(**updates)
+        if not claimed:
+            return None
+        execution.refresh_from_db()
+        return self.recorder_factory(
+            execution,
+            initial_prompt_provenance=initial_prompt_provenance,
+            publish_assistant_message=publish_assistant_message,
+        )

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -58,6 +58,53 @@ def _is_terminal(status: str) -> bool:
     }
 
 
+def _turn_trace_fields(turn: AssistantTurn | None) -> dict:
+    usage = turn.usage if turn else None
+    return {
+        "provider_stop_reason": turn.stop_reason.value if turn else "",
+        "input_tokens": usage.input_tokens if usage else None,
+        "output_tokens": usage.output_tokens if usage else None,
+        "cache_read_tokens": usage.cache_read_tokens if usage else None,
+        "cache_write_tokens": usage.cache_write_tokens if usage else None,
+        "latency_ms": turn.latency_ms if turn else None,
+    }
+
+
+def _apply_turn_metrics(
+    execution: AgentExecution,
+    turn: AssistantTurn | None,
+    trace_fields: dict,
+) -> list[str]:
+    if turn is None:
+        return []
+    execution.iterations += 1
+    execution.stop_reason = turn.stop_reason.value
+    execution.input_tokens = _add_optional(
+        execution.input_tokens, trace_fields["input_tokens"]
+    )
+    execution.output_tokens = _add_optional(
+        execution.output_tokens, trace_fields["output_tokens"]
+    )
+    execution.cache_read_tokens = _add_optional(
+        execution.cache_read_tokens, trace_fields["cache_read_tokens"]
+    )
+    execution.cache_write_tokens = _add_optional(
+        execution.cache_write_tokens, trace_fields["cache_write_tokens"]
+    )
+    execution.total_latency_ms = _add_optional(
+        execution.total_latency_ms, turn.latency_ms
+    )
+    return [
+        "iterations",
+        "stop_reason",
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "total_latency_ms",
+    ]
+
+
 class DatabaseAgentRecorder:
     """Persist required context and isolate optional observational trace writes."""
 
@@ -170,7 +217,7 @@ class DatabaseAgentRecorder:
             global_sequence = conversation.next_trace_sequence
             execution_sequence = execution.next_message_sequence
 
-            usage = turn.usage if turn else None
+            turn_fields = _turn_trace_fields(turn)
             AgentExecutionMessage.objects.create(
                 conversation=conversation,
                 execution=execution,
@@ -179,14 +226,9 @@ class DatabaseAgentRecorder:
                 role=message.role,
                 provenance=provenance,
                 content=content,
-                provider_stop_reason=turn.stop_reason.value if turn else "",
-                input_tokens=usage.input_tokens if usage else None,
-                output_tokens=usage.output_tokens if usage else None,
-                cache_read_tokens=usage.cache_read_tokens if usage else None,
-                cache_write_tokens=usage.cache_write_tokens if usage else None,
-                latency_ms=turn.latency_ms if turn else None,
                 is_truncated=is_truncated,
                 original_size_bytes=original_size if is_truncated else None,
+                **turn_fields,
             )
 
             conversation.next_trace_sequence += 1
@@ -199,39 +241,7 @@ class DatabaseAgentRecorder:
                 "last_activity_at",
                 "updated_date",
             ]
-            if turn:
-                execution.iterations += 1
-                execution.stop_reason = turn.stop_reason.value
-                execution.input_tokens = _add_optional(
-                    execution.input_tokens,
-                    usage.input_tokens if usage else None,
-                )
-                execution.output_tokens = _add_optional(
-                    execution.output_tokens,
-                    usage.output_tokens if usage else None,
-                )
-                execution.cache_read_tokens = _add_optional(
-                    execution.cache_read_tokens,
-                    usage.cache_read_tokens if usage else None,
-                )
-                execution.cache_write_tokens = _add_optional(
-                    execution.cache_write_tokens,
-                    usage.cache_write_tokens if usage else None,
-                )
-                execution.total_latency_ms = _add_optional(
-                    execution.total_latency_ms, turn.latency_ms
-                )
-                update_fields.extend(
-                    [
-                        "iterations",
-                        "stop_reason",
-                        "input_tokens",
-                        "output_tokens",
-                        "cache_read_tokens",
-                        "cache_write_tokens",
-                        "total_latency_ms",
-                    ]
-                )
+            update_fields.extend(_apply_turn_metrics(execution, turn, turn_fields))
             execution.save(update_fields=update_fields)
 
     def on_run_finished(self, result) -> None:

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -1,0 +1,374 @@
+"""Database-backed observational recorder for one agent execution."""
+
+import logging
+from datetime import timedelta
+
+from django.db import transaction
+from django.utils import timezone
+
+from research_ai.models import (
+    AgentContextMessage,
+    AgentConversation,
+    AgentConversationMessage,
+    AgentExecution,
+    AgentExecutionMessage,
+)
+from research_ai.services.agent.errors import IterationLimitError
+from research_ai.services.agent.types import (
+    AssistantTurn,
+    Message,
+    ToolResultBlock,
+)
+from research_ai.services.agent_persistence.content import (
+    bounded_payload,
+    serialize_context_message,
+    serialize_final_output,
+    serialize_trace_message,
+)
+
+logger = logging.getLogger(__name__)
+
+_MAX_ERROR_CHARS = 10_000
+
+
+def _add_optional(current: int | None, increment: int | None) -> int | None:
+    if increment is None:
+        return current
+    return (current or 0) + increment
+
+
+def _duration_ms(started_at, finished_at) -> int | None:
+    if started_at is None:
+        return None
+    elapsed: timedelta = finished_at - started_at
+    return max(0, round(elapsed.total_seconds() * 1000))
+
+
+def _safe_exception_message(error: object) -> str:
+    try:
+        return str(error)[:_MAX_ERROR_CHARS]
+    except Exception:  # noqa: BLE001 - terminal persistence must remain defensive
+        return f"<{type(error).__name__} message unavailable>"
+
+
+def _is_terminal(status: str) -> bool:
+    return status not in {
+        AgentExecution.Status.PENDING,
+        AgentExecution.Status.RUNNING,
+    }
+
+
+class DatabaseAgentRecorder:
+    """Persist required context and isolate optional observational trace writes."""
+
+    requires_durable_messages = True
+
+    def __init__(
+        self,
+        execution: AgentExecution,
+        *,
+        initial_prompt_provenance: str = AgentExecutionMessage.Provenance.BACKEND,
+        publish_assistant_message: bool | None = None,
+    ):
+        self.execution = execution
+        self.initial_prompt_provenance = initial_prompt_provenance
+        self.publish_assistant_message = (
+            execution.publish_output_to_chat
+            if publish_assistant_message is None
+            else publish_assistant_message
+        )
+        self._recorded_messages = 0
+        self.terminal_observed = False
+
+    def set_system_prompt(self, system_prompt: str) -> None:
+        """Snapshot model-only scaffolding after callers finish composing it."""
+        with transaction.atomic():
+            AgentExecution.objects.filter(id=self.execution.id).update(
+                system_prompt=system_prompt,
+                last_activity_at=timezone.now(),
+            )
+
+    def _provenance(self, message: Message) -> str:
+        if message.role == "assistant":
+            return AgentExecutionMessage.Provenance.MODEL
+        if any(isinstance(block, ToolResultBlock) for block in message.content):
+            return AgentExecutionMessage.Provenance.TOOL
+        if self._recorded_messages == 0:
+            return self.initial_prompt_provenance
+        return AgentExecutionMessage.Provenance.BACKEND
+
+    def record_message(
+        self, message: Message, *, turn: AssistantTurn | None = None
+    ) -> None:
+        context_content, is_compacted, context_original_size = (
+            serialize_context_message(message)
+        )
+        now = timezone.now()
+        provenance = self._provenance(message)
+
+        # Resumable context is durable state, not disposable debugging data.
+        # Commit it independently so a trace-specific failure cannot erase the
+        # context needed by a later turn.
+        with transaction.atomic():
+            execution = AgentExecution.objects.select_for_update().get(
+                id=self.execution.id
+            )
+            AgentContextMessage.objects.create(
+                execution=execution,
+                sequence=execution.next_context_sequence,
+                role=message.role,
+                content=context_content,
+                is_compacted=is_compacted,
+                original_size_bytes=(context_original_size if is_compacted else None),
+            )
+            execution.next_context_sequence += 1
+            execution.last_activity_at = now
+            execution.save(
+                update_fields=[
+                    "next_context_sequence",
+                    "last_activity_at",
+                    "updated_date",
+                ]
+            )
+        self._recorded_messages += 1
+
+        try:
+            content, is_truncated, original_size = serialize_trace_message(message)
+            self._record_trace(
+                message=message,
+                turn=turn,
+                content=content,
+                is_truncated=is_truncated,
+                original_size=original_size,
+                now=now,
+                provenance=provenance,
+            )
+        except Exception:  # noqa: BLE001 - trace data is optional observability
+            logger.warning("failed to persist optional agent trace", exc_info=True)
+
+    def _record_trace(
+        self,
+        *,
+        message: Message,
+        turn: AssistantTurn | None,
+        content: list[dict],
+        is_truncated: bool,
+        original_size: int,
+        now,
+        provenance: str,
+    ) -> None:
+        # The nested atomic block is intentional: if this write raises inside a
+        # caller's transaction, Django rolls back this savepoint before this
+        # optional trace failure is swallowed, leaving the outer transaction usable.
+        with transaction.atomic():
+            conversation = AgentConversation.objects.select_for_update().get(
+                id=self.execution.conversation_id
+            )
+            execution = AgentExecution.objects.select_for_update().get(
+                id=self.execution.id
+            )
+            global_sequence = conversation.next_trace_sequence
+            execution_sequence = execution.next_message_sequence
+
+            usage = turn.usage if turn else None
+            AgentExecutionMessage.objects.create(
+                conversation=conversation,
+                execution=execution,
+                sequence=global_sequence,
+                execution_sequence=execution_sequence,
+                role=message.role,
+                provenance=provenance,
+                content=content,
+                provider_stop_reason=turn.stop_reason.value if turn else "",
+                input_tokens=usage.input_tokens if usage else None,
+                output_tokens=usage.output_tokens if usage else None,
+                cache_read_tokens=usage.cache_read_tokens if usage else None,
+                cache_write_tokens=usage.cache_write_tokens if usage else None,
+                latency_ms=turn.latency_ms if turn else None,
+                is_truncated=is_truncated,
+                original_size_bytes=original_size if is_truncated else None,
+            )
+
+            conversation.next_trace_sequence += 1
+            conversation.save(update_fields=["next_trace_sequence", "updated_date"])
+
+            execution.next_message_sequence += 1
+            execution.last_activity_at = now
+            update_fields = [
+                "next_message_sequence",
+                "last_activity_at",
+                "updated_date",
+            ]
+            if turn:
+                execution.iterations += 1
+                execution.stop_reason = turn.stop_reason.value
+                execution.input_tokens = _add_optional(
+                    execution.input_tokens,
+                    usage.input_tokens if usage else None,
+                )
+                execution.output_tokens = _add_optional(
+                    execution.output_tokens,
+                    usage.output_tokens if usage else None,
+                )
+                execution.cache_read_tokens = _add_optional(
+                    execution.cache_read_tokens,
+                    usage.cache_read_tokens if usage else None,
+                )
+                execution.cache_write_tokens = _add_optional(
+                    execution.cache_write_tokens,
+                    usage.cache_write_tokens if usage else None,
+                )
+                execution.total_latency_ms = _add_optional(
+                    execution.total_latency_ms, turn.latency_ms
+                )
+                update_fields.extend(
+                    [
+                        "iterations",
+                        "stop_reason",
+                        "input_tokens",
+                        "output_tokens",
+                        "cache_read_tokens",
+                        "cache_write_tokens",
+                        "total_latency_ms",
+                    ]
+                )
+            execution.save(update_fields=update_fields)
+
+    def on_run_finished(self, result) -> None:
+        now = timezone.now()
+        final_output, _truncated, _size = serialize_final_output(result.final_text)
+        transitioned = False
+        with transaction.atomic():
+            execution = AgentExecution.objects.select_for_update().get(
+                id=self.execution.id
+            )
+            if execution.status == AgentExecution.Status.RUNNING:
+                execution.status = AgentExecution.Status.SUCCEEDED
+                execution.final_output = final_output
+                execution.stop_reason = result.stop_reason
+                execution.iterations = max(execution.iterations, result.iterations)
+                execution.finished_at = now
+                execution.last_activity_at = now
+                execution.duration_ms = _duration_ms(execution.started_at, now)
+                execution.save(
+                    update_fields=[
+                        "status",
+                        "final_output",
+                        "stop_reason",
+                        "iterations",
+                        "finished_at",
+                        "last_activity_at",
+                        "duration_ms",
+                        "updated_date",
+                    ]
+                )
+                transitioned = True
+            terminal = _is_terminal(execution.status)
+        self.terminal_observed = terminal
+        if not transitioned:
+            return
+        public_text = final_output["text"]
+        if self.publish_assistant_message and public_text:
+            try:
+                self.publish_assistant_output(public_text)
+            except Exception:  # noqa: BLE001 - trace terminal state already landed
+                logger.warning(
+                    "failed to publish agent response to chat", exc_info=True
+                )
+
+    def on_run_failed(self, error: Exception) -> None:
+        now = timezone.now()
+        raw_stop_reason = getattr(error, "stop_reason", "") or ""
+        stop_reason = _safe_exception_message(raw_stop_reason)
+        if not stop_reason:
+            if isinstance(error, InterruptedError):
+                stop_reason = "interrupted"
+            elif isinstance(error, IterationLimitError):
+                stop_reason = "iteration_limit"
+            else:
+                stop_reason = "error"
+        cause = getattr(error, "__cause__", None)
+        details = {
+            "stop_reason": stop_reason,
+            "iterations": getattr(error, "iterations", None),
+            "cause_type": type(cause).__name__ if cause else None,
+            "cause_message": _safe_exception_message(cause) if cause else None,
+        }
+        safe_details, _truncated, _size = bounded_payload(details)
+        status = (
+            AgentExecution.Status.INTERRUPTED
+            if isinstance(error, InterruptedError)
+            else AgentExecution.Status.FAILED
+        )
+        with transaction.atomic():
+            execution = AgentExecution.objects.select_for_update().get(
+                id=self.execution.id
+            )
+            if execution.status == AgentExecution.Status.RUNNING:
+                execution.status = status
+                execution.error_type = type(error).__name__
+                execution.error_message = _safe_exception_message(error)
+                execution.error_details = safe_details
+                execution.stop_reason = stop_reason
+                error_iterations = getattr(error, "iterations", None)
+                if error_iterations is not None:
+                    execution.iterations = max(execution.iterations, error_iterations)
+                execution.finished_at = now
+                execution.last_activity_at = now
+                execution.duration_ms = _duration_ms(execution.started_at, now)
+                execution.save(
+                    update_fields=[
+                        "status",
+                        "error_type",
+                        "error_message",
+                        "error_details",
+                        "stop_reason",
+                        "iterations",
+                        "finished_at",
+                        "last_activity_at",
+                        "duration_ms",
+                        "updated_date",
+                    ]
+                )
+            terminal = _is_terminal(execution.status)
+        self.terminal_observed = terminal
+
+    def publish_assistant_output(self, text: str | None = None) -> bool:
+        """Publish or repair the canonical assistant message idempotently."""
+        with transaction.atomic():
+            conversation = AgentConversation.objects.select_for_update().get(
+                id=self.execution.conversation_id
+            )
+            execution = AgentExecution.objects.select_for_update().get(
+                id=self.execution.id
+            )
+            if (
+                execution.status != AgentExecution.Status.SUCCEEDED
+                or not execution.publish_output_to_chat
+            ):
+                return False
+            if text is None:
+                final_output = execution.final_output
+                text = (
+                    final_output.get("text") if isinstance(final_output, dict) else None
+                )
+            if not isinstance(text, str) or not text:
+                return False
+            if execution.replaces_output_of_id:
+                AgentConversationMessage.objects.filter(
+                    generated_by_execution_id=execution.replaces_output_of_id
+                ).update(is_active=False)
+            _message, created = AgentConversationMessage.objects.get_or_create(
+                generated_by_execution_id=execution.id,
+                defaults={
+                    "conversation": conversation,
+                    "sequence": conversation.next_chat_sequence,
+                    "role": AgentConversationMessage.Role.ASSISTANT,
+                    "content": text,
+                    "in_reply_to_id": execution.trigger_message_id,
+                },
+            )
+            if created:
+                conversation.next_chat_sequence += 1
+                conversation.save(update_fields=["next_chat_sequence", "updated_date"])
+            return created

--- a/src/research_ai/services/agent_persistence/retention_service.py
+++ b/src/research_ai/services/agent_persistence/retention_service.py
@@ -1,0 +1,17 @@
+"""Explicit retention services for disposable execution traces."""
+
+from research_ai.models import AgentConversation, AgentExecution
+
+
+class AgentRetentionService:
+    """Remove debugging data without deleting chat or domain output."""
+
+    def delete_execution_trace(self, execution: AgentExecution) -> int:
+        deleted, _ = execution.messages.all().delete()
+        return deleted
+
+    def delete_conversation_debug(self, conversation: AgentConversation) -> None:
+        # Executions and context lineage are workflow state needed for retries,
+        # pending/failure markers, and continuation. Only observational trace
+        # rows are disposable.
+        conversation.trace_messages.all().delete()

--- a/src/research_ai/services/agent_persistence/run_details_service.py
+++ b/src/research_ai/services/agent_persistence/run_details_service.py
@@ -1,0 +1,61 @@
+"""Full execution-detail read service."""
+
+from research_ai.models import AgentExecution
+
+
+class AgentRunDetailsService:
+    def get(self, execution: AgentExecution) -> dict:
+        execution.refresh_from_db()
+        trace = [
+            {
+                "sequence": message.sequence,
+                "execution_sequence": message.execution_sequence,
+                "role": message.role,
+                "provenance": message.provenance,
+                "content": message.content,
+                "stop_reason": message.provider_stop_reason,
+                "usage": {
+                    "input_tokens": message.input_tokens,
+                    "output_tokens": message.output_tokens,
+                    "cache_read_tokens": message.cache_read_tokens,
+                    "cache_write_tokens": message.cache_write_tokens,
+                },
+                "latency_ms": message.latency_ms,
+                "is_truncated": message.is_truncated,
+                "original_size_bytes": message.original_size_bytes,
+            }
+            for message in execution.messages.order_by("execution_sequence")
+        ]
+        return {
+            "id": execution.id,
+            "conversation_id": execution.conversation_id,
+            "attempt": execution.attempt,
+            "status": execution.status,
+            "provider": execution.provider,
+            "model": execution.model,
+            "configuration": execution.configuration,
+            "system_prompt": execution.system_prompt,
+            "iterations": execution.iterations,
+            "usage": {
+                "input_tokens": execution.input_tokens,
+                "output_tokens": execution.output_tokens,
+                "cache_read_tokens": execution.cache_read_tokens,
+                "cache_write_tokens": execution.cache_write_tokens,
+            },
+            "total_latency_ms": execution.total_latency_ms,
+            "duration_ms": execution.duration_ms,
+            "stop_reason": execution.stop_reason,
+            "final_output": execution.final_output,
+            "failure": (
+                {
+                    "type": execution.error_type,
+                    "message": execution.error_message,
+                    "details": execution.error_details,
+                }
+                if execution.error_type
+                else None
+            ),
+            "started_at": execution.started_at,
+            "finished_at": execution.finished_at,
+            "trace": trace,
+        }

--- a/src/research_ai/services/proposal_draft/runner.py
+++ b/src/research_ai/services/proposal_draft/runner.py
@@ -44,7 +44,11 @@ import logging
 
 from django.conf import settings
 
-from research_ai.models import ProposalDraft, SearchExpert
+from research_ai.models import (
+    AgentExecution,
+    ProposalDraft,
+    SearchExpert,
+)
 from research_ai.prompts.proposal_draft_prompts import (
     build_proposal_system_prompt,
     build_proposal_user_prompt,
@@ -55,6 +59,11 @@ from research_ai.services.agent import (
     BedrockProvider,
     Tool,
     Toolset,
+)
+from research_ai.services.agent_persistence import (
+    AgentConversationService,
+    AgentExecutionService,
+    NoteAgentConversationService,
 )
 from research_ai.services.proposal_draft.config import ProposalDraftConfig
 from research_ai.services.proposal_draft.draft_recorder import DraftRecorder
@@ -114,6 +123,7 @@ class _ProposalDraftRunner:
         self.recorder = DraftRecorder(
             draft, self.state, progress_callback=progress_callback
         )
+        self.agent_recorder = None
 
         # Shared across the run: provenance the citation gate grounds against.
         self.provenance: set[str] = set()
@@ -145,17 +155,9 @@ class _ProposalDraftRunner:
     # -- public entry -----------------------------------------------------
 
     def run(self) -> dict:
-        self.recorder.mark_processing(
-            {
-                "generator_model_id": getattr(self.provider, "model_id", None)
-                or getattr(settings, "RESEARCH_AI_GENERATOR_MODEL_ID", None),
-                "judge_roster": list(self.panel.model_ids),
-                "max_rounds": self.config.max_rounds,
-                "panel_threshold": self.config.panel_threshold,
-                "style_threshold": self.config.style_threshold,
-                "max_iterations": self.config.max_iterations,
-            }
-        )
+        run_config = self._run_config()
+        self.recorder.mark_processing(run_config)
+        self._start_agent_recording(run_config)
         try:
             return self._run()
         except Exception as exc:  # noqa: BLE001 - no run may end still PROCESSING
@@ -164,6 +166,7 @@ class _ProposalDraftRunner:
             # the record in FAILED with a real message, never a stuck
             # PROCESSING with no explanation.
             logger.exception("proposal draft run crashed")
+            self._record_setup_failure(exc)
             return self._fail(f"unexpected error: {exc}")
 
     def _run(self) -> dict:
@@ -171,7 +174,9 @@ class _ProposalDraftRunner:
         # draft against -- the run could never succeed.
         self.rfp_context = self.context_toolset.get_rfp_context()
         if "error" in self.rfp_context:
-            return self._fail(f"cannot draft: {self.rfp_context['error']}")
+            message = f"cannot draft: {self.rfp_context['error']}"
+            self._record_setup_failure(AgentRunError(message, iterations=0))
+            return self._fail(message)
 
         self._ensure_profile()
 
@@ -204,6 +209,67 @@ class _ProposalDraftRunner:
 
     # -- setup ------------------------------------------------------------
 
+    def _run_config(self) -> dict:
+        generator_model_id = getattr(self.provider, "model_id", None)
+        if not generator_model_id and self.provider is not None:
+            generator_model_id = type(self.provider).__name__
+        if not generator_model_id:
+            generator_model_id = (
+                getattr(settings, "RESEARCH_AI_GENERATOR_MODEL_ID", None)
+                or BedrockProvider.default_model_id
+            )
+        return {
+            "generator_model_id": generator_model_id,
+            "judge_roster": list(self.panel.model_ids),
+            "max_rounds": self.config.max_rounds,
+            "panel_threshold": self.config.panel_threshold,
+            "style_threshold": self.config.style_threshold,
+            "max_iterations": self.config.max_iterations,
+            "max_tokens": self.config.max_tokens,
+            "temperature": self.config.temperature,
+        }
+
+    def _start_agent_recording(self, run_config: dict) -> None:
+        """Best-effort trace creation; proposal correctness never depends on it."""
+        try:
+            conversation = self.recorder.draft.agent_conversation
+            if conversation is None:
+                conversation = AgentConversationService().create(
+                    user=self.recorder.draft.created_by,
+                    workflow="proposal_draft",
+                )
+                self.recorder.draft.agent_conversation = conversation
+                self.recorder.draft.save(
+                    update_fields=["agent_conversation", "updated_date"]
+                )
+            retry_of = (
+                conversation.executions.exclude(status=AgentExecution.Status.RUNNING)
+                .order_by("-attempt")
+                .first()
+            )
+            provider_name = (
+                type(self.provider).__name__ if self.provider is not None else "Bedrock"
+            )
+            self.agent_recorder = AgentExecutionService().start(
+                conversation,
+                provider=provider_name,
+                model=str(run_config.get("generator_model_id") or ""),
+                configuration=run_config,
+                retry_of=retry_of,
+                publish_assistant_message=False,
+            )
+        except Exception:  # noqa: BLE001 - observability cannot break drafting
+            logger.warning("could not initialize proposal agent trace", exc_info=True)
+            self.agent_recorder = None
+
+    def _record_setup_failure(self, error: Exception) -> None:
+        if self.agent_recorder is None or self.agent_recorder.terminal_observed:
+            return
+        try:
+            self.agent_recorder.on_run_failed(error)
+        except Exception:  # noqa: BLE001 - observability cannot mask the run outcome
+            logger.warning("could not finalize proposal agent trace", exc_info=True)
+
     def _ensure_profile(self) -> None:
         """Build + persist the researcher profile when it is missing/stale."""
         if not _needs_profile(self.expert.profile):
@@ -219,6 +285,13 @@ class _ProposalDraftRunner:
     def _build_agent(self, system_prompt: str):
         provider = self.provider or BedrockProvider()
         toolset = self._compose_toolset()
+        if self.agent_recorder is not None:
+            try:
+                self.agent_recorder.set_system_prompt(system_prompt)
+            except Exception:  # noqa: BLE001 - observability cannot break drafting
+                logger.warning(
+                    "could not snapshot proposal system prompt", exc_info=True
+                )
         return AgentService(
             provider=provider, max_iterations=self.config.max_iterations
         ).create_agent(
@@ -226,6 +299,7 @@ class _ProposalDraftRunner:
             system_prompt=system_prompt,
             max_tokens=self.config.max_tokens,
             temperature=self.config.temperature,
+            recorder=self.agent_recorder,
         )
 
     def _compose_toolset(self) -> Toolset:
@@ -416,7 +490,21 @@ class _ProposalDraftRunner:
         note = write_proposal_note(
             submission, created_by=self.recorder.draft.created_by
         )
-        return self.recorder.complete(note)
+        result = self.recorder.complete(note)
+        self._attach_conversation_to_note(note)
+        return result
+
+    def _attach_conversation_to_note(self, note) -> None:
+        conversation = self.recorder.draft.agent_conversation
+        if conversation is None:
+            return
+        try:
+            NoteAgentConversationService().attach(conversation, note)
+        except Exception:  # noqa: BLE001 - observability cannot break drafting
+            logger.warning(
+                "could not attach proposal agent conversation to note",
+                exc_info=True,
+            )
 
     def _fail(self, message: str | None = None) -> dict:
         return self.recorder.fail(message or self.state.failure_message())

--- a/src/research_ai/tests/agent/persistence_test_helpers.py
+++ b/src/research_ai/tests/agent/persistence_test_helpers.py
@@ -1,0 +1,89 @@
+"""Shared fakes and builders for agent-persistence tests."""
+
+from django.test import TestCase
+
+from research_ai.models import AgentConversation
+from research_ai.services.agent.loop import Agent
+from research_ai.services.agent.providers.base import LLMProvider
+from research_ai.services.agent.tools import Toolset
+from research_ai.services.agent.types import (
+    AssistantTurn,
+    StopReason,
+    TextBlock,
+    ToolUseBlock,
+)
+from research_ai.services.agent_persistence import AgentExecutionService
+
+
+class FakeProvider(LLMProvider):
+    def __init__(self, turns, *, render_error=None):
+        self.turns = list(turns)
+        self.render_error = render_error
+        self.calls = []
+
+    def render_tools(self, tools):
+        if self.render_error:
+            raise self.render_error
+        return [tool.name for tool in tools]
+
+    def complete(self, **kwargs):
+        self.calls.append(list(kwargs["messages"]))
+        turn = self.turns.pop(0)
+        if isinstance(turn, BaseException):
+            raise turn
+        return turn
+
+
+def tool_turn(
+    call_id,
+    name,
+    tool_input,
+    *,
+    usage=None,
+    latency_ms=None,
+):
+    return AssistantTurn(
+        text_blocks=[TextBlock(text=f"calling {name}")],
+        tool_calls=[ToolUseBlock(id=call_id, name=name, input=tool_input)],
+        stop_reason=StopReason.TOOL_USE,
+        usage=usage,
+        latency_ms=latency_ms,
+    )
+
+
+def text_turn(text, *, usage=None, latency_ms=None):
+    return AssistantTurn(
+        text_blocks=[TextBlock(text=text)],
+        tool_calls=[],
+        stop_reason=StopReason.END_TURN,
+        usage=usage,
+        latency_ms=latency_ms,
+    )
+
+
+def agent(provider, recorder, tools=None):
+    return Agent(
+        provider,
+        Toolset(tools or []),
+        system_prompt="internal system scaffolding",
+        max_iterations=5,
+        max_tokens=2048,
+        temperature=0.1,
+        recorder=recorder,
+    )
+
+
+class AgentPersistenceTestCase(TestCase):
+    def setUp(self):
+        self.conversation = AgentConversation.objects.create(
+            workflow="notebook_chat",
+        )
+
+    def recorder(self, **kwargs):
+        return AgentExecutionService().start(
+            self.conversation,
+            provider="fake",
+            model="fake-model-v1",
+            configuration={"max_tokens": 2048, "temperature": 0.1},
+            **kwargs,
+        )

--- a/src/research_ai/tests/agent/test_persistence_chat.py
+++ b/src/research_ai/tests/agent/test_persistence_chat.py
@@ -1,0 +1,292 @@
+"""User-facing chat preparation, retry, publication, and repair coverage."""
+
+import json
+from unittest.mock import patch
+
+from django.db import IntegrityError
+
+from research_ai.models import AgentExecution, AgentExecutionMessage
+from research_ai.services.agent.tools import Tool
+from research_ai.services.agent_persistence import (
+    AgentChatService,
+    AgentConversationBusyError,
+    AgentConversationService,
+    AgentExecutionService,
+    DatabaseAgentRecorder,
+)
+from research_ai.services.agent_persistence.content import (
+    MAX_TRACE_MESSAGE_BYTES,
+    json_size_bytes,
+)
+from research_ai.tests.agent.persistence_test_helpers import (
+    AgentPersistenceTestCase,
+    FakeProvider,
+    agent,
+    text_turn,
+    tool_turn,
+)
+
+
+class AgentChatPersistenceTests(AgentPersistenceTestCase):
+    def test_backend_prompt_preserves_human_text_and_chat_filters_trace(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(
+            self.conversation,
+            "What I actually typed",
+            provider="fake",
+            model="fake-model-v1",
+            prompt_is_backend_composed=True,
+        )
+        wrapped_prompt = "Notebook context:\n...\nUser: What I actually typed"
+        tool = Tool("lookup", "lookup", {"type": "object"}, lambda _args: {"secret": 1})
+        provider = FakeProvider(
+            [tool_turn("c1", "lookup", {}), text_turn("Visible answer")]
+        )
+
+        # Act
+        agent(provider, prepared.recorder, [tool]).run(wrapped_prompt)
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["What I actually typed", "Visible answer"],
+        )
+        first_trace = prepared.execution.messages.order_by("execution_sequence").first()
+        self.assertEqual(
+            first_trace.provenance, AgentExecutionMessage.Provenance.BACKEND
+        )
+        self.assertEqual(first_trace.content[0]["text"], wrapped_prompt)
+        self.assertNotIn("secret", json.dumps(representation["messages"]))
+
+    def test_retry_reuses_human_message_and_provenance(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "One human turn")
+        prepared.recorder.on_run_failed(RuntimeError("temporary failure"))
+
+        # Act
+        retry = chat.prepare_retry(prepared.execution)
+        agent(FakeProvider([text_turn("Recovered")]), retry.recorder).run(
+            "One human turn"
+        )
+
+        # Assert
+        self.assertEqual(self.conversation.chat_messages.filter(role="USER").count(), 1)
+        self.assertEqual(retry.execution.trigger_message_id, prepared.human_message.id)
+        self.assertEqual(retry.execution.retry_of_id, prepared.execution.id)
+        self.assertEqual(
+            chat.representation(self.conversation)["messages"][-1]["content"],
+            "Recovered",
+        )
+        self.assertEqual(
+            retry.execution.messages.order_by("execution_sequence").first().provenance,
+            AgentExecutionMessage.Provenance.HUMAN,
+        )
+
+    def test_failed_assistant_publication_is_repaired_from_durable_intent(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+
+        # Act
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(FakeProvider([text_turn("Durable answer")]), prepared.recorder).run(
+                "Question"
+            )
+        execution = AgentExecution.objects.get(id=prepared.execution.id)
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        self.assertEqual(execution.status, AgentExecution.Status.SUCCEEDED)
+        self.assertTrue(execution.publish_output_to_chat)
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["Question", "Durable answer"],
+        )
+        self.assertFalse(representation["executions"][0]["assistant_message_pending"])
+
+    def test_large_assistant_output_repairs_as_the_same_bounded_text(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+        huge_answer = "x" * (MAX_TRACE_MESSAGE_BYTES * 2)
+
+        # Act
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(FakeProvider([text_turn(huge_answer)]), prepared.recorder).run(
+                "Question"
+            )
+        execution = AgentExecution.objects.get(id=prepared.execution.id)
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        stored_text = execution.final_output["text"]
+        self.assertIsInstance(stored_text, str)
+        self.assertTrue(execution.final_output["_truncated"])
+        self.assertLessEqual(
+            json_size_bytes(execution.final_output), MAX_TRACE_MESSAGE_BYTES
+        )
+        self.assertEqual(representation["messages"][-1]["content"], stored_text)
+
+    def test_public_representation_does_not_expose_internal_error_message(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+        prepared.recorder.on_run_failed(
+            RuntimeError("provider secret token must not be public")
+        )
+
+        # Act
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        self.assertNotIn("secret token", json.dumps(representation))
+        self.assertEqual(
+            representation["executions"][0]["error"],
+            {
+                "code": "agent_failed",
+                "message": "The agent could not complete this request.",
+            },
+        )
+
+    def test_public_representation_fetches_assistant_links_without_n_plus_one(self):
+        # Arrange
+        chat = AgentChatService()
+        first = chat.prepare_turn(self.conversation, "First")
+        agent(FakeProvider([text_turn("First answer")]), first.recorder).run("First")
+        second = chat.prepare_turn(self.conversation, "Second")
+        agent(FakeProvider([text_turn("Second answer")]), second.recorder).run("Second")
+
+        # Act / Assert
+        with self.assertNumQueries(3):
+            representation = chat.representation(self.conversation)
+        self.assertEqual(len(representation["executions"]), 2)
+
+    def test_regeneration_repair_replaces_prior_output_without_new_user_message(self):
+        # Arrange
+        chat = AgentChatService()
+        original = chat.prepare_turn(self.conversation, "Question")
+        agent(FakeProvider([text_turn("First answer")]), original.recorder).run(
+            "Question"
+        )
+        regeneration = chat.prepare_retry(original.execution, regenerate=True)
+
+        # Act
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(
+                FakeProvider([text_turn("Better answer")]),
+                regeneration.recorder,
+            ).run("Question")
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        regeneration.execution.refresh_from_db()
+        self.assertEqual(
+            regeneration.execution.replaces_output_of_id,
+            original.execution.id,
+        )
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["Question", "Better answer"],
+        )
+        self.assertEqual(self.conversation.chat_messages.filter(role="USER").count(), 1)
+
+    def test_prepare_turn_rolls_back_human_message_when_execution_start_fails(self):
+        # Arrange
+        chat = AgentChatService()
+
+        # Act / Assert
+        with (
+            patch.object(
+                AgentExecutionService,
+                "start",
+                side_effect=RuntimeError("execution insert failed"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "execution insert failed"),
+        ):
+            chat.prepare_turn(self.conversation, "Do not orphan me")
+        self.assertFalse(self.conversation.chat_messages.exists())
+
+    def test_prepare_turn_does_not_start_when_context_reconstruction_fails(self):
+        # Arrange
+        chat = AgentChatService()
+        first = chat.prepare_turn(self.conversation, "First")
+        agent(FakeProvider([text_turn("Answer")]), first.recorder).run("First")
+        message_count = self.conversation.chat_messages.count()
+        execution_count = self.conversation.executions.count()
+
+        # Act / Assert
+        with (
+            patch.object(
+                chat.contexts,
+                "reconstruct",
+                side_effect=ValueError("invalid durable context"),
+            ),
+            self.assertRaisesRegex(ValueError, "invalid durable context"),
+        ):
+            chat.prepare_turn(self.conversation, "Second")
+
+        self.assertEqual(self.conversation.chat_messages.count(), message_count)
+        self.assertEqual(self.conversation.executions.count(), execution_count)
+        self.assertFalse(
+            self.conversation.executions.filter(
+                status__in=[
+                    AgentExecution.Status.PENDING,
+                    AgentExecution.Status.RUNNING,
+                ]
+            ).exists()
+        )
+
+    def test_active_turn_blocks_a_second_linear_turn_without_new_message(self):
+        # Arrange
+        chat = AgentChatService()
+        first = chat.prepare_turn(self.conversation, "First")
+
+        # Act / Assert
+        with self.assertRaises(AgentConversationBusyError):
+            chat.prepare_turn(self.conversation, "Second")
+        self.assertEqual(self.conversation.chat_messages.count(), 1)
+        self.assertEqual(self.conversation.executions.count(), 1)
+        first.recorder.on_run_failed(InterruptedError("test cleanup"))
+
+    def test_pending_execution_is_visible_and_atomically_claimed(self):
+        # Arrange
+        human = AgentConversationService().add_human_message(
+            self.conversation, "Queued question"
+        )
+        service = AgentExecutionService()
+        pending = service.create_pending(
+            self.conversation,
+            trigger_message=human,
+            model="queued-model",
+        )
+
+        # Act
+        before = AgentChatService().representation(self.conversation)
+        recorder = service.claim_pending(pending, publish_assistant_message=True)
+        second_claim = service.claim_pending(pending)
+
+        # Assert
+        self.assertEqual(
+            before["executions"][0]["status"], AgentExecution.Status.PENDING
+        )
+        self.assertIsNotNone(recorder)
+        self.assertIsNone(second_claim)
+        self.assertEqual(
+            AgentExecution.objects.get(id=pending.id).status,
+            AgentExecution.Status.RUNNING,
+        )

--- a/src/research_ai/tests/agent/test_persistence_concurrency.py
+++ b/src/research_ai/tests/agent/test_persistence_concurrency.py
@@ -1,0 +1,55 @@
+"""Concurrent sequence allocation coverage for agent persistence."""
+
+import threading
+
+from django.db import close_old_connections
+from django.test import TransactionTestCase
+
+from research_ai.models import AgentConversation, AgentExecution, AgentExecutionMessage
+from research_ai.services.agent.types import Message, TextBlock
+from research_ai.services.agent_persistence import (
+    AgentExecutionService,
+    DatabaseAgentRecorder,
+)
+
+
+class AgentSequenceConcurrencyTests(TransactionTestCase):
+    reset_sequences = True
+
+    def test_concurrent_trace_writes_allocate_unique_ordered_sequences(self):
+        # Arrange
+        conversation = AgentConversation.objects.create()
+        execution = AgentExecutionService().start(conversation).execution
+        barrier = threading.Barrier(4)
+        errors = []
+
+        def record(index):
+            close_old_connections()
+            try:
+                local_execution = AgentExecution.objects.get(id=execution.id)
+                barrier.wait()
+                DatabaseAgentRecorder(local_execution).record_message(
+                    Message(role="user", content=[TextBlock(text=str(index))])
+                )
+            except Exception as exc:  # noqa: BLE001 - surfaced in main test thread
+                errors.append(exc)
+            finally:
+                close_old_connections()
+
+        # Act
+        threads = [threading.Thread(target=record, args=(index,)) for index in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        # Assert
+        self.assertFalse(errors)
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        rows = list(
+            AgentExecutionMessage.objects.filter(execution=execution).order_by(
+                "sequence"
+            )
+        )
+        self.assertEqual([row.sequence for row in rows], [1, 2, 3, 4])
+        self.assertEqual(sorted(row.execution_sequence for row in rows), [1, 2, 3, 4])

--- a/src/research_ai/tests/agent/test_persistence_recorder.py
+++ b/src/research_ai/tests/agent/test_persistence_recorder.py
@@ -1,0 +1,279 @@
+"""Execution recorder, lifecycle, and trace persistence coverage."""
+
+import json
+from unittest.mock import patch
+
+from django.db import IntegrityError, transaction
+
+from research_ai.models import (
+    AgentContextMessage,
+    AgentConversation,
+    AgentExecution,
+    AgentExecutionMessage,
+)
+from research_ai.services.agent.loop import AgentResult
+from research_ai.services.agent.tools import Tool
+from research_ai.services.agent.types import (
+    StopReason,
+    TurnUsage,
+    deserialize_messages,
+)
+from research_ai.services.agent_persistence import AgentExecutionService
+from research_ai.services.agent_persistence.content import (
+    MAX_CONTEXT_MESSAGE_BYTES,
+    MAX_TRACE_MESSAGE_BYTES,
+)
+from research_ai.tests.agent.persistence_test_helpers import (
+    AgentPersistenceTestCase,
+    FakeProvider,
+    agent,
+    text_turn,
+    tool_turn,
+)
+
+
+class AgentRecorderPersistenceTests(AgentPersistenceTestCase):
+    def test_successful_tool_run_persists_trace_metrics_and_details(self):
+        # Arrange
+        first_usage = TurnUsage(10, 4, 7, 3)
+        second_usage = TurnUsage(20, 5, 14, 2)
+        provider = FakeProvider(
+            [
+                tool_turn(
+                    "call-1",
+                    "lookup",
+                    {"query": "folding"},
+                    usage=first_usage,
+                    latency_ms=31,
+                ),
+                text_turn("Finished", usage=second_usage, latency_ms=47),
+            ]
+        )
+        recorder = self.recorder(
+            initial_prompt_provenance=AgentExecutionMessage.Provenance.HUMAN
+        )
+        tool = Tool(
+            "lookup",
+            "lookup",
+            {"type": "object"},
+            lambda _args: {"papers": ["A"]},
+        )
+
+        # Act
+        result = agent(provider, recorder, [tool]).run("Find papers")
+
+        # Assert
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertEqual(execution.status, AgentExecution.Status.SUCCEEDED)
+        self.assertEqual(execution.iterations, 2)
+        self.assertEqual(execution.input_tokens, 30)
+        self.assertEqual(execution.output_tokens, 9)
+        self.assertEqual(execution.cache_read_tokens, 21)
+        self.assertEqual(execution.cache_write_tokens, 5)
+        self.assertEqual(execution.total_latency_ms, 78)
+        self.assertEqual(execution.stop_reason, StopReason.END_TURN)
+        self.assertIsNotNone(execution.duration_ms)
+        self.assertEqual(execution.final_output, {"text": "Finished"})
+        self.assertEqual(result.final_text, "Finished")
+
+        trace = list(execution.messages.order_by("execution_sequence"))
+        self.assertEqual([row.execution_sequence for row in trace], [1, 2, 3, 4])
+        self.assertEqual(
+            [row.provenance for row in trace],
+            [
+                AgentExecutionMessage.Provenance.HUMAN,
+                AgentExecutionMessage.Provenance.MODEL,
+                AgentExecutionMessage.Provenance.TOOL,
+                AgentExecutionMessage.Provenance.MODEL,
+            ],
+        )
+        self.assertEqual(trace[1].content[1]["input"], {"query": "folding"})
+        self.assertEqual(trace[2].content[0]["content"], {"papers": ["A"]})
+
+    def test_failed_and_interrupted_runs_keep_partial_history(self):
+        # Arrange
+        failed_recorder = self.recorder()
+        provider = FakeProvider(
+            [
+                tool_turn("call-1", "lookup", {}),
+                ValueError("provider socket closed"),
+            ]
+        )
+        tool = Tool("lookup", "lookup", {"type": "object"}, lambda _args: {})
+
+        # Act / Assert
+        with self.assertRaisesRegex(Exception, "provider socket closed"):
+            agent(provider, failed_recorder, [tool]).run("start")
+        failed = AgentExecution.objects.get(id=failed_recorder.execution.id)
+        self.assertEqual(failed.status, AgentExecution.Status.FAILED)
+        self.assertEqual(failed.error_type, "ProviderError")
+        self.assertEqual(failed.messages.count(), 3)
+        self.assertEqual(failed.iterations, 1)
+
+        interrupted_recorder = self.recorder()
+        with self.assertRaises(InterruptedError):
+            agent(
+                FakeProvider([InterruptedError("worker stopped")]),
+                interrupted_recorder,
+            ).run("start")
+        interrupted = AgentExecution.objects.get(id=interrupted_recorder.execution.id)
+        self.assertEqual(interrupted.status, AgentExecution.Status.INTERRUPTED)
+        self.assertEqual(interrupted.messages.count(), 1)
+        self.assertEqual(interrupted.error_type, "InterruptedError")
+
+    def test_tool_errors_are_persisted_as_correlated_results(self):
+        # Arrange
+        recorder = self.recorder()
+        provider = FakeProvider(
+            [tool_turn("broken-1", "broken", {}), text_turn("recovered")]
+        )
+
+        def fail(_args):
+            raise RuntimeError("tool unavailable")
+
+        tool = Tool("broken", "broken", {"type": "object"}, fail)
+
+        # Act
+        agent(provider, recorder, [tool]).run("try it")
+
+        # Assert
+        result_block = recorder.execution.messages.get(execution_sequence=3).content[0]
+        self.assertEqual(result_block["tool_use_id"], "broken-1")
+        self.assertTrue(result_block["is_error"])
+        self.assertEqual(result_block["content"], {"error": "tool unavailable"})
+
+    def test_unexpected_setup_exception_marks_execution_failed(self):
+        # Arrange
+        recorder = self.recorder()
+        provider = FakeProvider([], render_error=RuntimeError("bad tool schema"))
+
+        # Act / Assert
+        with self.assertRaisesRegex(RuntimeError, "bad tool schema"):
+            agent(provider, recorder).run("hello")
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertEqual(execution.status, AgentExecution.Status.FAILED)
+        self.assertEqual(execution.error_type, "RuntimeError")
+        self.assertEqual(execution.messages.count(), 1)
+
+    def test_required_context_failure_marks_execution_failed(self):
+        # Arrange
+        recorder = self.recorder()
+        running_agent = agent(FakeProvider([text_turn("unreachable")]), recorder)
+
+        # Act / Assert
+        with (
+            patch.object(
+                AgentContextMessage.objects,
+                "create",
+                side_effect=IntegrityError("context write failed"),
+            ),
+            self.assertRaisesRegex(IntegrityError, "context write failed"),
+        ):
+            running_agent.run("hello")
+
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertEqual(execution.status, AgentExecution.Status.FAILED)
+        self.assertEqual(execution.error_type, "IntegrityError")
+        self.assertEqual(execution.context_messages.count(), 0)
+        self.assertEqual(execution.messages.count(), 0)
+
+    def test_terminal_callback_does_not_overwrite_cancelled_execution(self):
+        # Arrange
+        recorder = self.recorder(publish_assistant_message=True)
+        AgentExecution.objects.filter(id=recorder.execution.id).update(
+            status=AgentExecution.Status.CANCELLED
+        )
+        result = AgentResult(
+            messages=[],
+            final_text="late answer",
+            stop_reason=StopReason.END_TURN,
+            iterations=1,
+        )
+
+        # Act
+        recorder.on_run_finished(result)
+
+        # Assert
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
+        self.assertEqual(execution.final_output, {})
+        self.assertFalse(hasattr(execution, "generated_chat_message"))
+        self.assertTrue(recorder.terminal_observed)
+
+    def test_oversized_tool_content_is_bounded_and_still_deserializes(self):
+        # Arrange
+        huge = "x" * (MAX_TRACE_MESSAGE_BYTES * 4)
+        recorder = self.recorder()
+        provider = FakeProvider([tool_turn("large", "large_tool", {"body": huge})])
+        tool = Tool(
+            "large_tool",
+            "large",
+            {"type": "object"},
+            lambda _args: {"result": huge},
+            is_terminal=True,
+        )
+
+        # Act
+        agent(provider, recorder, [tool]).run("go")
+
+        # Assert
+        rows = list(recorder.execution.messages.order_by("execution_sequence"))
+        self.assertTrue(rows[1].is_truncated)
+        self.assertTrue(rows[2].is_truncated)
+        for row in rows:
+            self.assertLessEqual(
+                len(json.dumps(row.content).encode()), MAX_TRACE_MESSAGE_BYTES
+            )
+            deserialize_messages([{"role": row.role, "content": row.content}])
+
+        context_rows = list(recorder.execution.context_messages.order_by("sequence"))
+        self.assertTrue(context_rows[1].is_compacted)
+        self.assertTrue(context_rows[2].is_compacted)
+        for row in context_rows:
+            self.assertLessEqual(
+                len(json.dumps(row.content).encode()), MAX_CONTEXT_MESSAGE_BYTES
+            )
+            deserialize_messages([{"role": row.role, "content": row.content}])
+        self.assertEqual(len(context_rows), 3)
+
+    def test_headless_workflow_has_no_artificial_chat_messages(self):
+        # Arrange
+        workflow = AgentConversation.objects.create(workflow="headless")
+        recorder = AgentExecutionService().start(workflow)
+
+        # Act
+        agent(FakeProvider([text_turn("internal result")]), recorder).run(
+            "backend prompt"
+        )
+
+        # Assert
+        self.assertEqual(workflow.chat_messages.count(), 0)
+        self.assertEqual(
+            recorder.execution.messages.first().provenance,
+            AgentExecutionMessage.Provenance.BACKEND,
+        )
+
+    def test_optional_trace_failure_does_not_break_surrounding_transaction(self):
+        # Arrange
+        recorder = self.recorder()
+        running_agent = agent(FakeProvider([text_turn("still succeeds")]), recorder)
+
+        # Act
+        with transaction.atomic():
+            with patch.object(
+                AgentExecutionMessage.objects,
+                "create",
+                side_effect=IntegrityError("trace write failed"),
+            ):
+                result = running_agent.run("hello")
+            AgentConversation.objects.create()
+
+        # Assert
+        self.assertEqual(result.final_text, "still succeeds")
+        self.assertEqual(
+            AgentExecution.objects.get(id=recorder.execution.id).status,
+            AgentExecution.Status.SUCCEEDED,
+        )
+        self.assertEqual(recorder.execution.context_messages.count(), 2)
+        self.assertEqual(AgentExecutionMessage.objects.count(), 0)
+        self.assertEqual(AgentContextMessage.objects.count(), 2)

--- a/src/research_ai/tests/agent/test_persistence_services.py
+++ b/src/research_ai/tests/agent/test_persistence_services.py
@@ -1,0 +1,179 @@
+"""Conversation, context, run-detail, and retention service coverage."""
+
+from unittest.mock import patch
+
+from django.db import IntegrityError, transaction
+
+from note.models import Note
+from research_ai.models import (
+    AgentContextMessage,
+    AgentConversation,
+    AgentExecution,
+    AgentExecutionMessage,
+    NoteAgentConversation,
+)
+from research_ai.services.agent.types import StopReason
+from research_ai.services.agent_persistence import (
+    AgentContextService,
+    AgentConversationService,
+    AgentExecutionService,
+    AgentRetentionService,
+    AgentRunDetailsService,
+    NoteAgentConversationService,
+)
+from research_ai.tests.agent.persistence_test_helpers import (
+    AgentPersistenceTestCase,
+    FakeProvider,
+    agent,
+    text_turn,
+)
+from researchhub_document.models import ResearchhubUnifiedDocument
+from researchhub_document.related_models.constants.document_type import NOTE
+
+
+class AgentPersistenceServiceTests(AgentPersistenceTestCase):
+    def test_note_attachment_is_idempotent_and_queryable(self):
+        # Arrange
+        note = Note.objects.create(
+            unified_document=ResearchhubUnifiedDocument.objects.create(
+                document_type=NOTE
+            )
+        )
+        second_conversation = AgentConversationService().create(
+            workflow="notebook_chat",
+        )
+        service = NoteAgentConversationService()
+
+        # Act
+        first_link = service.attach(self.conversation, note)
+        repeated_link = service.attach(self.conversation, note)
+        service.attach(second_conversation, note)
+
+        # Assert
+        self.assertEqual(first_link, repeated_link)
+        self.assertEqual(NoteAgentConversation.objects.count(), 2)
+        self.assertEqual(
+            set(service.for_note(note).values_list("id", flat=True)),
+            {self.conversation.id, second_conversation.id},
+        )
+
+    def test_note_attachment_failure_does_not_break_surrounding_transaction(self):
+        # Arrange
+        note = Note.objects.create(
+            unified_document=ResearchhubUnifiedDocument.objects.create(
+                document_type=NOTE
+            )
+        )
+        service = NoteAgentConversationService()
+        service.attach(self.conversation, note)
+
+        def violate_unique(**_kwargs):
+            return NoteAgentConversation.objects.create(
+                note=note,
+                conversation=self.conversation,
+            )
+
+        # Act
+        with transaction.atomic():
+            with (
+                patch.object(
+                    NoteAgentConversation.objects,
+                    "get_or_create",
+                    side_effect=violate_unique,
+                ),
+                self.assertRaises(IntegrityError),
+            ):
+                service.attach(self.conversation, note)
+            surviving = AgentConversation.objects.create()
+
+        # Assert
+        self.assertTrue(AgentConversation.objects.filter(id=surviving.id).exists())
+
+    def test_debug_retention_does_not_delete_chat(self):
+        # Arrange
+        human_message = AgentConversationService().add_human_message(
+            self.conversation, "Keep me"
+        )
+        recorder = AgentExecutionService().start(
+            self.conversation,
+            trigger_message=human_message,
+            initial_prompt_provenance=AgentExecutionMessage.Provenance.HUMAN,
+            publish_assistant_message=True,
+        )
+        agent(FakeProvider([text_turn("Keep me too")]), recorder).run("Keep me")
+
+        # Act
+        AgentRetentionService().delete_conversation_debug(self.conversation)
+
+        # Assert
+        execution = self.conversation.executions.get()
+        self.assertEqual(execution.messages.count(), 0)
+        self.assertEqual(execution.context_messages.count(), 2)
+        rebuilt = AgentContextService().reconstruct(execution)
+        self.assertEqual(
+            [message.content[0].text for message in rebuilt],
+            ["Keep me", "Keep me too"],
+        )
+        self.assertEqual(
+            list(
+                self.conversation.chat_messages.order_by("sequence").values_list(
+                    "content", flat=True
+                )
+            ),
+            ["Keep me", "Keep me too"],
+        )
+        self.assertEqual(AgentExecutionMessage.objects.count(), 0)
+        self.assertEqual(AgentContextMessage.objects.count(), 2)
+
+    def test_context_reconstruction_orders_messages_across_executions(self):
+        # Arrange
+        first_recorder = self.recorder(
+            initial_prompt_provenance=AgentExecutionMessage.Provenance.HUMAN
+        )
+        agent(FakeProvider([text_turn("first answer")]), first_recorder).run(
+            "first question"
+        )
+        first = AgentExecution.objects.get(id=first_recorder.execution.id)
+        prior_context = AgentContextService().reconstruct(first)
+        second_recorder = self.recorder(
+            context_parent=first,
+            initial_prompt_provenance=AgentExecutionMessage.Provenance.HUMAN,
+        )
+
+        # Act
+        agent(
+            FakeProvider([text_turn("second answer")]), second_recorder
+        ).continue_conversation(prior_context, "follow up")
+        second = AgentExecution.objects.get(id=second_recorder.execution.id)
+        rebuilt = AgentContextService().reconstruct(second)
+
+        # Assert
+        self.assertEqual(
+            [message.content[0].text for message in rebuilt],
+            ["first question", "first answer", "follow up", "second answer"],
+        )
+        self.assertEqual(
+            list(
+                self.conversation.trace_messages.order_by("sequence").values_list(
+                    "sequence", flat=True
+                )
+            ),
+            [1, 2, 3, 4],
+        )
+
+    def test_run_details_exposes_metrics_and_trace(self):
+        # Arrange
+        recorder = self.recorder()
+        agent(FakeProvider([text_turn("done", latency_ms=23)]), recorder).run(
+            "question"
+        )
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+
+        # Act
+        details = AgentRunDetailsService().get(execution)
+
+        # Assert
+        self.assertEqual(details["status"], AgentExecution.Status.SUCCEEDED)
+        self.assertEqual(details["stop_reason"], StopReason.END_TURN)
+        self.assertEqual(details["total_latency_ms"], 23)
+        self.assertEqual(len(details["trace"]), 2)

--- a/src/research_ai/tests/proposal_draft/test_proposal_draft_service.py
+++ b/src/research_ai/tests/proposal_draft/test_proposal_draft_service.py
@@ -17,12 +17,23 @@ from django.utils import timezone
 
 from note.models import Note
 from purchase.models import Grant
-from research_ai.models import Expert, ExpertSearch, ProposalDraft, SearchExpert
+from research_ai.models import (
+    AgentExecution,
+    AgentExecutionMessage,
+    Expert,
+    ExpertSearch,
+    ProposalDraft,
+    SearchExpert,
+)
 from research_ai.services.agent.types import (
     AssistantTurn,
     StopReason,
     TextBlock,
     ToolUseBlock,
+)
+from research_ai.services.agent_persistence import (
+    AgentRetentionService,
+    NoteAgentConversationService,
 )
 from research_ai.services.proposal_draft import run_proposal_draft
 from research_ai.services.proposal_draft.runner import (
@@ -296,6 +307,21 @@ class ProposalDraftServiceTests(TestCase):
         self.assertEqual(draft.step, ProposalDraft.Step.DONE)
         self.assertEqual(draft.final_scores["overall"], 5)
         self.assertEqual(draft.rounds_used, 1)
+        self.assertIsNotNone(draft.agent_conversation_id)
+        self.assertEqual(draft.agent_conversation.workflow, "proposal_draft")
+        self.assertEqual(draft.agent_conversation.chat_messages.count(), 0)
+        execution = draft.agent_conversation.executions.get()
+        self.assertEqual(execution.status, AgentExecution.Status.SUCCEEDED)
+        self.assertEqual(
+            execution.messages.first().provenance,
+            AgentExecutionMessage.Provenance.BACKEND,
+        )
+        self.assertEqual(draft.agent_conversation.proposal_draft, draft)
+        self.assertEqual(execution.configuration, draft.run_config)
+        self.assertEqual(
+            list(NoteAgentConversationService().for_note(note)),
+            [draft.agent_conversation],
+        )
         self.assertTrue(panel.contexts)  # panel was scored at least once
         self.assertEqual(
             panel.contexts[0]["rfp"]["organization"],
@@ -305,6 +331,68 @@ class ProposalDraftServiceTests(TestCase):
             panel.contexts[0]["researcher_profile"]["works"][0]["source_url"],
             "https://doi.org/10.1/a",
         )
+
+        # Debug retention removes the trace, never the shipped proposal.
+        AgentRetentionService().delete_conversation_debug(draft.agent_conversation)
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, ProposalDraft.Status.COMPLETED)
+        self.assertTrue(Note.objects.filter(id=note.id).exists())
+        retained_execution = draft.agent_conversation.executions.get()
+        self.assertEqual(retained_execution.messages.count(), 0)
+        self.assertGreater(retained_execution.context_messages.count(), 0)
+        self.assertEqual(
+            note.agent_conversation_links.get().conversation_id,
+            draft.agent_conversation_id,
+        )
+
+    def test_note_attachment_failure_does_not_break_proposal(self):
+        # Arrange
+        provider = _ScriptedProvider([_submit_turn(_clean_payload())])
+
+        # Act
+        with patch.object(
+            NoteAgentConversationService,
+            "attach",
+            side_effect=RuntimeError("association database unavailable"),
+        ):
+            result = run_proposal_draft(
+                self.search_expert.id,
+                provider=provider,
+                panel=_FakePanel(overall=5),
+                oa_client=_FakeOpenAlex(),
+            )
+
+        # Assert
+        draft = ProposalDraft.objects.get(id=result["proposal_draft_id"])
+        self.assertEqual(result["status"], ProposalDraft.Status.COMPLETED)
+        self.assertEqual(draft.status, ProposalDraft.Status.COMPLETED)
+        self.assertIsNotNone(draft.note_id)
+        self.assertIsNotNone(draft.agent_conversation_id)
+        self.assertFalse(draft.note.agent_conversation_links.exists())
+        self.assertEqual(
+            list(NoteAgentConversationService().for_note(draft.note)),
+            [draft.agent_conversation],
+        )
+
+    def test_trace_initialization_failure_does_not_break_proposal(self):
+        # Arrange
+        provider = _ScriptedProvider([_submit_turn(_clean_payload())])
+
+        # Act
+        with patch(
+            "research_ai.services.proposal_draft.runner.AgentExecutionService.start",
+            side_effect=RuntimeError("trace database unavailable"),
+        ):
+            result = run_proposal_draft(
+                self.search_expert.id,
+                provider=provider,
+                panel=_FakePanel(overall=5),
+                oa_client=_FakeOpenAlex(),
+            )
+
+        # Assert
+        self.assertEqual(result["status"], ProposalDraft.Status.COMPLETED)
+        self.assertTrue(Note.objects.filter(id=result["note_id"]).exists())
 
     @override_settings(RESEARCH_AI_PROPOSAL_MAX_ROUNDS=1)
     def test_missing_limitations_section_is_blocked(self):


### PR DESCRIPTION
## Stack

1. #3843 — Persist agent execution lifecycles
2. #3844 — Add agent conversation services
3. #3831 — Add agent chat orchestration
4. **#3827 — Persist proposal draft agent histories**

## What changed

- Create and link a durable workflow conversation when proposal drafting begins.
- Start the database-backed execution recorder with a configuration snapshot.
- Expose the Bedrock default model identifier for accurate configuration snapshots.
- Preserve the headless backend prompt without creating artificial chat messages.
- Attach the completed proposal note to the existing workflow conversation.
- Keep persistence failures observational so proposal behavior remains unchanged.

## Why

Proposal drafting is the first production caller of the reusable persistence stack and needs inspectable execution history without coupling the core agent to Django.

## Impact

Completed or failed proposal drafts retain their existing behavior while gaining durable history and notebook association.

## Validation

- Full stacked `research_ai` suite: 651 tests passed.
- Ruff lint and formatting checks passed across `src`.
- Rebase onto current `main` verified with `git range-diff`; all four patches are unchanged.