### PR TITLE
Add email unsubscribe endpoint

### DIFF
--- a/src/mailing_list/serializers.py
+++ b/src/mailing_list/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+
+class EmailUnsubscribeSerializer(serializers.Serializer):
+    """
+    Used to validate the payload for unsubscribing an email using a signed code.
+    """
+
+    code = serializers.CharField(allow_blank=False, trim_whitespace=False)

--- a/src/mailing_list/services/__init__.py
+++ b/src/mailing_list/services/__init__.py
@@ -1,0 +1,6 @@
+from mailing_list.services.email_subscription_service import (
+    EmailSubscriptionService,
+    InvalidUnsubscribeCodeError,
+)
+
+__all__ = ["EmailSubscriptionService", "InvalidUnsubscribeCodeError"]

--- a/src/mailing_list/services/email_subscription_service.py
+++ b/src/mailing_list/services/email_subscription_service.py
@@ -1,0 +1,85 @@
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from django.conf import settings
+from django.core import signing
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+
+from mailing_list.models import EmailOptOut
+
+
+class InvalidUnsubscribeCodeError(ValueError):
+    """Raised when an unsubscribe code is invalid."""
+
+
+class EmailSubscriptionService:
+    """
+    Manage email subscription preferences and signed action codes.
+    """
+
+    def __init__(
+        self,
+        frontend_url: str | None = None,
+    ):
+        self._frontend_url = frontend_url or (
+            f"{settings.BASE_FRONTEND_URL.rstrip('/')}/email/unsubscribe/"
+        )
+
+    def _generate_unsubscribe_code(self, email: str) -> str:
+        """
+        Return a signed unsubscribe code for the given email address.
+        """
+        normalized_email = self._validate_and_normalize_email(email)
+        return signing.dumps(
+            {"email": normalized_email},
+            compress=True,
+        )
+
+    def generate_unsubscribe_url(self, email: str) -> str:
+        """
+        Return the frontend unsubscribe URL for the given email address.
+        """
+        code = self._generate_unsubscribe_code(email)
+        parts = urlsplit(self._frontend_url)
+        query = [
+            (key, value)
+            for key, value in parse_qsl(parts.query, keep_blank_values=True)
+            if key != "code"
+        ]
+        query.append(("code", code))
+        return urlunsplit(
+            (parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment)
+        )
+
+    def _read_unsubscribe_code(self, code: str) -> str:
+        """
+        Return the normalized email address carried by a trusted code.
+        """
+        try:
+            payload = signing.loads(code)
+            if not isinstance(payload, dict):
+                raise InvalidUnsubscribeCodeError("Invalid unsubscribe code")
+
+            return self._validate_and_normalize_email(payload.get("email"))
+        except (
+            signing.BadSignature,
+            ValidationError,
+            TypeError,
+            AttributeError,
+        ) as error:
+            raise InvalidUnsubscribeCodeError("Invalid unsubscribe code") from error
+
+    def unsubscribe(self, code: str) -> bool:
+        """
+        Opt out the address carried by a signed code.
+
+        Returns whether a new opt-out record was created.
+        """
+        email = self._read_unsubscribe_code(code)
+        return EmailOptOut.add(email)
+
+    @staticmethod
+    def _validate_and_normalize_email(email: str | None) -> str:
+        normalized_email = EmailOptOut._normalize(email)
+        validate_email(normalized_email)
+        return normalized_email

