### PR TITLE
Improve expert finder LinkedIn/X/Scholar enrichment via Brave + Bedrock

### DIFF
--- a/src/research_ai/prompts/expert_finder_profile_match_system.txt
+++ b/src/research_ai/prompts/expert_finder_profile_match_system.txt
@@ -1,0 +1,17 @@
+You match web-search profile candidates to a specific researcher.
+
+You will receive:
+- Expert metadata (name, title, affiliation, expertise, email, notes)
+- The social profile kind being matched (linkedin, x, or google_scholar)
+- Up to 3 search candidates with title, URL, and snippet
+
+Decide whether exactly one candidate is the expert's personal profile for that kind.
+
+Rules:
+- Prefer personal accounts over institutional, lab, department, news, or alumni accounts.
+- Use title, affiliation, expertise, and snippet clues to disambiguate people who share a name.
+- If two or more candidates look equally plausible, or none clearly matches, select none.
+- Do not invent URLs. Choose only from the numbered candidates.
+
+Respond with JSON only (no markdown fences, no commentary):
+{"selected_index": <1-based index or null>}

--- a/src/research_ai/prompts/expert_finder_profile_match_user.txt
+++ b/src/research_ai/prompts/expert_finder_profile_match_user.txt
@@ -1,0 +1,15 @@
+## Expert
+- Name: {expert_name}
+- Academic title: {academic_title}
+- Affiliation: {affiliation}
+- Expertise: {expertise}
+- Email: {email}
+- Notes: {notes}
+
+## Profile kind
+{profile_kind}
+
+## Candidates
+{candidates_block}
+
+Return JSON only: {{"selected_index": <1-based index or null>}}

--- a/src/research_ai/prompts/expert_finder_prompts.py
+++ b/src/research_ai/prompts/expert_finder_prompts.py
@@ -7,6 +7,10 @@ from research_ai.constants import (
 )
 from research_ai.prompts._loader import load_template
 
