### PR TITLE
Make agent traces forward-compatible

### DIFF
--- a/src/research_ai/services/agent/__init__.py
+++ b/src/research_ai/services/agent/__init__.py
@@ -3,8 +3,9 @@
 Public surface:
 
 - Neutral types: ``Message``, ``TextBlock``, ``ToolUseBlock``,
-  ``ToolResultBlock``, ``AssistantTurn``, ``TurnUsage``, ``StopReason``, and
-  the ``serialize_messages`` / ``deserialize_messages`` helpers.
+  ``ToolResultBlock``, ``UnknownBlock``, ``AssistantTurn``, ``TurnUsage``,
+  ``StopReason``, and the ``serialize_messages`` / ``deserialize_messages``
+  helpers.
 - Tools: ``Tool``, ``Toolset``.
 - Providers: ``LLMProvider`` (ABC), ``BedrockProvider``.
 - Loop: ``Agent``, ``AgentResult``.
@@ -37,6 +38,7 @@ from research_ai.services.agent.types import (
     ToolResultBlock,
     ToolUseBlock,
     TurnUsage,
+    UnknownBlock,
     deserialize_messages,
     serialize_messages,
 )
@@ -61,6 +63,7 @@ __all__ = [
     "ToolUseBlock",
     "Toolset",
     "TurnUsage",
+    "UnknownBlock",
     "deserialize_messages",
     "serialize_messages",
 ]

--- a/src/research_ai/services/agent/loop.py
+++ b/src/research_ai/services/agent/loop.py
@@ -166,6 +166,10 @@ class Agent:
             exc.messages = messages
             exc.iterations = iteration - 1
             raise
+        except InterruptedError:
+            # Preserve an explicit interruption so persistence can distinguish
+            # it from an ordinary provider failure.
+            raise
         except Exception as exc:
             # A provider that leaks a foreign exception still surfaces as
             # the typed contract, transcript attached.
@@ -208,6 +212,12 @@ class Agent:
         except AgentRunError as error:
             # Every message up to the failure was already recorded as it was
             # appended; this only marks the terminal outcome.
+            self._record("on_run_failed", error)
+            raise
+        except Exception as error:
+            # Setup/core failures outside the typed provider contract (for
+            # example tool-spec rendering) must also terminate an observational
+            # execution instead of leaving it permanently RUNNING.
             self._record("on_run_failed", error)
             raise
         self._record("on_run_finished", result)

--- a/src/research_ai/services/agent/providers/bedrock.py
+++ b/src/research_ai/services/agent/providers/bedrock.py
@@ -22,6 +22,7 @@ from research_ai.services.agent.types import (
     ToolResultBlock,
     ToolUseBlock,
     TurnUsage,
+    UnknownBlock,
 )
 from utils.aws import bedrock_runtime_client
 
@@ -30,7 +31,7 @@ logger = logging.getLogger(__name__)
 # Default generator model. Bedrock requires the cross-region inference profile
 # (the ``us.`` prefix); the bare ``anthropic.claude-opus-4-8`` is provisioned-
 # throughput only. Override per environment via RESEARCH_AI_GENERATOR_MODEL_ID.
-_DEFAULT_MODEL_ID = "us.anthropic.claude-opus-4-8"
+DEFAULT_MODEL_ID = "us.anthropic.claude-opus-4-8"
 
 # Opus 4.7+ and Fable reject sampling params (temperature/top_p/top_k) with a
 # 400 ("`temperature` is deprecated for this model"). Match by substring so the
