### PR TITLE
Add agent chat orchestration

### DIFF
--- a/src/research_ai/services/agent_persistence/__init__.py
+++ b/src/research_ai/services/agent_persistence/__init__.py
@@ -1,5 +1,6 @@
-"""Serialization and persistence services for the provider-neutral agent core."""
+"""Django persistence and read services for the provider-neutral agent core."""
 
+from .chat_service import AgentChatService, PreparedAgentExecution
 from .context_service import AgentContextService
 from .conversation_service import (
     AgentConversationService,
@@ -14,6 +15,7 @@ from .run_details_service import (
 )
 
 __all__ = [
+    "AgentChatService",
     "AgentContextService",
     "AgentConversationBusyError",
     "AgentConversationService",
@@ -23,4 +25,5 @@ __all__ = [
     "AgentRunDetailsService",
     "DatabaseAgentRecorder",
     "NoteAgentConversationService",
+    "PreparedAgentExecution",
 ]

--- a/src/research_ai/services/agent_persistence/__init__.py
+++ b/src/research_ai/services/agent_persistence/__init__.py
@@ -6,7 +6,11 @@ from .conversation_service import (
     AgentConversationService,
     NoteAgentConversationService,
 )
-from .execution_service import AgentConversationBusyError, AgentExecutionService
+from .execution_service import (
+    AgentConversationBusyError,
+    AgentExecutionService,
+    AgentStaleRetryError,
+)
 from .recorder import DatabaseAgentRecorder
 from .retention_service import AgentRetentionService
 from .run_details_service import (
@@ -23,6 +27,7 @@ __all__ = [
     "AgentRetentionService",
     "AgentRunDetails",
     "AgentRunDetailsService",
+    "AgentStaleRetryError",
     "DatabaseAgentRecorder",
     "NoteAgentConversationService",
     "PreparedAgentExecution",

--- a/src/research_ai/services/agent_persistence/chat_service.py
+++ b/src/research_ai/services/agent_persistence/chat_service.py
@@ -93,6 +93,12 @@ class AgentChatService:
             locked = AgentConversation.objects.select_for_update().get(
                 id=conversation.id
             )
+            # Land any answer still waiting to publish before this question
+            # takes the next sequence. Publication numbers a message when it
+            # succeeds, not when its run finished, so repairing afterwards
+            # would file the previous answer behind the question that follows
+            # it -- an order the model's own context contradicts.
+            self.repair_pending_outputs(locked)
             # A new turn continues from the latest stopped attempt as well as
             # the latest successful one: a run that failed after recording its
             # prompt still holds user-visible context, and skipping back to an
@@ -242,12 +248,11 @@ class AgentChatService:
     def repair_pending_outputs(self, conversation: AgentConversation) -> int:
         """Retry any successful chat publication that previously failed.
 
-        Two kinds of success are deliberately left unrepaired. An answer a
-        regeneration already published would append *after* the one replacing
-        it, with both active, because its replacement deactivated nothing when
-        it ran -- there was no message to deactivate. An answer with no final
-        text has nothing to publish at all, so retrying it would take write
-        locks on every read for a publication that can never succeed.
+        Two kinds of success are skipped before publication is even attempted:
+        an answer a regeneration already published, and an answer with no final
+        text. Neither can ever publish, so calling through would take two row
+        locks on every read to be refused. Publication re-checks supersession
+        under its own lock, so this pass is an optimisation, not the guarantee.
         """
         candidates = [
             execution
@@ -266,9 +271,14 @@ class AgentChatService:
             if execution.id in superseded:
                 continue
             try:
-                repaired += int(
-                    self.recorder_factory(execution).publish_assistant_output()
-                )
+                # A savepoint keeps a failed repair from poisoning a caller's
+                # transaction: prepare_turn repairs inside the lock it holds to
+                # add the next question, and swallowing a database error
+                # without one would break every write that follows.
+                with transaction.atomic():
+                    repaired += int(
+                        self.recorder_factory(execution).publish_assistant_output()
+                    )
             except Exception:  # noqa: BLE001 - reads still expose pending state
                 logger.warning(
                     "failed to repair agent response publication",

--- a/src/research_ai/services/agent_persistence/chat_service.py
+++ b/src/research_ai/services/agent_persistence/chat_service.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from django.db import transaction
+from django.db.models import Exists, OuterRef
 
 from research_ai.models import (
     AgentConversation,
@@ -25,6 +26,16 @@ from research_ai.services.agent_persistence.recorder import DatabaseAgentRecorde
 logger = logging.getLogger(__name__)
 
 RecorderFactory = Callable[..., DatabaseAgentRecorder]
+
+
+def _output_superseded() -> Exists:
+    """Match executions whose answer a regeneration has already published."""
+    return Exists(
+        AgentExecution.objects.filter(
+            replaces_output_of_id=OuterRef("pk"),
+            generated_chat_message__isnull=False,
+        )
+    )
 
 
 @dataclass(frozen=True)
@@ -78,11 +89,14 @@ class AgentChatService:
             locked = AgentConversation.objects.select_for_update().get(
                 id=conversation.id
             )
-            parent = (
-                locked.executions.filter(status=AgentExecution.Status.SUCCEEDED)
-                .order_by("-attempt")
-                .first()
-            )
+            # A new turn continues from the latest stopped attempt as well as
+            # the latest successful one: a run that failed after recording its
+            # prompt still holds user-visible context, and skipping back to an
+            # older attempt would drop it from the model's view while the chat
+            # still shows it.
+            parent = self.contexts.latest_for_continuation(locked, include_partial=True)
+            if parent is not None:
+                self.contexts.seal_interrupted_tool_calls(parent)
             context = self.contexts.reconstruct(parent) if parent else []
             human_message = self.conversations.add_human_message(locked, human_content)
             recorder = self.executions.start(
@@ -106,8 +120,15 @@ class AgentChatService:
 
     @staticmethod
     def _retry_provenance(execution: AgentExecution) -> str:
+        """Reuse the provenance the original attempt recorded for its prompt.
+
+        Only the first trace row can answer this. Trace writes are best-effort,
+        so a later row surviving on its own says nothing about who wrote the
+        prompt -- reading whichever row came first would label a human prompt
+        ``MODEL`` or ``TOOL``.
+        """
         provenance = (
-            execution.messages.order_by("execution_sequence")
+            execution.messages.filter(execution_sequence=1)
             .values_list("provenance", flat=True)
             .first()
         )
@@ -198,12 +219,15 @@ class AgentChatService:
                     execution.status == AgentExecution.Status.SUCCEEDED
                     and execution.publish_output_to_chat
                     and not hasattr(execution, "generated_chat_message")
+                    and not execution.output_superseded
                 ),
                 "error": self._public_error(execution),
             }
             for execution in conversation.executions.select_related(
                 "generated_chat_message"
-            ).order_by("attempt")
+            )
+            .annotate(output_superseded=_output_superseded())
+            .order_by("attempt")
         ]
         return {
             "conversation_id": conversation.id,
@@ -212,13 +236,24 @@ class AgentChatService:
         }
 
     def repair_pending_outputs(self, conversation: AgentConversation) -> int:
-        """Retry any successful chat publication that previously failed."""
+        """Retry any successful chat publication that previously failed.
+
+        An answer a regeneration already published is deliberately left
+        unrepaired. Its replacement deactivated nothing when it ran -- there was
+        no message to deactivate -- so publishing it now would append the
+        superseded answer *after* the one that replaced it, with both active.
+        """
         repaired = 0
-        pending = conversation.executions.filter(
-            status=AgentExecution.Status.SUCCEEDED,
-            publish_output_to_chat=True,
-            generated_chat_message__isnull=True,
-        ).order_by("attempt")
+        pending = (
+            conversation.executions.filter(
+                status=AgentExecution.Status.SUCCEEDED,
+                publish_output_to_chat=True,
+                generated_chat_message__isnull=True,
+            )
+            .annotate(output_superseded=_output_superseded())
+            .filter(output_superseded=False)
+            .order_by("attempt")
+        )
         for execution in pending:
             try:
                 repaired += int(

--- a/src/research_ai/services/agent_persistence/chat_service.py
+++ b/src/research_ai/services/agent_persistence/chat_service.py
@@ -5,7 +5,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from django.db import transaction
-from django.db.models import Exists, OuterRef
 
 from research_ai.models import (
     AgentConversation,
@@ -22,20 +21,25 @@ from research_ai.services.agent_persistence.execution_service import (
     AgentExecutionService,
 )
 from research_ai.services.agent_persistence.recorder import DatabaseAgentRecorder
+from research_ai.services.agent_persistence.replacement import (
+    superseded_execution_ids,
+)
 
 logger = logging.getLogger(__name__)
 
 RecorderFactory = Callable[..., DatabaseAgentRecorder]
 
 
-def _output_superseded() -> Exists:
-    """Match executions whose answer a regeneration has already published."""
-    return Exists(
-        AgentExecution.objects.filter(
-            replaces_output_of_id=OuterRef("pk"),
-            generated_chat_message__isnull=False,
-        )
-    )
+def _has_publishable_output(execution: AgentExecution) -> bool:
+    """Report whether a successful attempt left text the chat can show.
+
+    A run that ends on a terminal tool answers through that tool and records no
+    final text. Its result is domain output rather than conversation, so there
+    is nothing to publish and nothing to keep waiting for.
+    """
+    output = execution.final_output
+    text = output.get("text") if isinstance(output, dict) else None
+    return isinstance(text, str) and bool(text)
 
 
 @dataclass(frozen=True)
@@ -194,6 +198,7 @@ class AgentChatService:
     def representation(self, conversation: AgentConversation) -> dict:
         """Repair pending publication and return user-safe chat lifecycle data."""
         self.repair_pending_outputs(conversation)
+        superseded = superseded_execution_ids(conversation)
         messages = [
             {
                 "id": message.id,
@@ -219,15 +224,14 @@ class AgentChatService:
                     execution.status == AgentExecution.Status.SUCCEEDED
                     and execution.publish_output_to_chat
                     and not hasattr(execution, "generated_chat_message")
-                    and not execution.output_superseded
+                    and _has_publishable_output(execution)
+                    and execution.id not in superseded
                 ),
                 "error": self._public_error(execution),
             }
             for execution in conversation.executions.select_related(
                 "generated_chat_message"
-            )
-            .annotate(output_superseded=_output_superseded())
-            .order_by("attempt")
+            ).order_by("attempt")
         ]
         return {
             "conversation_id": conversation.id,
@@ -238,23 +242,29 @@ class AgentChatService:
     def repair_pending_outputs(self, conversation: AgentConversation) -> int:
         """Retry any successful chat publication that previously failed.
 
-        An answer a regeneration already published is deliberately left
-        unrepaired. Its replacement deactivated nothing when it ran -- there was
-        no message to deactivate -- so publishing it now would append the
-        superseded answer *after* the one that replaced it, with both active.
+        Two kinds of success are deliberately left unrepaired. An answer a
+        regeneration already published would append *after* the one replacing
+        it, with both active, because its replacement deactivated nothing when
+        it ran -- there was no message to deactivate. An answer with no final
+        text has nothing to publish at all, so retrying it would take write
+        locks on every read for a publication that can never succeed.
         """
-        repaired = 0
-        pending = (
-            conversation.executions.filter(
+        candidates = [
+            execution
+            for execution in conversation.executions.filter(
                 status=AgentExecution.Status.SUCCEEDED,
                 publish_output_to_chat=True,
                 generated_chat_message__isnull=True,
-            )
-            .annotate(output_superseded=_output_superseded())
-            .filter(output_superseded=False)
-            .order_by("attempt")
-        )
-        for execution in pending:
+            ).order_by("attempt")
+            if _has_publishable_output(execution)
+        ]
+        if not candidates:
+            return 0
+        superseded = superseded_execution_ids(conversation)
+        repaired = 0
+        for execution in candidates:
+            if execution.id in superseded:
+                continue
             try:
                 repaired += int(
                     self.recorder_factory(execution).publish_assistant_output()

--- a/src/research_ai/services/agent_persistence/chat_service.py
+++ b/src/research_ai/services/agent_persistence/chat_service.py
@@ -204,7 +204,20 @@ class AgentChatService:
     def representation(self, conversation: AgentConversation) -> dict:
         """Repair pending publication and return user-safe chat lifecycle data."""
         self.repair_pending_outputs(conversation)
+        # Skew here is safe in the one direction it can go: an answer published
+        # after this read is reported still pending, which costs a poll. Reading
+        # it later could not report a live answer as already superseded.
         superseded = superseded_execution_ids(conversation)
+        # One read answers both what the chat shows and what is still pending.
+        # Asking the execution rows instead would let a publication landing
+        # between the two queries report an answer as delivered while the
+        # message list that should carry it was read a moment too early.
+        chat_messages = list(conversation.chat_messages.order_by("sequence"))
+        published = {
+            message.generated_by_execution_id
+            for message in chat_messages
+            if message.generated_by_execution_id is not None
+        }
         messages = [
             {
                 "id": message.id,
@@ -213,9 +226,8 @@ class AgentChatService:
                 "content": message.content,
                 "execution_id": message.generated_by_execution_id,
             }
-            for message in conversation.chat_messages.filter(is_active=True).order_by(
-                "sequence"
-            )
+            for message in chat_messages
+            if message.is_active
         ]
         executions = [
             {
@@ -229,15 +241,13 @@ class AgentChatService:
                 "assistant_message_pending": (
                     execution.status == AgentExecution.Status.SUCCEEDED
                     and execution.publish_output_to_chat
-                    and not hasattr(execution, "generated_chat_message")
+                    and execution.id not in published
                     and _has_publishable_output(execution)
                     and execution.id not in superseded
                 ),
                 "error": self._public_error(execution),
             }
-            for execution in conversation.executions.select_related(
-                "generated_chat_message"
-            ).order_by("attempt")
+            for execution in conversation.executions.order_by("attempt")
         ]
         return {
             "conversation_id": conversation.id,

--- a/src/research_ai/services/agent_persistence/chat_service.py
+++ b/src/research_ai/services/agent_persistence/chat_service.py
@@ -1,0 +1,232 @@
+"""User-facing chat preparation and representation services."""
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from django.db import transaction
+
+from research_ai.models import (
+    AgentConversation,
+    AgentConversationMessage,
+    AgentExecution,
+    AgentExecutionMessage,
+)
+from research_ai.services.agent.types import Message
+from research_ai.services.agent_persistence.context_service import AgentContextService
+from research_ai.services.agent_persistence.conversation_service import (
+    AgentConversationService,
+)
+from research_ai.services.agent_persistence.execution_service import (
+    AgentExecutionService,
+)
+from research_ai.services.agent_persistence.recorder import DatabaseAgentRecorder
+
+logger = logging.getLogger(__name__)
+
+RecorderFactory = Callable[..., DatabaseAgentRecorder]
+
+
+@dataclass(frozen=True)
+class PreparedAgentExecution:
+    execution: AgentExecution
+    recorder: DatabaseAgentRecorder
+    human_message: AgentConversationMessage | None
+    context: list[Message]
+
+
+class AgentChatService:
+    def __init__(
+        self,
+        *,
+        conversation_service: AgentConversationService | None = None,
+        execution_service: AgentExecutionService | None = None,
+        context_service: AgentContextService | None = None,
+        recorder_factory: RecorderFactory | None = None,
+    ):
+        self.conversations = (
+            AgentConversationService()
+            if conversation_service is None
+            else conversation_service
+        )
+        self.executions = (
+            AgentExecutionService(recorder_factory=recorder_factory)
+            if execution_service is None
+            else execution_service
+        )
+        self.contexts = (
+            AgentContextService() if context_service is None else context_service
+        )
+        self.recorder_factory = (
+            getattr(self.executions, "recorder_factory", DatabaseAgentRecorder)
+            if recorder_factory is None
+            else recorder_factory
+        )
+
+    def prepare_turn(
+        self,
+        conversation: AgentConversation,
+        human_content: str,
+        *,
+        provider: str = "",
+        model: str = "",
+        configuration: dict | None = None,
+        system_prompt: str = "",
+        prompt_is_backend_composed: bool = False,
+    ) -> PreparedAgentExecution:
+        with transaction.atomic():
+            locked = AgentConversation.objects.select_for_update().get(
+                id=conversation.id
+            )
+            parent = (
+                locked.executions.filter(status=AgentExecution.Status.SUCCEEDED)
+                .order_by("-attempt")
+                .first()
+            )
+            context = self.contexts.reconstruct(parent) if parent else []
+            human_message = self.conversations.add_human_message(locked, human_content)
+            recorder = self.executions.start(
+                locked,
+                provider=provider,
+                model=model,
+                configuration=configuration,
+                system_prompt=system_prompt,
+                trigger_message=human_message,
+                context_parent=parent,
+                initial_prompt_provenance=(
+                    AgentExecutionMessage.Provenance.BACKEND
+                    if prompt_is_backend_composed
+                    else AgentExecutionMessage.Provenance.HUMAN
+                ),
+                publish_assistant_message=True,
+            )
+        return PreparedAgentExecution(
+            recorder.execution, recorder, human_message, context
+        )
+
+    @staticmethod
+    def _retry_provenance(execution: AgentExecution) -> str:
+        provenance = (
+            execution.messages.order_by("execution_sequence")
+            .values_list("provenance", flat=True)
+            .first()
+        )
+        if provenance in AgentExecutionMessage.Provenance.values:
+            return provenance
+        if execution.trigger_message_id:
+            return AgentExecutionMessage.Provenance.HUMAN
+        return AgentExecutionMessage.Provenance.BACKEND
+
+    def prepare_retry(
+        self,
+        execution: AgentExecution,
+        *,
+        configuration: dict | None = None,
+        system_prompt: str | None = None,
+        regenerate: bool = False,
+        initial_prompt_provenance: str | None = None,
+    ) -> PreparedAgentExecution:
+        context = (
+            self.contexts.reconstruct(execution.context_parent)
+            if execution.context_parent
+            else []
+        )
+        recorder = self.executions.start(
+            execution.conversation,
+            provider=execution.provider,
+            model=execution.model,
+            configuration=(
+                execution.configuration if configuration is None else configuration
+            ),
+            system_prompt=(
+                execution.system_prompt if system_prompt is None else system_prompt
+            ),
+            trigger_message=execution.trigger_message,
+            context_parent=execution.context_parent,
+            retry_of=execution,
+            initial_prompt_provenance=(
+                self._retry_provenance(execution)
+                if initial_prompt_provenance is None
+                else initial_prompt_provenance
+            ),
+            publish_assistant_message=True,
+            replaces_output_of=execution if regenerate else None,
+        )
+        return PreparedAgentExecution(
+            recorder.execution, recorder, execution.trigger_message, context
+        )
+
+    @staticmethod
+    def _public_error(execution: AgentExecution) -> dict[str, str] | None:
+        if not execution.error_type:
+            return None
+        if execution.status == AgentExecution.Status.INTERRUPTED:
+            return {
+                "code": "agent_interrupted",
+                "message": "The agent request was interrupted.",
+            }
+        return {
+            "code": "agent_failed",
+            "message": "The agent could not complete this request.",
+        }
+
+    def representation(self, conversation: AgentConversation) -> dict:
+        """Repair pending publication and return user-safe chat lifecycle data."""
+        self.repair_pending_outputs(conversation)
+        messages = [
+            {
+                "id": message.id,
+                "sequence": message.sequence,
+                "role": message.role.lower(),
+                "content": message.content,
+                "execution_id": message.generated_by_execution_id,
+            }
+            for message in conversation.chat_messages.filter(is_active=True).order_by(
+                "sequence"
+            )
+        ]
+        executions = [
+            {
+                "id": execution.id,
+                "attempt": execution.attempt,
+                "status": execution.status,
+                "trigger_message_id": execution.trigger_message_id,
+                "retry_of_id": execution.retry_of_id,
+                "context_parent_id": execution.context_parent_id,
+                "stop_reason": execution.stop_reason,
+                "assistant_message_pending": (
+                    execution.status == AgentExecution.Status.SUCCEEDED
+                    and execution.publish_output_to_chat
+                    and not hasattr(execution, "generated_chat_message")
+                ),
+                "error": self._public_error(execution),
+            }
+            for execution in conversation.executions.select_related(
+                "generated_chat_message"
+            ).order_by("attempt")
+        ]
+        return {
+            "conversation_id": conversation.id,
+            "messages": messages,
+            "executions": executions,
+        }
+
+    def repair_pending_outputs(self, conversation: AgentConversation) -> int:
+        """Retry any successful chat publication that previously failed."""
+        repaired = 0
+        pending = conversation.executions.filter(
+            status=AgentExecution.Status.SUCCEEDED,
+            publish_output_to_chat=True,
+            generated_chat_message__isnull=True,
+        ).order_by("attempt")
+        for execution in pending:
+            try:
+                repaired += int(
+                    self.recorder_factory(execution).publish_assistant_output()
+                )
+            except Exception:  # noqa: BLE001 - reads still expose pending state
+                logger.warning(
+                    "failed to repair agent response publication",
+                    exc_info=True,
+                )
+        return repaired

--- a/src/research_ai/services/agent_persistence/context_service.py
+++ b/src/research_ai/services/agent_persistence/context_service.py
@@ -1,7 +1,36 @@
 """Durable model-context reconstruction services."""
 
-from research_ai.models import AgentConversation, AgentExecution
-from research_ai.services.agent.types import Message, deserialize_messages
+from django.db import transaction
+
+from research_ai.models import AgentContextMessage, AgentConversation, AgentExecution
+from research_ai.services.agent.types import (
+    Message,
+    ToolResultBlock,
+    ToolUseBlock,
+    deserialize_messages,
+)
+from research_ai.services.agent_persistence.content import serialize_context_message
+
+INTERRUPTED_TOOL_RESULT = {
+    "type": "text",
+    "text": "The tool call did not finish because the agent run stopped.",
+}
+
+
+def _unanswered_tool_use_ids(messages: list[Message]) -> list[str]:
+    """Return tool calls in ``messages`` that no later result ever answered."""
+    answered = {
+        block.tool_use_id
+        for message in messages
+        for block in message.content
+        if isinstance(block, ToolResultBlock)
+    }
+    return [
+        block.id
+        for message in messages
+        for block in message.content
+        if isinstance(block, ToolUseBlock) and block.id not in answered
+    ]
 
 
 class AgentContextService:
@@ -30,9 +59,10 @@ class AgentContextService:
             )
         return deserialize_messages(serialized_messages)
 
-    def for_continuation(
+    def latest_for_continuation(
         self, conversation: AgentConversation, *, include_partial: bool = False
-    ) -> list[Message]:
+    ) -> AgentExecution | None:
+        """Return the execution whose durable context a new attempt extends."""
         statuses = [AgentExecution.Status.SUCCEEDED]
         if include_partial:
             # A stopped run holds durable context rows, including the human
@@ -48,9 +78,62 @@ class AgentContextService:
                     AgentExecution.Status.CANCELLED,
                 ]
             )
-        execution = (
+        return (
             conversation.executions.filter(status__in=statuses)
             .order_by("-attempt")
             .first()
         )
+
+    def for_continuation(
+        self, conversation: AgentConversation, *, include_partial: bool = False
+    ) -> list[Message]:
+        execution = self.latest_for_continuation(
+            conversation, include_partial=include_partial
+        )
         return self.reconstruct(execution) if execution else []
+
+    def seal_interrupted_tool_calls(self, execution: AgentExecution) -> int:
+        """Answer tool calls a stopped run left open, so its context can resume.
+
+        A run recorded its tool calls before dispatching them, so stopping in
+        between leaves a durable ``tool_use`` with no ``tool_result``. Providers
+        reject that pairing on replay, and the gap is permanent once a later
+        attempt chains onto these rows. Closing it with an explicit error result
+        keeps the lineage valid without editing or dropping what was recorded:
+        block order and signed reasoning must survive untouched.
+
+        Returns the number of tool calls sealed, and is a no-op when the
+        recorded context is already complete.
+        """
+        with transaction.atomic():
+            locked = AgentExecution.objects.select_for_update().get(id=execution.id)
+            unanswered = _unanswered_tool_use_ids(self.reconstruct(locked))
+            if not unanswered:
+                return 0
+            content, provider_state, is_compacted, original_size = (
+                serialize_context_message(
+                    Message(
+                        role="user",
+                        content=[
+                            ToolResultBlock(
+                                tool_use_id=tool_use_id,
+                                content=INTERRUPTED_TOOL_RESULT,
+                                is_error=True,
+                            )
+                            for tool_use_id in unanswered
+                        ],
+                    )
+                )
+            )
+            AgentContextMessage.objects.create(
+                execution=locked,
+                sequence=locked.next_context_sequence,
+                role="user",
+                content=content,
+                provider_state=provider_state,
+                is_compacted=is_compacted,
+                original_size_bytes=(original_size if is_compacted else None),
+            )
+            locked.next_context_sequence += 1
+            locked.save(update_fields=["next_context_sequence", "updated_date"])
+        return len(unanswered)

--- a/src/research_ai/services/agent_persistence/execution_service.py
+++ b/src/research_ai/services/agent_persistence/execution_service.py
@@ -21,6 +21,10 @@ class AgentConversationBusyError(RuntimeError):
     """Raised when a linear conversation already has an active execution."""
 
 
+class AgentStaleRetryError(RuntimeError):
+    """Raised when a retry targets an attempt a later turn has moved past."""
+
+
 class AgentExecutionService:
     def __init__(self, *, recorder_factory: RecorderFactory | None = None):
         self.recorder_factory = (
@@ -60,6 +64,26 @@ class AgentExecutionService:
                 "agent conversation already has an active execution"
             )
 
+    @staticmethod
+    def _ensure_retry_target_is_latest(
+        *,
+        retry_of: AgentExecution | None,
+        replaces_output_of: AgentExecution | None,
+        max_attempt: int,
+    ) -> None:
+        """Refuse to retry an attempt a later turn has already continued past.
+
+        A retry inherits its target's ``context_parent`` but takes the highest
+        attempt, and continuation reads the highest attempt. Allowing an older
+        target would make a branch that never saw the turns since canonical,
+        dropping them from the model's view while the chat still shows them.
+        """
+        for target in (retry_of, replaces_output_of):
+            if target is not None and target.attempt < max_attempt:
+                raise AgentStaleRetryError(
+                    "agent execution has been superseded by a later attempt"
+                )
+
     def _create_execution(
         self,
         conversation: AgentConversation,
@@ -93,6 +117,13 @@ class AgentExecutionService:
                     value=Max("attempt")
                 )["value"]
                 or 0
+            )
+            # Checked here, not in the caller: the lock this block holds is what
+            # keeps a turn from landing between the check and the insert.
+            self._ensure_retry_target_is_latest(
+                retry_of=retry_of,
+                replaces_output_of=replaces_output_of,
+                max_attempt=max_attempt,
             )
             timestamps = (
                 {"started_at": now, "last_activity_at": now}

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -25,6 +25,7 @@ from research_ai.services.agent_persistence.content import (
     serialize_final_output,
     serialize_trace_message,
 )
+from research_ai.services.agent_persistence.replacement import replaced_execution_ids
 
 logger = logging.getLogger(__name__)
 
@@ -378,7 +379,7 @@ class DatabaseAgentRecorder:
                 return False
             if execution.replaces_output_of_id:
                 AgentConversationMessage.objects.filter(
-                    generated_by_execution_id=execution.replaces_output_of_id
+                    generated_by_execution_id__in=replaced_execution_ids(execution)
                 ).update(is_active=False)
             _message, created = AgentConversationMessage.objects.get_or_create(
                 generated_by_execution_id=execution.id,

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -25,7 +25,10 @@ from research_ai.services.agent_persistence.content import (
     serialize_final_output,
     serialize_trace_message,
 )
-from research_ai.services.agent_persistence.replacement import replaced_execution_ids
+from research_ai.services.agent_persistence.replacement import (
+    replaced_execution_ids,
+    superseded_execution_ids,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -376,6 +379,12 @@ class DatabaseAgentRecorder:
                     final_output.get("text") if isinstance(final_output, dict) else None
                 )
             if not isinstance(text, str) or not text:
+                return False
+            # Re-read supersession here rather than trusting the caller's scan.
+            # A regeneration that publishes between that scan and this lock
+            # finds no ancestor message to deactivate, so nothing but this
+            # check stops the answer it replaced from landing behind it.
+            if execution.id in superseded_execution_ids(conversation):
                 return False
             if execution.replaces_output_of_id:
                 AgentConversationMessage.objects.filter(

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -173,6 +173,12 @@ class DatabaseAgentRecorder:
             execution = AgentExecution.objects.select_for_update().get(
                 id=self.execution.id
             )
+            # A cancellation from another process ends this run's claim on its
+            # own context. Continuing to append would land after the seal a
+            # later turn wrote to close this run's open tool calls, leaving two
+            # results for one call in a lineage providers reject on replay.
+            if _is_terminal(execution.status):
+                raise InterruptedError("agent execution is no longer running")
             AgentContextMessage.objects.create(
                 execution=execution,
                 sequence=execution.next_context_sequence,

--- a/src/research_ai/services/agent_persistence/replacement.py
+++ b/src/research_ai/services/agent_persistence/replacement.py
@@ -1,0 +1,52 @@
+"""Regeneration lineage shared by assistant-output publication and repair.
+
+Regenerations chain: C replaces B, which replaced A. Both publication and
+repair have to read that chain transitively, because a link that never
+published a message of its own supersedes nothing by itself and would
+otherwise conceal the answer behind it.
+"""
+
+from research_ai.models import AgentConversation, AgentExecution
+
+
+def _walk_replaced(
+    parents: dict[int, int | None], start_id: int, seen: set[int]
+) -> None:
+    """Collect the replacement ancestors of ``start_id`` into ``seen``."""
+    current = parents.get(start_id)
+    while current is not None and current not in seen:
+        seen.add(current)
+        current = parents.get(current)
+
+
+def replaced_execution_ids(execution: AgentExecution) -> list[int]:
+    """Return every earlier answer that publishing ``execution`` supersedes."""
+    parents = dict(
+        AgentExecution.objects.filter(
+            conversation_id=execution.conversation_id
+        ).values_list("id", "replaces_output_of_id")
+    )
+    replaced: set[int] = set()
+    _walk_replaced(parents, execution.id, replaced)
+    return list(replaced)
+
+
+def superseded_execution_ids(conversation: AgentConversation) -> set[int]:
+    """Return executions whose answer a later regeneration already published.
+
+    Walking up from each attempt that published keeps an unpublished link in
+    the chain from hiding the ancestors behind it. Deactivated messages still
+    count as published: their attempt answered, and a further regeneration has
+    since replaced it.
+    """
+    rows = list(
+        conversation.executions.values_list(
+            "id", "replaces_output_of_id", "generated_chat_message__id"
+        )
+    )
+    parents = {execution_id: parent_id for execution_id, parent_id, _ in rows}
+    superseded: set[int] = set()
+    for execution_id, _parent_id, message_id in rows:
+        if message_id is not None:
+            _walk_replaced(parents, execution_id, superseded)
+    return superseded

--- a/src/research_ai/tests/agent/test_persistence_chat.py
+++ b/src/research_ai/tests/agent/test_persistence_chat.py
@@ -8,7 +8,9 @@ from django.db import IntegrityError
 from research_ai.models import AgentExecution, AgentExecutionMessage
 from research_ai.services.agent.tools import Tool
 from research_ai.services.agent.types import (
+    AssistantTurn,
     Message,
+    StopReason,
     TextBlock,
     ToolResultBlock,
     ToolUseBlock,
@@ -174,9 +176,16 @@ class AgentChatPersistenceTests(AgentPersistenceTestCase):
         agent(FakeProvider([text_turn("Second answer")]), second.recorder).run("Second")
 
         # Act / Assert
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             representation = chat.representation(self.conversation)
         self.assertEqual(len(representation["executions"]), 2)
+
+        # A further turn must not cost another query
+        third = chat.prepare_turn(self.conversation, "Third")
+        agent(FakeProvider([text_turn("Third answer")]), third.recorder).run("Third")
+        with self.assertNumQueries(4):
+            representation = chat.representation(self.conversation)
+        self.assertEqual(len(representation["executions"]), 3)
 
     def test_regeneration_repair_replaces_prior_output_without_new_user_message(self):
         # Arrange
@@ -404,4 +413,111 @@ class AgentChatPersistenceTests(AgentPersistenceTestCase):
         self.assertEqual(
             retry.execution.messages.order_by("execution_sequence").first().provenance,
             AgentExecutionMessage.Provenance.HUMAN,
+        )
+
+    def test_regenerating_a_regeneration_hides_the_original_answer(self):
+        # Arrange: the first answer publishes, its regeneration does not
+        chat = AgentChatService()
+        original = chat.prepare_turn(self.conversation, "Question")
+        agent(FakeProvider([text_turn("Stale answer")]), original.recorder).run(
+            "Question"
+        )
+        first_regeneration = chat.prepare_retry(original.execution, regenerate=True)
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(
+                FakeProvider([text_turn("Lost answer")]), first_regeneration.recorder
+            ).run("Question")
+
+        # Act: the user regenerates again, and that attempt publishes
+        second_regeneration = chat.prepare_retry(
+            first_regeneration.execution, regenerate=True
+        )
+        agent(
+            FakeProvider([text_turn("Better answer")]), second_regeneration.recorder
+        ).run("Question")
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["Question", "Better answer"],
+        )
+
+    def test_repair_skips_an_answer_a_regeneration_chain_replaced(self):
+        # Arrange: neither the original nor its regeneration manages to publish
+        chat = AgentChatService()
+        original = chat.prepare_turn(self.conversation, "Question")
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(FakeProvider([text_turn("Stale answer")]), original.recorder).run(
+                "Question"
+            )
+            first_regeneration = chat.prepare_retry(original.execution, regenerate=True)
+            agent(
+                FakeProvider([text_turn("Lost answer")]), first_regeneration.recorder
+            ).run("Question")
+
+        # Act
+        second_regeneration = chat.prepare_retry(
+            first_regeneration.execution, regenerate=True
+        )
+        agent(
+            FakeProvider([text_turn("Better answer")]), second_regeneration.recorder
+        ).run("Question")
+        representation = chat.representation(self.conversation)
+
+        # Assert: repair must not append the original behind its replacement
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["Question", "Better answer"],
+        )
+        self.assertEqual(
+            [
+                item["assistant_message_pending"]
+                for item in representation["executions"]
+                if item["id"] != second_regeneration.execution.id
+            ],
+            [False, False],
+        )
+
+    def test_success_through_a_terminal_tool_is_never_pending(self):
+        # Arrange: a terminal tool answers, so the run records no final text
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+        submit = Tool(
+            "submit",
+            "submit",
+            {"type": "object"},
+            lambda _args: {"saved": True},
+            is_terminal=True,
+        )
+        provider = FakeProvider(
+            [
+                AssistantTurn(
+                    text_blocks=[],
+                    tool_calls=[ToolUseBlock(id="c1", name="submit", input={})],
+                    stop_reason=StopReason.TOOL_USE,
+                )
+            ]
+        )
+
+        # Act
+        result = agent(provider, prepared.recorder, [submit]).run("Question")
+        with patch.object(DatabaseAgentRecorder, "publish_assistant_output") as publish:
+            representation = chat.representation(self.conversation)
+
+        # Assert
+        self.assertEqual(result.final_text, "")
+        publish.assert_not_called()
+        self.assertFalse(representation["executions"][0]["assistant_message_pending"])
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["Question"],
         )

--- a/src/research_ai/tests/agent/test_persistence_chat.py
+++ b/src/research_ai/tests/agent/test_persistence_chat.py
@@ -7,6 +7,12 @@ from django.db import IntegrityError
 
 from research_ai.models import AgentExecution, AgentExecutionMessage
 from research_ai.services.agent.tools import Tool
+from research_ai.services.agent.types import (
+    Message,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
 from research_ai.services.agent_persistence import (
     AgentChatService,
     AgentConversationBusyError,
@@ -289,4 +295,113 @@ class AgentChatPersistenceTests(AgentPersistenceTestCase):
         self.assertEqual(
             AgentExecution.objects.get(id=pending.id).status,
             AgentExecution.Status.RUNNING,
+        )
+
+    def test_regeneration_supersedes_an_answer_that_never_published(self):
+        # Arrange: the original succeeds but its chat publication fails
+        chat = AgentChatService()
+        original = chat.prepare_turn(self.conversation, "Question")
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(FakeProvider([text_turn("Stale answer")]), original.recorder).run(
+                "Question"
+            )
+
+        # Act: the user regenerates before any read repairs the original
+        regeneration = chat.prepare_retry(original.execution, regenerate=True)
+        agent(FakeProvider([text_turn("Better answer")]), regeneration.recorder).run(
+            "Question"
+        )
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["Question", "Better answer"],
+        )
+        superseded = next(
+            item
+            for item in representation["executions"]
+            if item["id"] == original.execution.id
+        )
+        self.assertFalse(superseded["assistant_message_pending"])
+
+    def test_new_turn_keeps_the_prompt_of_a_run_that_failed(self):
+        # Arrange: the second turn fails after recording its own prompt
+        chat = AgentChatService()
+        first = chat.prepare_turn(self.conversation, "First question")
+        agent(FakeProvider([text_turn("First answer")]), first.recorder).run(
+            "First question"
+        )
+        second = chat.prepare_turn(self.conversation, "Second question")
+        with self.assertRaises(RuntimeError):
+            agent(FakeProvider([RuntimeError("provider down")]), second.recorder).run(
+                "Second question"
+            )
+
+        # Act
+        third = chat.prepare_turn(self.conversation, "Third question")
+
+        # Assert
+        self.assertEqual(third.execution.context_parent_id, second.execution.id)
+        self.assertEqual(
+            [
+                block.text
+                for message in third.context
+                for block in message.content
+                if isinstance(block, TextBlock)
+            ],
+            ["First question", "First answer", "Second question"],
+        )
+
+    def test_continuing_a_stopped_run_answers_its_open_tool_calls(self):
+        # Arrange: a run stops after recording tool calls but before their results
+        chat = AgentChatService()
+        stopped = chat.prepare_turn(self.conversation, "Interrupted question")
+        stopped.recorder.record_message(
+            Message(role="user", content=[TextBlock(text="Interrupted question")])
+        )
+        stopped.recorder.record_message(
+            Message(
+                role="assistant",
+                content=[ToolUseBlock(id="call-1", name="lookup", input={})],
+            )
+        )
+        stopped.recorder.on_run_failed(InterruptedError("worker stopped"))
+
+        # Act
+        resumed = chat.prepare_turn(self.conversation, "Next question")
+
+        # Assert
+        answered = [
+            block.tool_use_id
+            for message in resumed.context
+            for block in message.content
+            if isinstance(block, ToolResultBlock)
+        ]
+        self.assertEqual(answered, ["call-1"])
+        self.assertEqual(resumed.context[-1].role, "user")
+
+    def test_retry_ignores_later_trace_rows_when_the_prompt_row_is_lost(self):
+        # Arrange: trace rows are best-effort, so drop only the prompt row
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+        agent(FakeProvider([text_turn("Answer")]), prepared.recorder).run("Question")
+        prepared.execution.messages.filter(execution_sequence=1).delete()
+        self.assertEqual(
+            prepared.execution.messages.first().provenance,
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+
+        # Act
+        retry = chat.prepare_retry(prepared.execution)
+        agent(FakeProvider([text_turn("Recovered")]), retry.recorder).run("Question")
+
+        # Assert
+        self.assertEqual(
+            retry.execution.messages.order_by("execution_sequence").first().provenance,
+            AgentExecutionMessage.Provenance.HUMAN,
         )

--- a/src/research_ai/tests/agent/test_persistence_chat.py
+++ b/src/research_ai/tests/agent/test_persistence_chat.py
@@ -1,0 +1,292 @@
+"""User-facing chat preparation, retry, publication, and repair coverage."""
+
+import json
+from unittest.mock import patch
+
+from django.db import IntegrityError
+
+from research_ai.models import AgentExecution, AgentExecutionMessage
+from research_ai.services.agent.tools import Tool
+from research_ai.services.agent_persistence import (
+    AgentChatService,
+    AgentConversationBusyError,
+    AgentConversationService,
+    AgentExecutionService,
+    DatabaseAgentRecorder,
+)
+from research_ai.services.agent_persistence.content import (
+    MAX_TRACE_MESSAGE_BYTES,
+    json_size_bytes,
+)
+from research_ai.tests.agent.persistence_test_helpers import (
+    AgentPersistenceTestCase,
+    FakeProvider,
+    agent,
+    text_turn,
+    tool_turn,
+)
+
+
+class AgentChatPersistenceTests(AgentPersistenceTestCase):
+    def test_backend_prompt_preserves_human_text_and_chat_filters_trace(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(
+            self.conversation,
+            "What I actually typed",
+            provider="fake",
+            model="fake-model-v1",
+            prompt_is_backend_composed=True,
+        )
+        wrapped_prompt = "Notebook context:\n...\nUser: What I actually typed"
+        tool = Tool("lookup", "lookup", {"type": "object"}, lambda _args: {"secret": 1})
+        provider = FakeProvider(
+            [tool_turn("c1", "lookup", {}), text_turn("Visible answer")]
+        )
+
+        # Act
+        agent(provider, prepared.recorder, [tool]).run(wrapped_prompt)
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["What I actually typed", "Visible answer"],
+        )
+        first_trace = prepared.execution.messages.order_by("execution_sequence").first()
+        self.assertEqual(
+            first_trace.provenance, AgentExecutionMessage.Provenance.BACKEND
+        )
+        self.assertEqual(first_trace.content[0]["text"], wrapped_prompt)
+        self.assertNotIn("secret", json.dumps(representation["messages"]))
+
+    def test_retry_reuses_human_message_and_provenance(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "One human turn")
+        prepared.recorder.on_run_failed(RuntimeError("temporary failure"))
+
+        # Act
+        retry = chat.prepare_retry(prepared.execution)
+        agent(FakeProvider([text_turn("Recovered")]), retry.recorder).run(
+            "One human turn"
+        )
+
+        # Assert
+        self.assertEqual(self.conversation.chat_messages.filter(role="USER").count(), 1)
+        self.assertEqual(retry.execution.trigger_message_id, prepared.human_message.id)
+        self.assertEqual(retry.execution.retry_of_id, prepared.execution.id)
+        self.assertEqual(
+            chat.representation(self.conversation)["messages"][-1]["content"],
+            "Recovered",
+        )
+        self.assertEqual(
+            retry.execution.messages.order_by("execution_sequence").first().provenance,
+            AgentExecutionMessage.Provenance.HUMAN,
+        )
+
+    def test_failed_assistant_publication_is_repaired_from_durable_intent(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+
+        # Act
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(FakeProvider([text_turn("Durable answer")]), prepared.recorder).run(
+                "Question"
+            )
+        execution = AgentExecution.objects.get(id=prepared.execution.id)
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        self.assertEqual(execution.status, AgentExecution.Status.SUCCEEDED)
+        self.assertTrue(execution.publish_output_to_chat)
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["Question", "Durable answer"],
+        )
+        self.assertFalse(representation["executions"][0]["assistant_message_pending"])
+
+    def test_large_assistant_output_repairs_as_the_same_bounded_text(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+        huge_answer = "x" * (MAX_TRACE_MESSAGE_BYTES * 2)
+
+        # Act
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(FakeProvider([text_turn(huge_answer)]), prepared.recorder).run(
+                "Question"
+            )
+        execution = AgentExecution.objects.get(id=prepared.execution.id)
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        stored_text = execution.final_output["text"]
+        self.assertIsInstance(stored_text, str)
+        self.assertTrue(execution.final_output["_truncated"])
+        self.assertLessEqual(
+            json_size_bytes(execution.final_output), MAX_TRACE_MESSAGE_BYTES
+        )
+        self.assertEqual(representation["messages"][-1]["content"], stored_text)
+
+    def test_public_representation_does_not_expose_internal_error_message(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+        prepared.recorder.on_run_failed(
+            RuntimeError("provider secret token must not be public")
+        )
+
+        # Act
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        self.assertNotIn("secret token", json.dumps(representation))
+        self.assertEqual(
+            representation["executions"][0]["error"],
+            {
+                "code": "agent_failed",
+                "message": "The agent could not complete this request.",
+            },
+        )
+
+    def test_public_representation_fetches_assistant_links_without_n_plus_one(self):
+        # Arrange
+        chat = AgentChatService()
+        first = chat.prepare_turn(self.conversation, "First")
+        agent(FakeProvider([text_turn("First answer")]), first.recorder).run("First")
+        second = chat.prepare_turn(self.conversation, "Second")
+        agent(FakeProvider([text_turn("Second answer")]), second.recorder).run("Second")
+
+        # Act / Assert
+        with self.assertNumQueries(3):
+            representation = chat.representation(self.conversation)
+        self.assertEqual(len(representation["executions"]), 2)
+
+    def test_regeneration_repair_replaces_prior_output_without_new_user_message(self):
+        # Arrange
+        chat = AgentChatService()
+        original = chat.prepare_turn(self.conversation, "Question")
+        agent(FakeProvider([text_turn("First answer")]), original.recorder).run(
+            "Question"
+        )
+        regeneration = chat.prepare_retry(original.execution, regenerate=True)
+
+        # Act
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(
+                FakeProvider([text_turn("Better answer")]),
+                regeneration.recorder,
+            ).run("Question")
+        representation = chat.representation(self.conversation)
+
+        # Assert
+        regeneration.execution.refresh_from_db()
+        self.assertEqual(
+            regeneration.execution.replaces_output_of_id,
+            original.execution.id,
+        )
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["Question", "Better answer"],
+        )
+        self.assertEqual(self.conversation.chat_messages.filter(role="USER").count(), 1)
+
+    def test_prepare_turn_rolls_back_human_message_when_execution_start_fails(self):
+        # Arrange
+        chat = AgentChatService()
+
+        # Act / Assert
+        with (
+            patch.object(
+                AgentExecutionService,
+                "start",
+                side_effect=RuntimeError("execution insert failed"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "execution insert failed"),
+        ):
+            chat.prepare_turn(self.conversation, "Do not orphan me")
+        self.assertFalse(self.conversation.chat_messages.exists())
+
+    def test_prepare_turn_does_not_start_when_context_reconstruction_fails(self):
+        # Arrange
+        chat = AgentChatService()
+        first = chat.prepare_turn(self.conversation, "First")
+        agent(FakeProvider([text_turn("Answer")]), first.recorder).run("First")
+        message_count = self.conversation.chat_messages.count()
+        execution_count = self.conversation.executions.count()
+
+        # Act / Assert
+        with (
+            patch.object(
+                chat.contexts,
+                "reconstruct",
+                side_effect=ValueError("invalid durable context"),
+            ),
+            self.assertRaisesRegex(ValueError, "invalid durable context"),
+        ):
+            chat.prepare_turn(self.conversation, "Second")
+
+        self.assertEqual(self.conversation.chat_messages.count(), message_count)
+        self.assertEqual(self.conversation.executions.count(), execution_count)
+        self.assertFalse(
+            self.conversation.executions.filter(
+                status__in=[
+                    AgentExecution.Status.PENDING,
+                    AgentExecution.Status.RUNNING,
+                ]
+            ).exists()
+        )
+
+    def test_active_turn_blocks_a_second_linear_turn_without_new_message(self):
+        # Arrange
+        chat = AgentChatService()
+        first = chat.prepare_turn(self.conversation, "First")
+
+        # Act / Assert
+        with self.assertRaises(AgentConversationBusyError):
+            chat.prepare_turn(self.conversation, "Second")
+        self.assertEqual(self.conversation.chat_messages.count(), 1)
+        self.assertEqual(self.conversation.executions.count(), 1)
+        first.recorder.on_run_failed(InterruptedError("test cleanup"))
+
+    def test_pending_execution_is_visible_and_atomically_claimed(self):
+        # Arrange
+        human = AgentConversationService().add_human_message(
+            self.conversation, "Queued question"
+        )
+        service = AgentExecutionService()
+        pending = service.create_pending(
+            self.conversation,
+            trigger_message=human,
+            model="queued-model",
+        )
+
+        # Act
+        before = AgentChatService().representation(self.conversation)
+        recorder = service.claim_pending(pending, publish_assistant_message=True)
+        second_claim = service.claim_pending(pending)
+
+        # Assert
+        self.assertEqual(
+            before["executions"][0]["status"], AgentExecution.Status.PENDING
+        )
+        self.assertIsNotNone(recorder)
+        self.assertIsNone(second_claim)
+        self.assertEqual(
+            AgentExecution.objects.get(id=pending.id).status,
+            AgentExecution.Status.RUNNING,
+        )

--- a/src/research_ai/tests/agent/test_persistence_chat.py
+++ b/src/research_ai/tests/agent/test_persistence_chat.py
@@ -3,7 +3,7 @@
 import json
 from unittest.mock import patch
 
-from django.db import IntegrityError
+from django.db import IntegrityError, connection
 
 from research_ai.models import AgentExecution, AgentExecutionMessage
 from research_ai.services.agent.tools import Tool
@@ -520,4 +520,93 @@ class AgentChatPersistenceTests(AgentPersistenceTestCase):
         self.assertEqual(
             [message["content"] for message in representation["messages"]],
             ["Question"],
+        )
+
+    def test_next_turn_publishes_a_pending_answer_before_its_question(self):
+        # Arrange: the first answer succeeds but never reaches the chat
+        chat = AgentChatService()
+        first = chat.prepare_turn(self.conversation, "Question A")
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(FakeProvider([text_turn("Answer A")]), first.recorder).run(
+                "Question A"
+            )
+
+        # Act
+        chat.prepare_turn(self.conversation, "Question B")
+        representation = chat.representation(self.conversation)
+
+        # Assert: the recovered answer belongs to the question it answered
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]],
+            ["Question A", "Answer A", "Question B"],
+        )
+
+    def test_publication_refuses_an_answer_a_replacement_already_published(self):
+        # Arrange: a regeneration publishes while the original is still pending,
+        # so a repair scan taken beforehand still holds a stale verdict on it
+        chat = AgentChatService()
+        original = chat.prepare_turn(self.conversation, "Question")
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(FakeProvider([text_turn("Stale answer")]), original.recorder).run(
+                "Question"
+            )
+        regeneration = chat.prepare_retry(original.execution, regenerate=True)
+        agent(FakeProvider([text_turn("Better answer")]), regeneration.recorder).run(
+            "Question"
+        )
+        original.execution.refresh_from_db()
+
+        # Act
+        published = DatabaseAgentRecorder(original.execution).publish_assistant_output()
+
+        # Assert: the lock, not the caller's snapshot, settles supersession
+        self.assertFalse(published)
+        self.assertEqual(
+            [
+                message["content"]
+                for message in chat.representation(self.conversation)["messages"]
+            ],
+            ["Question", "Better answer"],
+        )
+
+    def test_repair_failure_leaves_a_new_turn_writable(self):
+        # Arrange: the answer stays pending, then its repair fails at the
+        # database level inside the transaction prepare_turn holds
+        chat = AgentChatService()
+        first = chat.prepare_turn(self.conversation, "Question A")
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(FakeProvider([text_turn("Answer A")]), first.recorder).run(
+                "Question A"
+            )
+
+        def failing_publish(self, text=None):
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 1 FROM table_that_does_not_exist")
+
+        # Act
+        with patch.object(
+            DatabaseAgentRecorder, "publish_assistant_output", failing_publish
+        ):
+            prepared = chat.prepare_turn(self.conversation, "Question B")
+
+        # Assert: the swallowed database error did not break the enclosing write
+        self.assertIsNotNone(prepared.human_message)
+        self.assertEqual(
+            [
+                message["content"]
+                for message in chat.representation(self.conversation)["messages"]
+            ],
+            ["Question A", "Question B", "Answer A"],
         )

--- a/src/research_ai/tests/agent/test_persistence_chat.py
+++ b/src/research_ai/tests/agent/test_persistence_chat.py
@@ -5,7 +5,11 @@ from unittest.mock import patch
 
 from django.db import IntegrityError, connection
 
-from research_ai.models import AgentExecution, AgentExecutionMessage
+from research_ai.models import (
+    AgentConversation,
+    AgentExecution,
+    AgentExecutionMessage,
+)
 from research_ai.services.agent.tools import Tool
 from research_ai.services.agent.types import (
     AssistantTurn,
@@ -20,6 +24,7 @@ from research_ai.services.agent_persistence import (
     AgentConversationBusyError,
     AgentConversationService,
     AgentExecutionService,
+    AgentStaleRetryError,
     DatabaseAgentRecorder,
 )
 from research_ai.services.agent_persistence.content import (
@@ -33,6 +38,21 @@ from research_ai.tests.agent.persistence_test_helpers import (
     text_turn,
     tool_turn,
 )
+
+
+class ChatMessageSnapshot:
+    """Serve chat rows as they stood before a concurrent publication."""
+
+    def __init__(self, rows):
+        self.rows = rows
+
+    def filter(self, **kwargs):
+        return ChatMessageSnapshot(
+            [row for row in self.rows if row.is_active == kwargs["is_active"]]
+        )
+
+    def order_by(self, *_fields):
+        return self.rows
 
 
 class AgentChatPersistenceTests(AgentPersistenceTestCase):
@@ -610,3 +630,107 @@ class AgentChatPersistenceTests(AgentPersistenceTestCase):
             ],
             ["Question A", "Question B", "Answer A"],
         )
+
+    def test_retry_of_a_turn_the_conversation_moved_past_is_refused(self):
+        # Arrange: a second turn answers after the first one already did
+        chat = AgentChatService()
+        first = chat.prepare_turn(self.conversation, "First question")
+        agent(FakeProvider([text_turn("First answer")]), first.recorder).run(
+            "First question"
+        )
+        second = chat.prepare_turn(self.conversation, "Second question")
+        agent(FakeProvider([text_turn("Second answer")]), second.recorder).run(
+            "Second question"
+        )
+
+        # Act / Assert: either retry would make the stale branch canonical
+        with self.assertRaises(AgentStaleRetryError):
+            chat.prepare_retry(first.execution)
+        with self.assertRaises(AgentStaleRetryError):
+            chat.prepare_retry(first.execution, regenerate=True)
+
+        # The refusal costs nothing: the next turn still sees both exchanges
+        self.assertEqual(self.conversation.executions.count(), 2)
+        third = chat.prepare_turn(self.conversation, "Third question")
+        self.assertEqual(
+            [
+                block.text
+                for message in third.context
+                for block in message.content
+                if isinstance(block, TextBlock)
+            ],
+            ["First question", "First answer", "Second question", "Second answer"],
+        )
+
+    def test_a_cancelled_run_cannot_append_context_after_its_calls_are_sealed(self):
+        # Arrange: a run records a tool call, then another process cancels it
+        # while its worker is still dispatching that call
+        chat = AgentChatService()
+        stopped = chat.prepare_turn(self.conversation, "Interrupted question")
+        stopped.recorder.record_message(
+            Message(role="user", content=[TextBlock(text="Interrupted question")])
+        )
+        stopped.recorder.record_message(
+            Message(
+                role="assistant",
+                content=[ToolUseBlock(id="call-1", name="lookup", input={})],
+            )
+        )
+        AgentExecution.objects.filter(id=stopped.execution.id).update(
+            status=AgentExecution.Status.CANCELLED
+        )
+        resumed = chat.prepare_turn(self.conversation, "Next question")
+
+        # Act: the worker returns with the result the seal already stood in for
+        with self.assertRaises(InterruptedError):
+            stopped.recorder.record_message(
+                Message(
+                    role="user",
+                    content=[
+                        ToolResultBlock(
+                            tool_use_id="call-1",
+                            content={"type": "text", "text": "late result"},
+                            is_error=False,
+                        )
+                    ],
+                )
+            )
+
+        # Assert: one call still has exactly one result
+        answered = [
+            block.tool_use_id
+            for message in chat.contexts.reconstruct(resumed.execution)
+            for block in message.content
+            if isinstance(block, ToolResultBlock)
+        ]
+        self.assertEqual(answered, ["call-1"])
+
+    def test_representation_keeps_polling_for_an_answer_it_could_not_carry(self):
+        # Arrange: the answer stays pending, then a worker publishes it after
+        # the chat rows are read -- the skew a second connection opens between
+        # two queries of one response
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+        with patch.object(
+            DatabaseAgentRecorder,
+            "publish_assistant_output",
+            side_effect=IntegrityError("chat insert failed"),
+        ):
+            agent(FakeProvider([text_turn("Answer")]), prepared.recorder).run(
+                "Question"
+            )
+        stale_rows = list(self.conversation.chat_messages.order_by("sequence"))
+        prepared.execution.refresh_from_db()
+        DatabaseAgentRecorder(prepared.execution).publish_assistant_output()
+
+        # Act
+        with patch.object(
+            AgentConversation, "chat_messages", ChatMessageSnapshot(stale_rows)
+        ):
+            representation = chat.representation(self.conversation)
+
+        # Assert: an answer this response omits is never reported as delivered
+        self.assertEqual(
+            [message["content"] for message in representation["messages"]], ["Question"]
+        )
+        self.assertTrue(representation["executions"][0]["assistant_message_pending"])


### PR DESCRIPTION
Replaces #3831 with the same commit and a fresh review timeline.

## PR order

This work is split into four layers and should be reviewed and merged in this order:

1. ✅ #3843 — Persist agent execution lifecycles (merged)
2. ✅ #3844 — Add agent conversation services (merged)
3. **#3901 — Add agent chat orchestration (this PR; merge next)**
4. #3902 — Persist proposal draft agent histories (stacked on this PR; merge last)

#3902 deliberately targets this PR's branch so its diff contains only the final proposal-draft integration.

## What changed

- Coordinate atomic user turns, execution creation, and durable context preparation.
- Preserve prompt provenance across retries and regeneration.
- Publish or repair canonical assistant messages idempotently.
- Return user-safe lifecycle errors without exposing internal provider details.
- Avoid per-execution queries when checking generated assistant messages.
- Add focused coverage for retries, publication repair, bounded output, rollback behavior, and query count.

## Why

The lower persistence layers need a user-facing orchestration boundary that composes conversations, context, executions, and assistant publication safely.

## Impact

Callers can prepare chat turns and retries, repair failed publication, and expose a stable public conversation representation without handling persistence internals.

## Validation

- Full `research_ai` suite: 649 tests passed.
- Ruff lint and formatting checks passed across `src`.
- Production files are identical to the validated pre-split implementation.
- Rebase onto current `main` verified with `git range-diff`; all four patches are unchanged.