### PR TITLE
Add agent chat orchestration

### DIFF
--- a/src/research_ai/services/agent_persistence/__init__.py
+++ b/src/research_ai/services/agent_persistence/__init__.py
@@ -1,5 +1,6 @@
-"""Serialization and persistence services for the provider-neutral agent core."""
+"""Django persistence and read services for the provider-neutral agent core."""
 
+from .chat_service import AgentChatService, PreparedAgentExecution
 from .context_service import AgentContextService
 from .conversation_service import (
     AgentConversationService,
@@ -14,6 +15,7 @@ from .run_details_service import (
 )
 
 __all__ = [
+    "AgentChatService",
     "AgentContextService",
     "AgentConversationBusyError",
     "AgentConversationService",
@@ -23,4 +25,5 @@ __all__ = [
     "AgentRunDetailsService",
     "DatabaseAgentRecorder",
     "NoteAgentConversationService",
+    "PreparedAgentExecution",
 ]

--- a/src/research_ai/services/agent_persistence/chat_service.py
+++ b/src/research_ai/services/agent_persistence/chat_service.py
@@ -1,0 +1,232 @@
+"""User-facing chat preparation and representation services."""
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from django.db import transaction
+
+from research_ai.models import (
+    AgentConversation,
+    AgentConversationMessage,
+    AgentExecution,
+    AgentExecutionMessage,
+)
+from research_ai.services.agent.types import Message
+from research_ai.services.agent_persistence.context_service import AgentContextService
+from research_ai.services.agent_persistence.conversation_service import (
+    AgentConversationService,
+)
+from research_ai.services.agent_persistence.execution_service import (
+    AgentExecutionService,
+)
+from research_ai.services.agent_persistence.recorder import DatabaseAgentRecorder
+
+logger = logging.getLogger(__name__)
+
+RecorderFactory = Callable[..., DatabaseAgentRecorder]
+
+
+@dataclass(frozen=True)
+class PreparedAgentExecution:
+    execution: AgentExecution
+    recorder: DatabaseAgentRecorder
+    human_message: AgentConversationMessage | None
+    context: list[Message]
+
+
+class AgentChatService:
+    def __init__(
+        self,
+        *,
+        conversation_service: AgentConversationService | None = None,
+        execution_service: AgentExecutionService | None = None,
+        context_service: AgentContextService | None = None,
+        recorder_factory: RecorderFactory | None = None,
+    ):
+        self.conversations = (
+            AgentConversationService()
+            if conversation_service is None
+            else conversation_service
+        )
+        self.executions = (
+            AgentExecutionService(recorder_factory=recorder_factory)
+            if execution_service is None
+            else execution_service
+        )
+        self.contexts = (
+            AgentContextService() if context_service is None else context_service
+        )
+        self.recorder_factory = (
+            getattr(self.executions, "recorder_factory", DatabaseAgentRecorder)
+            if recorder_factory is None
+            else recorder_factory
+        )
+
+    def prepare_turn(
+        self,
+        conversation: AgentConversation,
+        human_content: str,
+        *,
+        provider: str = "",
+        model: str = "",
+        configuration: dict | None = None,
+        system_prompt: str = "",
+        prompt_is_backend_composed: bool = False,
+    ) -> PreparedAgentExecution:
+        with transaction.atomic():
+            locked = AgentConversation.objects.select_for_update().get(
+                id=conversation.id
+            )
+            parent = (
+                locked.executions.filter(status=AgentExecution.Status.SUCCEEDED)
+                .order_by("-attempt")
+                .first()
+            )
+            context = self.contexts.reconstruct(parent) if parent else []
+            human_message = self.conversations.add_human_message(locked, human_content)
+            recorder = self.executions.start(
+                locked,
+                provider=provider,
+                model=model,
+                configuration=configuration,
+                system_prompt=system_prompt,
+                trigger_message=human_message,
+                context_parent=parent,
+                initial_prompt_provenance=(
+                    AgentExecutionMessage.Provenance.BACKEND
+                    if prompt_is_backend_composed
+                    else AgentExecutionMessage.Provenance.HUMAN
+                ),
+                publish_assistant_message=True,
+            )
+        return PreparedAgentExecution(
+            recorder.execution, recorder, human_message, context
+        )
+
+    @staticmethod
+    def _retry_provenance(execution: AgentExecution) -> str:
+        provenance = (
+            execution.messages.order_by("execution_sequence")
+            .values_list("provenance", flat=True)
+            .first()
+        )
+        if provenance in AgentExecutionMessage.Provenance.values:
+            return provenance
+        if execution.trigger_message_id:
+            return AgentExecutionMessage.Provenance.HUMAN
+        return AgentExecutionMessage.Provenance.BACKEND
+
+    def prepare_retry(
+        self,
+        execution: AgentExecution,
+        *,
+        configuration: dict | None = None,
+        system_prompt: str | None = None,
+        regenerate: bool = False,
+        initial_prompt_provenance: str | None = None,
+    ) -> PreparedAgentExecution:
+        context = (
+            self.contexts.reconstruct(execution.context_parent)
+            if execution.context_parent
+            else []
+        )
+        recorder = self.executions.start(
+            execution.conversation,
+            provider=execution.provider,
+            model=execution.model,
+            configuration=(
+                execution.configuration if configuration is None else configuration
+            ),
+            system_prompt=(
+                execution.system_prompt if system_prompt is None else system_prompt
+            ),
+            trigger_message=execution.trigger_message,
+            context_parent=execution.context_parent,
+            retry_of=execution,
+            initial_prompt_provenance=(
+                self._retry_provenance(execution)
+                if initial_prompt_provenance is None
+                else initial_prompt_provenance
+            ),
+            publish_assistant_message=True,
+            replaces_output_of=execution if regenerate else None,
+        )
+        return PreparedAgentExecution(
+            recorder.execution, recorder, execution.trigger_message, context
+        )
+
+    @staticmethod
+    def _public_error(execution: AgentExecution) -> dict[str, str] | None:
+        if not execution.error_type:
+            return None
+        if execution.status == AgentExecution.Status.INTERRUPTED:
+            return {
+                "code": "agent_interrupted",
+                "message": "The agent request was interrupted.",
+            }
+        return {
+            "code": "agent_failed",
+            "message": "The agent could not complete this request.",
+        }
+
+    def representation(self, conversation: AgentConversation) -> dict:
+        """Repair pending publication and return user-safe chat lifecycle data."""
+        self.repair_pending_outputs(conversation)
+        messages = [
+            {
+                "id": message.id,
+                "sequence": message.sequence,
+                "role": message.role.lower(),
+                "content": message.content,
+                "execution_id": message.generated_by_execution_id,
+            }
+            for message in conversation.chat_messages.filter(is_active=True).order_by(
+                "sequence"
+            )
+        ]
+        executions = [
+            {
+                "id": execution.id,
+                "attempt": execution.attempt,
+                "status": execution.status,
+                "trigger_message_id": execution.trigger_message_id,
+                "retry_of_id": execution.retry_of_id,
+                "context_parent_id": execution.context_parent_id,
+                "stop_reason": execution.stop_reason,
+                "assistant_message_pending": (
+                    execution.status == AgentExecution.Status.SUCCEEDED
+                    and execution.publish_output_to_chat
+                    and not hasattr(execution, "generated_chat_message")
+                ),
+                "error": self._public_error(execution),
+            }
+            for execution in conversation.executions.select_related(
+                "generated_chat_message"
+            ).order_by("attempt")
+        ]
+        return {
+            "conversation_id": conversation.id,
+            "messages": messages,
+            "executions": executions,
+        }
+
+    def repair_pending_outputs(self, conversation: AgentConversation) -> int:
+        """Retry any successful chat publication that previously failed."""
+        repaired = 0
+        pending = conversation.executions.filter(
+            status=AgentExecution.Status.SUCCEEDED,
+            publish_output_to_chat=True,
+            generated_chat_message__isnull=True,
+        ).order_by("attempt")
+        for execution in pending:
+            try:
+                repaired += int(
+                    self.recorder_factory(execution).publish_assistant_output()
+                )
+            except Exception:  # noqa: BLE001 - reads still expose pending state
+                logger.warning(
+                    "failed to repair agent response publication",
+                    exc_info=True,
+                )
+        return repaired

--- a/src/research_ai/tests/agent/test_persistence_chat.py
+++ b/src/research_ai/tests/agent/test_persistence_chat.py
@@ -1,0 +1,292 @@
+"""User-facing chat preparation, retry, publication, and repair coverage."""
+
+import json
+from unittest.mock import patch
+
+from django.db import IntegrityError
+
+from research_ai.models import AgentExecution, AgentExecutionMessage
+from research_ai.services.agent.tools import Tool
+from research_ai.services.agent_persistence import (
+    AgentChatService,
+    AgentConversationBusyError,
+    AgentConversationService,
+    AgentExecutionService,
+    DatabaseAgentRecorder,
+)
+from research_ai.services.agent_persistence.content import (
+    MAX_TRACE_MESSAGE_BYTES,
+    json_size_bytes,
+)
+from research_ai.tests.agent.persistence_test_helpers import (
+    AgentPersistenceTestCase,
+    FakeProvider,
+    agent,
+    text_turn,
+    tool_turn,
+)
+
+
+class AgentChatPersistenceTests(AgentPersistenceTestCase):
+    def test_backend_prompt_preserves_human_text_and_chat_filters_trace(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(
+            self.conversation,
+            "What I actually typed",
+            provider="fake",
+            model="fake-model-v1",
+            prompt_is_backend_composed=True,
+        )
+        wrapped_prompt = "Notebook context:\n...\nUser: What I actually typed"
+        tool = Tool("lookup", "lookup", {"type": "object"}, lambda _args: {"secret": 1})
+        provider = FakeProvider(
+            [tool_turn("c1", "lookup", {}), text_turn("Visible answer")]
+        )
+
+        # Act
+        agent(provider, prepared.recorder, [tool]).run(wrapped_prompt)
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["What I actually typed", "Visible answer"],
+        )
+        first_trace = prepared.execution.messages.order_by("execution_sequence").first()
+        self.assertEqual(
+            first_trace.provenance, AgentExecutionMessage.Provenance.BACKEND
+        )
+        self.assertEqual(first_trace.content[0]["text"], wrapped_prompt)
+        self.assertNotIn("secret", json.dumps(representation["messages"]))
+
+    def test_retry_reuses_human_message_and_provenance(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "One human turn")
+        prepared.recorder.on_run_failed(RuntimeError("temporary failure"))
+
+        # Act
+        retry = chat.prepare_retry(prepared.execution)
+        agent(FakeProvider([text_turn("Recovered")]), retry.recorder).run(
+            "One human turn"
+        )
+
+        # Assert
+        self.assertEqual(self.conversation.chat_messages.filter(role="USER").count(), 1)
+        self.assertEqual(retry.execution.trigger_message_id, prepared.human_message.id)
+        self.assertEqual(retry.execution.retry_of_id, prepared.execution.id)
+        self.assertEqual(
+            chat.representation(self.conversation)["messages"][-1]["content"],
+            "Recovered",
+        )
+        self.assertEqual(
+            retry.execution.messages.order_by("execution_sequence").first().provenance,
+            AgentExecutionMessage.Provenance.HUMAN,
+        )
+
+    def test_failed_assistant_publication_is_repaired_from_durable_intent(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+
+        # Act
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(FakeProvider([text_turn("Durable answer")]), prepared.recorder).run(
+                "Question"
+            )
+        execution = AgentExecution.objects.get(id=prepared.execution.id)
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        self.assertEqual(execution.status, AgentExecution.Status.SUCCEEDED)
+        self.assertTrue(execution.publish_output_to_chat)
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["Question", "Durable answer"],
+        )
+        self.assertFalse(representation["executions"][0]["assistant_message_pending"])
+
+    def test_large_assistant_output_repairs_as_the_same_bounded_text(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+        huge_answer = "x" * (MAX_TRACE_MESSAGE_BYTES * 2)
+
+        # Act
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(FakeProvider([text_turn(huge_answer)]), prepared.recorder).run(
+                "Question"
+            )
+        execution = AgentExecution.objects.get(id=prepared.execution.id)
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        stored_text = execution.final_output["text"]
+        self.assertIsInstance(stored_text, str)
+        self.assertTrue(execution.final_output["_truncated"])
+        self.assertLessEqual(
+            json_size_bytes(execution.final_output), MAX_TRACE_MESSAGE_BYTES
+        )
+        self.assertEqual(representation["messages"][-1]["content"], stored_text)
+
+    def test_public_representation_does_not_expose_internal_error_message(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+        prepared.recorder.on_run_failed(
+            RuntimeError("provider secret token must not be public")
+        )
+
+        # Act
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        self.assertNotIn("secret token", json.dumps(representation))
+        self.assertEqual(
+            representation["executions"][0]["error"],
+            {
+                "code": "agent_failed",
+                "message": "The agent could not complete this request.",
+            },
+        )
+
+    def test_public_representation_fetches_assistant_links_without_n_plus_one(self):
+        # Arrange
+        chat = AgentChatService()
+        first = chat.prepare_turn(self.conversation, "First")
+        agent(FakeProvider([text_turn("First answer")]), first.recorder).run("First")
+        second = chat.prepare_turn(self.conversation, "Second")
+        agent(FakeProvider([text_turn("Second answer")]), second.recorder).run("Second")
+
+        # Act / Assert
+        with self.assertNumQueries(3):
+            representation = chat.representation(self.conversation)
+        self.assertEqual(len(representation["executions"]), 2)
+
+    def test_regeneration_repair_replaces_prior_output_without_new_user_message(self):
+        # Arrange
+        chat = AgentChatService()
+        original = chat.prepare_turn(self.conversation, "Question")
+        agent(FakeProvider([text_turn("First answer")]), original.recorder).run(
+            "Question"
+        )
+        regeneration = chat.prepare_retry(original.execution, regenerate=True)
+
+        # Act
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(
+                FakeProvider([text_turn("Better answer")]),
+                regeneration.recorder,
+            ).run("Question")
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        regeneration.execution.refresh_from_db()
+        self.assertEqual(
+            regeneration.execution.replaces_output_of_id,
+            original.execution.id,
+        )
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["Question", "Better answer"],
+        )
+        self.assertEqual(self.conversation.chat_messages.filter(role="USER").count(), 1)
+
+    def test_prepare_turn_rolls_back_human_message_when_execution_start_fails(self):
+        # Arrange
+        chat = AgentChatService()
+
+        # Act / Assert
+        with (
+            patch.object(
+                AgentExecutionService,
+                "start",
+                side_effect=RuntimeError("execution insert failed"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "execution insert failed"),
+        ):
+            chat.prepare_turn(self.conversation, "Do not orphan me")
+        self.assertFalse(self.conversation.chat_messages.exists())
+
+    def test_prepare_turn_does_not_start_when_context_reconstruction_fails(self):
+        # Arrange
+        chat = AgentChatService()
+        first = chat.prepare_turn(self.conversation, "First")
+        agent(FakeProvider([text_turn("Answer")]), first.recorder).run("First")
+        message_count = self.conversation.chat_messages.count()
+        execution_count = self.conversation.executions.count()
+
+        # Act / Assert
+        with (
+            patch.object(
+                chat.contexts,
+                "reconstruct",
+                side_effect=ValueError("invalid durable context"),
+            ),
+            self.assertRaisesRegex(ValueError, "invalid durable context"),
+        ):
+            chat.prepare_turn(self.conversation, "Second")
+
+        self.assertEqual(self.conversation.chat_messages.count(), message_count)
+        self.assertEqual(self.conversation.executions.count(), execution_count)
+        self.assertFalse(
+            self.conversation.executions.filter(
+                status__in=[
+                    AgentExecution.Status.PENDING,
+                    AgentExecution.Status.RUNNING,
+                ]
+            ).exists()
+        )
+
+    def test_active_turn_blocks_a_second_linear_turn_without_new_message(self):
+        # Arrange
+        chat = AgentChatService()
+        first = chat.prepare_turn(self.conversation, "First")
+
+        # Act / Assert
+        with self.assertRaises(AgentConversationBusyError):
+            chat.prepare_turn(self.conversation, "Second")
+        self.assertEqual(self.conversation.chat_messages.count(), 1)
+        self.assertEqual(self.conversation.executions.count(), 1)
+        first.recorder.on_run_failed(InterruptedError("test cleanup"))
+
+    def test_pending_execution_is_visible_and_atomically_claimed(self):
+        # Arrange
+        human = AgentConversationService().add_human_message(
+            self.conversation, "Queued question"
+        )
+        service = AgentExecutionService()
+        pending = service.create_pending(
+            self.conversation,
+            trigger_message=human,
+            model="queued-model",
+        )
+
+        # Act
+        before = AgentChatService().representation(self.conversation)
+        recorder = service.claim_pending(pending, publish_assistant_message=True)
+        second_claim = service.claim_pending(pending)
+
+        # Assert
+        self.assertEqual(
+            before["executions"][0]["status"], AgentExecution.Status.PENDING
+        )
+        self.assertIsNotNone(recorder)
+        self.assertIsNone(second_claim)
+        self.assertEqual(
+            AgentExecution.objects.get(id=pending.id).status,
+            AgentExecution.Status.RUNNING,
+        )


### PR DESCRIPTION
## Stack

1. #3843 — Persist agent execution lifecycles
2. #3844 — Add agent conversation services
3. **#3831 — Add agent chat orchestration**
4. #3827 — Persist proposal draft agent histories

## What changed

- Coordinate atomic user turns, execution creation, and durable context preparation.
- Preserve prompt provenance across retries and regeneration.
- Publish or repair canonical assistant messages idempotently.
- Return user-safe lifecycle errors without exposing internal provider details.
- Avoid per-execution queries when checking generated assistant messages.
- Add focused coverage for retries, publication repair, bounded output, rollback behavior, and query count.

## Why

The lower persistence layers need a user-facing orchestration boundary that composes conversations, context, executions, and assistant publication safely.

## Impact

Callers can prepare chat turns and retries, repair failed publication, and expose a stable public conversation representation without handling persistence internals.

## Validation

- Full `research_ai` suite: 649 tests passed.
- Ruff lint and formatting checks passed across `src`.
- Production files are identical to the validated pre-split implementation.
- Rebase onto current `main` verified with `git range-diff`; all four patches are unchanged.