--- a/src/mailing_list/tests/test_email_subscription_service.py
+++ b/src/mailing_list/tests/test_email_subscription_service.py
@@ -1,0 +1,117 @@
+from urllib.parse import parse_qs, urlsplit
+
+from django.core import signing
+from django.test import TestCase
+
+from mailing_list.models import EmailOptOut
+from mailing_list.services.email_subscription_service import (
+    EmailSubscriptionService,
+    InvalidUnsubscribeCodeError,
+)
+
+EMAIL = "reader@example.com"
+
+
+def _unsubscribe_code(service: EmailSubscriptionService, email: str = EMAIL) -> str:
+    url = service.generate_unsubscribe_url(email)
+    return parse_qs(urlsplit(url).query)["code"][0]
+
+
+class GenerateCodeTests(TestCase):
+    def setUp(self):
+        self.service = EmailSubscriptionService()
+
+    def test_code_round_trips_a_normalized_email(self):
+        # Arrange
+        code = _unsubscribe_code(self.service, " Reader@Example.COM ")
+
+        # Act
+        self.service.unsubscribe(code)
+
+        # Assert
+        self.assertTrue(EmailOptOut.objects.filter(email=EMAIL).exists())
+
+    def test_codes_differ_between_addresses(self):
+        # Act
+        first = _unsubscribe_code(self.service, EMAIL)
+        second = _unsubscribe_code(self.service, "other@example.com")
+
+        # Assert
+        self.assertNotEqual(first, second)
+
+
+class GenerateUrlTests(TestCase):
+    def test_url_points_to_the_frontend_and_carries_the_code(self):
+        # Arrange
+        service = EmailSubscriptionService(
+            frontend_url="https://www.example.com/email/unsubscribe/"
+        )
+
+        # Act
+        url = service.generate_unsubscribe_url(EMAIL)
+
+        # Assert
+        parsed_url = urlsplit(url)
+        code = parse_qs(parsed_url.query)["code"][0]
+        self.assertEqual(
+            f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}",
+            "https://www.example.com/email/unsubscribe/",
+        )
+        self.assertTrue(code)
+        self.assertNotIn("email=", url)
+
+    def test_preserves_existing_query_parameters(self):
+        # Arrange
+        service = EmailSubscriptionService(
+            frontend_url="https://www.example.com/email/unsubscribe/?source=email"
+        )
+
+        # Act
+        url = service.generate_unsubscribe_url(EMAIL)
+
+        # Assert
+        self.assertEqual(parse_qs(urlsplit(url).query)["source"], ["email"])
+
+
+class ReadCodeTests(TestCase):
+    def setUp(self):
+        self.service = EmailSubscriptionService()
+
+    def test_rejects_a_malformed_code(self):
+        # Act & Assert
+        with self.assertRaises(InvalidUnsubscribeCodeError):
+            self.service.unsubscribe("not-a-code")
+
+    def test_rejects_a_signed_payload_without_a_valid_email(self):
+        # Arrange
+        service = EmailSubscriptionService()
+        code = signing.dumps({"email": "not-an-email"})
+
+        # Act & Assert
+        with self.assertRaises(InvalidUnsubscribeCodeError):
+            service.unsubscribe(code)
+
+
+class UnsubscribeTests(TestCase):
+    def setUp(self):
+        self.service = EmailSubscriptionService()
+        self.code = _unsubscribe_code(self.service)
+
+    def test_creates_an_email_opt_out(self):
+        # Act
+        created = self.service.unsubscribe(self.code)
+
+        # Assert
+        self.assertTrue(created)
+        self.assertTrue(EmailOptOut.objects.filter(email=EMAIL).exists())
+
+    def test_is_idempotent(self):
+        # Arrange
+        self.service.unsubscribe(self.code)
+
+        # Act
+        created = self.service.unsubscribe(self.code)
+
+        # Assert
+        self.assertFalse(created)
+        self.assertEqual(EmailOptOut.objects.count(), 1)

