### PR TITLE
Remove Google redirect URLs

### DIFF
--- a/src/oauth/views.py
+++ b/src/oauth/views.py
@@ -1,6 +1,5 @@
 import requests
 from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
-from allauth.socialaccount.providers.oauth2.client import OAuth2Client
 from dj_rest_auth.registration.views import SocialLoginView
 from django.conf import settings
 from rest_framework.decorators import api_view, permission_classes
@@ -40,6 +39,4 @@ def captcha_verify(request):
 # -> adaptor functions are called in "#complete_login"
 class GoogleLogin(SocialLoginView):
     adapter_class = GoogleOAuth2Adapter
-    callback_url = settings.GOOGLE_REDIRECT_URL
-    client_class = OAuth2Client
     serializer_class = SocialLoginSerializer

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -425,17 +425,6 @@ SOCIALACCOUNT_PROVIDERS = {
     },
 }
 
-
-GOOGLE_REDIRECT_URL = "http://localhost:8000/auth/google/login/callback/"
-if PRODUCTION:
-    GOOGLE_REDIRECT_URL = (
-        "https://backend.prod.researchhub.com/auth/google/login/callback/"
-    )
-if STAGING:
-    GOOGLE_REDIRECT_URL = (
-        "https://backend.staging.researchhub.com/auth/google/login/callback/"
-    )
-
 ORCID_CLIENT_ID = os.environ.get(
     "ORCID_CLIENT_ID", getattr(keys, "ORCID_CLIENT_ID", "")
 )


### PR DESCRIPTION
Remove the unused configuration settings for Google redirect URLs. The frontend is hooked up with NextAuth, which completes the authorization flow with Google itself.