### PR TITLE
Persist agent execution lifecycles

### DIFF
--- a/src/research_ai/services/agent/loop.py
+++ b/src/research_ai/services/agent/loop.py
@@ -23,6 +23,7 @@ from research_ai.services.agent.providers.base import LLMProvider
 from research_ai.services.agent.recorder import AgentRecorder
 from research_ai.services.agent.tools import Toolset
 from research_ai.services.agent.types import (
+    AssistantTurn,
     Message,
     ServerToolBlock,
     StopReason,
@@ -152,8 +153,7 @@ class Agent:
     def run(self, user_prompt: str) -> AgentResult:
         """Drive a fresh conversation from ``user_prompt`` to completion."""
         seed = Message(role="user", content=[TextBlock(text=user_prompt)])
-        self._record("record_message", seed)
-        return self._drive([seed])
+        return self._drive([seed], new_message=seed)
 
     def continue_conversation(
         self,
@@ -167,20 +167,33 @@ class Agent:
         recorded by the runs that produced it.
         """
         appended = Message(role="user", content=[TextBlock(text=user_message)])
-        self._record("record_message", appended)
-        return self._drive(list(messages) + [appended])
+        return self._drive(list(messages) + [appended], new_message=appended)
 
-    def _record(self, hook: str, *args, **kwargs) -> None:
-        """Invoke a recorder hook; a raising recorder never breaks the run.
+    def _record_message(
+        self, message: Message, *, turn: AssistantTurn | None = None
+    ) -> None:
+        """Persist an appended message before the run advances.
 
-        The transcript is observability -- persistence failing must not kill
-        the run it observes (same contract as ``progress_callback``).
+        Ordinary observers remain best-effort. A recorder may opt into required
+        message persistence with ``requires_durable_messages``; the database
+        recorder uses that contract while isolating its optional trace writes.
         """
         if self.recorder is None:
             return
         try:
-            getattr(self.recorder, hook)(*args, **kwargs)
-        except Exception:  # noqa: BLE001 - recording must not break the run
+            self.recorder.record_message(message, turn=turn)
+        except Exception:  # noqa: BLE001 - observer failures are best-effort
+            if getattr(self.recorder, "requires_durable_messages", False):
+                raise
+            logger.warning("agent recorder record_message failed", exc_info=True)
+
+    def _record_terminal(self, hook: str, *args) -> None:
+        """Best-effort terminal observation must not mask the run outcome."""
+        if self.recorder is None:
+            return
+        try:
+            getattr(self.recorder, hook)(*args)
+        except Exception:  # noqa: BLE001 - preserve the original run outcome
             logger.warning("agent recorder %s failed", hook, exc_info=True)
 
     def _complete_turn(self, messages, rendered_tools, iteration):
@@ -197,6 +210,10 @@ class Agent:
             # conversation resumable via ``continue_conversation``.
             exc.messages = messages
             exc.iterations = iteration - 1
+            raise
+        except InterruptedError:
+            # Preserve an explicit interruption so persistence can distinguish
+            # it from an ordinary provider failure.
             raise
         except Exception as exc:
             # A provider that leaks a foreign exception still surfaces as
@@ -261,15 +278,16 @@ class Agent:
             )
         return result_blocks, stop
 
-    def _drive(self, messages: list[Message]) -> AgentResult:
+    def _drive(self, messages: list[Message], *, new_message: Message) -> AgentResult:
         try:
+            self._record_message(new_message)
             result = self._loop(messages)
-        except AgentRunError as error:
+        except Exception as error:
             # Every message up to the failure was already recorded as it was
             # appended; this only marks the terminal outcome.
-            self._record("on_run_failed", error)
+            self._record_terminal("on_run_failed", error)
             raise
-        self._record("on_run_finished", result)
+        self._record_terminal("on_run_finished", result)
         return result
 
     def _loop(self, messages: list[Message]) -> AgentResult:
@@ -292,7 +310,7 @@ class Agent:
                 provider_state=turn.provider_state,
             )
             messages.append(assistant_message)
-            self._record("record_message", assistant_message, turn=turn)
+            self._record_message(assistant_message, turn=turn)
 
             # The assistant's text on a tool-calling turn is its stated reason for
             # the calls -- log it so the trace shows *why* a tool was picked.
@@ -331,7 +349,7 @@ class Agent:
             result_blocks, stop = self._dispatch_tool_calls(turn.tool_calls, iteration)
             tool_result_message = Message(role="user", content=result_blocks)
             messages.append(tool_result_message)
-            self._record("record_message", tool_result_message)
+            self._record_message(tool_result_message)
 
             if stop:
                 logger.info("iter %d stop_tool: terminal tool ended the run", iteration)

--- a/src/research_ai/services/agent/recorder.py
+++ b/src/research_ai/services/agent/recorder.py
@@ -6,10 +6,10 @@ An ``AgentRecorder`` observes a run as it happens: the loop calls
 one of ``on_run_finished`` / ``on_run_failed`` when the run ends.
 
 This module defines only the protocol -- implementations live outside the
-``agent`` package (e.g. a Django recorder persisting ``AgentMessage`` rows) and
-are injected by callers, keeping the core Django-free. The loop wraps every
-recorder call: a raising recorder is logged and ignored, never fatal to the
-run (a transcript is observability, same contract as ``progress_callback``).
+``agent`` package and are injected by callers, keeping the core Django-free.
+Message-hook failures are best-effort unless an implementation opts into the
+``requires_durable_messages`` contract; terminal-hook failures are logged
+without masking the original run outcome.
 """
 
 from __future__ import annotations
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Protocol
 from research_ai.services.agent.types import AssistantTurn, Message
 
 if TYPE_CHECKING:
-    from research_ai.services.agent.errors import AgentRunError
     from research_ai.services.agent.loop import AgentResult
 
 
@@ -32,7 +31,9 @@ class AgentRecorder(Protocol):
         """Record one appended message.
 
         ``turn`` is set only for assistant messages, carrying the per-turn
-        metadata (usage, latency, stop reason) alongside the content.
+        metadata (usage, latency, stop reason) alongside the content. A recorder
+        that sets ``requires_durable_messages`` may propagate required-write
+        failures; optional writes should be isolated by the implementation.
         """
         ...
 
@@ -40,6 +41,6 @@ class AgentRecorder(Protocol):
         """The run completed; every message was already recorded."""
         ...
 
-    def on_run_failed(self, error: AgentRunError) -> None:
+    def on_run_failed(self, error: Exception) -> None:
         """The run failed; every message up to the failure was recorded."""
         ...

--- a/src/research_ai/services/agent/tools.py
+++ b/src/research_ai/services/agent/tools.py
@@ -26,6 +26,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Backstop on one tool result (~32k tokens). Tools are expected to bound their
+# own output to something the context window can afford -- a page of results, a
+# capped slice of a document -- and every one of ours does. This catches the one
+# that forgets: without it an unbounded result floods the context, costs a turn's
+# budget, and outgrows the row it has to be stored in to resume the run.
+MAX_TOOL_RESULT_BYTES = 128 * 1024
+
 # Handler signature: receives the model's parsed tool input, returns a dict.
 ToolHandler = Callable[[dict], dict]
 
@@ -108,10 +115,22 @@ class Toolset:
                 )
             }, False
         try:
-            json.dumps(result, allow_nan=False)
+            encoded = json.dumps(result, allow_nan=False)
         except (TypeError, ValueError, RecursionError):
             logger.warning("tool %r returned invalid JSON", name, exc_info=True)
             return {"error": f"tool {name!r} returned invalid JSON"}, False
+        size = len(encoded.encode("utf-8"))
+        if size > MAX_TOOL_RESULT_BYTES:
+            # Reported to the model, not truncated for it: it can narrow the
+            # query or page through the result, which a silent slice of someone
+            # else's JSON would deny it.
+            logger.warning("tool %r returned %d bytes, over the limit", name, size)
+            return {
+                "error": (
+                    f"tool {name!r} returned {size} bytes, over the "
+                    f"{MAX_TOOL_RESULT_BYTES} byte limit; request less at a time"
+                )
+            }, False
         is_error = isinstance(result, dict) and "error" in result
         return result, tool.is_terminal and not is_error
 

--- a/src/research_ai/services/agent_persistence/__init__.py
+++ b/src/research_ai/services/agent_persistence/__init__.py
@@ -1,1 +1,10 @@
 """Serialization and persistence services for the provider-neutral agent core."""
+
+from .execution_service import AgentConversationBusyError, AgentExecutionService
+from .recorder import DatabaseAgentRecorder
+
+__all__ = [
+    "AgentConversationBusyError",
+    "AgentExecutionService",
+    "DatabaseAgentRecorder",
+]

--- a/src/research_ai/services/agent_persistence/content.py
+++ b/src/research_ai/services/agent_persistence/content.py
@@ -11,6 +11,9 @@ MAX_CONTEXT_MESSAGE_BYTES = 512 * 1024
 _PREVIEW_CHARS = 2048
 _FINAL_OUTPUT_SUFFIX = "\n[Response truncated for durable storage.]"
 _COMPACTED_BLOCK_TEXT = "[Text omitted because it exceeded the durable row limit.]"
+# Blocks whose payload a provider validates on replay, so it survives whole or
+# not at all.
+_OPAQUE_BLOCK_TYPES = frozenset({"thinking", "server_tool"})
 _COMPACTED_MESSAGE_TEXT = (
     "[Earlier model-context message compacted because it exceeded the durable row "
     "limit.]"
@@ -92,9 +95,9 @@ def _compacted_block(block: dict, original_size: int) -> dict:
     Tool identifiers have to survive compaction. A provider rejects the next
     turn outright when a ``tool_result`` no longer answers a ``tool_use`` in
     the turn before it, so discarding the block would make the conversation
-    unresumable rather than merely lossy. Signed reasoning and server-tool
-    blocks keep their position for the same reason, but their payload is
-    opaque and cannot be shortened without invalidating it.
+    unresumable rather than merely lossy. Text keeps only its marker: losing
+    the citation payload a provider replays whole costs fidelity, not
+    acceptance.
     """
     marker = {"_truncated": True, "original_size_bytes": original_size}
     block_type = block["type"]
@@ -112,15 +115,24 @@ def _compacted_block(block: dict, original_size: int) -> dict:
             "content": marker,
             "is_error": block.get("is_error", False),
         }
-    if block_type == "text":
-        return {"type": "text", "text": _COMPACTED_BLOCK_TEXT}
-    return {"type": block_type, "data": marker}
+    return {"type": "text", "text": _COMPACTED_BLOCK_TEXT}
 
 
 def _compact_context_content(blocks: list[dict], block_limit: int) -> list[dict]:
-    """Bound every block against ``block_limit``, preserving message shape."""
+    """Bound editable blocks against ``block_limit``, preserving message shape.
+
+    Opaque blocks are never rewritten. Both adapters replay signed reasoning
+    and server-tool payloads byte for byte and fail validation on an edited
+    one, so a marker in their place would reject the next turn rather than
+    shorten it. One too large to store whole therefore keeps the message over
+    the limit, dropping it to the caller's text fallback -- lossy, but a
+    conversation the provider still accepts.
+    """
     compacted = []
     for block in blocks:
+        if block["type"] in _OPAQUE_BLOCK_TYPES:
+            compacted.append(block)
+            continue
         safe_block, was_replaced, block_size = _bounded_json(block, limit=block_limit)
         compacted.append(
             _compacted_block(block, block_size) if was_replaced else safe_block
@@ -135,11 +147,12 @@ def serialize_context_message(
 
     Provider continuation state is bounded together with the content because
     both are required to resume a provider turn correctly. An oversized message
-    is compacted block by block -- first only the blocks that are individually
-    too large, then all of them -- so tool-call correlation and block structure
-    survive the row limit. Only a message still too large after that degrades
-    to a single text block, which also drops the provider state because it no
-    longer corresponds to the stored content.
+    is compacted block by block -- first only the editable blocks that are
+    individually too large, then all of them -- so tool-call correlation and
+    block structure survive the row limit. A message still too large after
+    that, which is what an unstorable signed block leaves behind, degrades to a
+    single text block and drops the provider state along with the structure it
+    described.
     """
     serialized = serialize_messages([message])[0]
     content = serialized["content"]

--- a/src/research_ai/services/agent_persistence/content.py
+++ b/src/research_ai/services/agent_persistence/content.py
@@ -10,6 +10,11 @@ MAX_BLOCK_PAYLOAD_BYTES = 48 * 1024
 MAX_CONTEXT_MESSAGE_BYTES = 512 * 1024
 _PREVIEW_CHARS = 2048
 _FINAL_OUTPUT_SUFFIX = "\n[Response truncated for durable storage.]"
+_COMPACTED_BLOCK_TEXT = "[Text omitted because it exceeded the durable row limit.]"
+_COMPACTED_MESSAGE_TEXT = (
+    "[Earlier model-context message compacted because it exceeded the durable row "
+    "limit.]"
+)
 
 
 def _encode_json(value: Any) -> str:
@@ -81,23 +86,66 @@ def serialize_trace_message(message: Message) -> tuple[list[dict], bool, int]:
     )
 
 
+def _compacted_block(block: dict, original_size: int) -> dict:
+    """Drop one block's payload while keeping the fields replay depends on.
+
+    Tool identifiers have to survive compaction. A provider rejects the next
+    turn outright when a ``tool_result`` no longer answers a ``tool_use`` in
+    the turn before it, so discarding the block would make the conversation
+    unresumable rather than merely lossy. Signed reasoning and server-tool
+    blocks keep their position for the same reason, but their payload is
+    opaque and cannot be shortened without invalidating it.
+    """
+    marker = {"_truncated": True, "original_size_bytes": original_size}
+    block_type = block["type"]
+    if block_type == "tool_use":
+        return {
+            "type": "tool_use",
+            "id": block["id"],
+            "name": block["name"],
+            "input": marker,
+        }
+    if block_type == "tool_result":
+        return {
+            "type": "tool_result",
+            "tool_use_id": block["tool_use_id"],
+            "content": marker,
+            "is_error": block.get("is_error", False),
+        }
+    if block_type == "text":
+        return {"type": "text", "text": _COMPACTED_BLOCK_TEXT}
+    return {"type": block_type, "data": marker}
+
+
+def _compact_context_content(blocks: list[dict], block_limit: int) -> list[dict]:
+    """Bound every block against ``block_limit``, preserving message shape."""
+    compacted = []
+    for block in blocks:
+        safe_block, was_replaced, block_size = _bounded_json(block, limit=block_limit)
+        compacted.append(
+            _compacted_block(block, block_size) if was_replaced else safe_block
+        )
+    return compacted
+
+
 def serialize_context_message(
     message: Message,
 ) -> tuple[list[dict], dict, bool, int]:
-    """Keep complete resumable context or replace it with valid text.
+    """Keep complete resumable context, or compact it without breaking replay.
 
     Provider continuation state is bounded together with the content because
-    both are required to resume a provider turn correctly. If the combined
-    payload is too large or invalid, compact both rather than retaining state
-    that no longer corresponds to the stored content.
+    both are required to resume a provider turn correctly. An oversized message
+    is compacted block by block -- first only the blocks that are individually
+    too large, then all of them -- so tool-call correlation and block structure
+    survive the row limit. Only a message still too large after that degrades
+    to a single text block, which also drops the provider state because it no
+    longer corresponds to the stored content.
     """
     serialized = serialize_messages([message])[0]
-    payload = {
-        "content": serialized["content"],
-        "provider_state": serialized.get("provider_state") or {},
-    }
+    content = serialized["content"]
+    provider_state = serialized.get("provider_state") or {}
     safe_payload, was_replaced, original_size = _bounded_json(
-        payload,
+        {"content": content, "provider_state": provider_state},
         limit=MAX_CONTEXT_MESSAGE_BYTES,
     )
     if not was_replaced:
@@ -107,16 +155,25 @@ def serialize_context_message(
             False,
             original_size,
         )
-    return (
-        [
+
+    for block_limit in (MAX_BLOCK_PAYLOAD_BYTES, 0):
+        candidate, still_oversized, _size = _bounded_json(
             {
-                "type": "text",
-                "text": (
-                    "[Earlier model-context message compacted because it "
-                    "exceeded the durable row limit.]"
-                ),
-            }
-        ],
+                "content": _compact_context_content(content, block_limit),
+                "provider_state": provider_state,
+            },
+            limit=MAX_CONTEXT_MESSAGE_BYTES,
+        )
+        if not still_oversized:
+            return (
+                candidate["content"],
+                candidate["provider_state"],
+                True,
+                original_size,
+            )
+
+    return (
+        [{"type": "text", "text": _COMPACTED_MESSAGE_TEXT}],
         {},
         True,
         original_size,

--- a/src/research_ai/services/agent_persistence/content.py
+++ b/src/research_ai/services/agent_persistence/content.py
@@ -11,8 +11,8 @@ MAX_CONTEXT_MESSAGE_BYTES = 512 * 1024
 _PREVIEW_CHARS = 2048
 _FINAL_OUTPUT_SUFFIX = "\n[Response truncated for durable storage.]"
 _COMPACTED_BLOCK_TEXT = "[Text omitted because it exceeded the durable row limit.]"
-# Blocks whose payload a provider validates on replay, so it survives whole or
-# not at all.
+# Blocks that always carry a provider payload replayed as-is, so it survives
+# whole or not at all.
 _OPAQUE_BLOCK_TYPES = frozenset({"thinking", "server_tool"})
 _COMPACTED_MESSAGE_TEXT = (
     "[Earlier model-context message compacted because it exceeded the durable row "
@@ -89,6 +89,21 @@ def serialize_trace_message(message: Message) -> tuple[list[dict], bool, int]:
     )
 
 
+def _is_opaque(block: dict) -> bool:
+    """Report whether a provider validates this block's payload on replay.
+
+    Signed reasoning and server-tool blocks always carry one. A tool call does
+    only when the provider attached its own block: Claude's programmatic calls
+    keep the ``caller`` tying them to code still pending in the container, and
+    the adapter replays that block instead of rebuilding one from ``id``,
+    ``name``, and ``input``. An ordinary call carries no such payload and stays
+    editable.
+    """
+    if block["type"] in _OPAQUE_BLOCK_TYPES:
+        return True
+    return block["type"] == "tool_use" and block.get("data") is not None
+
+
 def _compacted_block(block: dict, original_size: int) -> dict:
     """Drop one block's payload while keeping the fields replay depends on.
 
@@ -121,16 +136,17 @@ def _compacted_block(block: dict, original_size: int) -> dict:
 def _compact_context_content(blocks: list[dict], block_limit: int) -> list[dict]:
     """Bound editable blocks against ``block_limit``, preserving message shape.
 
-    Opaque blocks are never rewritten. Both adapters replay signed reasoning
-    and server-tool payloads byte for byte and fail validation on an edited
-    one, so a marker in their place would reject the next turn rather than
+    Opaque blocks are never rewritten. Adapters replay their payloads byte for
+    byte, so a marker in their place would reject the next turn rather than
     shorten it. One too large to store whole therefore keeps the message over
-    the limit, dropping it to the caller's text fallback -- lossy, but a
-    conversation the provider still accepts.
+    the limit and drops it to the caller's text fallback: lossy, and for an
+    oversized programmatic call it also costs the correlation an ordinary call
+    would have kept, but neither is worse than replaying a payload the provider
+    refuses.
     """
     compacted = []
     for block in blocks:
-        if block["type"] in _OPAQUE_BLOCK_TYPES:
+        if _is_opaque(block):
             compacted.append(block)
             continue
         safe_block, was_replaced, block_size = _bounded_json(block, limit=block_limit)

--- a/src/research_ai/services/agent_persistence/content.py
+++ b/src/research_ai/services/agent_persistence/content.py
@@ -1,19 +1,18 @@
 """Agent-specific serialization policies for persisted message content."""
 
 import json
+import logging
 from typing import Any
 
 from research_ai.services.agent.types import Message, serialize_messages
+
+logger = logging.getLogger(__name__)
 
 MAX_TRACE_MESSAGE_BYTES = 128 * 1024
 MAX_BLOCK_PAYLOAD_BYTES = 48 * 1024
 MAX_CONTEXT_MESSAGE_BYTES = 512 * 1024
 _PREVIEW_CHARS = 2048
 _FINAL_OUTPUT_SUFFIX = "\n[Response truncated for durable storage.]"
-_COMPACTED_BLOCK_TEXT = "[Text omitted because it exceeded the durable row limit.]"
-# Blocks that always carry a provider payload replayed as-is, so it survives
-# whole or not at all.
-_OPAQUE_BLOCK_TYPES = frozenset({"thinking", "server_tool"})
 _COMPACTED_MESSAGE_TEXT = (
     "[Earlier model-context message compacted because it exceeded the durable row "
     "limit.]"
@@ -89,92 +88,26 @@ def serialize_trace_message(message: Message) -> tuple[list[dict], bool, int]:
     )
 
 
-def _is_opaque(block: dict) -> bool:
-    """Report whether a provider validates this block's payload on replay.
-
-    Signed reasoning and server-tool blocks always carry one. A tool call does
-    only when the provider attached its own block: Claude's programmatic calls
-    keep the ``caller`` tying them to code still pending in the container, and
-    the adapter replays that block instead of rebuilding one from ``id``,
-    ``name``, and ``input``. An ordinary call carries no such payload and stays
-    editable.
-    """
-    if block["type"] in _OPAQUE_BLOCK_TYPES:
-        return True
-    return block["type"] == "tool_use" and block.get("data") is not None
-
-
-def _compacted_block(block: dict, original_size: int) -> dict:
-    """Drop one block's payload while keeping the fields replay depends on.
-
-    Tool identifiers have to survive compaction. A provider rejects the next
-    turn outright when a ``tool_result`` no longer answers a ``tool_use`` in
-    the turn before it, so discarding the block would make the conversation
-    unresumable rather than merely lossy. Text keeps only its marker: losing
-    the citation payload a provider replays whole costs fidelity, not
-    acceptance.
-    """
-    marker = {"_truncated": True, "original_size_bytes": original_size}
-    block_type = block["type"]
-    if block_type == "tool_use":
-        return {
-            "type": "tool_use",
-            "id": block["id"],
-            "name": block["name"],
-            "input": marker,
-        }
-    if block_type == "tool_result":
-        return {
-            "type": "tool_result",
-            "tool_use_id": block["tool_use_id"],
-            "content": marker,
-            "is_error": block.get("is_error", False),
-        }
-    return {"type": "text", "text": _COMPACTED_BLOCK_TEXT}
-
-
-def _compact_context_content(blocks: list[dict], block_limit: int) -> list[dict]:
-    """Bound editable blocks against ``block_limit``, preserving message shape.
-
-    Opaque blocks are never rewritten. Adapters replay their payloads byte for
-    byte, so a marker in their place would reject the next turn rather than
-    shorten it. One too large to store whole therefore keeps the message over
-    the limit and drops it to the caller's text fallback: lossy, and for an
-    oversized programmatic call it also costs the correlation an ordinary call
-    would have kept, but neither is worse than replaying a payload the provider
-    refuses.
-    """
-    compacted = []
-    for block in blocks:
-        if _is_opaque(block):
-            compacted.append(block)
-            continue
-        safe_block, was_replaced, block_size = _bounded_json(block, limit=block_limit)
-        compacted.append(
-            _compacted_block(block, block_size) if was_replaced else safe_block
-        )
-    return compacted
-
-
 def serialize_context_message(
     message: Message,
 ) -> tuple[list[dict], dict, bool, int]:
-    """Keep complete resumable context, or compact it without breaking replay.
+    """Keep complete resumable context or replace it with valid text.
 
     Provider continuation state is bounded together with the content because
-    both are required to resume a provider turn correctly. An oversized message
-    is compacted block by block -- first only the editable blocks that are
-    individually too large, then all of them -- so tool-call correlation and
-    block structure survive the row limit. A message still too large after
-    that, which is what an unstorable signed block leaves behind, degrades to a
-    single text block and drops the provider state along with the structure it
-    described.
+    both are required to resume a provider turn correctly. Neither should ever
+    reach the limit: model output is capped by ``max_tokens`` and tool results
+    by ``MAX_TOOL_RESULT_BYTES``, so a message this large means one of those
+    bounds is missing rather than that a conversation grew. The row still has
+    to hold something, so it holds text the provider accepts -- a compacted
+    marker, and no state describing content that is no longer there.
     """
     serialized = serialize_messages([message])[0]
-    content = serialized["content"]
-    provider_state = serialized.get("provider_state") or {}
+    payload = {
+        "content": serialized["content"],
+        "provider_state": serialized.get("provider_state") or {},
+    }
     safe_payload, was_replaced, original_size = _bounded_json(
-        {"content": content, "provider_state": provider_state},
+        payload,
         limit=MAX_CONTEXT_MESSAGE_BYTES,
     )
     if not was_replaced:
@@ -184,23 +117,11 @@ def serialize_context_message(
             False,
             original_size,
         )
-
-    for block_limit in (MAX_BLOCK_PAYLOAD_BYTES, 0):
-        candidate, still_oversized, _size = _bounded_json(
-            {
-                "content": _compact_context_content(content, block_limit),
-                "provider_state": provider_state,
-            },
-            limit=MAX_CONTEXT_MESSAGE_BYTES,
-        )
-        if not still_oversized:
-            return (
-                candidate["content"],
-                candidate["provider_state"],
-                True,
-                original_size,
-            )
-
+    logger.error(
+        "agent context message of %d bytes exceeded the durable row limit; "
+        "the conversation is no longer resumable from this turn",
+        original_size,
+    )
     return (
         [{"type": "text", "text": _COMPACTED_MESSAGE_TEXT}],
         {},

--- a/src/research_ai/services/agent_persistence/execution_service.py
+++ b/src/research_ai/services/agent_persistence/execution_service.py
@@ -1,0 +1,206 @@
+"""Execution creation and atomic claim services."""
+
+from collections.abc import Callable
+
+from django.db import transaction
+from django.db.models import Max
+from django.utils import timezone
+
+from research_ai.models import (
+    AgentConversation,
+    AgentConversationMessage,
+    AgentExecution,
+    AgentExecutionMessage,
+)
+from research_ai.services.agent_persistence.recorder import DatabaseAgentRecorder
+
+RecorderFactory = Callable[..., DatabaseAgentRecorder]
+
+
+class AgentConversationBusyError(RuntimeError):
+    """Raised when a linear conversation already has an active execution."""
+
+
+class AgentExecutionService:
+    def __init__(self, *, recorder_factory: RecorderFactory | None = None):
+        self.recorder_factory = (
+            DatabaseAgentRecorder if recorder_factory is None else recorder_factory
+        )
+
+    @staticmethod
+    def _validate_relationships(
+        conversation: AgentConversation,
+        *,
+        trigger_message: AgentConversationMessage | None,
+        context_parent: AgentExecution | None,
+        retry_of: AgentExecution | None,
+        replaces_output_of: AgentExecution | None,
+    ) -> None:
+        related = [context_parent, retry_of, replaces_output_of]
+        if any(
+            item is not None and item.conversation_id != conversation.id
+            for item in related
+        ):
+            raise ValueError("agent execution relationships cross conversations")
+        if (
+            trigger_message is not None
+            and trigger_message.conversation_id != conversation.id
+        ):
+            raise ValueError("trigger message belongs to another conversation")
+
+    @staticmethod
+    def _ensure_no_active_execution(conversation: AgentConversation) -> None:
+        if conversation.executions.filter(
+            status__in=[
+                AgentExecution.Status.PENDING,
+                AgentExecution.Status.RUNNING,
+            ]
+        ).exists():
+            raise AgentConversationBusyError(
+                "agent conversation already has an active execution"
+            )
+
+    def _create_execution(
+        self,
+        conversation: AgentConversation,
+        *,
+        status: str,
+        provider: str,
+        model: str,
+        configuration: dict | None,
+        system_prompt: str,
+        trigger_message: AgentConversationMessage | None,
+        context_parent: AgentExecution | None,
+        retry_of: AgentExecution | None,
+        publish_assistant_message: bool,
+        replaces_output_of: AgentExecution | None,
+    ) -> AgentExecution:
+        self._validate_relationships(
+            conversation,
+            trigger_message=trigger_message,
+            context_parent=context_parent,
+            retry_of=retry_of,
+            replaces_output_of=replaces_output_of,
+        )
+        now = timezone.now()
+        with transaction.atomic():
+            locked = AgentConversation.objects.select_for_update().get(
+                id=conversation.id
+            )
+            self._ensure_no_active_execution(locked)
+            max_attempt = (
+                AgentExecution.objects.filter(conversation=locked).aggregate(
+                    value=Max("attempt")
+                )["value"]
+                or 0
+            )
+            timestamps = (
+                {"started_at": now, "last_activity_at": now}
+                if status == AgentExecution.Status.RUNNING
+                else {}
+            )
+            return AgentExecution.objects.create(
+                conversation=locked,
+                status=status,
+                attempt=max_attempt + 1,
+                context_parent=context_parent,
+                retry_of=retry_of,
+                replaces_output_of=replaces_output_of,
+                trigger_message=trigger_message,
+                provider=provider,
+                model=model,
+                configuration=configuration if configuration is not None else {},
+                system_prompt=system_prompt,
+                publish_output_to_chat=publish_assistant_message,
+                **timestamps,
+            )
+
+    def start(
+        self,
+        conversation: AgentConversation,
+        *,
+        provider: str = "",
+        model: str = "",
+        configuration: dict | None = None,
+        system_prompt: str = "",
+        trigger_message: AgentConversationMessage | None = None,
+        context_parent: AgentExecution | None = None,
+        retry_of: AgentExecution | None = None,
+        initial_prompt_provenance: str = AgentExecutionMessage.Provenance.BACKEND,
+        publish_assistant_message: bool = False,
+        replaces_output_of: AgentExecution | None = None,
+    ) -> DatabaseAgentRecorder:
+        execution = self._create_execution(
+            conversation,
+            status=AgentExecution.Status.RUNNING,
+            provider=provider,
+            model=model,
+            configuration=configuration,
+            system_prompt=system_prompt,
+            trigger_message=trigger_message,
+            context_parent=context_parent,
+            retry_of=retry_of,
+            publish_assistant_message=publish_assistant_message,
+            replaces_output_of=replaces_output_of,
+        )
+        return self.recorder_factory(
+            execution,
+            initial_prompt_provenance=initial_prompt_provenance,
+            publish_assistant_message=publish_assistant_message,
+        )
+
+    def create_pending(
+        self,
+        conversation: AgentConversation,
+        *,
+        provider: str = "",
+        model: str = "",
+        configuration: dict | None = None,
+        system_prompt: str = "",
+        trigger_message: AgentConversationMessage | None = None,
+        context_parent: AgentExecution | None = None,
+        retry_of: AgentExecution | None = None,
+        publish_assistant_message: bool = False,
+    ) -> AgentExecution:
+        """Create a queued attempt that a worker can claim later."""
+        return self._create_execution(
+            conversation,
+            status=AgentExecution.Status.PENDING,
+            provider=provider,
+            model=model,
+            configuration=configuration,
+            system_prompt=system_prompt,
+            trigger_message=trigger_message,
+            context_parent=context_parent,
+            retry_of=retry_of,
+            publish_assistant_message=publish_assistant_message,
+            replaces_output_of=None,
+        )
+
+    def claim_pending(
+        self,
+        execution: AgentExecution,
+        *,
+        initial_prompt_provenance: str = AgentExecutionMessage.Provenance.BACKEND,
+        publish_assistant_message: bool | None = None,
+    ) -> DatabaseAgentRecorder | None:
+        """Atomically claim a queued attempt; return ``None`` if already claimed."""
+        now = timezone.now()
+        updates = {
+            "status": AgentExecution.Status.RUNNING,
+            "started_at": now,
+            "last_activity_at": now,
+        }
+        if publish_assistant_message is not None:
+            updates["publish_output_to_chat"] = publish_assistant_message
+        claimed = AgentExecution.objects.filter(
+            id=execution.id, status=AgentExecution.Status.PENDING
+        ).update(**updates)
+        if not claimed:
+            return None
+        execution.refresh_from_db()
+        return self.recorder_factory(
+            execution,
+            initial_prompt_provenance=initial_prompt_provenance,
+            publish_assistant_message=publish_assistant_message,
+        )

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -51,6 +51,33 @@ def _safe_exception_message(error: object) -> str:
         return f"<{type(error).__name__} message unavailable>"
 
 
+def _durable_output_text(execution: AgentExecution) -> str | None:
+    """Recover the answer to publish from the most complete durable copy.
+
+    ``final_output`` is bounded for the execution row, so a long response
+    survives there only as a prefix. The assistant's own context message keeps
+    that text under a limit four times larger, which is what a repair should
+    publish while it is intact. A compacted row is skipped rather than searched
+    past: an earlier turn holds a different answer, and publishing that would
+    be worse than publishing a short one.
+    """
+    row = (
+        execution.context_messages.filter(role="assistant")
+        .order_by("-sequence")
+        .first()
+    )
+    if row is not None and not row.is_compacted:
+        text = "".join(
+            block.get("text", "")
+            for block in row.content
+            if isinstance(block, dict) and block.get("type") == "text"
+        )
+        if text:
+            return text
+    final_output = execution.final_output
+    return final_output.get("text") if isinstance(final_output, dict) else None
+
+
 def _is_terminal(status: str) -> bool:
     return status not in {
         AgentExecution.Status.PENDING,
@@ -370,10 +397,7 @@ class DatabaseAgentRecorder:
             ):
                 return False
             if text is None:
-                final_output = execution.final_output
-                text = (
-                    final_output.get("text") if isinstance(final_output, dict) else None
-                )
+                text = _durable_output_text(execution)
             if not isinstance(text, str) or not text:
                 return False
             if execution.replaces_output_of_id:

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -147,7 +147,7 @@ class DatabaseAgentRecorder:
     def record_message(
         self, message: Message, *, turn: AssistantTurn | None = None
     ) -> None:
-        context_content, is_compacted, context_original_size = (
+        context_content, context_provider_state, is_compacted, context_original_size = (
             serialize_context_message(message)
         )
         now = timezone.now()
@@ -165,6 +165,7 @@ class DatabaseAgentRecorder:
                 sequence=execution.next_context_sequence,
                 role=message.role,
                 content=context_content,
+                provider_state=context_provider_state,
                 is_compacted=is_compacted,
                 original_size_bytes=(context_original_size if is_compacted else None),
             )

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -287,10 +287,12 @@ class DatabaseAgentRecorder:
         self.terminal_observed = terminal
         if not transitioned:
             return
-        public_text = final_output["text"]
-        if self.publish_assistant_message and public_text:
+        # Publish what the model actually answered, not the snapshot trimmed to
+        # fit the execution row: chat content is unbounded text, so truncating
+        # it here would drop the tail of a successful response for good.
+        if self.publish_assistant_message and result.final_text:
             try:
-                self.publish_assistant_output(public_text)
+                self.publish_assistant_output(result.final_text)
             except Exception:  # noqa: BLE001 - trace terminal state already landed
                 logger.warning(
                     "failed to publish agent response to chat", exc_info=True

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -58,6 +58,53 @@ def _is_terminal(status: str) -> bool:
     }
 
 
+def _turn_trace_fields(turn: AssistantTurn | None) -> dict:
+    usage = turn.usage if turn else None
+    return {
+        "provider_stop_reason": turn.stop_reason.value if turn else "",
+        "input_tokens": usage.input_tokens if usage else None,
+        "output_tokens": usage.output_tokens if usage else None,
+        "cache_read_tokens": usage.cache_read_tokens if usage else None,
+        "cache_write_tokens": usage.cache_write_tokens if usage else None,
+        "latency_ms": turn.latency_ms if turn else None,
+    }
+
+
+def _apply_turn_metrics(
+    execution: AgentExecution,
+    turn: AssistantTurn | None,
+    trace_fields: dict,
+) -> list[str]:
+    if turn is None:
+        return []
+    execution.iterations += 1
+    execution.stop_reason = turn.stop_reason.value
+    execution.input_tokens = _add_optional(
+        execution.input_tokens, trace_fields["input_tokens"]
+    )
+    execution.output_tokens = _add_optional(
+        execution.output_tokens, trace_fields["output_tokens"]
+    )
+    execution.cache_read_tokens = _add_optional(
+        execution.cache_read_tokens, trace_fields["cache_read_tokens"]
+    )
+    execution.cache_write_tokens = _add_optional(
+        execution.cache_write_tokens, trace_fields["cache_write_tokens"]
+    )
+    execution.total_latency_ms = _add_optional(
+        execution.total_latency_ms, turn.latency_ms
+    )
+    return [
+        "iterations",
+        "stop_reason",
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "total_latency_ms",
+    ]
+
+
 class DatabaseAgentRecorder:
     """Persist required context and isolate optional observational trace writes."""
 
@@ -170,7 +217,7 @@ class DatabaseAgentRecorder:
             global_sequence = conversation.next_trace_sequence
             execution_sequence = execution.next_message_sequence
 
-            usage = turn.usage if turn else None
+            turn_fields = _turn_trace_fields(turn)
             AgentExecutionMessage.objects.create(
                 conversation=conversation,
                 execution=execution,
@@ -179,14 +226,9 @@ class DatabaseAgentRecorder:
                 role=message.role,
                 provenance=provenance,
                 content=content,
-                provider_stop_reason=turn.stop_reason.value if turn else "",
-                input_tokens=usage.input_tokens if usage else None,
-                output_tokens=usage.output_tokens if usage else None,
-                cache_read_tokens=usage.cache_read_tokens if usage else None,
-                cache_write_tokens=usage.cache_write_tokens if usage else None,
-                latency_ms=turn.latency_ms if turn else None,
                 is_truncated=is_truncated,
                 original_size_bytes=original_size if is_truncated else None,
+                **turn_fields,
             )
 
             conversation.next_trace_sequence += 1
@@ -199,39 +241,7 @@ class DatabaseAgentRecorder:
                 "last_activity_at",
                 "updated_date",
             ]
-            if turn:
-                execution.iterations += 1
-                execution.stop_reason = turn.stop_reason.value
-                execution.input_tokens = _add_optional(
-                    execution.input_tokens,
-                    usage.input_tokens if usage else None,
-                )
-                execution.output_tokens = _add_optional(
-                    execution.output_tokens,
-                    usage.output_tokens if usage else None,
-                )
-                execution.cache_read_tokens = _add_optional(
-                    execution.cache_read_tokens,
-                    usage.cache_read_tokens if usage else None,
-                )
-                execution.cache_write_tokens = _add_optional(
-                    execution.cache_write_tokens,
-                    usage.cache_write_tokens if usage else None,
-                )
-                execution.total_latency_ms = _add_optional(
-                    execution.total_latency_ms, turn.latency_ms
-                )
-                update_fields.extend(
-                    [
-                        "iterations",
-                        "stop_reason",
-                        "input_tokens",
-                        "output_tokens",
-                        "cache_read_tokens",
-                        "cache_write_tokens",
-                        "total_latency_ms",
-                    ]
-                )
+            update_fields.extend(_apply_turn_metrics(execution, turn, turn_fields))
             execution.save(update_fields=update_fields)
 
     def on_run_finished(self, result) -> None:

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -1,0 +1,374 @@
+"""Database-backed observational recorder for one agent execution."""
+
+import logging
+from datetime import timedelta
+
+from django.db import transaction
+from django.utils import timezone
+
+from research_ai.models import (
+    AgentContextMessage,
+    AgentConversation,
+    AgentConversationMessage,
+    AgentExecution,
+    AgentExecutionMessage,
+)
+from research_ai.services.agent.errors import IterationLimitError
+from research_ai.services.agent.types import (
+    AssistantTurn,
+    Message,
+    ToolResultBlock,
+)
+from research_ai.services.agent_persistence.content import (
+    bounded_payload,
+    serialize_context_message,
+    serialize_final_output,
+    serialize_trace_message,
+)
+
+logger = logging.getLogger(__name__)
+
+_MAX_ERROR_CHARS = 10_000
+
+
+def _add_optional(current: int | None, increment: int | None) -> int | None:
+    if increment is None:
+        return current
+    return (current or 0) + increment
+
+
+def _duration_ms(started_at, finished_at) -> int | None:
+    if started_at is None:
+        return None
+    elapsed: timedelta = finished_at - started_at
+    return max(0, round(elapsed.total_seconds() * 1000))
+
+
+def _safe_exception_message(error: object) -> str:
+    try:
+        return str(error)[:_MAX_ERROR_CHARS]
+    except Exception:  # noqa: BLE001 - terminal persistence must remain defensive
+        return f"<{type(error).__name__} message unavailable>"
+
+
+def _is_terminal(status: str) -> bool:
+    return status not in {
+        AgentExecution.Status.PENDING,
+        AgentExecution.Status.RUNNING,
+    }
+
+
+class DatabaseAgentRecorder:
+    """Persist required context and isolate optional observational trace writes."""
+
+    requires_durable_messages = True
+
+    def __init__(
+        self,
+        execution: AgentExecution,
+        *,
+        initial_prompt_provenance: str = AgentExecutionMessage.Provenance.BACKEND,
+        publish_assistant_message: bool | None = None,
+    ):
+        self.execution = execution
+        self.initial_prompt_provenance = initial_prompt_provenance
+        self.publish_assistant_message = (
+            execution.publish_output_to_chat
+            if publish_assistant_message is None
+            else publish_assistant_message
+        )
+        self._recorded_messages = 0
+        self.terminal_observed = False
+
+    def set_system_prompt(self, system_prompt: str) -> None:
+        """Snapshot model-only scaffolding after callers finish composing it."""
+        with transaction.atomic():
+            AgentExecution.objects.filter(id=self.execution.id).update(
+                system_prompt=system_prompt,
+                last_activity_at=timezone.now(),
+            )
+
+    def _provenance(self, message: Message) -> str:
+        if message.role == "assistant":
+            return AgentExecutionMessage.Provenance.MODEL
+        if any(isinstance(block, ToolResultBlock) for block in message.content):
+            return AgentExecutionMessage.Provenance.TOOL
+        if self._recorded_messages == 0:
+            return self.initial_prompt_provenance
+        return AgentExecutionMessage.Provenance.BACKEND
+
+    def record_message(
+        self, message: Message, *, turn: AssistantTurn | None = None
+    ) -> None:
+        context_content, is_compacted, context_original_size = (
+            serialize_context_message(message)
+        )
+        now = timezone.now()
+        provenance = self._provenance(message)
+
+        # Resumable context is durable state, not disposable debugging data.
+        # Commit it independently so a trace-specific failure cannot erase the
+        # context needed by a later turn.
+        with transaction.atomic():
+            execution = AgentExecution.objects.select_for_update().get(
+                id=self.execution.id
+            )
+            AgentContextMessage.objects.create(
+                execution=execution,
+                sequence=execution.next_context_sequence,
+                role=message.role,
+                content=context_content,
+                is_compacted=is_compacted,
+                original_size_bytes=(context_original_size if is_compacted else None),
+            )
+            execution.next_context_sequence += 1
+            execution.last_activity_at = now
+            execution.save(
+                update_fields=[
+                    "next_context_sequence",
+                    "last_activity_at",
+                    "updated_date",
+                ]
+            )
+        self._recorded_messages += 1
+
+        try:
+            content, is_truncated, original_size = serialize_trace_message(message)
+            self._record_trace(
+                message=message,
+                turn=turn,
+                content=content,
+                is_truncated=is_truncated,
+                original_size=original_size,
+                now=now,
+                provenance=provenance,
+            )
+        except Exception:  # noqa: BLE001 - trace data is optional observability
+            logger.warning("failed to persist optional agent trace", exc_info=True)
+
+    def _record_trace(
+        self,
+        *,
+        message: Message,
+        turn: AssistantTurn | None,
+        content: list[dict],
+        is_truncated: bool,
+        original_size: int,
+        now,
+        provenance: str,
+    ) -> None:
+        # The nested atomic block is intentional: if this write raises inside a
+        # caller's transaction, Django rolls back this savepoint before this
+        # optional trace failure is swallowed, leaving the outer transaction usable.
+        with transaction.atomic():
+            conversation = AgentConversation.objects.select_for_update().get(
+                id=self.execution.conversation_id
+            )
+            execution = AgentExecution.objects.select_for_update().get(
+                id=self.execution.id
+            )
+            global_sequence = conversation.next_trace_sequence
+            execution_sequence = execution.next_message_sequence
+
+            usage = turn.usage if turn else None
+            AgentExecutionMessage.objects.create(
+                conversation=conversation,
+                execution=execution,
+                sequence=global_sequence,
+                execution_sequence=execution_sequence,
+                role=message.role,
+                provenance=provenance,
+                content=content,
+                provider_stop_reason=turn.stop_reason.value if turn else "",
+                input_tokens=usage.input_tokens if usage else None,
+                output_tokens=usage.output_tokens if usage else None,
+                cache_read_tokens=usage.cache_read_tokens if usage else None,
+                cache_write_tokens=usage.cache_write_tokens if usage else None,
+                latency_ms=turn.latency_ms if turn else None,
+                is_truncated=is_truncated,
+                original_size_bytes=original_size if is_truncated else None,
+            )
+
+            conversation.next_trace_sequence += 1
+            conversation.save(update_fields=["next_trace_sequence", "updated_date"])
+
+            execution.next_message_sequence += 1
+            execution.last_activity_at = now
+            update_fields = [
+                "next_message_sequence",
+                "last_activity_at",
+                "updated_date",
+            ]
+            if turn:
+                execution.iterations += 1
+                execution.stop_reason = turn.stop_reason.value
+                execution.input_tokens = _add_optional(
+                    execution.input_tokens,
+                    usage.input_tokens if usage else None,
+                )
+                execution.output_tokens = _add_optional(
+                    execution.output_tokens,
+                    usage.output_tokens if usage else None,
+                )
+                execution.cache_read_tokens = _add_optional(
+                    execution.cache_read_tokens,
+                    usage.cache_read_tokens if usage else None,
+                )
+                execution.cache_write_tokens = _add_optional(
+                    execution.cache_write_tokens,
+                    usage.cache_write_tokens if usage else None,
+                )
+                execution.total_latency_ms = _add_optional(
+                    execution.total_latency_ms, turn.latency_ms
+                )
+                update_fields.extend(
+                    [
+                        "iterations",
+                        "stop_reason",
+                        "input_tokens",
+                        "output_tokens",
+                        "cache_read_tokens",
+                        "cache_write_tokens",
+                        "total_latency_ms",
+                    ]
+                )
+            execution.save(update_fields=update_fields)
+
+    def on_run_finished(self, result) -> None:
+        now = timezone.now()
+        final_output, _truncated, _size = serialize_final_output(result.final_text)
+        transitioned = False
+        with transaction.atomic():
+            execution = AgentExecution.objects.select_for_update().get(
+                id=self.execution.id
+            )
+            if execution.status == AgentExecution.Status.RUNNING:
+                execution.status = AgentExecution.Status.SUCCEEDED
+                execution.final_output = final_output
+                execution.stop_reason = result.stop_reason
+                execution.iterations = max(execution.iterations, result.iterations)
+                execution.finished_at = now
+                execution.last_activity_at = now
+                execution.duration_ms = _duration_ms(execution.started_at, now)
+                execution.save(
+                    update_fields=[
+                        "status",
+                        "final_output",
+                        "stop_reason",
+                        "iterations",
+                        "finished_at",
+                        "last_activity_at",
+                        "duration_ms",
+                        "updated_date",
+                    ]
+                )
+                transitioned = True
+            terminal = _is_terminal(execution.status)
+        self.terminal_observed = terminal
+        if not transitioned:
+            return
+        public_text = final_output["text"]
+        if self.publish_assistant_message and public_text:
+            try:
+                self.publish_assistant_output(public_text)
+            except Exception:  # noqa: BLE001 - trace terminal state already landed
+                logger.warning(
+                    "failed to publish agent response to chat", exc_info=True
+                )
+
+    def on_run_failed(self, error: Exception) -> None:
+        now = timezone.now()
+        raw_stop_reason = getattr(error, "stop_reason", "") or ""
+        stop_reason = _safe_exception_message(raw_stop_reason)
+        if not stop_reason:
+            if isinstance(error, InterruptedError):
+                stop_reason = "interrupted"
+            elif isinstance(error, IterationLimitError):
+                stop_reason = "iteration_limit"
+            else:
+                stop_reason = "error"
+        cause = getattr(error, "__cause__", None)
+        details = {
+            "stop_reason": stop_reason,
+            "iterations": getattr(error, "iterations", None),
+            "cause_type": type(cause).__name__ if cause else None,
+            "cause_message": _safe_exception_message(cause) if cause else None,
+        }
+        safe_details, _truncated, _size = bounded_payload(details)
+        status = (
+            AgentExecution.Status.INTERRUPTED
+            if isinstance(error, InterruptedError)
+            else AgentExecution.Status.FAILED
+        )
+        with transaction.atomic():
+            execution = AgentExecution.objects.select_for_update().get(
+                id=self.execution.id
+            )
+            if execution.status == AgentExecution.Status.RUNNING:
+                execution.status = status
+                execution.error_type = type(error).__name__
+                execution.error_message = _safe_exception_message(error)
+                execution.error_details = safe_details
+                execution.stop_reason = stop_reason
+                error_iterations = getattr(error, "iterations", None)
+                if error_iterations is not None:
+                    execution.iterations = max(execution.iterations, error_iterations)
+                execution.finished_at = now
+                execution.last_activity_at = now
+                execution.duration_ms = _duration_ms(execution.started_at, now)
+                execution.save(
+                    update_fields=[
+                        "status",
+                        "error_type",
+                        "error_message",
+                        "error_details",
+                        "stop_reason",
+                        "iterations",
+                        "finished_at",
+                        "last_activity_at",
+                        "duration_ms",
+                        "updated_date",
+                    ]
+                )
+            terminal = _is_terminal(execution.status)
+        self.terminal_observed = terminal
+
+    def publish_assistant_output(self, text: str | None = None) -> bool:
+        """Publish or repair the canonical assistant message idempotently."""
+        with transaction.atomic():
+            conversation = AgentConversation.objects.select_for_update().get(
+                id=self.execution.conversation_id
+            )
+            execution = AgentExecution.objects.select_for_update().get(
+                id=self.execution.id
+            )
+            if (
+                execution.status != AgentExecution.Status.SUCCEEDED
+                or not execution.publish_output_to_chat
+            ):
+                return False
+            if text is None:
+                final_output = execution.final_output
+                text = (
+                    final_output.get("text") if isinstance(final_output, dict) else None
+                )
+            if not isinstance(text, str) or not text:
+                return False
+            if execution.replaces_output_of_id:
+                AgentConversationMessage.objects.filter(
+                    generated_by_execution_id=execution.replaces_output_of_id
+                ).update(is_active=False)
+            _message, created = AgentConversationMessage.objects.get_or_create(
+                generated_by_execution_id=execution.id,
+                defaults={
+                    "conversation": conversation,
+                    "sequence": conversation.next_chat_sequence,
+                    "role": AgentConversationMessage.Role.ASSISTANT,
+                    "content": text,
+                    "in_reply_to_id": execution.trigger_message_id,
+                },
+            )
+            if created:
+                conversation.next_chat_sequence += 1
+                conversation.save(update_fields=["next_chat_sequence", "updated_date"])
+            return created

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -106,7 +106,14 @@ def _apply_turn_metrics(
 
 
 class DatabaseAgentRecorder:
-    """Persist required context and isolate optional observational trace writes."""
+    """Persist required context and isolate optional observational trace writes.
+
+    Callers must drive the agent outside their own ``transaction.atomic()``
+    block. Django nests ``atomic()`` as a savepoint, so an outer rollback would
+    discard the context rows and the terminal status transition together, and an
+    execution created before that transaction would stay ``RUNNING`` and block
+    every later execution on the conversation.
+    """
 
     requires_durable_messages = True
 
@@ -153,9 +160,11 @@ class DatabaseAgentRecorder:
         now = timezone.now()
         provenance = self._provenance(message)
 
-        # Resumable context is durable state, not disposable debugging data.
-        # Commit it independently so a trace-specific failure cannot erase the
-        # context needed by a later turn.
+        # Resumable context is durable state, not disposable debugging data, so
+        # it gets its own atomic block: the trace write that follows rolls back
+        # to its own savepoint instead of erasing the context a later turn
+        # needs. That isolates it from the trace write, not from a caller's
+        # transaction -- see the class docstring.
         with transaction.atomic():
             execution = AgentExecution.objects.select_for_update().get(
                 id=self.execution.id

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -51,33 +51,6 @@ def _safe_exception_message(error: object) -> str:
         return f"<{type(error).__name__} message unavailable>"
 
 
-def _durable_output_text(execution: AgentExecution) -> str | None:
-    """Recover the answer to publish from the most complete durable copy.
-
-    ``final_output`` is bounded for the execution row, so a long response
-    survives there only as a prefix. The assistant's own context message keeps
-    that text under a limit four times larger, which is what a repair should
-    publish while it is intact. A compacted row is skipped rather than searched
-    past: an earlier turn holds a different answer, and publishing that would
-    be worse than publishing a short one.
-    """
-    row = (
-        execution.context_messages.filter(role="assistant")
-        .order_by("-sequence")
-        .first()
-    )
-    if row is not None and not row.is_compacted:
-        text = "".join(
-            block.get("text", "")
-            for block in row.content
-            if isinstance(block, dict) and block.get("type") == "text"
-        )
-        if text:
-            return text
-    final_output = execution.final_output
-    return final_output.get("text") if isinstance(final_output, dict) else None
-
-
 def _is_terminal(status: str) -> bool:
     return status not in {
         AgentExecution.Status.PENDING,
@@ -397,7 +370,10 @@ class DatabaseAgentRecorder:
             ):
                 return False
             if text is None:
-                text = _durable_output_text(execution)
+                final_output = execution.final_output
+                text = (
+                    final_output.get("text") if isinstance(final_output, dict) else None
+                )
             if not isinstance(text, str) or not text:
                 return False
             if execution.replaces_output_of_id:

--- a/src/research_ai/tests/agent/persistence_test_helpers.py
+++ b/src/research_ai/tests/agent/persistence_test_helpers.py
@@ -51,13 +51,14 @@ def tool_turn(
     )
 
 
-def text_turn(text, *, usage=None, latency_ms=None):
+def text_turn(text, *, usage=None, latency_ms=None, provider_state=None):
     return AssistantTurn(
         text_blocks=[TextBlock(text=text)],
         tool_calls=[],
         stop_reason=StopReason.END_TURN,
         usage=usage,
         latency_ms=latency_ms,
+        provider_state=provider_state or {},
     )
 
 

--- a/src/research_ai/tests/agent/persistence_test_helpers.py
+++ b/src/research_ai/tests/agent/persistence_test_helpers.py
@@ -1,0 +1,89 @@
+"""Shared fakes and builders for agent-persistence tests."""
+
+from django.test import TestCase
+
+from research_ai.models import AgentConversation
+from research_ai.services.agent.loop import Agent
+from research_ai.services.agent.providers.base import LLMProvider
+from research_ai.services.agent.tools import Toolset
+from research_ai.services.agent.types import (
+    AssistantTurn,
+    StopReason,
+    TextBlock,
+    ToolUseBlock,
+)
+from research_ai.services.agent_persistence import AgentExecutionService
+
+
+class FakeProvider(LLMProvider):
+    def __init__(self, turns, *, render_error=None):
+        self.turns = list(turns)
+        self.render_error = render_error
+        self.calls = []
+
+    def render_tools(self, tools):
+        if self.render_error:
+            raise self.render_error
+        return [tool.name for tool in tools]
+
+    def complete(self, **kwargs):
+        self.calls.append(list(kwargs["messages"]))
+        turn = self.turns.pop(0)
+        if isinstance(turn, BaseException):
+            raise turn
+        return turn
+
+
+def tool_turn(
+    call_id,
+    name,
+    tool_input,
+    *,
+    usage=None,
+    latency_ms=None,
+):
+    return AssistantTurn(
+        text_blocks=[TextBlock(text=f"calling {name}")],
+        tool_calls=[ToolUseBlock(id=call_id, name=name, input=tool_input)],
+        stop_reason=StopReason.TOOL_USE,
+        usage=usage,
+        latency_ms=latency_ms,
+    )
+
+
+def text_turn(text, *, usage=None, latency_ms=None):
+    return AssistantTurn(
+        text_blocks=[TextBlock(text=text)],
+        tool_calls=[],
+        stop_reason=StopReason.END_TURN,
+        usage=usage,
+        latency_ms=latency_ms,
+    )
+
+
+def agent(provider, recorder, tools=None):
+    return Agent(
+        provider,
+        Toolset(tools or []),
+        system_prompt="internal system scaffolding",
+        max_iterations=5,
+        max_tokens=2048,
+        temperature=0.1,
+        recorder=recorder,
+    )
+
+
+class AgentPersistenceTestCase(TestCase):
+    def setUp(self):
+        self.conversation = AgentConversation.objects.create(
+            workflow="notebook_chat",
+        )
+
+    def recorder(self, **kwargs):
+        return AgentExecutionService().start(
+            self.conversation,
+            provider="fake",
+            model="fake-model-v1",
+            configuration={"max_tokens": 2048, "temperature": 0.1},
+            **kwargs,
+        )

--- a/src/research_ai/tests/agent/test_persistence_concurrency.py
+++ b/src/research_ai/tests/agent/test_persistence_concurrency.py
@@ -1,0 +1,55 @@
+"""Concurrent sequence allocation coverage for agent persistence."""
+
+import threading
+
+from django.db import close_old_connections
+from django.test import TransactionTestCase
+
+from research_ai.models import AgentConversation, AgentExecution, AgentExecutionMessage
+from research_ai.services.agent.types import Message, TextBlock
+from research_ai.services.agent_persistence import (
+    AgentExecutionService,
+    DatabaseAgentRecorder,
+)
+
+
+class AgentSequenceConcurrencyTests(TransactionTestCase):
+    reset_sequences = True
+
+    def test_concurrent_trace_writes_allocate_unique_ordered_sequences(self):
+        # Arrange
+        conversation = AgentConversation.objects.create()
+        execution = AgentExecutionService().start(conversation).execution
+        barrier = threading.Barrier(4)
+        errors = []
+
+        def record(index):
+            close_old_connections()
+            try:
+                local_execution = AgentExecution.objects.get(id=execution.id)
+                barrier.wait()
+                DatabaseAgentRecorder(local_execution).record_message(
+                    Message(role="user", content=[TextBlock(text=str(index))])
+                )
+            except Exception as exc:  # noqa: BLE001 - surfaced in main test thread
+                errors.append(exc)
+            finally:
+                close_old_connections()
+
+        # Act
+        threads = [threading.Thread(target=record, args=(index,)) for index in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        # Assert
+        self.assertFalse(errors)
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        rows = list(
+            AgentExecutionMessage.objects.filter(execution=execution).order_by(
+                "sequence"
+            )
+        )
+        self.assertEqual([row.sequence for row in rows], [1, 2, 3, 4])
+        self.assertEqual(sorted(row.execution_sequence for row in rows), [1, 2, 3, 4])

--- a/src/research_ai/tests/agent/test_persistence_content.py
+++ b/src/research_ai/tests/agent/test_persistence_content.py
@@ -5,8 +5,6 @@ from unittest import TestCase
 from research_ai.services.agent.types import (
     Message,
     TextBlock,
-    ThinkingBlock,
-    ToolResultBlock,
     ToolUseBlock,
     deserialize_messages,
     serialize_messages,
@@ -166,7 +164,9 @@ class AgentPersistenceContentTests(TestCase):
         self.assertEqual(restored, message)
 
     def test_context_compacts_complete_message_over_limit(self):
-        # Arrange
+        # Arrange: only a missing upstream bound can produce a message this
+        # large, so the row keeps a marker the provider still accepts rather
+        # than a structure preserving content that is no longer there.
         message = Message(
             role="assistant",
             content=[
@@ -186,10 +186,8 @@ class AgentPersistenceContentTests(TestCase):
 
         # Assert
         self.assertTrue(is_compacted)
-        self.assertEqual(content[0]["type"], "tool_use")
-        self.assertEqual(content[0]["id"], "call-1")
-        self.assertEqual(content[0]["name"], "lookup")
-        self.assertTrue(content[0]["input"]["_truncated"])
+        self.assertEqual(len(content), 1)
+        self.assertEqual(content[0]["type"], "text")
         self.assertEqual(provider_state, {})
         self.assertEqual(
             original_size,
@@ -198,179 +196,10 @@ class AgentPersistenceContentTests(TestCase):
         self.assertLessEqual(json_size_bytes(content), MAX_CONTEXT_MESSAGE_BYTES)
         deserialize_messages([{"role": message.role, "content": content}])
 
-    def test_context_compaction_keeps_tool_results_answering_their_calls(self):
-        # Arrange: a tool that returns more than the row limit is the common
-        # case, and its result must keep answering the call in the turn before
-        # it -- an unpaired tool_use fails every later provider turn.
-        call = Message(
-            role="assistant",
-            content=[
-                TextBlock(text="looking that up"),
-                ToolUseBlock(id="call-1", name="fetch", input={"doi": "10.1/abc"}),
-            ],
-        )
-        result = Message(
-            role="user",
-            content=[
-                ToolResultBlock(
-                    tool_use_id="call-1",
-                    content={"body": "x" * MAX_CONTEXT_MESSAGE_BYTES},
-                )
-            ],
-        )
-
-        # Act
-        call_content, _state, call_compacted, _size = serialize_context_message(call)
-        result_content, _state, result_compacted, _size = serialize_context_message(
-            result
-        )
-
-        # Assert
-        self.assertFalse(call_compacted)
-        self.assertTrue(result_compacted)
-        restored = deserialize_messages(
-            [
-                {"role": call.role, "content": call_content},
-                {"role": result.role, "content": result_content},
-            ]
-        )
-        self.assertEqual(restored[0], call)
-        self.assertEqual(restored[1].content[0].tool_use_id, "call-1")
-        self.assertLessEqual(json_size_bytes(result_content), MAX_CONTEXT_MESSAGE_BYTES)
-
-    def test_context_compacts_every_block_when_no_single_block_is_oversized(self):
-        # Arrange: each block fits the per-block budget, so only compacting the
-        # individually oversized ones would leave the message over the limit.
-        body_bytes = MAX_BLOCK_PAYLOAD_BYTES // 2
-        block_count = (MAX_CONTEXT_MESSAGE_BYTES // body_bytes) + 2
-        message = Message(
-            role="assistant",
-            content=[
-                ToolUseBlock(
-                    id=f"call-{index}",
-                    name="lookup",
-                    input={"body": "x" * body_bytes},
-                )
-                for index in range(block_count)
-            ],
-        )
-
-        # Act
-        content, _provider_state, is_compacted, _size = serialize_context_message(
-            message
-        )
-
-        # Assert
-        self.assertTrue(is_compacted)
-        self.assertEqual(
-            [block["id"] for block in content],
-            [f"call-{index}" for index in range(block_count)],
-        )
-        self.assertLessEqual(json_size_bytes(content), MAX_CONTEXT_MESSAGE_BYTES)
-        deserialize_messages([{"role": message.role, "content": content}])
-
-    def test_context_compaction_leaves_signed_blocks_byte_for_byte(self):
-        # Arrange: adapters replay reasoning payloads unedited, so compacting a
-        # neighbouring block must not rewrite one that already fits.
-        thinking = ThinkingBlock(data={"signature": "sig-1", "thinking": "weighing"})
-        message = Message(
-            role="assistant",
-            content=[
-                thinking,
-                ToolUseBlock(
-                    id="call-1",
-                    name="lookup",
-                    input={"body": "x" * MAX_CONTEXT_MESSAGE_BYTES},
-                ),
-            ],
-        )
-
-        # Act
-        content, _provider_state, is_compacted, _size = serialize_context_message(
-            message
-        )
-
-        # Assert
-        self.assertTrue(is_compacted)
-        restored = deserialize_messages([{"role": message.role, "content": content}])[0]
-        self.assertEqual(restored.content[0], thinking)
-        self.assertTrue(content[1]["input"]["_truncated"])
-
-    def test_context_compaction_leaves_provider_tool_calls_byte_for_byte(self):
-        # Arrange: no single block is oversized, so compaction reaches the pass
-        # that rewrites every block -- but Claude replays a programmatic call's
-        # own block, including the caller tying it to pending container code.
-        programmatic = ToolUseBlock(
-            id="call-code",
-            name="run",
-            input={"code": "print(1)"},
-            data={
-                "type": "tool_use",
-                "id": "call-code",
-                "name": "run",
-                "input": {"code": "print(1)"},
-                "caller": {
-                    "type": "code_execution_20250825",
-                    "tool_id": "srvtoolu_1",
-                },
-            },
-        )
-        body_bytes = MAX_BLOCK_PAYLOAD_BYTES // 2
-        block_count = (MAX_CONTEXT_MESSAGE_BYTES // body_bytes) + 2
-        message = Message(
-            role="assistant",
-            content=[programmatic]
-            + [
-                ToolUseBlock(
-                    id=f"call-{index}",
-                    name="lookup",
-                    input={"body": "x" * body_bytes},
-                )
-                for index in range(block_count)
-            ],
-        )
-
-        # Act
-        content, _provider_state, is_compacted, _size = serialize_context_message(
-            message
-        )
-
-        # Assert
-        self.assertTrue(is_compacted)
-        restored = deserialize_messages([{"role": message.role, "content": content}])[0]
-        self.assertEqual(restored.content[0], programmatic)
-        self.assertTrue(content[1]["input"]["_truncated"])
-
-    def test_context_falls_back_to_text_when_a_signed_block_cannot_fit(self):
-        # Arrange: a marker in place of the signed payload would be rejected on
-        # replay, so the message degrades to text the provider still accepts.
-        message = Message(
-            role="assistant",
-            content=[
-                ThinkingBlock(
-                    data={
-                        "signature": "sig-1",
-                        "thinking": "x" * MAX_CONTEXT_MESSAGE_BYTES,
-                    }
-                )
-            ],
-        )
-
-        # Act
-        content, _provider_state, is_compacted, _size = serialize_context_message(
-            message
-        )
-
-        # Assert
-        self.assertTrue(is_compacted)
-        self.assertEqual(len(content), 1)
-        self.assertEqual(content[0]["type"], "text")
-        self.assertLessEqual(json_size_bytes(content), MAX_CONTEXT_MESSAGE_BYTES)
-        deserialize_messages([{"role": message.role, "content": content}])
-
     def test_context_falls_back_to_text_when_state_alone_is_oversized(self):
-        # Arrange: nothing about the message can be compacted into the row, so
-        # structure and the state describing it are dropped together.
+        # Arrange: the content fits but the state beside it does not, and the
+        # two are bounded together -- a turn resumed with one and not the other
+        # is not the turn that was recorded.
         message = Message(
             role="assistant",
             content=[TextBlock(text="done")],

--- a/src/research_ai/tests/agent/test_persistence_content.py
+++ b/src/research_ai/tests/agent/test_persistence_content.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from research_ai.services.agent.types import (
     Message,
     TextBlock,
+    ToolResultBlock,
     ToolUseBlock,
     deserialize_messages,
     serialize_messages,
@@ -184,12 +185,107 @@ class AgentPersistenceContentTests(TestCase):
 
         # Assert
         self.assertTrue(is_compacted)
-        self.assertEqual(content[0]["type"], "text")
+        self.assertEqual(content[0]["type"], "tool_use")
+        self.assertEqual(content[0]["id"], "call-1")
+        self.assertEqual(content[0]["name"], "lookup")
+        self.assertTrue(content[0]["input"]["_truncated"])
         self.assertEqual(provider_state, {})
         self.assertEqual(
             original_size,
             json_size_bytes({"content": blocks, "provider_state": {}}),
         )
+        self.assertLessEqual(json_size_bytes(content), MAX_CONTEXT_MESSAGE_BYTES)
+        deserialize_messages([{"role": message.role, "content": content}])
+
+    def test_context_compaction_keeps_tool_results_answering_their_calls(self):
+        # Arrange: a tool that returns more than the row limit is the common
+        # case, and its result must keep answering the call in the turn before
+        # it -- an unpaired tool_use fails every later provider turn.
+        call = Message(
+            role="assistant",
+            content=[
+                TextBlock(text="looking that up"),
+                ToolUseBlock(id="call-1", name="fetch", input={"doi": "10.1/abc"}),
+            ],
+        )
+        result = Message(
+            role="user",
+            content=[
+                ToolResultBlock(
+                    tool_use_id="call-1",
+                    content={"body": "x" * MAX_CONTEXT_MESSAGE_BYTES},
+                )
+            ],
+        )
+
+        # Act
+        call_content, _state, call_compacted, _size = serialize_context_message(call)
+        result_content, _state, result_compacted, _size = serialize_context_message(
+            result
+        )
+
+        # Assert
+        self.assertFalse(call_compacted)
+        self.assertTrue(result_compacted)
+        restored = deserialize_messages(
+            [
+                {"role": call.role, "content": call_content},
+                {"role": result.role, "content": result_content},
+            ]
+        )
+        self.assertEqual(restored[0], call)
+        self.assertEqual(restored[1].content[0].tool_use_id, "call-1")
+        self.assertLessEqual(json_size_bytes(result_content), MAX_CONTEXT_MESSAGE_BYTES)
+
+    def test_context_compacts_every_block_when_no_single_block_is_oversized(self):
+        # Arrange: each block fits the per-block budget, so only compacting the
+        # individually oversized ones would leave the message over the limit.
+        body_bytes = MAX_BLOCK_PAYLOAD_BYTES // 2
+        block_count = (MAX_CONTEXT_MESSAGE_BYTES // body_bytes) + 2
+        message = Message(
+            role="assistant",
+            content=[
+                ToolUseBlock(
+                    id=f"call-{index}",
+                    name="lookup",
+                    input={"body": "x" * body_bytes},
+                )
+                for index in range(block_count)
+            ],
+        )
+
+        # Act
+        content, _provider_state, is_compacted, _size = serialize_context_message(
+            message
+        )
+
+        # Assert
+        self.assertTrue(is_compacted)
+        self.assertEqual(
+            [block["id"] for block in content],
+            [f"call-{index}" for index in range(block_count)],
+        )
+        self.assertLessEqual(json_size_bytes(content), MAX_CONTEXT_MESSAGE_BYTES)
+        deserialize_messages([{"role": message.role, "content": content}])
+
+    def test_context_falls_back_to_text_when_state_alone_is_oversized(self):
+        # Arrange: nothing about the message can be compacted into the row, so
+        # structure and the state describing it are dropped together.
+        message = Message(
+            role="assistant",
+            content=[TextBlock(text="done")],
+            provider_state={"blob": "x" * (MAX_CONTEXT_MESSAGE_BYTES * 2)},
+        )
+
+        # Act
+        content, provider_state, is_compacted, _size = serialize_context_message(
+            message
+        )
+
+        # Assert
+        self.assertTrue(is_compacted)
+        self.assertEqual(content[0]["type"], "text")
+        self.assertEqual(provider_state, {})
         self.assertLessEqual(json_size_bytes(content), MAX_CONTEXT_MESSAGE_BYTES)
         deserialize_messages([{"role": message.role, "content": content}])
 

--- a/src/research_ai/tests/agent/test_persistence_content.py
+++ b/src/research_ai/tests/agent/test_persistence_content.py
@@ -296,6 +296,51 @@ class AgentPersistenceContentTests(TestCase):
         self.assertEqual(restored.content[0], thinking)
         self.assertTrue(content[1]["input"]["_truncated"])
 
+    def test_context_compaction_leaves_provider_tool_calls_byte_for_byte(self):
+        # Arrange: no single block is oversized, so compaction reaches the pass
+        # that rewrites every block -- but Claude replays a programmatic call's
+        # own block, including the caller tying it to pending container code.
+        programmatic = ToolUseBlock(
+            id="call-code",
+            name="run",
+            input={"code": "print(1)"},
+            data={
+                "type": "tool_use",
+                "id": "call-code",
+                "name": "run",
+                "input": {"code": "print(1)"},
+                "caller": {
+                    "type": "code_execution_20250825",
+                    "tool_id": "srvtoolu_1",
+                },
+            },
+        )
+        body_bytes = MAX_BLOCK_PAYLOAD_BYTES // 2
+        block_count = (MAX_CONTEXT_MESSAGE_BYTES // body_bytes) + 2
+        message = Message(
+            role="assistant",
+            content=[programmatic]
+            + [
+                ToolUseBlock(
+                    id=f"call-{index}",
+                    name="lookup",
+                    input={"body": "x" * body_bytes},
+                )
+                for index in range(block_count)
+            ],
+        )
+
+        # Act
+        content, _provider_state, is_compacted, _size = serialize_context_message(
+            message
+        )
+
+        # Assert
+        self.assertTrue(is_compacted)
+        restored = deserialize_messages([{"role": message.role, "content": content}])[0]
+        self.assertEqual(restored.content[0], programmatic)
+        self.assertTrue(content[1]["input"]["_truncated"])
+
     def test_context_falls_back_to_text_when_a_signed_block_cannot_fit(self):
         # Arrange: a marker in place of the signed payload would be rejected on
         # replay, so the message degrades to text the provider still accepts.

--- a/src/research_ai/tests/agent/test_persistence_content.py
+++ b/src/research_ai/tests/agent/test_persistence_content.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from research_ai.services.agent.types import (
     Message,
     TextBlock,
+    ThinkingBlock,
     ToolResultBlock,
     ToolUseBlock,
     deserialize_messages,
@@ -265,6 +266,60 @@ class AgentPersistenceContentTests(TestCase):
             [block["id"] for block in content],
             [f"call-{index}" for index in range(block_count)],
         )
+        self.assertLessEqual(json_size_bytes(content), MAX_CONTEXT_MESSAGE_BYTES)
+        deserialize_messages([{"role": message.role, "content": content}])
+
+    def test_context_compaction_leaves_signed_blocks_byte_for_byte(self):
+        # Arrange: adapters replay reasoning payloads unedited, so compacting a
+        # neighbouring block must not rewrite one that already fits.
+        thinking = ThinkingBlock(data={"signature": "sig-1", "thinking": "weighing"})
+        message = Message(
+            role="assistant",
+            content=[
+                thinking,
+                ToolUseBlock(
+                    id="call-1",
+                    name="lookup",
+                    input={"body": "x" * MAX_CONTEXT_MESSAGE_BYTES},
+                ),
+            ],
+        )
+
+        # Act
+        content, _provider_state, is_compacted, _size = serialize_context_message(
+            message
+        )
+
+        # Assert
+        self.assertTrue(is_compacted)
+        restored = deserialize_messages([{"role": message.role, "content": content}])[0]
+        self.assertEqual(restored.content[0], thinking)
+        self.assertTrue(content[1]["input"]["_truncated"])
+
+    def test_context_falls_back_to_text_when_a_signed_block_cannot_fit(self):
+        # Arrange: a marker in place of the signed payload would be rejected on
+        # replay, so the message degrades to text the provider still accepts.
+        message = Message(
+            role="assistant",
+            content=[
+                ThinkingBlock(
+                    data={
+                        "signature": "sig-1",
+                        "thinking": "x" * MAX_CONTEXT_MESSAGE_BYTES,
+                    }
+                )
+            ],
+        )
+
+        # Act
+        content, _provider_state, is_compacted, _size = serialize_context_message(
+            message
+        )
+
+        # Assert
+        self.assertTrue(is_compacted)
+        self.assertEqual(len(content), 1)
+        self.assertEqual(content[0]["type"], "text")
         self.assertLessEqual(json_size_bytes(content), MAX_CONTEXT_MESSAGE_BYTES)
         deserialize_messages([{"role": message.role, "content": content}])
 

--- a/src/research_ai/tests/agent/test_persistence_recorder.py
+++ b/src/research_ai/tests/agent/test_persistence_recorder.py
@@ -13,16 +13,13 @@ from research_ai.models import (
     AgentExecutionMessage,
 )
 from research_ai.services.agent.loop import AgentResult
-from research_ai.services.agent.tools import Tool
+from research_ai.services.agent.tools import MAX_TOOL_RESULT_BYTES, Tool
 from research_ai.services.agent.types import (
     StopReason,
     TurnUsage,
     deserialize_messages,
 )
-from research_ai.services.agent_persistence import (
-    AgentExecutionService,
-    DatabaseAgentRecorder,
-)
+from research_ai.services.agent_persistence import AgentExecutionService
 from research_ai.services.agent_persistence.content import (
     MAX_CONTEXT_MESSAGE_BYTES,
     MAX_TRACE_MESSAGE_BYTES,
@@ -204,50 +201,39 @@ class AgentRecorderPersistenceTests(AgentPersistenceTestCase):
         self.assertFalse(hasattr(execution, "generated_chat_message"))
         self.assertTrue(recorder.terminal_observed)
 
-    def test_oversized_tool_content_is_bounded_and_still_deserializes(self):
-        # Arrange
-        huge = "x" * (MAX_TRACE_MESSAGE_BYTES * 4)
+    def test_oversized_tool_result_never_reaches_the_durable_rows(self):
+        # Arrange: the dispatch cap turns a flooding tool into an error the
+        # model can act on, which is why persistence never has to compact a
+        # message to fit its row.
         recorder = self.recorder()
-        provider = FakeProvider([tool_turn("large", "large_tool", {"body": huge})])
+        provider = FakeProvider(
+            [
+                tool_turn("large", "large_tool", {"query": "everything"}),
+                text_turn("narrowing the query"),
+            ]
+        )
         tool = Tool(
             "large_tool",
             "large",
             {"type": "object"},
-            lambda _args: {"result": huge},
-            is_terminal=True,
+            lambda _args: {"result": "x" * (MAX_TOOL_RESULT_BYTES * 2)},
         )
 
         # Act
         agent(provider, recorder, [tool]).run("go")
 
         # Assert
-        rows = list(recorder.execution.messages.order_by("execution_sequence"))
-        self.assertTrue(rows[1].is_truncated)
-        self.assertTrue(rows[2].is_truncated)
-        for row in rows:
-            self.assertLessEqual(
-                len(json.dumps(row.content).encode()), MAX_TRACE_MESSAGE_BYTES
-            )
-            deserialize_messages([{"role": row.role, "content": row.content}])
-
         context_rows = list(recorder.execution.context_messages.order_by("sequence"))
-        self.assertTrue(context_rows[1].is_compacted)
-        self.assertTrue(context_rows[2].is_compacted)
+        self.assertFalse(any(row.is_compacted for row in context_rows))
+        result_block = context_rows[2].content[0]
+        self.assertEqual(result_block["tool_use_id"], "large")
+        self.assertTrue(result_block["is_error"])
+        self.assertIn("over the", result_block["content"]["error"])
         for row in context_rows:
             self.assertLessEqual(
                 len(json.dumps(row.content).encode()), MAX_CONTEXT_MESSAGE_BYTES
             )
             deserialize_messages([{"role": row.role, "content": row.content}])
-        self.assertEqual(len(context_rows), 3)
-
-        # Compaction keeps the call answerable: a tool_result orphaned from its
-        # tool_use would make every later provider turn fail, not just this one.
-        restored = deserialize_messages(
-            [{"role": row.role, "content": row.content} for row in context_rows]
-        )
-        self.assertEqual(restored[1].content[1].id, "large")
-        self.assertEqual(restored[1].content[1].name, "large_tool")
-        self.assertEqual(restored[2].content[0].tool_use_id, "large")
 
     def test_chat_publication_keeps_the_untruncated_response(self):
         # Arrange: chat content is unbounded, so the answer the user reads must
@@ -267,58 +253,6 @@ class AgentRecorderPersistenceTests(AgentPersistenceTestCase):
             generated_by_execution_id=execution.id
         )
         self.assertEqual(published.content, long_answer)
-
-    def test_publication_repair_recovers_the_untruncated_response(self):
-        # Arrange: the first publication attempt fails after the terminal
-        # commit, so the repair path has only durable storage to publish from.
-        long_answer = "x" * (MAX_TRACE_MESSAGE_BYTES * 2)
-        recorder = self.recorder(publish_assistant_message=True)
-        with patch.object(
-            DatabaseAgentRecorder,
-            "publish_assistant_output",
-            side_effect=IntegrityError("chat write failed"),
-        ):
-            agent(FakeProvider([text_turn(long_answer)]), recorder).run("go")
-        self.assertEqual(AgentConversationMessage.objects.count(), 0)
-
-        # Act
-        created = recorder.publish_assistant_output()
-
-        # Assert
-        self.assertTrue(created)
-        published = AgentConversationMessage.objects.get(
-            generated_by_execution_id=recorder.execution.id
-        )
-        self.assertEqual(published.content, long_answer)
-
-    def test_publication_repair_never_publishes_an_earlier_answer(self):
-        # Arrange: the final turn is too large for its context row too, so the
-        # bounded snapshot is the best copy left -- the intact row before it
-        # holds a different turn, not a shorter version of this one.
-        unstorable = "y" * (MAX_CONTEXT_MESSAGE_BYTES * 2)
-        recorder = self.recorder(publish_assistant_message=True)
-        provider = FakeProvider(
-            [tool_turn("call-1", "lookup", {}), text_turn(unstorable)]
-        )
-        tool = Tool("lookup", "lookup", {"type": "object"}, lambda _args: {})
-        with patch.object(
-            DatabaseAgentRecorder,
-            "publish_assistant_output",
-            side_effect=IntegrityError("chat write failed"),
-        ):
-            agent(provider, recorder, [tool]).run("go")
-
-        # Act
-        created = recorder.publish_assistant_output()
-
-        # Assert
-        execution = AgentExecution.objects.get(id=recorder.execution.id)
-        self.assertTrue(created)
-        published = AgentConversationMessage.objects.get(
-            generated_by_execution_id=execution.id
-        )
-        self.assertEqual(published.content, execution.final_output["text"])
-        self.assertTrue(published.content.startswith("y"))
 
     def test_provider_state_round_trips_through_context_messages(self):
         # Arrange: Claude's container id is request-level state the next turn

--- a/src/research_ai/tests/agent/test_persistence_recorder.py
+++ b/src/research_ai/tests/agent/test_persistence_recorder.py
@@ -8,6 +8,7 @@ from django.db import IntegrityError, transaction
 from research_ai.models import (
     AgentContextMessage,
     AgentConversation,
+    AgentConversationMessage,
     AgentExecution,
     AgentExecutionMessage,
 )
@@ -244,6 +245,25 @@ class AgentRecorderPersistenceTests(AgentPersistenceTestCase):
         self.assertEqual(restored[1].content[1].id, "large")
         self.assertEqual(restored[1].content[1].name, "large_tool")
         self.assertEqual(restored[2].content[0].tool_use_id, "large")
+
+    def test_chat_publication_keeps_the_untruncated_response(self):
+        # Arrange: chat content is unbounded, so the answer the user reads must
+        # not inherit the truncation that bounds the execution row.
+        long_answer = "x" * (MAX_TRACE_MESSAGE_BYTES * 2)
+        recorder = self.recorder(publish_assistant_message=True)
+        provider = FakeProvider([text_turn(long_answer)])
+
+        # Act
+        agent(provider, recorder).run("go")
+
+        # Assert
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertTrue(execution.final_output["_truncated"])
+        self.assertLess(len(execution.final_output["text"]), len(long_answer))
+        published = AgentConversationMessage.objects.get(
+            generated_by_execution_id=execution.id
+        )
+        self.assertEqual(published.content, long_answer)
 
     def test_provider_state_round_trips_through_context_messages(self):
         # Arrange: Claude's container id is request-level state the next turn

--- a/src/research_ai/tests/agent/test_persistence_recorder.py
+++ b/src/research_ai/tests/agent/test_persistence_recorder.py
@@ -236,6 +236,41 @@ class AgentRecorderPersistenceTests(AgentPersistenceTestCase):
             deserialize_messages([{"role": row.role, "content": row.content}])
         self.assertEqual(len(context_rows), 3)
 
+    def test_provider_state_round_trips_through_context_messages(self):
+        # Arrange: Claude's container id is request-level state the next turn
+        # must replay, so it has to survive the recorder, not just the serializer.
+        container = {
+            "anthropic": {
+                "container": {
+                    "id": "container_123",
+                    "expires_at": "2026-07-29T21:30:00Z",
+                }
+            }
+        }
+        recorder = self.recorder()
+        provider = FakeProvider([text_turn("Done", provider_state=container)])
+
+        # Act
+        agent(provider, recorder).run("go")
+
+        # Assert
+        assistant_row = recorder.execution.context_messages.get(role="assistant")
+        self.assertEqual(assistant_row.provider_state, container)
+        restored = deserialize_messages(
+            [
+                {
+                    "role": assistant_row.role,
+                    "content": assistant_row.content,
+                    "provider_state": assistant_row.provider_state,
+                }
+            ]
+        )[0]
+        self.assertEqual(restored.provider_state, container)
+
+        # A turn without provider state stays empty rather than inheriting.
+        user_row = recorder.execution.context_messages.get(role="user")
+        self.assertEqual(user_row.provider_state, {})
+
     def test_headless_workflow_has_no_artificial_chat_messages(self):
         # Arrange
         workflow = AgentConversation.objects.create(workflow="headless")

--- a/src/research_ai/tests/agent/test_persistence_recorder.py
+++ b/src/research_ai/tests/agent/test_persistence_recorder.py
@@ -1,0 +1,279 @@
+"""Execution recorder, lifecycle, and trace persistence coverage."""
+
+import json
+from unittest.mock import patch
+
+from django.db import IntegrityError, transaction
+
+from research_ai.models import (
+    AgentContextMessage,
+    AgentConversation,
+    AgentExecution,
+    AgentExecutionMessage,
+)
+from research_ai.services.agent.loop import AgentResult
+from research_ai.services.agent.tools import Tool
+from research_ai.services.agent.types import (
+    StopReason,
+    TurnUsage,
+    deserialize_messages,
+)
+from research_ai.services.agent_persistence import AgentExecutionService
+from research_ai.services.agent_persistence.content import (
+    MAX_CONTEXT_MESSAGE_BYTES,
+    MAX_TRACE_MESSAGE_BYTES,
+)
+from research_ai.tests.agent.persistence_test_helpers import (
+    AgentPersistenceTestCase,
+    FakeProvider,
+    agent,
+    text_turn,
+    tool_turn,
+)
+
+
+class AgentRecorderPersistenceTests(AgentPersistenceTestCase):
+    def test_successful_tool_run_persists_trace_metrics_and_details(self):
+        # Arrange
+        first_usage = TurnUsage(10, 4, 7, 3)
+        second_usage = TurnUsage(20, 5, 14, 2)
+        provider = FakeProvider(
+            [
+                tool_turn(
+                    "call-1",
+                    "lookup",
+                    {"query": "folding"},
+                    usage=first_usage,
+                    latency_ms=31,
+                ),
+                text_turn("Finished", usage=second_usage, latency_ms=47),
+            ]
+        )
+        recorder = self.recorder(
+            initial_prompt_provenance=AgentExecutionMessage.Provenance.HUMAN
+        )
+        tool = Tool(
+            "lookup",
+            "lookup",
+            {"type": "object"},
+            lambda _args: {"papers": ["A"]},
+        )
+
+        # Act
+        result = agent(provider, recorder, [tool]).run("Find papers")
+
+        # Assert
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertEqual(execution.status, AgentExecution.Status.SUCCEEDED)
+        self.assertEqual(execution.iterations, 2)
+        self.assertEqual(execution.input_tokens, 30)
+        self.assertEqual(execution.output_tokens, 9)
+        self.assertEqual(execution.cache_read_tokens, 21)
+        self.assertEqual(execution.cache_write_tokens, 5)
+        self.assertEqual(execution.total_latency_ms, 78)
+        self.assertEqual(execution.stop_reason, StopReason.END_TURN)
+        self.assertIsNotNone(execution.duration_ms)
+        self.assertEqual(execution.final_output, {"text": "Finished"})
+        self.assertEqual(result.final_text, "Finished")
+
+        trace = list(execution.messages.order_by("execution_sequence"))
+        self.assertEqual([row.execution_sequence for row in trace], [1, 2, 3, 4])
+        self.assertEqual(
+            [row.provenance for row in trace],
+            [
+                AgentExecutionMessage.Provenance.HUMAN,
+                AgentExecutionMessage.Provenance.MODEL,
+                AgentExecutionMessage.Provenance.TOOL,
+                AgentExecutionMessage.Provenance.MODEL,
+            ],
+        )
+        self.assertEqual(trace[1].content[1]["input"], {"query": "folding"})
+        self.assertEqual(trace[2].content[0]["content"], {"papers": ["A"]})
+
+    def test_failed_and_interrupted_runs_keep_partial_history(self):
+        # Arrange
+        failed_recorder = self.recorder()
+        provider = FakeProvider(
+            [
+                tool_turn("call-1", "lookup", {}),
+                ValueError("provider socket closed"),
+            ]
+        )
+        tool = Tool("lookup", "lookup", {"type": "object"}, lambda _args: {})
+
+        # Act / Assert
+        with self.assertRaisesRegex(Exception, "provider socket closed"):
+            agent(provider, failed_recorder, [tool]).run("start")
+        failed = AgentExecution.objects.get(id=failed_recorder.execution.id)
+        self.assertEqual(failed.status, AgentExecution.Status.FAILED)
+        self.assertEqual(failed.error_type, "ProviderError")
+        self.assertEqual(failed.messages.count(), 3)
+        self.assertEqual(failed.iterations, 1)
+
+        interrupted_recorder = self.recorder()
+        with self.assertRaises(InterruptedError):
+            agent(
+                FakeProvider([InterruptedError("worker stopped")]),
+                interrupted_recorder,
+            ).run("start")
+        interrupted = AgentExecution.objects.get(id=interrupted_recorder.execution.id)
+        self.assertEqual(interrupted.status, AgentExecution.Status.INTERRUPTED)
+        self.assertEqual(interrupted.messages.count(), 1)
+        self.assertEqual(interrupted.error_type, "InterruptedError")
+
+    def test_tool_errors_are_persisted_as_correlated_results(self):
+        # Arrange
+        recorder = self.recorder()
+        provider = FakeProvider(
+            [tool_turn("broken-1", "broken", {}), text_turn("recovered")]
+        )
+
+        def fail(_args):
+            raise RuntimeError("tool unavailable")
+
+        tool = Tool("broken", "broken", {"type": "object"}, fail)
+
+        # Act
+        agent(provider, recorder, [tool]).run("try it")
+
+        # Assert
+        result_block = recorder.execution.messages.get(execution_sequence=3).content[0]
+        self.assertEqual(result_block["tool_use_id"], "broken-1")
+        self.assertTrue(result_block["is_error"])
+        self.assertEqual(result_block["content"], {"error": "tool unavailable"})
+
+    def test_unexpected_setup_exception_marks_execution_failed(self):
+        # Arrange
+        recorder = self.recorder()
+        provider = FakeProvider([], render_error=RuntimeError("bad tool schema"))
+
+        # Act / Assert
+        with self.assertRaisesRegex(RuntimeError, "bad tool schema"):
+            agent(provider, recorder).run("hello")
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertEqual(execution.status, AgentExecution.Status.FAILED)
+        self.assertEqual(execution.error_type, "RuntimeError")
+        self.assertEqual(execution.messages.count(), 1)
+
+    def test_required_context_failure_marks_execution_failed(self):
+        # Arrange
+        recorder = self.recorder()
+        running_agent = agent(FakeProvider([text_turn("unreachable")]), recorder)
+
+        # Act / Assert
+        with (
+            patch.object(
+                AgentContextMessage.objects,
+                "create",
+                side_effect=IntegrityError("context write failed"),
+            ),
+            self.assertRaisesRegex(IntegrityError, "context write failed"),
+        ):
+            running_agent.run("hello")
+
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertEqual(execution.status, AgentExecution.Status.FAILED)
+        self.assertEqual(execution.error_type, "IntegrityError")
+        self.assertEqual(execution.context_messages.count(), 0)
+        self.assertEqual(execution.messages.count(), 0)
+
+    def test_terminal_callback_does_not_overwrite_cancelled_execution(self):
+        # Arrange
+        recorder = self.recorder(publish_assistant_message=True)
+        AgentExecution.objects.filter(id=recorder.execution.id).update(
+            status=AgentExecution.Status.CANCELLED
+        )
+        result = AgentResult(
+            messages=[],
+            final_text="late answer",
+            stop_reason=StopReason.END_TURN,
+            iterations=1,
+        )
+
+        # Act
+        recorder.on_run_finished(result)
+
+        # Assert
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
+        self.assertEqual(execution.final_output, {})
+        self.assertFalse(hasattr(execution, "generated_chat_message"))
+        self.assertTrue(recorder.terminal_observed)
+
+    def test_oversized_tool_content_is_bounded_and_still_deserializes(self):
+        # Arrange
+        huge = "x" * (MAX_TRACE_MESSAGE_BYTES * 4)
+        recorder = self.recorder()
+        provider = FakeProvider([tool_turn("large", "large_tool", {"body": huge})])
+        tool = Tool(
+            "large_tool",
+            "large",
+            {"type": "object"},
+            lambda _args: {"result": huge},
+            is_terminal=True,
+        )
+
+        # Act
+        agent(provider, recorder, [tool]).run("go")
+
+        # Assert
+        rows = list(recorder.execution.messages.order_by("execution_sequence"))
+        self.assertTrue(rows[1].is_truncated)
+        self.assertTrue(rows[2].is_truncated)
+        for row in rows:
+            self.assertLessEqual(
+                len(json.dumps(row.content).encode()), MAX_TRACE_MESSAGE_BYTES
+            )
+            deserialize_messages([{"role": row.role, "content": row.content}])
+
+        context_rows = list(recorder.execution.context_messages.order_by("sequence"))
+        self.assertTrue(context_rows[1].is_compacted)
+        self.assertTrue(context_rows[2].is_compacted)
+        for row in context_rows:
+            self.assertLessEqual(
+                len(json.dumps(row.content).encode()), MAX_CONTEXT_MESSAGE_BYTES
+            )
+            deserialize_messages([{"role": row.role, "content": row.content}])
+        self.assertEqual(len(context_rows), 3)
+
+    def test_headless_workflow_has_no_artificial_chat_messages(self):
+        # Arrange
+        workflow = AgentConversation.objects.create(workflow="headless")
+        recorder = AgentExecutionService().start(workflow)
+
+        # Act
+        agent(FakeProvider([text_turn("internal result")]), recorder).run(
+            "backend prompt"
+        )
+
+        # Assert
+        self.assertEqual(workflow.chat_messages.count(), 0)
+        self.assertEqual(
+            recorder.execution.messages.first().provenance,
+            AgentExecutionMessage.Provenance.BACKEND,
+        )
+
+    def test_optional_trace_failure_does_not_break_surrounding_transaction(self):
+        # Arrange
+        recorder = self.recorder()
+        running_agent = agent(FakeProvider([text_turn("still succeeds")]), recorder)
+
+        # Act
+        with transaction.atomic():
+            with patch.object(
+                AgentExecutionMessage.objects,
+                "create",
+                side_effect=IntegrityError("trace write failed"),
+            ):
+                result = running_agent.run("hello")
+            AgentConversation.objects.create()
+
+        # Assert
+        self.assertEqual(result.final_text, "still succeeds")
+        self.assertEqual(
+            AgentExecution.objects.get(id=recorder.execution.id).status,
+            AgentExecution.Status.SUCCEEDED,
+        )
+        self.assertEqual(recorder.execution.context_messages.count(), 2)
+        self.assertEqual(AgentExecutionMessage.objects.count(), 0)
+        self.assertEqual(AgentContextMessage.objects.count(), 2)

--- a/src/research_ai/tests/agent/test_persistence_recorder.py
+++ b/src/research_ai/tests/agent/test_persistence_recorder.py
@@ -236,6 +236,15 @@ class AgentRecorderPersistenceTests(AgentPersistenceTestCase):
             deserialize_messages([{"role": row.role, "content": row.content}])
         self.assertEqual(len(context_rows), 3)
 
+        # Compaction keeps the call answerable: a tool_result orphaned from its
+        # tool_use would make every later provider turn fail, not just this one.
+        restored = deserialize_messages(
+            [{"role": row.role, "content": row.content} for row in context_rows]
+        )
+        self.assertEqual(restored[1].content[1].id, "large")
+        self.assertEqual(restored[1].content[1].name, "large_tool")
+        self.assertEqual(restored[2].content[0].tool_use_id, "large")
+
     def test_provider_state_round_trips_through_context_messages(self):
         # Arrange: Claude's container id is request-level state the next turn
         # must replay, so it has to survive the recorder, not just the serializer.

--- a/src/research_ai/tests/agent/test_persistence_recorder.py
+++ b/src/research_ai/tests/agent/test_persistence_recorder.py
@@ -19,7 +19,10 @@ from research_ai.services.agent.types import (
     TurnUsage,
     deserialize_messages,
 )
-from research_ai.services.agent_persistence import AgentExecutionService
+from research_ai.services.agent_persistence import (
+    AgentExecutionService,
+    DatabaseAgentRecorder,
+)
 from research_ai.services.agent_persistence.content import (
     MAX_CONTEXT_MESSAGE_BYTES,
     MAX_TRACE_MESSAGE_BYTES,
@@ -264,6 +267,58 @@ class AgentRecorderPersistenceTests(AgentPersistenceTestCase):
             generated_by_execution_id=execution.id
         )
         self.assertEqual(published.content, long_answer)
+
+    def test_publication_repair_recovers_the_untruncated_response(self):
+        # Arrange: the first publication attempt fails after the terminal
+        # commit, so the repair path has only durable storage to publish from.
+        long_answer = "x" * (MAX_TRACE_MESSAGE_BYTES * 2)
+        recorder = self.recorder(publish_assistant_message=True)
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat write failed"),
+        ):
+            agent(FakeProvider([text_turn(long_answer)]), recorder).run("go")
+        self.assertEqual(AgentConversationMessage.objects.count(), 0)
+
+        # Act
+        created = recorder.publish_assistant_output()
+
+        # Assert
+        self.assertTrue(created)
+        published = AgentConversationMessage.objects.get(
+            generated_by_execution_id=recorder.execution.id
+        )
+        self.assertEqual(published.content, long_answer)
+
+    def test_publication_repair_never_publishes_an_earlier_answer(self):
+        # Arrange: the final turn is too large for its context row too, so the
+        # bounded snapshot is the best copy left -- the intact row before it
+        # holds a different turn, not a shorter version of this one.
+        unstorable = "y" * (MAX_CONTEXT_MESSAGE_BYTES * 2)
+        recorder = self.recorder(publish_assistant_message=True)
+        provider = FakeProvider(
+            [tool_turn("call-1", "lookup", {}), text_turn(unstorable)]
+        )
+        tool = Tool("lookup", "lookup", {"type": "object"}, lambda _args: {})
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat write failed"),
+        ):
+            agent(provider, recorder, [tool]).run("go")
+
+        # Act
+        created = recorder.publish_assistant_output()
+
+        # Assert
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertTrue(created)
+        published = AgentConversationMessage.objects.get(
+            generated_by_execution_id=execution.id
+        )
+        self.assertEqual(published.content, execution.final_output["text"])
+        self.assertTrue(published.content.startswith("y"))
 
     def test_provider_state_round_trips_through_context_messages(self):
         # Arrange: Claude's container id is request-level state the next turn

--- a/src/research_ai/tests/agent/test_tools.py
+++ b/src/research_ai/tests/agent/test_tools.py
@@ -2,7 +2,7 @@
 
 from django.test import SimpleTestCase
 
-from research_ai.services.agent.tools import Tool, Toolset
+from research_ai.services.agent.tools import MAX_TOOL_RESULT_BYTES, Tool, Toolset
 
 
 def _build_ok_tool(name, *, is_terminal=False):
@@ -92,6 +92,39 @@ class ToolsetDispatchTests(SimpleTestCase):
 
         # Assert
         self.assertEqual(result, {"error": "tool 'broken' returned invalid JSON"})
+        self.assertFalse(stop)
+
+    def test_oversized_result_is_rejected_at_the_tool_boundary(self):
+        # Arrange: a result no context window can afford, and no durable row
+        # can hold, has to be stopped where the model can still react to it.
+        tool = Tool(
+            "flood",
+            "flood",
+            {"type": "object"},
+            lambda _input: {"body": "x" * (MAX_TOOL_RESULT_BYTES + 1)},
+            is_terminal=True,
+        )
+        toolset = Toolset([tool])
+
+        # Act
+        result, stop = toolset.dispatch("flood", {})
+
+        # Assert
+        self.assertIn("over the", result["error"])
+        self.assertFalse(stop)
+
+    def test_result_at_the_size_limit_is_delivered(self):
+        # Arrange: the cap rejects what exceeds it, not what merely approaches
+        # it -- a tool paging right up to the budget still gets through.
+        body = "x" * (MAX_TOOL_RESULT_BYTES - 100)
+        tool = Tool("big", "big", {"type": "object"}, lambda _input: {"body": body})
+        toolset = Toolset([tool])
+
+        # Act
+        result, stop = toolset.dispatch("big", {})
+
+        # Assert
+        self.assertEqual(result, {"body": body})
         self.assertFalse(stop)
 
     def test_terminal_tool_signals_stop(self):


### PR DESCRIPTION
## Stack

1. **#3843 — Persist agent execution lifecycles**
2. #3844 — Add agent conversation services
3. #3831 — Add agent chat orchestration
4. #3827 — Persist proposal draft agent histories

## What changed

- Add injectable recorder hooks to the provider-neutral agent loop.
- Persist required resumable context and isolate optional trace writes.
- Track execution status, metrics, failures, terminal output, and atomic sequence allocation.
- Add execution creation and pending-claim services with recorder dependency injection.
- Add focused lifecycle, trace, failure, and concurrency coverage.

## Why

Agent executions need durable state without coupling the core loop to Django or allowing optional observability failures to break successful work.

## Impact

Callers can start or claim an execution and receive a database recorder that captures the complete lifecycle safely.

## Validation

- 27 recorder, lifecycle, serialization, and concurrency tests passed.
- Ruff lint and formatting checks passed for the changed scope.
- Rebase onto current `main` verified with `git range-diff`; all four patches are unchanged.