@@ -57,10 +58,14 @@ _STOP_REASONS = {
 class BedrockProvider(LLMProvider):
     """Adapts the neutral agent types to the Bedrock Converse API."""
 
+    default_model_id = DEFAULT_MODEL_ID
+
     def __init__(self, *, client: Any = None, model_id: str | None = None):
         self._client = client or bedrock_runtime_client()
-        self.model_id = model_id or getattr(
-            settings, "RESEARCH_AI_GENERATOR_MODEL_ID", _DEFAULT_MODEL_ID
+        self.model_id = (
+            model_id
+            or getattr(settings, "RESEARCH_AI_GENERATOR_MODEL_ID", None)
+            or DEFAULT_MODEL_ID
         )
         # Prompt caching is the dominant cost lever for this uncached, ever-growing
         # tool loop: the tools+system prefix is byte-identical every turn and the
@@ -173,6 +178,12 @@ class BedrockProvider(LLMProvider):
             if block.is_error:
                 tool_result["status"] = "error"
             return {"toolResult": tool_result}
+        if isinstance(block, UnknownBlock):
+            # Preserve resumability when a newer protocol wrote a block this
+            # adapter does not understand yet. The raw block remains in the DB;
+            # the provider receives an explicit placeholder instead of an
+            # invalid wire object.
+            return {"text": f"[Unsupported historical block: {block.type}]"}
         raise TypeError(f"unrenderable block: {block!r}")
 
     def _parse_turn(self, response: dict) -> AssistantTurn:

--- a/src/research_ai/services/agent/recorder.py
+++ b/src/research_ai/services/agent/recorder.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Protocol
 from research_ai.services.agent.types import AssistantTurn, Message
 
 if TYPE_CHECKING:
-    from research_ai.services.agent.errors import AgentRunError
     from research_ai.services.agent.loop import AgentResult
 
 
@@ -40,6 +39,6 @@ class AgentRecorder(Protocol):
         """The run completed; every message was already recorded."""
         ...
 
-    def on_run_failed(self, error: AgentRunError) -> None:
+    def on_run_failed(self, error: Exception) -> None:
         """The run failed; every message up to the failure was recorded."""
         ...

--- a/src/research_ai/services/agent/types.py
+++ b/src/research_ai/services/agent/types.py
@@ -7,8 +7,9 @@ them from) its own wire format. Keeping the core neutral is what lets a later
 PR run the same conversation through multiple providers (e.g. a judge panel).
 
 Every block carries a ``type`` discriminator and is JSON round-trippable via
-``serialize_messages`` / ``deserialize_messages`` -- that JSON shape is exactly
-what a future ``AgentMessage.JSONField`` will persist. No Django models here.
+``serialize_messages`` / ``deserialize_messages``. Unknown additive block types
+round-trip as ``UnknownBlock`` so older workers can inspect newer traces without
+discarding data. No Django models live here.
 
 Id-correlation invariant: a ``ToolUseBlock.id`` emitted by the assistant is
 echoed back as the ``ToolResultBlock.tool_use_id`` of its result. Adapters must
@@ -60,8 +61,19 @@ class ToolResultBlock:
     type: str = "tool_result"
 
 
-# A content block is one of the three block types above.
-Block = TextBlock | ToolUseBlock | ToolResultBlock
+@dataclass(frozen=True)
+class UnknownBlock:
+    """Opaque future protocol block preserved across persistence round trips."""
+
+    raw: dict
+
+    @property
+    def type(self) -> str:
+        return str(self.raw.get("type") or "unknown")
+
+
+# Unknown blocks are retained rather than making old readers reject new data.
+Block = TextBlock | ToolUseBlock | ToolResultBlock | UnknownBlock
 
 
 @dataclass(frozen=True)
@@ -127,6 +139,8 @@ def _serialize_block(block: Block) -> dict:
             "content": block.content,
             "is_error": block.is_error,
         }
+    if isinstance(block, UnknownBlock):
+        return dict(block.raw)
     raise TypeError(f"unserializable block: {block!r}")
 
 
@@ -142,7 +156,7 @@ def _deserialize_block(data: dict) -> Block:
             content=data["content"],
             is_error=data.get("is_error", False),
         )
-    raise ValueError(f"unknown block type: {block_type!r}")
+    return UnknownBlock(raw=dict(data))
 
 
 def serialize_messages(messages: list[Message]) -> list[dict]:


### PR DESCRIPTION
## Stack

1. **#3829 — Make agent traces forward-compatible**
2. #3830 — Add agent conversation persistence models
3. #3831 — Add durable agent persistence services
4. #3827 — Persist proposal draft agent histories

This PR is layer 1 of 4 and targets `main`.

## What changed

- Preserve unknown additive content-block types through serialization.
- Make Bedrock replay unknown historical blocks safely.
- Record interruptions and unexpected setup/core failures through the recorder lifecycle.
- Expose stable provider model metadata for configuration snapshots.

## Why

Durable traces must remain readable as provider protocols evolve, and observational persistence needs terminal callbacks even when failures happen outside the normal provider error contract.

## Impact

The reusable agent loop remains independent from Django while providing the lifecycle and protocol information required by a database-backed recorder.

## Validation

- 72 focused agent and proposal-drafting tests passed.
- Ruff check and formatting passed.
- Django reported no migration drift.