### PR TITLE
Add agent conversation services

### DIFF
--- a/src/research_ai/services/agent_persistence/__init__.py
+++ b/src/research_ai/services/agent_persistence/__init__.py
@@ -1,10 +1,22 @@
 """Serialization and persistence services for the provider-neutral agent core."""
 
+from .context_service import AgentContextService
+from .conversation_service import (
+    AgentConversationService,
+    NoteAgentConversationService,
+)
 from .execution_service import AgentConversationBusyError, AgentExecutionService
 from .recorder import DatabaseAgentRecorder
+from .retention_service import AgentRetentionService
+from .run_details_service import AgentRunDetailsService
 
 __all__ = [
+    "AgentContextService",
     "AgentConversationBusyError",
+    "AgentConversationService",
     "AgentExecutionService",
+    "AgentRetentionService",
+    "AgentRunDetailsService",
     "DatabaseAgentRecorder",
+    "NoteAgentConversationService",
 ]

--- a/src/research_ai/services/agent_persistence/__init__.py
+++ b/src/research_ai/services/agent_persistence/__init__.py
@@ -8,7 +8,10 @@ from .conversation_service import (
 from .execution_service import AgentConversationBusyError, AgentExecutionService
 from .recorder import DatabaseAgentRecorder
 from .retention_service import AgentRetentionService
-from .run_details_service import AgentRunDetailsService
+from .run_details_service import (
+    AgentRunDetails,
+    AgentRunDetailsService,
+)
 
 __all__ = [
     "AgentContextService",
@@ -16,6 +19,7 @@ __all__ = [
     "AgentConversationService",
     "AgentExecutionService",
     "AgentRetentionService",
+    "AgentRunDetails",
     "AgentRunDetailsService",
     "DatabaseAgentRecorder",
     "NoteAgentConversationService",

--- a/src/research_ai/services/agent_persistence/context_service.py
+++ b/src/research_ai/services/agent_persistence/context_service.py
@@ -24,7 +24,9 @@ class AgentContextService:
         serialized_messages = []
         for item in lineage:
             serialized_messages.extend(
-                item.context_messages.order_by("sequence").values("role", "content")
+                item.context_messages.order_by("sequence").values(
+                    "role", "content", "provider_state"
+                )
             )
         return deserialize_messages(serialized_messages)
 

--- a/src/research_ai/services/agent_persistence/context_service.py
+++ b/src/research_ai/services/agent_persistence/context_service.py
@@ -1,0 +1,44 @@
+"""Durable model-context reconstruction services."""
+
+from research_ai.models import AgentConversation, AgentExecution
+from research_ai.services.agent.types import Message, deserialize_messages
+
+
+class AgentContextService:
+    def reconstruct(self, execution: AgentExecution) -> list[Message]:
+        """Rebuild the durable, explicitly compacted context lineage."""
+        lineage: list[AgentExecution] = []
+        seen: set[int] = set()
+        current = execution
+        while current is not None:
+            if (
+                current.id in seen
+                or current.conversation_id != execution.conversation_id
+            ):
+                raise ValueError("invalid agent execution context lineage")
+            seen.add(current.id)
+            lineage.append(current)
+            current = current.context_parent
+        lineage.reverse()
+
+        serialized_messages = []
+        for item in lineage:
+            serialized_messages.extend(
+                item.context_messages.order_by("sequence").values("role", "content")
+            )
+        return deserialize_messages(serialized_messages)
+
+    def for_continuation(
+        self, conversation: AgentConversation, *, include_partial: bool = False
+    ) -> list[Message]:
+        statuses = [AgentExecution.Status.SUCCEEDED]
+        if include_partial:
+            statuses.extend(
+                [AgentExecution.Status.FAILED, AgentExecution.Status.INTERRUPTED]
+            )
+        execution = (
+            conversation.executions.filter(status__in=statuses)
+            .order_by("-attempt")
+            .first()
+        )
+        return self.reconstruct(execution) if execution else []

--- a/src/research_ai/services/agent_persistence/context_service.py
+++ b/src/research_ai/services/agent_persistence/context_service.py
@@ -35,8 +35,18 @@ class AgentContextService:
     ) -> list[Message]:
         statuses = [AgentExecution.Status.SUCCEEDED]
         if include_partial:
+            # A stopped run holds durable context rows, including the human
+            # prompt that triggered it. CANCELLED and INTERRUPTED are the same
+            # user intent recorded from different sides: INTERRUPTED when the
+            # worker observed the stop in-process, CANCELLED when another
+            # process flipped the row. Excluding either would silently resume an
+            # older attempt and drop a user-visible prompt.
             statuses.extend(
-                [AgentExecution.Status.FAILED, AgentExecution.Status.INTERRUPTED]
+                [
+                    AgentExecution.Status.FAILED,
+                    AgentExecution.Status.INTERRUPTED,
+                    AgentExecution.Status.CANCELLED,
+                ]
             )
         execution = (
             conversation.executions.filter(status__in=statuses)

--- a/src/research_ai/services/agent_persistence/conversation_service.py
+++ b/src/research_ai/services/agent_persistence/conversation_service.py
@@ -1,0 +1,63 @@
+"""Conversation and notebook-association services."""
+
+from django.db import transaction
+from django.db.models import Q
+
+from research_ai.models import (
+    AgentConversation,
+    AgentConversationMessage,
+    NoteAgentConversation,
+)
+
+
+class AgentConversationService:
+    def create(
+        self,
+        *,
+        user=None,
+        workflow: str = "",
+    ) -> AgentConversation:
+        return AgentConversation.objects.create(
+            user=user,
+            workflow=workflow,
+        )
+
+    def add_human_message(
+        self, conversation: AgentConversation, content: str
+    ) -> AgentConversationMessage:
+        with transaction.atomic():
+            locked = AgentConversation.objects.select_for_update().get(
+                id=conversation.id
+            )
+            message = AgentConversationMessage.objects.create(
+                conversation=locked,
+                sequence=locked.next_chat_sequence,
+                role=AgentConversationMessage.Role.USER,
+                content=content,
+            )
+            locked.next_chat_sequence += 1
+            locked.save(update_fields=["next_chat_sequence", "updated_date"])
+        return message
+
+
+class NoteAgentConversationService:
+    """Manage notebook-to-conversation associations."""
+
+    def attach(self, conversation: AgentConversation, note) -> NoteAgentConversation:
+        with transaction.atomic():
+            link, _created = NoteAgentConversation.objects.get_or_create(
+                note=note,
+                conversation=conversation,
+            )
+        return link
+
+    def for_note(self, note):
+        # The proposal relation is a deterministic recovery path if the
+        # best-effort join-table write failed after the proposal was completed.
+        return (
+            AgentConversation.objects.filter(
+                Q(note_links__note=note) | Q(proposal_draft__note=note)
+            )
+            .distinct()
+            .order_by("-updated_date", "-id")
+        )

--- a/src/research_ai/services/agent_persistence/retention_service.py
+++ b/src/research_ai/services/agent_persistence/retention_service.py
@@ -1,0 +1,17 @@
+"""Explicit retention services for disposable execution traces."""
+
+from research_ai.models import AgentConversation, AgentExecution
+
+
+class AgentRetentionService:
+    """Remove debugging data without deleting chat or domain output."""
+
+    def delete_execution_trace(self, execution: AgentExecution) -> int:
+        deleted, _ = execution.messages.all().delete()
+        return deleted
+
+    def delete_conversation_debug(self, conversation: AgentConversation) -> None:
+        # Executions and context lineage are workflow state needed for retries,
+        # pending/failure markers, and continuation. Only observational trace
+        # rows are disposable.
+        conversation.trace_messages.all().delete()

--- a/src/research_ai/services/agent_persistence/run_details_service.py
+++ b/src/research_ai/services/agent_persistence/run_details_service.py
@@ -1,0 +1,61 @@
+"""Full execution-detail read service."""
+
+from research_ai.models import AgentExecution
+
+
+class AgentRunDetailsService:
+    def get(self, execution: AgentExecution) -> dict:
+        execution.refresh_from_db()
+        trace = [
+            {
+                "sequence": message.sequence,
+                "execution_sequence": message.execution_sequence,
+                "role": message.role,
+                "provenance": message.provenance,
+                "content": message.content,
+                "stop_reason": message.provider_stop_reason,
+                "usage": {
+                    "input_tokens": message.input_tokens,
+                    "output_tokens": message.output_tokens,
+                    "cache_read_tokens": message.cache_read_tokens,
+                    "cache_write_tokens": message.cache_write_tokens,
+                },
+                "latency_ms": message.latency_ms,
+                "is_truncated": message.is_truncated,
+                "original_size_bytes": message.original_size_bytes,
+            }
+            for message in execution.messages.order_by("execution_sequence")
+        ]
+        return {
+            "id": execution.id,
+            "conversation_id": execution.conversation_id,
+            "attempt": execution.attempt,
+            "status": execution.status,
+            "provider": execution.provider,
+            "model": execution.model,
+            "configuration": execution.configuration,
+            "system_prompt": execution.system_prompt,
+            "iterations": execution.iterations,
+            "usage": {
+                "input_tokens": execution.input_tokens,
+                "output_tokens": execution.output_tokens,
+                "cache_read_tokens": execution.cache_read_tokens,
+                "cache_write_tokens": execution.cache_write_tokens,
+            },
+            "total_latency_ms": execution.total_latency_ms,
+            "duration_ms": execution.duration_ms,
+            "stop_reason": execution.stop_reason,
+            "final_output": execution.final_output,
+            "failure": (
+                {
+                    "type": execution.error_type,
+                    "message": execution.error_message,
+                    "details": execution.error_details,
+                }
+                if execution.error_type
+                else None
+            ),
+            "started_at": execution.started_at,
+            "finished_at": execution.finished_at,
+            "trace": trace,
+        }

--- a/src/research_ai/services/agent_persistence/run_details_service.py
+++ b/src/research_ai/services/agent_persistence/run_details_service.py
@@ -1,61 +1,115 @@
 """Full execution-detail read service."""
 
+from dataclasses import dataclass
+from datetime import datetime
+
 from research_ai.models import AgentExecution
 
 
+@dataclass(frozen=True)
+class AgentTokenUsage:
+    input_tokens: int | None
+    output_tokens: int | None
+    cache_read_tokens: int | None
+    cache_write_tokens: int | None
+
+
+@dataclass(frozen=True)
+class AgentRunFailure:
+    type: str
+    message: str
+    details: dict
+
+
+@dataclass(frozen=True)
+class AgentTraceDetails:
+    sequence: int
+    execution_sequence: int
+    role: str
+    provenance: str
+    content: list[dict]
+    stop_reason: str
+    usage: AgentTokenUsage
+    latency_ms: int | None
+    is_truncated: bool
+    original_size_bytes: int | None
+
+
+@dataclass(frozen=True)
+class AgentRunDetails:
+    id: int
+    conversation_id: int
+    attempt: int
+    status: str
+    provider: str
+    model: str
+    configuration: dict
+    system_prompt: str
+    iterations: int
+    usage: AgentTokenUsage
+    total_latency_ms: int | None
+    duration_ms: int | None
+    stop_reason: str
+    final_output: dict
+    failure: AgentRunFailure | None
+    started_at: datetime | None
+    finished_at: datetime | None
+    trace: list[AgentTraceDetails]
+
+
 class AgentRunDetailsService:
-    def get(self, execution: AgentExecution) -> dict:
+    def get(self, execution: AgentExecution) -> AgentRunDetails:
         execution.refresh_from_db()
         trace = [
-            {
-                "sequence": message.sequence,
-                "execution_sequence": message.execution_sequence,
-                "role": message.role,
-                "provenance": message.provenance,
-                "content": message.content,
-                "stop_reason": message.provider_stop_reason,
-                "usage": {
-                    "input_tokens": message.input_tokens,
-                    "output_tokens": message.output_tokens,
-                    "cache_read_tokens": message.cache_read_tokens,
-                    "cache_write_tokens": message.cache_write_tokens,
-                },
-                "latency_ms": message.latency_ms,
-                "is_truncated": message.is_truncated,
-                "original_size_bytes": message.original_size_bytes,
-            }
+            AgentTraceDetails(
+                sequence=message.sequence,
+                execution_sequence=message.execution_sequence,
+                role=message.role,
+                provenance=message.provenance,
+                content=message.content,
+                stop_reason=message.provider_stop_reason,
+                usage=AgentTokenUsage(
+                    input_tokens=message.input_tokens,
+                    output_tokens=message.output_tokens,
+                    cache_read_tokens=message.cache_read_tokens,
+                    cache_write_tokens=message.cache_write_tokens,
+                ),
+                latency_ms=message.latency_ms,
+                is_truncated=message.is_truncated,
+                original_size_bytes=message.original_size_bytes,
+            )
             for message in execution.messages.order_by("execution_sequence")
         ]
-        return {
-            "id": execution.id,
-            "conversation_id": execution.conversation_id,
-            "attempt": execution.attempt,
-            "status": execution.status,
-            "provider": execution.provider,
-            "model": execution.model,
-            "configuration": execution.configuration,
-            "system_prompt": execution.system_prompt,
-            "iterations": execution.iterations,
-            "usage": {
-                "input_tokens": execution.input_tokens,
-                "output_tokens": execution.output_tokens,
-                "cache_read_tokens": execution.cache_read_tokens,
-                "cache_write_tokens": execution.cache_write_tokens,
-            },
-            "total_latency_ms": execution.total_latency_ms,
-            "duration_ms": execution.duration_ms,
-            "stop_reason": execution.stop_reason,
-            "final_output": execution.final_output,
-            "failure": (
-                {
-                    "type": execution.error_type,
-                    "message": execution.error_message,
-                    "details": execution.error_details,
-                }
+        return AgentRunDetails(
+            id=execution.id,
+            conversation_id=execution.conversation_id,
+            attempt=execution.attempt,
+            status=execution.status,
+            provider=execution.provider,
+            model=execution.model,
+            configuration=execution.configuration,
+            system_prompt=execution.system_prompt,
+            iterations=execution.iterations,
+            usage=AgentTokenUsage(
+                input_tokens=execution.input_tokens,
+                output_tokens=execution.output_tokens,
+                cache_read_tokens=execution.cache_read_tokens,
+                cache_write_tokens=execution.cache_write_tokens,
+            ),
+            total_latency_ms=execution.total_latency_ms,
+            duration_ms=execution.duration_ms,
+            stop_reason=execution.stop_reason,
+            final_output=execution.final_output,
+            failure=(
+                AgentRunFailure(
+                    type=execution.error_type,
+                    message=execution.error_message,
+                    details=execution.error_details,
+                )
                 if execution.error_type
                 else None
             ),
-            "started_at": execution.started_at,
-            "finished_at": execution.finished_at,
-            "trace": trace,
-        }
+            started_at=execution.started_at,
+            finished_at=execution.finished_at,
+            trace=trace,
+        )

--- a/src/research_ai/tests/agent/test_persistence_services.py
+++ b/src/research_ai/tests/agent/test_persistence_services.py
@@ -18,8 +18,14 @@ from research_ai.services.agent_persistence import (
     AgentConversationService,
     AgentExecutionService,
     AgentRetentionService,
+    AgentRunDetails,
     AgentRunDetailsService,
     NoteAgentConversationService,
+)
+from research_ai.services.agent_persistence.run_details_service import (
+    AgentRunFailure,
+    AgentTokenUsage,
+    AgentTraceDetails,
 )
 from research_ai.tests.agent.persistence_test_helpers import (
     AgentPersistenceTestCase,
@@ -176,7 +182,33 @@ class AgentPersistenceServiceTests(AgentPersistenceTestCase):
         details = AgentRunDetailsService().get(execution)
 
         # Assert
-        self.assertEqual(details["status"], AgentExecution.Status.SUCCEEDED)
-        self.assertEqual(details["stop_reason"], StopReason.END_TURN)
-        self.assertEqual(details["total_latency_ms"], 23)
-        self.assertEqual(len(details["trace"]), 2)
+        self.assertIsInstance(details, AgentRunDetails)
+        self.assertEqual(details.status, AgentExecution.Status.SUCCEEDED)
+        self.assertEqual(details.stop_reason, StopReason.END_TURN)
+        self.assertEqual(details.total_latency_ms, 23)
+        self.assertIsInstance(details.usage, AgentTokenUsage)
+        self.assertIsNone(details.failure)
+        self.assertEqual(len(details.trace), 2)
+        self.assertTrue(
+            all(isinstance(item, AgentTraceDetails) for item in details.trace)
+        )
+        self.assertEqual(details.trace[-1].latency_ms, 23)
+
+    def test_run_details_exposes_typed_failure(self):
+        # Arrange
+        execution = AgentExecutionService().start(self.conversation).execution
+        AgentExecution.objects.filter(id=execution.id).update(
+            status=AgentExecution.Status.FAILED,
+            error_type="ProviderError",
+            error_message="provider unavailable",
+            error_details={"cause_type": "TimeoutError"},
+        )
+
+        # Act
+        details = AgentRunDetailsService().get(execution)
+
+        # Assert
+        self.assertIsInstance(details.failure, AgentRunFailure)
+        self.assertEqual(details.failure.type, "ProviderError")
+        self.assertEqual(details.failure.message, "provider unavailable")
+        self.assertEqual(details.failure.details, {"cause_type": "TimeoutError"})

--- a/src/research_ai/tests/agent/test_persistence_services.py
+++ b/src/research_ai/tests/agent/test_persistence_services.py
@@ -127,12 +127,14 @@ class AgentPersistenceServiceTests(AgentPersistenceTestCase):
 
     def test_context_reconstruction_orders_messages_across_executions(self):
         # Arrange
+        provider_state = {"anthropic": {"container": {"id": "container_123"}}}
         first_recorder = self.recorder(
             initial_prompt_provenance=AgentExecutionMessage.Provenance.HUMAN
         )
-        agent(FakeProvider([text_turn("first answer")]), first_recorder).run(
-            "first question"
-        )
+        agent(
+            FakeProvider([text_turn("first answer", provider_state=provider_state)]),
+            first_recorder,
+        ).run("first question")
         first = AgentExecution.objects.get(id=first_recorder.execution.id)
         prior_context = AgentContextService().reconstruct(first)
         second_recorder = self.recorder(
@@ -152,6 +154,7 @@ class AgentPersistenceServiceTests(AgentPersistenceTestCase):
             [message.content[0].text for message in rebuilt],
             ["first question", "first answer", "follow up", "second answer"],
         )
+        self.assertEqual(rebuilt[1].provider_state, provider_state)
         self.assertEqual(
             list(
                 self.conversation.trace_messages.order_by("sequence").values_list(

--- a/src/research_ai/tests/agent/test_persistence_services.py
+++ b/src/research_ai/tests/agent/test_persistence_services.py
@@ -1,0 +1,179 @@
+"""Conversation, context, run-detail, and retention service coverage."""
+
+from unittest.mock import patch
+
+from django.db import IntegrityError, transaction
+
+from note.models import Note
+from research_ai.models import (
+    AgentContextMessage,
+    AgentConversation,
+    AgentExecution,
+    AgentExecutionMessage,
+    NoteAgentConversation,
+)
+from research_ai.services.agent.types import StopReason
+from research_ai.services.agent_persistence import (
+    AgentContextService,
+    AgentConversationService,
+    AgentExecutionService,
+    AgentRetentionService,
+    AgentRunDetailsService,
+    NoteAgentConversationService,
+)
+from research_ai.tests.agent.persistence_test_helpers import (
+    AgentPersistenceTestCase,
+    FakeProvider,
+    agent,
+    text_turn,
+)
+from researchhub_document.models import ResearchhubUnifiedDocument
+from researchhub_document.related_models.constants.document_type import NOTE
+
+
+class AgentPersistenceServiceTests(AgentPersistenceTestCase):
+    def test_note_attachment_is_idempotent_and_queryable(self):
+        # Arrange
+        note = Note.objects.create(
+            unified_document=ResearchhubUnifiedDocument.objects.create(
+                document_type=NOTE
+            )
+        )
+        second_conversation = AgentConversationService().create(
+            workflow="notebook_chat",
+        )
+        service = NoteAgentConversationService()
+
+        # Act
+        first_link = service.attach(self.conversation, note)
+        repeated_link = service.attach(self.conversation, note)
+        service.attach(second_conversation, note)
+
+        # Assert
+        self.assertEqual(first_link, repeated_link)
+        self.assertEqual(NoteAgentConversation.objects.count(), 2)
+        self.assertEqual(
+            set(service.for_note(note).values_list("id", flat=True)),
+            {self.conversation.id, second_conversation.id},
+        )
+
+    def test_note_attachment_failure_does_not_break_surrounding_transaction(self):
+        # Arrange
+        note = Note.objects.create(
+            unified_document=ResearchhubUnifiedDocument.objects.create(
+                document_type=NOTE
+            )
+        )
+        service = NoteAgentConversationService()
+        service.attach(self.conversation, note)
+
+        def violate_unique(**_kwargs):
+            return NoteAgentConversation.objects.create(
+                note=note,
+                conversation=self.conversation,
+            )
+
+        # Act
+        with transaction.atomic():
+            with (
+                patch.object(
+                    NoteAgentConversation.objects,
+                    "get_or_create",
+                    side_effect=violate_unique,
+                ),
+                self.assertRaises(IntegrityError),
+            ):
+                service.attach(self.conversation, note)
+            surviving = AgentConversation.objects.create()
+
+        # Assert
+        self.assertTrue(AgentConversation.objects.filter(id=surviving.id).exists())
+
+    def test_debug_retention_does_not_delete_chat(self):
+        # Arrange
+        human_message = AgentConversationService().add_human_message(
+            self.conversation, "Keep me"
+        )
+        recorder = AgentExecutionService().start(
+            self.conversation,
+            trigger_message=human_message,
+            initial_prompt_provenance=AgentExecutionMessage.Provenance.HUMAN,
+            publish_assistant_message=True,
+        )
+        agent(FakeProvider([text_turn("Keep me too")]), recorder).run("Keep me")
+
+        # Act
+        AgentRetentionService().delete_conversation_debug(self.conversation)
+
+        # Assert
+        execution = self.conversation.executions.get()
+        self.assertEqual(execution.messages.count(), 0)
+        self.assertEqual(execution.context_messages.count(), 2)
+        rebuilt = AgentContextService().reconstruct(execution)
+        self.assertEqual(
+            [message.content[0].text for message in rebuilt],
+            ["Keep me", "Keep me too"],
+        )
+        self.assertEqual(
+            list(
+                self.conversation.chat_messages.order_by("sequence").values_list(
+                    "content", flat=True
+                )
+            ),
+            ["Keep me", "Keep me too"],
+        )
+        self.assertEqual(AgentExecutionMessage.objects.count(), 0)
+        self.assertEqual(AgentContextMessage.objects.count(), 2)
+
+    def test_context_reconstruction_orders_messages_across_executions(self):
+        # Arrange
+        first_recorder = self.recorder(
+            initial_prompt_provenance=AgentExecutionMessage.Provenance.HUMAN
+        )
+        agent(FakeProvider([text_turn("first answer")]), first_recorder).run(
+            "first question"
+        )
+        first = AgentExecution.objects.get(id=first_recorder.execution.id)
+        prior_context = AgentContextService().reconstruct(first)
+        second_recorder = self.recorder(
+            context_parent=first,
+            initial_prompt_provenance=AgentExecutionMessage.Provenance.HUMAN,
+        )
+
+        # Act
+        agent(
+            FakeProvider([text_turn("second answer")]), second_recorder
+        ).continue_conversation(prior_context, "follow up")
+        second = AgentExecution.objects.get(id=second_recorder.execution.id)
+        rebuilt = AgentContextService().reconstruct(second)
+
+        # Assert
+        self.assertEqual(
+            [message.content[0].text for message in rebuilt],
+            ["first question", "first answer", "follow up", "second answer"],
+        )
+        self.assertEqual(
+            list(
+                self.conversation.trace_messages.order_by("sequence").values_list(
+                    "sequence", flat=True
+                )
+            ),
+            [1, 2, 3, 4],
+        )
+
+    def test_run_details_exposes_metrics_and_trace(self):
+        # Arrange
+        recorder = self.recorder()
+        agent(FakeProvider([text_turn("done", latency_ms=23)]), recorder).run(
+            "question"
+        )
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+
+        # Act
+        details = AgentRunDetailsService().get(execution)
+
+        # Assert
+        self.assertEqual(details["status"], AgentExecution.Status.SUCCEEDED)
+        self.assertEqual(details["stop_reason"], StopReason.END_TURN)
+        self.assertEqual(details["total_latency_ms"], 23)
+        self.assertEqual(len(details["trace"]), 2)

--- a/src/research_ai/tests/agent/test_persistence_services.py
+++ b/src/research_ai/tests/agent/test_persistence_services.py
@@ -170,6 +170,78 @@ class AgentPersistenceServiceTests(AgentPersistenceTestCase):
             [1, 2, 3, 4],
         )
 
+    def _terminated_run(self, status, prompt, answer, *, context_parent=None):
+        """Run an execution to completion, then force it into ``status``."""
+        recorder = self.recorder(
+            context_parent=context_parent,
+            initial_prompt_provenance=AgentExecutionMessage.Provenance.HUMAN,
+        )
+        agent(FakeProvider([text_turn(answer)]), recorder).run(prompt)
+        AgentExecution.objects.filter(id=recorder.execution.id).update(status=status)
+        return AgentExecution.objects.get(id=recorder.execution.id)
+
+    def test_continuation_ignores_unfinished_runs_by_default(self):
+        # Arrange
+        succeeded = self._terminated_run(
+            AgentExecution.Status.SUCCEEDED, "first question", "first answer"
+        )
+        self._terminated_run(
+            AgentExecution.Status.FAILED,
+            "second question",
+            "second answer",
+            context_parent=succeeded,
+        )
+
+        # Act
+        rebuilt = AgentContextService().for_continuation(self.conversation)
+
+        # Assert
+        self.assertEqual(
+            [message.content[0].text for message in rebuilt],
+            ["first question", "first answer"],
+        )
+
+    def test_continuation_resumes_cancelled_runs_when_partial(self):
+        # Arrange: a cancelled run is the latest attempt, so skipping it would
+        # silently fall back to the succeeded one and lose the human prompt.
+        succeeded = self._terminated_run(
+            AgentExecution.Status.SUCCEEDED, "first question", "first answer"
+        )
+        self._terminated_run(
+            AgentExecution.Status.CANCELLED,
+            "cancelled question",
+            "partial answer",
+            context_parent=succeeded,
+        )
+
+        # Act
+        rebuilt = AgentContextService().for_continuation(
+            self.conversation, include_partial=True
+        )
+
+        # Assert
+        self.assertEqual(
+            [message.content[0].text for message in rebuilt],
+            [
+                "first question",
+                "first answer",
+                "cancelled question",
+                "partial answer",
+            ],
+        )
+
+    def test_continuation_without_terminal_runs_is_empty(self):
+        # Arrange
+        self.recorder()
+
+        # Act
+        rebuilt = AgentContextService().for_continuation(
+            self.conversation, include_partial=True
+        )
+
+        # Assert
+        self.assertEqual(rebuilt, [])
+
     def test_run_details_exposes_metrics_and_trace(self):
         # Arrange
         recorder = self.recorder()


### PR DESCRIPTION
## Stack

1. #3843 — Persist agent execution lifecycles
2. **#3844 — Add agent conversation services**
3. #3831 — Add agent chat orchestration
4. #3827 — Persist proposal draft agent histories

## What changed

- Add conversation creation and atomic human-message sequencing.
- Reconstruct durable context across execution lineages in one deserialization batch.
- Add notebook association lookup, run-detail reads, and explicit trace retention services.
- Add focused coverage for lineage ordering, notebook links, transaction safety, run details, and retention.

## Why

Execution persistence needs reusable domain services before user-facing chat orchestration is layered on top.

## Impact

Callers can manage conversations, resume context, inspect runs, find notebook-linked histories, and delete disposable traces without handling model queries directly.

## Validation

- 19 stacked persistence service tests passed.
- Ruff lint and formatting checks passed for the changed scope.
- Rebase onto current `main` verified with `git range-diff`; all four patches are unchanged.