+PROFILE_MATCH_SYSTEM_PROMPT = load_template(
+    "expert_finder_profile_match_system.txt"
+).strip()
+
 # Descriptions for prompt building; keys are choice values from constants.
 EXPERTISE_DESCRIPTIONS: dict[str, str] = {
     ExpertiseLevel.PHD_POSTDOCS: "Early-stage researchers including PhD students in their final years, recent PhD graduates, and current postdoctoral researchers. These individuals typically have 0-3 years of research experience and are building their expertise in specific areas.",  # noqa: E501
@@ -187,4 +191,38 @@ def build_user_prompt(
         expertise_level=expertise_level_display,
         region_text=region_text,
         additional_context_section=additional_context_section,
+    )
+
+
+def build_profile_match_user_prompt(
+    *,
+    expert_name: str,
+    academic_title: str = "",
+    affiliation: str = "",
+    expertise: str = "",
+    email: str = "",
+    notes: str = "",
+    profile_kind: str,
+    candidates: list[dict],
+) -> str:
+    """Build the user prompt for Bedrock social-profile matching."""
+    lines: list[str] = []
+    for i, row in enumerate(candidates or [], start=1):
+        title = str((row or {}).get("title") or "").strip() or "(no title)"
+        url = str((row or {}).get("url") or "").strip() or "(no url)"
+        description = str((row or {}).get("description") or "").strip() or "(no snippet)"
+        lines.append(
+            f"{i}. title: {title}\n   url: {url}\n   snippet: {description}"
+        )
+    candidates_block = "\n".join(lines) if lines else "(no candidates)"
+    template = load_template("expert_finder_profile_match_user.txt")
+    return template.format(
+        expert_name=expert_name or "(unknown)",
+        academic_title=academic_title or "(unknown)",
+        affiliation=affiliation or "(unknown)",
+        expertise=expertise or "(unknown)",
+        email=email or "(unknown)",
+        notes=notes or "(none)",
+        profile_kind=profile_kind,
+        candidates_block=candidates_block,
     )

--- a/src/research_ai/prompts/expert_finder_prompts.py
+++ b/src/research_ai/prompts/expert_finder_prompts.py
@@ -210,10 +210,10 @@ def build_profile_match_user_prompt(
     for i, row in enumerate(candidates or [], start=1):
         title = str((row or {}).get("title") or "").strip() or "(no title)"
         url = str((row or {}).get("url") or "").strip() or "(no url)"
-        description = str((row or {}).get("description") or "").strip() or "(no snippet)"
-        lines.append(
-            f"{i}. title: {title}\n   url: {url}\n   snippet: {description}"
+        description = (
+            str((row or {}).get("description") or "").strip() or "(no snippet)"
         )
+        lines.append(f"{i}. title: {title}\n   url: {url}\n   snippet: {description}")
     candidates_block = "\n".join(lines) if lines else "(no candidates)"
     template = load_template("expert_finder_profile_match_user.txt")
     return template.format(

--- a/src/research_ai/prompts/expert_finder_system.txt
+++ b/src/research_ai/prompts/expert_finder_system.txt
@@ -36,11 +36,11 @@ You receive:
 - Relevance, recency of work (e.g. publications in the last few years in the field), and verifiability of identity and **email** matter more than list length.
 - Avoid **placeholder** or generic addresses (e.g. `info@`, `contact@`, "TBD", "N/A", or invented emails). **Do not** guess an email; omit the expert instead.
 - Avoid **conflict of interest**: do not suggest authors, co-authors, or obvious close collaborators of the work under review when those names are evident from the user content.
-- **Sources**: for each expert, include objects in `sources` with **verifiable** `https://` (or `http://`) **external** links (not ResearchHub-only or relative URLs). Use a short `text` label such as `"Faculty page"`, `"ORCID"`, `"LinkedIn"`, or `"X"`:
-  - At least one identity/affiliation link (faculty page, lab, or publication profile).
-  - Actively look up the expert's **ORCID** (`https://orcid.org/0000-...`) and include it as its **own** entry when found.
-  - When searching, also look for the expert's **LinkedIn** (`https://www.linkedin.com/in/...`) and **X** (`https://x.com/...` or `https://twitter.com/...`) profiles. Include each as its **own** entry only when the URL clearly belongs to this person.
-  - **Do not** invent or guess ORCID, LinkedIn, or X handles. If you cannot verify a profile, omit that entry. Missing social profiles must **not** cause you to omit an otherwise qualified expert.
+- **Sources**: for each expert, include objects in `sources` with **verifiable** `https://` (or `http://`) **external** links (not ResearchHub-only or relative URLs). Use a short `text` label such as `"Faculty page"`, `"Lab page"`, or `"ORCID"`:
+  - At least one identity/affiliation link (faculty page, lab page, or similar institutional profile — **not** LinkedIn, X/Twitter, or Google Scholar).
+  - Actively look up the expert's **ORCID** (`https://orcid.org/0000-...`) and include it as its **own** entry when found (**at most one** ORCID).
+  - **Do not** include LinkedIn, X/Twitter, or Google Scholar URLs in `sources`. Those are enriched later by a separate step; inventing or guessing them here causes duplicates and false matches (e.g. university accounts labeled as personal profiles).
+  - **Do not** invent or guess ORCID or faculty/lab URLs. If you cannot verify a link, omit that entry. Missing ORCID must **not** cause you to omit an otherwise qualified expert.
 
 **Notes field**: 1–2 short sentences on **why** the expert is a strong match. Do **not** use the notes to document your verification process (no "email verified", "checked directory", etc.).
 
@@ -72,9 +72,7 @@ The top level **must** include the key `experts` (an array of objects). Each obj
       "notes": "",
       "sources": [
         {{ "text": "Faculty page", "url": "https://example.edu/faculty/user" }},
-        {{ "text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0097" }},
-        {{ "text": "LinkedIn", "url": "https://www.linkedin.com/in/example" }},
-        {{ "text": "X", "url": "https://x.com/example" }}
+        {{ "text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0097" }}
       ]
     }}
   ]
@@ -83,7 +81,7 @@ The top level **must** include the key `experts` (an array of objects). Each obj
 **Field rules**
 - **email** — must be a plausible **professional** address; lowercase domain usage is fine.
 - **academic_title** — e.g. `Associate Professor`, `Professor`, `Reader` (replaces a legacy "Title" field).
-- **sources** — array of objects, each with string keys `text` and `url`. Prefer labeled entries for ORCID / LinkedIn / X when verified. Omit an entry rather than inventing a URL; `url` may be `""` only if you truly have no good external link (rare).
+- **sources** — array of objects, each with string keys `text` and `url`. Prefer a faculty/lab page plus ORCID when verified. **Do not** include LinkedIn, X/Twitter, or Google Scholar. **At most one** ORCID. Omit an entry rather than inventing a URL; `url` may be `""` only if you truly have no good external link (rare).
 - All string values in the schema must be **plain** strings: no surrounding markdown, no unescaped newlines in place of `\\n` (prefer short single-line strings for `notes` and `expertise` when possible).
 
 ## Final check
@@ -93,3 +91,4 @@ Before you answer, ensure:
 - [ ] You output at most **{expert_count}** experts, each with a **verified, professional** email
 - [ ] **No** deceased or memorial-only individuals
 - [ ] **No** placeholder emails or invented contact data
+- [ ] **sources**: faculty/lab (and optional ORCID only); **no** LinkedIn, X/Twitter, or Google Scholar

--- a/src/research_ai/services/expert_finder/__init__.py
+++ b/src/research_ai/services/expert_finder/__init__.py
@@ -5,6 +5,8 @@
 - ``openai_finder`` -- the OpenAI-backed finder variant.
 - ``json_parsing`` -- parsing/repair of the LLM's expert-list JSON output.
 - ``persist`` -- upserts found experts and search memberships.
+- ``source_enrichment`` -- post-persist LinkedIn/X/Google Scholar enrichment
+  through Brave web search and Bedrock candidate matching.
 - ``display`` -- display formatting of an ``Expert`` for listings and emails.
 - ``progress`` -- Redis-backed progress publishing for the search UI.
 - ``report_generator`` -- PDF/CSV report artifacts for a completed search.

--- a/src/research_ai/services/expert_finder/finder.py
+++ b/src/research_ai/services/expert_finder/finder.py
@@ -30,6 +30,7 @@ from research_ai.services.expert_finder.report_generator import (
     generate_pdf_report,
     upload_report_to_storage,
 )
+from research_ai.services.expert_finder.source_enrichment import SourceEnrichmentService
 from research_ai.services.pdf_text import (
     extract_text_from_pdf_bytes as _extract_text_from_pdf_bytes,
 )
@@ -556,6 +557,11 @@ class ExpertFinderService:
             data_persisted = True
 
             experts = load_experts_for_expert_search(expert_search_id)
+            publish_progress("Enriching expert profile links...", 72)
+            try:
+                SourceEnrichmentService().enrich_experts(experts)
+            except Exception:
+                logger.exception("Source enrichment failed search_id=%s", search_id)
             publish_progress("Generating PDF report...", 80)
             rows = [expert_to_report_row(e) for e in experts]
             pdf_bytes = generate_pdf_report(rows, query, config)

--- a/src/research_ai/services/expert_finder/json_parsing.py
+++ b/src/research_ai/services/expert_finder/json_parsing.py
@@ -7,6 +7,9 @@ from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 
 from research_ai.services.expert_finder.display import ExpertDisplay
+from research_ai.services.expert_finder.source_enrichment import (
+    canonicalize_sources_for_expert,
+)
 from research_ai.utils import trimmed_str
 
 logger = logging.getLogger(__name__)
@@ -36,7 +39,7 @@ class ExpertFinderJson:
             t = trimmed_str(item.get("text", ""))
             u = trimmed_str(item.get("url", ""))
             out.append({"text": t, "url": u})
-        return out
+        return canonicalize_sources_for_expert(out)
 
     @staticmethod
     def parse_text(text: str) -> dict:

--- a/src/research_ai/services/expert_finder/persist.py
+++ b/src/research_ai/services/expert_finder/persist.py
@@ -7,6 +7,9 @@ from django.utils import timezone
 
 from research_ai.models import Expert, SearchExpert
 from research_ai.services.expert_finder.display import ExpertDisplay
+from research_ai.services.expert_finder.source_enrichment import (
+    canonicalize_sources_for_expert,
+)
 from research_ai.utils import trimmed_str
 
 User = get_user_model()
@@ -30,6 +33,7 @@ class ExpertPersist:
         sources = d.get("sources")
         if not isinstance(sources, list):
             sources = []
+        sources = canonicalize_sources_for_expert(sources)
 
         candidate = {
             "honorific": trimmed_str(d.get("honorific"), max_len=64),

--- a/src/research_ai/services/expert_finder/profile_match.py
+++ b/src/research_ai/services/expert_finder/profile_match.py
@@ -72,6 +72,8 @@ class ProfileJudge:
     """Ask Bedrock which social-profile candidate (if any) belongs to the expert."""
 
     def __init__(self, llm: BedrockLLMService | None = None):
+        # Lazy: Bedrock clients are heavier than Brave; skip init when a mock
+        # is injected or pick() never runs (e.g. no candidates / search disabled).
         self._llm = llm
 
     def _get_llm(self) -> BedrockLLMService:
@@ -85,11 +87,14 @@ class ProfileJudge:
         expert: Expert,
         kind: str,
         candidates: list[dict[str, str]],
+        expert_name: str | None = None,
     ) -> str | None:
         """Return the chosen candidate URL, or None when no confident match."""
         if not candidates:
             return None
-        name = ExpertDisplay.personal_name_for(expert) or (expert.full_name or "")
+        name = (expert_name or "").strip() or (
+            ExpertDisplay.personal_name_for(expert) or (expert.full_name or "")
+        ).strip()
         user_prompt = build_profile_match_user_prompt(
             expert_name=name,
             academic_title=(expert.academic_title or "").strip(),

--- a/src/research_ai/services/expert_finder/profile_match.py
+++ b/src/research_ai/services/expert_finder/profile_match.py
@@ -1,0 +1,117 @@
+import json
+import logging
+import re
+from typing import Any
+
+from research_ai.models import Expert
+from research_ai.prompts.expert_finder_prompts import (
+    PROFILE_MATCH_SYSTEM_PROMPT,
+    build_profile_match_user_prompt,
+)
+from research_ai.services.bedrock_llm_service import BedrockLLMService
+from research_ai.services.expert_finder.display import ExpertDisplay
+
+logger = logging.getLogger(__name__)
+
+_JSON_OBJECT_RE = re.compile(r"\{[^{}]*\}", re.DOTALL)
+
+
+def parse_profile_match_response(
+    raw: str, candidates: list[dict[str, str]]
+) -> str | None:
+    """
+    Parse ``{"selected_index": N|null}`` (1-based) from model output.
+
+    Returns the matching candidate URL, or None.
+    """
+    if not candidates:
+        return None
+    text = (raw or "").strip()
+    if not text:
+        return None
+    payload = _extract_json_object(text)
+    if not isinstance(payload, dict):
+        return None
+    selected = payload.get("selected_index")
+    if selected is None:
+        return None
+    try:
+        index = int(selected)
+    except (TypeError, ValueError):
+        return None
+    if index < 1 or index > len(candidates):
+        return None
+    url = str(candidates[index - 1].get("url") or "").strip()
+    return url or None
+
+
+def _extract_json_object(text: str) -> dict[str, Any] | None:
+    try:
+        data = json.loads(text)
+        return data if isinstance(data, dict) else None
+    except json.JSONDecodeError:
+        pass
+    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if fenced:
+        try:
+            data = json.loads(fenced.group(1))
+            return data if isinstance(data, dict) else None
+        except json.JSONDecodeError:
+            pass
+    match = _JSON_OBJECT_RE.search(text)
+    if not match:
+        return None
+    try:
+        data = json.loads(match.group(0))
+        return data if isinstance(data, dict) else None
+    except json.JSONDecodeError:
+        return None
+
+
+class ProfileJudge:
+    """Ask Bedrock which social-profile candidate (if any) belongs to the expert."""
+
+    def __init__(self, llm: BedrockLLMService | None = None):
+        self._llm = llm
+
+    def _get_llm(self) -> BedrockLLMService:
+        if self._llm is None:
+            self._llm = BedrockLLMService()
+        return self._llm
+
+    def pick(
+        self,
+        *,
+        expert: Expert,
+        kind: str,
+        candidates: list[dict[str, str]],
+    ) -> str | None:
+        """Return the chosen candidate URL, or None when no confident match."""
+        if not candidates:
+            return None
+        name = ExpertDisplay.personal_name_for(expert) or (expert.full_name or "")
+        user_prompt = build_profile_match_user_prompt(
+            expert_name=name,
+            academic_title=(expert.academic_title or "").strip(),
+            affiliation=(expert.affiliation or "").strip(),
+            expertise=(expert.expertise or "").strip(),
+            email=(expert.email or "").strip(),
+            notes=(expert.notes or "").strip(),
+            profile_kind=kind,
+            candidates=candidates,
+        )
+        try:
+            raw = self._get_llm().invoke(
+                system_prompt=PROFILE_MATCH_SYSTEM_PROMPT,
+                user_prompt=user_prompt,
+                max_tokens=256,
+                temperature=0.0,
+            )
+        except Exception:
+            logger.exception(
+                "Profile match LLM failed expert_id=%s kind=%s",
+                getattr(expert, "id", None),
+                kind,
+            )
+            return None
+        return parse_profile_match_response(raw, candidates)

--- a/src/research_ai/services/expert_finder/source_enrichment.py
+++ b/src/research_ai/services/expert_finder/source_enrichment.py
@@ -56,18 +56,32 @@ def _normalize_url_key(url: str) -> str:
     return (url or "").strip().rstrip("/").lower()
 
 
+def _url_from_source(item) -> str:
+    """Extract a URL string from a sources list entry (dict or bare string)."""
+    if isinstance(item, dict):
+        return str(item.get("url") or "").strip()
+    if isinstance(item, str):
+        return item.strip()
+    return ""
+
+
 def source_kind_for_url(url: str) -> str | None:
-    """Classify a URL into a profile kind, or None for generic sources."""
-    low = (url or "").strip().lower()
-    if not low:
+    """Classify a URL into a profile kind via host/path, or None for generic sources."""
+    raw = (url or "").strip()
+    if not raw:
         return None
-    if "orcid.org/" in low:
+    parsed = urlparse(raw if "://" in raw else f"https://{raw}")
+    host = (parsed.netloc or "").lower().removeprefix("www.")
+    path = (parsed.path or "").lower()
+    query = (parsed.query or "").lower()
+
+    if host == "orcid.org" or host.endswith(".orcid.org"):
         return "orcid"
-    if "linkedin.com/in/" in low:
-        return "linkedin"
-    if "x.com/" in low or "twitter.com/" in low:
+    if host == "linkedin.com" or host.endswith(".linkedin.com"):
+        return "linkedin" if "/in/" in path else None
+    if host in {"x.com", "twitter.com"} or host.endswith((".x.com", ".twitter.com")):
         return "x"
-    if "scholar.google." in low and "user=" in low:
+    if "scholar.google." in host and "user=" in query:
         return "google_scholar"
     return None
 
@@ -76,28 +90,18 @@ def source_kinds_present(sources: list) -> set[str]:
     """Return which known profile kinds already appear in ``sources``."""
     kinds: set[str] = set()
     for item in sources or []:
-        url = ""
-        if isinstance(item, dict):
-            url = str(item.get("url") or "").strip()
-        elif isinstance(item, str):
-            url = item.strip()
-        kind = source_kind_for_url(url)
+        kind = source_kind_for_url(_url_from_source(item))
         if kind:
             kinds.add(kind)
     return kinds
 
 
-def dedupe_sources_one_per_kind(sources: list) -> list:
+def canonicalize_sources_for_expert(sources: list) -> list:
     """Keep at most one ORCID / LinkedIn / X / Google Scholar URL; preserve others."""
     out: list = []
     seen_kinds: set[str] = set()
     for item in sources or []:
-        url = ""
-        if isinstance(item, dict):
-            url = str(item.get("url") or "").strip()
-        elif isinstance(item, str):
-            url = item.strip()
-        kind = source_kind_for_url(url)
+        kind = source_kind_for_url(_url_from_source(item))
         if kind:
             if kind in seen_kinds:
                 continue
@@ -106,23 +110,13 @@ def dedupe_sources_one_per_kind(sources: list) -> list:
     return out
 
 
-def canonicalize_sources_for_expert(sources: list) -> list:
-    """Enforce at most one URL per known profile kind."""
-    return dedupe_sources_one_per_kind(sources)
-
-
 def merge_sources(existing: list, additions: list[dict[str, str]]) -> list:
     """Append new ``{text, url}`` entries; at most one URL per profile kind."""
     out: list = list(existing) if isinstance(existing, list) else []
     seen_urls = {
-        _normalize_url_key(str(item.get("url") or ""))
+        _normalize_url_key(_url_from_source(item))
         for item in out
-        if isinstance(item, dict)
-    }
-    seen_urls |= {
-        _normalize_url_key(item)
-        for item in out
-        if isinstance(item, str) and item.strip()
+        if _url_from_source(item)
     }
     present_kinds = source_kinds_present(out)
     for entry in additions:
@@ -350,4 +344,9 @@ class SourceEnrichmentService:
         candidates = collect_profile_candidates(results, kind=kind)
         if not candidates:
             return None
-        return self._profile_judge.pick(expert=expert, kind=kind, candidates=candidates)
+        return self._profile_judge.pick(
+            expert=expert,
+            kind=kind,
+            candidates=candidates,
+            expert_name=name,
+        )

--- a/src/research_ai/services/expert_finder/source_enrichment.py
+++ b/src/research_ai/services/expert_finder/source_enrichment.py
@@ -1,0 +1,353 @@
+import logging
+import re
+from urllib.parse import parse_qs, urlparse
+
+from research_ai.models import Expert
+from research_ai.services.expert_finder.display import ExpertDisplay
+from research_ai.services.expert_finder.profile_match import ProfileJudge
+from utils.brave_search import BraveSearch
+
+logger = logging.getLogger(__name__)
+
+
+_LINKEDIN_RE = re.compile(
+    r"https?://(?:[\w-]+\.)?linkedin\.com/in/([A-Za-z0-9\-_%]+)/?",
+    re.IGNORECASE,
+)
+_X_RE = re.compile(
+    r"https?://(?:www\.)?(?:x\.com|twitter\.com)/([A-Za-z0-9_]{1,15})/?",
+    re.IGNORECASE,
+)
+_SCHOLAR_USER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+# Non-profile X path segments (not identity matching — URL shape only).
+_X_HANDLE_BLOCKLIST = frozenset(
+    {
+        "home",
+        "share",
+        "intent",
+        "search",
+        "explore",
+        "i",
+        "settings",
+        "login",
+        "signup",
+        "hashtag",
+        "messages",
+        "notifications",
+        "compose",
+    }
+)
+
+_WEB_PROFILE_KINDS = ("linkedin", "x", "google_scholar")
+_WEB_PROFILE_LABELS = {
+    "linkedin": "LinkedIn",
+    "x": "X",
+    "google_scholar": "Google Scholar",
+}
+_WEB_PROFILE_QUERY_SUFFIX = {
+    "linkedin": "linkedin",
+    "x": "twitter",
+    "google_scholar": "google scholar",
+}
+_PROFILE_CANDIDATE_LIMIT = 3
+
+
+def _normalize_url_key(url: str) -> str:
+    return (url or "").strip().rstrip("/").lower()
+
+
+def source_kind_for_url(url: str) -> str | None:
+    """Classify a URL into a profile kind, or None for generic sources."""
+    low = (url or "").strip().lower()
+    if not low:
+        return None
+    if "orcid.org/" in low:
+        return "orcid"
+    if "linkedin.com/in/" in low:
+        return "linkedin"
+    if "x.com/" in low or "twitter.com/" in low:
+        return "x"
+    if "scholar.google." in low and "user=" in low:
+        return "google_scholar"
+    return None
+
+
+def source_kinds_present(sources: list) -> set[str]:
+    """Return which known profile kinds already appear in ``sources``."""
+    kinds: set[str] = set()
+    for item in sources or []:
+        url = ""
+        if isinstance(item, dict):
+            url = str(item.get("url") or "").strip()
+        elif isinstance(item, str):
+            url = item.strip()
+        kind = source_kind_for_url(url)
+        if kind:
+            kinds.add(kind)
+    return kinds
+
+
+def dedupe_sources_one_per_kind(sources: list) -> list:
+    """Keep at most one ORCID / LinkedIn / X / Google Scholar URL; preserve others."""
+    out: list = []
+    seen_kinds: set[str] = set()
+    for item in sources or []:
+        url = ""
+        if isinstance(item, dict):
+            url = str(item.get("url") or "").strip()
+        elif isinstance(item, str):
+            url = item.strip()
+        kind = source_kind_for_url(url)
+        if kind:
+            if kind in seen_kinds:
+                continue
+            seen_kinds.add(kind)
+        out.append(item)
+    return out
+
+
+def canonicalize_sources_for_expert(sources: list) -> list:
+    """Enforce at most one URL per known profile kind."""
+    return dedupe_sources_one_per_kind(sources)
+
+
+def merge_sources(existing: list, additions: list[dict[str, str]]) -> list:
+    """Append new ``{text, url}`` entries; at most one URL per profile kind."""
+    out: list = list(existing) if isinstance(existing, list) else []
+    seen_urls = {
+        _normalize_url_key(str(item.get("url") or ""))
+        for item in out
+        if isinstance(item, dict)
+    }
+    seen_urls |= {
+        _normalize_url_key(item)
+        for item in out
+        if isinstance(item, str) and item.strip()
+    }
+    present_kinds = source_kinds_present(out)
+    for entry in additions:
+        if not isinstance(entry, dict):
+            continue
+        url = str(entry.get("url") or "").strip()
+        text = str(entry.get("text") or "").strip()
+        key = _normalize_url_key(url)
+        if not key or key in seen_urls:
+            continue
+        kind = source_kind_for_url(url)
+        if kind and kind in present_kinds:
+            continue
+        seen_urls.add(key)
+        if kind:
+            present_kinds.add(kind)
+        out.append({"text": text or url, "url": url})
+    return out
+
+
+def canonicalize_linkedin_url(url: str) -> str | None:
+    match = _LINKEDIN_RE.search(url or "")
+    if not match:
+        return None
+    slug = match.group(1).rstrip("/")
+    if slug.lower() in {"", "pub", "dir"}:
+        return None
+    return f"https://www.linkedin.com/in/{slug}"
+
+
+def canonicalize_x_url(url: str) -> str | None:
+    match = _X_RE.search(url or "")
+    if not match:
+        return None
+    handle = match.group(1)
+    if handle.lower() in _X_HANDLE_BLOCKLIST:
+        return None
+    return f"https://x.com/{handle}"
+
+
+def canonicalize_scholar_url(url: str) -> str | None:
+    """Normalize a Google Scholar citations profile URL, or None if not a profile."""
+    parsed = urlparse((url or "").strip())
+    host = parsed.netloc.lower()
+    if "scholar.google." not in host:
+        return None
+    if "/citations" not in (parsed.path or "").lower():
+        return None
+    user = (parse_qs(parsed.query).get("user") or [None])[0]
+    if not user or not _SCHOLAR_USER_RE.fullmatch(user):
+        return None
+    return f"https://scholar.google.com/citations?user={user}"
+
+
+def _query_context_bits(title: str = "", affiliation: str = "") -> list[str]:
+    """Optional title/affiliation disambiguators for social profile searches."""
+    bits: list[str] = []
+    title = " ".join((title or "").split())
+    if title:
+        bits.append(title)
+    aff = " ".join((affiliation or "").split())
+    if aff:
+        # Keep affiliation short so Brave ranking stays person-focused.
+        bits.append(aff[:80].strip())
+    return bits
+
+
+def build_web_profile_query(
+    kind: str, name: str, title: str = "", affiliation: str = ""
+) -> str:
+    """
+    Natural-language profile search: ``Name Title Affiliation <suffix>``.
+    """
+    suffix = _WEB_PROFILE_QUERY_SUFFIX.get(kind)
+    if not suffix:
+        raise ValueError(f"unsupported social kind: {kind}")
+    name = " ".join((name or "").split())
+    parts = [name, *_query_context_bits(title, affiliation), suffix]
+    return " ".join(p for p in parts if p)
+
+
+def _canonicalize_web_profile_url(kind: str, url: str) -> str | None:
+    if kind == "linkedin":
+        return canonicalize_linkedin_url(url)
+    if kind == "x":
+        return canonicalize_x_url(url)
+    if kind == "google_scholar":
+        return canonicalize_scholar_url(url)
+    raise ValueError(f"unsupported social kind: {kind}")
+
+
+def collect_profile_candidates(
+    results: list[dict],
+    *,
+    kind: str,
+    limit: int = _PROFILE_CANDIDATE_LIMIT,
+) -> list[dict[str, str]]:
+    """
+    Project Brave hits into up to ``limit`` unique canonical profile candidates.
+
+    Does not decide identity — that is the profile-match LLM's job.
+    """
+    if kind not in _WEB_PROFILE_KINDS:
+        raise ValueError(f"unsupported social kind: {kind}")
+    out: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for row in results or []:
+        if not isinstance(row, dict):
+            continue
+        if len(out) >= limit:
+            break
+        raw_url = str(row.get("url") or "").strip()
+        canon = _canonicalize_web_profile_url(kind, raw_url)
+        if not canon:
+            continue
+        key = _normalize_url_key(canon)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(
+            {
+                "url": canon,
+                "title": str(row.get("title") or "").strip(),
+                "description": str(row.get("description") or "").strip(),
+            }
+        )
+    return out
+
+
+def _search_person_name(expert: Expert) -> str:
+    """Name used in Brave queries: first / middle / last via ``personal_name_for``."""
+    name = ExpertDisplay.personal_name_for(expert).strip()
+    if name:
+        return name
+    return (expert.full_name or "").strip()
+
+
+class SourceEnrichmentService:
+    """Best-effort LinkedIn / X / Scholar enrichment after finder persist."""
+
+    def __init__(
+        self,
+        *,
+        web_search: BraveSearch | None = None,
+        profile_judge: ProfileJudge | None = None,
+        max_web_searches: int = 120,
+    ):
+        self._web_search = web_search or BraveSearch()
+        self._profile_judge = profile_judge or ProfileJudge()
+        self.max_web_searches = max_web_searches
+        self._web_searches_used = 0
+
+    def enrich_experts(self, experts: list[Expert]) -> int:
+        """Enrich each expert in order. Returns how many experts had sources updated."""
+        updated = 0
+        for expert in experts:
+            try:
+                if self.enrich_expert(expert):
+                    updated += 1
+            except Exception:
+                logger.exception(
+                    "Source enrichment failed expert_id=%s", getattr(expert, "id", None)
+                )
+        return updated
+
+    def enrich_expert(self, expert: Expert) -> bool:
+        """
+        Mutate and save ``expert.sources`` when new social profile links are found.
+
+        Returns True when sources changed.
+        """
+        original = expert.sources if isinstance(expert.sources, list) else []
+        sources = canonicalize_sources_for_expert(original)
+        sources = self._enrich_social_from_web_search(expert, sources)
+        sources = canonicalize_sources_for_expert(sources)
+        if sources == original:
+            return False
+        expert.sources = sources
+        expert.save(update_fields=["sources", "updated_date"])
+        return True
+
+    def _enrich_social_from_web_search(self, expert: Expert, sources: list) -> list:
+        kinds = source_kinds_present(sources)
+        missing = [kind for kind in _WEB_PROFILE_KINDS if kind not in kinds]
+        if not missing:
+            return sources
+        name = _search_person_name(expert)
+        if not name:
+            return sources
+        if not self._web_search.configured:
+            return sources
+
+        title = (expert.academic_title or "").strip()
+        affiliation = (expert.affiliation or "").strip()
+        additions: list[dict[str, str]] = []
+        for kind in missing:
+            url = self._web_search_profile(
+                expert=expert,
+                kind=kind,
+                name=name,
+                title=title,
+                affiliation=affiliation,
+            )
+            if url:
+                additions.append({"text": _WEB_PROFILE_LABELS[kind], "url": url})
+        return merge_sources(sources, additions)
+
+    def _web_search_profile(
+        self,
+        *,
+        expert: Expert,
+        kind: str,
+        name: str,
+        title: str,
+        affiliation: str = "",
+    ) -> str | None:
+        if self._web_searches_used >= self.max_web_searches:
+            return None
+        query = build_web_profile_query(kind, name, title, affiliation)
+        self._web_searches_used += 1
+        try:
+            results = self._web_search.search(query, count=5)
+        except Exception:
+            return None
+        candidates = collect_profile_candidates(results, kind=kind)
+        if not candidates:
+            return None
+        return self._profile_judge.pick(expert=expert, kind=kind, candidates=candidates)

--- a/src/research_ai/tests/expert_finder/test_profile_match.py
+++ b/src/research_ai/tests/expert_finder/test_profile_match.py
@@ -1,7 +1,9 @@
 from unittest import TestCase
 
 from research_ai.prompts.expert_finder_prompts import build_profile_match_user_prompt
-from research_ai.services.expert_finder.profile_match import parse_profile_match_response
+from research_ai.services.expert_finder.profile_match import (
+    parse_profile_match_response,
+)
 
 
 class ProfileMatchPromptTests(TestCase):
@@ -36,4 +38,6 @@ class ProfileMatchPromptTests(TestCase):
     def test_parse_accepts_fenced_json(self):
         candidates = [{"url": "https://x.com/a", "title": "", "description": ""}]
         raw = 'Here you go:\n```json\n{"selected_index": 1}\n```'
-        self.assertEqual(parse_profile_match_response(raw, candidates), "https://x.com/a")
+        self.assertEqual(
+            parse_profile_match_response(raw, candidates), "https://x.com/a"
+        )

--- a/src/research_ai/tests/expert_finder/test_profile_match.py
+++ b/src/research_ai/tests/expert_finder/test_profile_match.py
@@ -1,0 +1,39 @@
+from unittest import TestCase
+
+from research_ai.prompts.expert_finder_prompts import build_profile_match_user_prompt
+from research_ai.services.expert_finder.profile_match import parse_profile_match_response
+
+
+class ProfileMatchPromptTests(TestCase):
+    def test_build_profile_match_user_prompt_lists_candidates(self):
+        prompt = build_profile_match_user_prompt(
+            expert_name="Robert M. Cox",
+            academic_title="Assistant Professor",
+            affiliation="Georgia State University",
+            expertise="virology",
+            email="rcox@gsu.edu",
+            notes="",
+            profile_kind="x",
+            candidates=[
+                {
+                    "url": "https://x.com/wrong",
+                    "title": "Robert Cox",
+                    "description": "Sports",
+                },
+                {
+                    "url": "https://x.com/right",
+                    "title": "Robert Cox GSU",
+                    "description": "Assistant Professor",
+                },
+            ],
+        )
+        self.assertIn("Robert M. Cox", prompt)
+        self.assertIn("Georgia State University", prompt)
+        self.assertIn("1. title:", prompt)
+        self.assertIn("https://x.com/right", prompt)
+        self.assertIn('{"selected_index":', prompt)
+
+    def test_parse_accepts_fenced_json(self):
+        candidates = [{"url": "https://x.com/a", "title": "", "description": ""}]
+        raw = 'Here you go:\n```json\n{"selected_index": 1}\n```'
+        self.assertEqual(parse_profile_match_response(raw, candidates), "https://x.com/a")

--- a/src/research_ai/tests/expert_finder/test_source_enrichment.py
+++ b/src/research_ai/tests/expert_finder/test_source_enrichment.py
@@ -321,17 +321,16 @@ class SourceEnrichmentServiceTests(TestCase):
 
     def test_enrich_experts_respects_web_search_budget(self):
         # Arrange
-        experts = []
-        for i in range(3):
-            experts.append(
-                Expert.objects.create(
-                    email=f"e{i}@uni.edu",
-                    first_name="Ada",
-                    last_name=f"Lovelace{i}",
-                    affiliation="Uni",
-                    sources=[],
-                )
+        experts = [
+            Expert.objects.create(
+                email=f"e{i}@uni.edu",
+                first_name="Ada",
+                last_name=f"Lovelace{i}",
+                affiliation="Uni",
+                sources=[],
             )
+            for i in range(3)
+        ]
         web = MagicMock()
         web.configured = True
         web.search.return_value = [

--- a/src/research_ai/tests/expert_finder/test_source_enrichment.py
+++ b/src/research_ai/tests/expert_finder/test_source_enrichment.py
@@ -1,0 +1,350 @@
+from unittest import TestCase as UnitTestCase
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from research_ai.models import Expert
+from research_ai.services.expert_finder.profile_match import parse_profile_match_response
+from research_ai.services.expert_finder.source_enrichment import (
+    SourceEnrichmentService,
+    build_web_profile_query,
+    canonicalize_scholar_url,
+    canonicalize_sources_for_expert,
+    collect_profile_candidates,
+    dedupe_sources_one_per_kind,
+    merge_sources,
+    source_kinds_present,
+)
+
+
+def _empty_web_search():
+    client = MagicMock()
+    client.configured = False
+    client.search.return_value = []
+    return client
+
+
+def _web_search_with_results(results_by_query: dict[str, list[dict]]):
+    client = MagicMock()
+    client.configured = True
+
+    def _search(query: str, *, count: int = 5):
+        return list(results_by_query.get(query, []))
+
+    client.search.side_effect = _search
+    return client
+
+
+def _judge_picks_first():
+    judge = MagicMock()
+
+    def _pick(*, expert, kind, candidates):
+        return candidates[0]["url"] if candidates else None
+
+    judge.pick.side_effect = _pick
+    return judge
+
+
+class SourceLinkHelpersTests(UnitTestCase):
+    def test_merge_sources_dedupes_urls(self):
+        existing = [{"text": "Faculty", "url": "https://example.edu/jane"}]
+        merged = merge_sources(
+            existing,
+            [
+                {"text": "LinkedIn", "url": "https://www.linkedin.com/in/jane/"},
+                {"text": "LinkedIn", "url": "https://www.linkedin.com/in/jane"},
+            ],
+        )
+        self.assertEqual(len(merged), 2)
+        self.assertEqual(merged[1]["url"], "https://www.linkedin.com/in/jane/")
+
+    def test_source_kinds_present(self):
+        kinds = source_kinds_present(
+            [
+                {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0097"},
+                {"text": "X", "url": "https://x.com/jane"},
+                {
+                    "text": "Google Scholar",
+                    "url": "https://scholar.google.com/citations?user=ABCD1234",
+                },
+            ]
+        )
+        self.assertEqual(kinds, {"orcid", "x", "google_scholar"})
+
+    def test_canonicalize_scholar_url(self):
+        self.assertEqual(
+            canonicalize_scholar_url(
+                "https://scholar.google.co.uk/citations?hl=en&user=ABCD1234"
+                "&view_op=list_works"
+            ),
+            "https://scholar.google.com/citations?user=ABCD1234",
+        )
+        self.assertIsNone(
+            canonicalize_scholar_url("https://scholar.google.com/scholar?q=jane")
+        )
+
+    def test_build_search_queries(self):
+        self.assertEqual(
+            build_web_profile_query(
+                "linkedin",
+                "Brian Gowen",
+                "Research Professor",
+                "Utah State University",
+            ),
+            "Brian Gowen Research Professor Utah State University linkedin",
+        )
+        self.assertEqual(
+            build_web_profile_query("x", "Jane Doe", "Associate Professor", "MIT"),
+            "Jane Doe Associate Professor MIT twitter",
+        )
+        self.assertEqual(
+            build_web_profile_query(
+                "google_scholar",
+                "Brian Gowen",
+                "Research Professor",
+                "Utah State University",
+            ),
+            "Brian Gowen Research Professor Utah State University google scholar",
+        )
+
+    def test_collect_profile_candidates_limits_and_skips_non_profiles(self):
+        results = [
+            {
+                "title": "News",
+                "url": "https://example.edu/news/jane",
+                "description": "",
+            },
+            {
+                "title": "Jane Doe | LinkedIn",
+                "url": "https://www.linkedin.com/in/jane-doe/",
+                "description": "MIT",
+            },
+            {
+                "title": "Other | LinkedIn",
+                "url": "https://www.linkedin.com/in/other/",
+                "description": "",
+            },
+            {
+                "title": "Third | LinkedIn",
+                "url": "https://www.linkedin.com/in/third/",
+                "description": "",
+            },
+            {
+                "title": "Fourth | LinkedIn",
+                "url": "https://www.linkedin.com/in/fourth/",
+                "description": "",
+            },
+        ]
+        candidates = collect_profile_candidates(results, kind="linkedin", limit=3)
+        self.assertEqual(
+            [c["url"] for c in candidates],
+            [
+                "https://www.linkedin.com/in/jane-doe",
+                "https://www.linkedin.com/in/other",
+                "https://www.linkedin.com/in/third",
+            ],
+        )
+
+    def test_dedupe_sources_one_per_kind(self):
+        sources = [
+            {"text": "Faculty", "url": "https://mit.edu/jane"},
+            {"text": "X", "url": "https://x.com/janedoe"},
+            {"text": "X", "url": "https://x.com/MIT"},
+            {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0097"},
+            {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0098"},
+        ]
+        deduped = dedupe_sources_one_per_kind(sources)
+        self.assertEqual(len(deduped), 3)
+        self.assertEqual(source_kinds_present(deduped), {"x", "orcid"})
+
+    def test_canonicalize_sources_keeps_first_per_kind(self):
+        cleaned = canonicalize_sources_for_expert(
+            [
+                {"text": "X", "url": "https://x.com/MIT"},
+                {"text": "X", "url": "https://x.com/janedoe"},
+                {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0097"},
+                {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0098"},
+            ]
+        )
+        self.assertEqual(
+            cleaned,
+            [
+                {"text": "X", "url": "https://x.com/MIT"},
+                {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0097"},
+            ],
+        )
+
+    def test_parse_profile_match_response(self):
+        candidates = [
+            {"url": "https://x.com/wrong", "title": "A", "description": ""},
+            {"url": "https://x.com/right", "title": "B", "description": ""},
+        ]
+        self.assertEqual(
+            parse_profile_match_response('{"selected_index": 2}', candidates),
+            "https://x.com/right",
+        )
+        self.assertIsNone(
+            parse_profile_match_response('{"selected_index": null}', candidates)
+        )
+        self.assertIsNone(
+            parse_profile_match_response('{"selected_index": 9}', candidates)
+        )
+
+
+class SourceEnrichmentServiceTests(TestCase):
+    def test_enrich_expert_preserves_initial_sources_without_page_scan(self):
+        # Arrange
+        expert = Expert.objects.create(
+            email="jane@mit.edu",
+            first_name="Jane",
+            last_name="Doe",
+            affiliation="MIT",
+            sources=[
+                {"text": "Faculty page", "url": "https://mit.edu/jane"},
+                {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0097"},
+            ],
+        )
+
+        # Act
+        changed = SourceEnrichmentService(
+            web_search=_empty_web_search(),
+            profile_judge=MagicMock(),
+        ).enrich_expert(expert)
+
+        # Assert
+        self.assertFalse(changed)
+        expert.refresh_from_db()
+        self.assertEqual(
+            source_kinds_present(expert.sources),
+            {"orcid"},
+        )
+
+    def test_enrich_expert_web_searches_linkedin_x_and_scholar(self):
+        # Arrange
+        expert = Expert.objects.create(
+            email="jane@mit.edu",
+            first_name="Jane",
+            middle_name="Q",
+            last_name="Doe",
+            academic_title="Associate Professor",
+            affiliation="MIT",
+            sources=[{"text": "Faculty page", "url": "https://mit.edu/jane"}],
+        )
+        linkedin_q = build_web_profile_query(
+            "linkedin", "Jane Q Doe", "Associate Professor", "MIT"
+        )
+        x_q = build_web_profile_query(
+            "x", "Jane Q Doe", "Associate Professor", "MIT"
+        )
+        scholar_q = build_web_profile_query(
+            "google_scholar", "Jane Q Doe", "Associate Professor", "MIT"
+        )
+        web = _web_search_with_results(
+            {
+                linkedin_q: [
+                    {
+                        "title": "Jane Doe - MIT | LinkedIn",
+                        "url": "https://www.linkedin.com/in/jane-doe",
+                        "description": "Professor at MIT",
+                    }
+                ],
+                x_q: [
+                    {
+                        "title": "Wrong person",
+                        "url": "https://x.com/othercox",
+                        "description": "Unrelated",
+                    },
+                    {
+                        "title": "Jane Doe (@janedoe) / X",
+                        "url": "https://x.com/janedoe",
+                        "description": "Neuroscientist at MIT",
+                    },
+                ],
+                scholar_q: [
+                    {
+                        "title": "Jane Doe - Google Scholar",
+                        "url": "https://scholar.google.com/citations?user=ABCD1234&hl=en",
+                        "description": "MIT",
+                    }
+                ],
+            }
+        )
+        judge = MagicMock()
+
+        def _pick(*, expert, kind, candidates):
+            if kind == "x":
+                return "https://x.com/janedoe"
+            return candidates[0]["url"]
+
+        judge.pick.side_effect = _pick
+
+        # Act
+        changed = SourceEnrichmentService(
+            web_search=web,
+            profile_judge=judge,
+        ).enrich_expert(expert)
+
+        # Assert
+        self.assertTrue(changed)
+        expert.refresh_from_db()
+        self.assertEqual(
+            source_kinds_present(expert.sources),
+            {"linkedin", "x", "google_scholar"},
+        )
+        self.assertEqual(web.search.call_count, 3)
+        self.assertEqual(judge.pick.call_count, 3)
+        x_urls = [
+            item["url"]
+            for item in expert.sources
+            if isinstance(item, dict) and "x.com/" in item.get("url", "")
+        ]
+        self.assertEqual(x_urls, ["https://x.com/janedoe"])
+
+    def test_enrich_experts_respects_web_search_budget(self):
+        # Arrange
+        experts = []
+        for i in range(3):
+            experts.append(
+                Expert.objects.create(
+                    email=f"e{i}@uni.edu",
+                    first_name="Ada",
+                    last_name=f"Lovelace{i}",
+                    affiliation="Uni",
+                    sources=[],
+                )
+            )
+        web = MagicMock()
+        web.configured = True
+        web.search.return_value = [
+            {
+                "title": "Ada Lovelace0 | LinkedIn",
+                "url": "https://www.linkedin.com/in/ada0",
+                "description": "",
+            }
+        ]
+        service = SourceEnrichmentService(
+            web_search=web,
+            profile_judge=_judge_picks_first(),
+            max_web_searches=2,
+        )
+
+        # Act
+        service.enrich_experts(experts)
+
+        # Assert
+        self.assertEqual(web.search.call_count, 2)
+
+    def test_enrich_expert_noop_when_nothing_found(self):
+        expert = Expert.objects.create(
+            email="safe@uni.edu",
+            first_name="Safe",
+            last_name="User",
+            sources=[{"text": "Faculty", "url": "https://uni.edu/safe"}],
+        )
+        service = SourceEnrichmentService(
+            web_search=_empty_web_search(),
+            profile_judge=MagicMock(),
+        )
+        self.assertFalse(service.enrich_expert(expert))
+        expert.refresh_from_db()
+        self.assertEqual(len(expert.sources), 1)

--- a/src/research_ai/tests/expert_finder/test_source_enrichment.py
+++ b/src/research_ai/tests/expert_finder/test_source_enrichment.py
@@ -13,8 +13,8 @@ from research_ai.services.expert_finder.source_enrichment import (
     canonicalize_scholar_url,
     canonicalize_sources_for_expert,
     collect_profile_candidates,
-    dedupe_sources_one_per_kind,
     merge_sources,
+    source_kind_for_url,
     source_kinds_present,
 )
 
@@ -40,7 +40,7 @@ def _web_search_with_results(results_by_query: dict[str, list[dict]]):
 def _judge_picks_first():
     judge = MagicMock()
 
-    def _pick(*, expert, kind, candidates):
+    def _pick(*, expert, kind, candidates, expert_name=None):
         return candidates[0]["url"] if candidates else None
 
     judge.pick.side_effect = _pick
@@ -147,7 +147,26 @@ class SourceLinkHelpersTests(UnitTestCase):
             ],
         )
 
-    def test_dedupe_sources_one_per_kind(self):
+    def test_source_kind_for_url_uses_host_not_substring(self):
+        self.assertEqual(
+            source_kind_for_url("https://x.com/jane"),
+            "x",
+        )
+        self.assertEqual(
+            source_kind_for_url("https://twitter.com/jane"),
+            "x",
+        )
+        self.assertIsNone(
+            source_kind_for_url("https://example.edu/blog/about-x.com/jane")
+        )
+        self.assertIsNone(source_kind_for_url("https://notlinkedin.com/in/jane"))
+        self.assertEqual(
+            source_kind_for_url("https://uk.linkedin.com/in/jane"),
+            "linkedin",
+        )
+        self.assertIsNone(source_kind_for_url("https://www.linkedin.com/company/acme"))
+
+    def test_canonicalize_sources_keeps_first_per_kind(self):
         sources = [
             {"text": "Faculty", "url": "https://mit.edu/jane"},
             {"text": "X", "url": "https://x.com/janedoe"},
@@ -155,21 +174,18 @@ class SourceLinkHelpersTests(UnitTestCase):
             {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0097"},
             {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0098"},
         ]
-        deduped = dedupe_sources_one_per_kind(sources)
-        self.assertEqual(len(deduped), 3)
-        self.assertEqual(source_kinds_present(deduped), {"x", "orcid"})
-
-    def test_canonicalize_sources_keeps_first_per_kind(self):
-        cleaned = canonicalize_sources_for_expert(
-            [
-                {"text": "X", "url": "https://x.com/MIT"},
-                {"text": "X", "url": "https://x.com/janedoe"},
-                {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0097"},
-                {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0098"},
-            ]
-        )
+        cleaned = canonicalize_sources_for_expert(sources)
+        self.assertEqual(len(cleaned), 3)
+        self.assertEqual(source_kinds_present(cleaned), {"x", "orcid"})
         self.assertEqual(
-            cleaned,
+            canonicalize_sources_for_expert(
+                [
+                    {"text": "X", "url": "https://x.com/MIT"},
+                    {"text": "X", "url": "https://x.com/janedoe"},
+                    {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0097"},
+                    {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0098"},
+                ]
+            ),
             [
                 {"text": "X", "url": "https://x.com/MIT"},
                 {"text": "ORCID", "url": "https://orcid.org/0000-0002-1825-0097"},
@@ -271,7 +287,7 @@ class SourceEnrichmentServiceTests(TestCase):
         )
         judge = MagicMock()
 
-        def _pick(*, expert, kind, candidates):
+        def _pick(*, expert, kind, candidates, expert_name=None):
             if kind == "x":
                 return "https://x.com/janedoe"
             return candidates[0]["url"]
@@ -293,10 +309,13 @@ class SourceEnrichmentServiceTests(TestCase):
         )
         self.assertEqual(web.search.call_count, 3)
         self.assertEqual(judge.pick.call_count, 3)
+        for call in judge.pick.call_args_list:
+            self.assertEqual(call.kwargs.get("expert_name"), "Jane Q Doe")
         x_urls = [
             item["url"]
             for item in expert.sources
-            if isinstance(item, dict) and "x.com/" in item.get("url", "")
+            if isinstance(item, dict)
+            and source_kind_for_url(item.get("url", "")) == "x"
         ]
         self.assertEqual(x_urls, ["https://x.com/janedoe"])
 

--- a/src/research_ai/tests/expert_finder/test_source_enrichment.py
+++ b/src/research_ai/tests/expert_finder/test_source_enrichment.py
@@ -4,7 +4,9 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 
 from research_ai.models import Expert
-from research_ai.services.expert_finder.profile_match import parse_profile_match_response
+from research_ai.services.expert_finder.profile_match import (
+    parse_profile_match_response,
+)
 from research_ai.services.expert_finder.source_enrichment import (
     SourceEnrichmentService,
     build_web_profile_query,
@@ -233,9 +235,7 @@ class SourceEnrichmentServiceTests(TestCase):
         linkedin_q = build_web_profile_query(
             "linkedin", "Jane Q Doe", "Associate Professor", "MIT"
         )
-        x_q = build_web_profile_query(
-            "x", "Jane Q Doe", "Associate Professor", "MIT"
-        )
+        x_q = build_web_profile_query("x", "Jane Q Doe", "Associate Professor", "MIT")
         scholar_q = build_web_profile_query(
             "google_scholar", "Jane Q Doe", "Associate Professor", "MIT"
         )


### PR DESCRIPTION
## Summary
- Enrich expert sources after finder persist with Brave web search for personal LinkedIn, X, and Google Scholar profiles (name + title + affiliation queries).
- Use a Bedrock profile-match step to choose among top Brave candidates so we don’t save university handles or wrong same-name profiles.