--- a/src/mailing_list/tests/test_email_unsubscribe_view.py
+++ b/src/mailing_list/tests/test_email_unsubscribe_view.py
@@ -1,0 +1,75 @@
+from urllib.parse import parse_qs, urlencode, urlsplit
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from mailing_list.models import EmailOptOut
+from mailing_list.services import EmailSubscriptionService
+
+EMAIL = "reader@example.com"
+
+
+class EmailUnsubscribeViewTests(APITestCase):
+    def setUp(self):
+        self.url = reverse("email_unsubscribe")
+        unsubscribe_url = EmailSubscriptionService().generate_unsubscribe_url(EMAIL)
+        self.code = parse_qs(urlsplit(unsubscribe_url).query)["code"][0]
+
+    def test_opts_out_from_a_json_body(self):
+        # Act
+        response = self.client.post(self.url, {"code": self.code}, format="json")
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"detail": "Email address unsubscribed."})
+        self.assertTrue(EmailOptOut.objects.filter(email=EMAIL).exists())
+
+    def test_one_click_post_reads_the_code_from_the_query_string(self):
+        # Arrange
+        url = f"{self.url}?{urlencode({'code': self.code})}"
+
+        # Act
+        response = self.client.post(
+            url,
+            "List-Unsubscribe=One-Click",
+            content_type="application/x-www-form-urlencoded",
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(EmailOptOut.objects.filter(email=EMAIL).exists())
+
+    def test_repeated_unsubscribe_stays_successful(self):
+        # Arrange
+        EmailOptOut.add(EMAIL)
+
+        # Act
+        response = self.client.post(self.url, {"code": self.code}, format="json")
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(EmailOptOut.objects.count(), 1)
+
+    def test_rejects_invalid_code(self):
+        # Arrange
+        invalid_code = "invalid-code"
+
+        # Act
+        response = self.client.post(
+            self.url,
+            {"code": invalid_code},
+            format="json",
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(EmailOptOut.objects.count(), 0)
+
+    def test_rejects_a_request_without_a_code(self):
+        # Act
+        response = self.client.post(self.url, {}, format="json")
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(EmailOptOut.objects.count(), 0)

--- a/src/mailing_list/views/__init__.py
+++ b/src/mailing_list/views/__init__.py
@@ -1,0 +1,3 @@
+from mailing_list.views.email_unsubscribe_view import EmailUnsubscribeView
+
+__all__ = ["EmailUnsubscribeView"]

--- a/src/mailing_list/views/email_unsubscribe_view.py
+++ b/src/mailing_list/views/email_unsubscribe_view.py
@@ -1,0 +1,55 @@
+from typing import override
+
+from rest_framework import serializers, status
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from mailing_list.serializers import EmailUnsubscribeSerializer
+from mailing_list.services import EmailSubscriptionService, InvalidUnsubscribeCodeError
+
+
+class EmailUnsubscribeView(APIView):
+    """
+    Endpoint for unsubscribing an email address using a signed code.
+    """
+
+    authentication_classes = []
+    permission_classes = [AllowAny]
+    serializer_class = EmailUnsubscribeSerializer
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._subscription_service = EmailSubscriptionService()
+
+    def post(self, request: Request) -> Response:
+        payload = self._request_payload(request)
+        serializer = self.serializer_class(data=payload)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            self._subscription_service.unsubscribe(serializer.validated_data["code"])
+        except InvalidUnsubscribeCodeError as e:
+            raise serializers.ValidationError(
+                {"code": ["Invalid unsubscribe code."]}
+            ) from e
+
+        return Response(
+            {"detail": "Email address unsubscribed."},
+            status=status.HTTP_200_OK,
+        )
+
+    @staticmethod
+    def _request_payload(request: Request) -> dict:
+        """
+        Read the code from JSON/form data or the query string.
+
+        One-click unsubscribe clients POST an otherwise unrelated form body to
+        the URL from the List-Unsubscribe header, so the code may live in the
+        query string.
+        """
+        payload = dict(request.data.items()) if hasattr(request.data, "items") else {}
+        if "code" not in payload and request.query_params.get("code"):
+            payload["code"] = request.query_params["code"]
+        return payload

--- a/src/mailing_list/views/email_unsubscribe_view.py
+++ b/src/mailing_list/views/email_unsubscribe_view.py
@@ -1,5 +1,3 @@
-from typing import override
-
 from rest_framework import serializers, status
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request

--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -40,6 +40,7 @@ from feed.views import (
     JournalV2FeedViewSet,
     ModeratorFeedViewSet,
 )
+from mailing_list.views import EmailUnsubscribeView
 from orcid.views import OrcidCallbackView, OrcidConnectView, OrcidFetchView
 from organizations.views import NonprofitFundraiseLinkViewSet, NonprofitOrgViewSet
 from paper.views import paper_upload_views
@@ -199,6 +200,11 @@ urlpatterns = [
         "api/researchhubpost/create_registered_report_draft/",
         researchhub_document_views.RegisteredReportDraftView.as_view(),
         name="registered-report-draft",
+    ),
+    path(
+        "api/email/unsubscribe/",
+        EmailUnsubscribeView.as_view(),
+        name="email_unsubscribe",
     ),
     re_path(r"^api/", include(router.urls)),
     # Nested routes for list items


### PR DESCRIPTION
Add a new endpoint to allow unsubscribing email addresses via both JSON payload (proxied by the frontend) or query string (from `List-Unsubscribe` email headers).