### PR TITLE
Bugfix: Increasing image file name length for cover images

### DIFF
--- a/src/researchhub_document/migrations/0079_alter_researchhubpost_preview_img.py
+++ b/src/researchhub_document/migrations/0079_alter_researchhubpost_preview_img.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        (
+            "researchhub_document",
+            "0078_remove_researchjourney_journal_fields",
+        ),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="researchhubpost",
+            name="preview_img",
+            field=models.URLField(
+                blank=True,
+                default=None,
+                max_length=2048,
+                null=True,
+            ),
+        ),
+    ]

--- a/src/researchhub_document/related_models/researchhub_post_model.py
+++ b/src/researchhub_document/related_models/researchhub_post_model.py
@@ -159,6 +159,7 @@ class ResearchhubPost(AbstractGenericReactionModel):
     preview_img = models.URLField(
         blank=True,
         default=None,
+        max_length=2048,
         null=True,
     )
     renderable_text = models.TextField(

--- a/src/researchhub_document/tests/test_models.py
+++ b/src/researchhub_document/tests/test_models.py
@@ -230,6 +230,7 @@ class ModelTests(TestCase):
         # Assert
         self.assertEqual(markdown, "Discussion body")
 
+
 class ResearchhubPostStatusTests(TestCase):
     def setUp(self):
         self.user = create_random_default_user("post_status_user")

--- a/src/researchhub_document/tests/test_models.py
+++ b/src/researchhub_document/tests/test_models.py
@@ -11,14 +11,8 @@ from paper.tests.helpers import create_paper
 from researchhub_comment.related_models.rh_comment_model import RhCommentModel
 from researchhub_comment.tests.helpers import create_rh_comment
 from researchhub_document.helpers import create_post
-from researchhub_document.models import (
-    ResearchhubPost,
+from researchhub_document.related_models.researchhub_unified_document_model import (
     ResearchhubUnifiedDocument,
-)
-from researchhub_document.related_models.constants.document_type import (
-    GRANT,
-    PREREGISTRATION,
-    REGISTERED_REPORT,
 )
 from review.models import Review
 from user.tests.helpers import create_random_default_user
@@ -235,36 +229,6 @@ class ModelTests(TestCase):
 
         # Assert
         self.assertEqual(markdown, "Discussion body")
-
-    def test_saves_long_cover_image_urls_for_work_posts(self) -> None:
-        """Persist long cover image URLs for proposals, grants, and reports."""
-        # Arrange
-        cover_image_url = (
-            "https://storage.test.researchhub.com/uploads/posts/users/"
-            f"{self.user.id}/{'a' * 201}.png"
-        )
-        document_types = (PREREGISTRATION, GRANT, REGISTERED_REPORT)
-
-        # Act
-        posts = [
-            ResearchhubPost.objects.create(
-                created_by=self.user,
-                document_type=document_type,
-                preview_img=cover_image_url,
-                unified_document=ResearchhubUnifiedDocument.objects.create(
-                    document_type=document_type,
-                ),
-            )
-            for document_type in document_types
-        ]
-
-        # Assert
-        self.assertGreater(len(cover_image_url), 200)
-        self.assertEqual(
-            [post.preview_img for post in posts],
-            [cover_image_url] * len(document_types),
-        )
-
 
 class ResearchhubPostStatusTests(TestCase):
     def setUp(self):

--- a/src/researchhub_document/tests/test_models.py
+++ b/src/researchhub_document/tests/test_models.py
@@ -11,8 +11,14 @@ from paper.tests.helpers import create_paper
 from researchhub_comment.related_models.rh_comment_model import RhCommentModel
 from researchhub_comment.tests.helpers import create_rh_comment
 from researchhub_document.helpers import create_post
-from researchhub_document.related_models.researchhub_unified_document_model import (
+from researchhub_document.models import (
+    ResearchhubPost,
     ResearchhubUnifiedDocument,
+)
+from researchhub_document.related_models.constants.document_type import (
+    GRANT,
+    PREREGISTRATION,
+    REGISTERED_REPORT,
 )
 from review.models import Review
 from user.tests.helpers import create_random_default_user
@@ -229,6 +235,35 @@ class ModelTests(TestCase):
 
         # Assert
         self.assertEqual(markdown, "Discussion body")
+
+    def test_saves_long_cover_image_urls_for_work_posts(self) -> None:
+        """Persist long cover image URLs for proposals, grants, and reports."""
+        # Arrange
+        cover_image_url = (
+            "https://storage.test.researchhub.com/uploads/posts/users/"
+            f"{self.user.id}/{'a' * 201}.png"
+        )
+        document_types = (PREREGISTRATION, GRANT, REGISTERED_REPORT)
+
+        # Act
+        posts = [
+            ResearchhubPost.objects.create(
+                created_by=self.user,
+                document_type=document_type,
+                preview_img=cover_image_url,
+                unified_document=ResearchhubUnifiedDocument.objects.create(
+                    document_type=document_type,
+                ),
+            )
+            for document_type in document_types
+        ]
+
+        # Assert
+        self.assertGreater(len(cover_image_url), 200)
+        self.assertEqual(
+            [post.preview_img for post in posts],
+            [cover_image_url] * len(document_types),
+        )
 
 
 class ResearchhubPostStatusTests(TestCase):


### PR DESCRIPTION
## Overview ##

This PR updates the maximum image file name length for cover images on notebook publishing.