### PR TITLE
Add notebook document runtime

### DIFF
--- a/src/note/services/document_engine/__init__.py
+++ b/src/note/services/document_engine/__init__.py
@@ -1,5 +1,6 @@
-"""Public schema primitives for the ResearchHub Tiptap document engine."""
+"""Public API for the ResearchHub Tiptap document engine."""
 
+from note.services.document_engine.engine import NoteDocumentEngine
 from note.services.document_engine.errors import (
     DocumentSchemaMismatch,
     InvalidDocument,
@@ -17,5 +18,6 @@ __all__ = [
     "InvalidDocument",
     "InvalidDocumentOperation",
     "LEGACY_SCHEMA_VERSION",
+    "NoteDocumentEngine",
     "SCHEMA_FINGERPRINT",
 ]

--- a/src/note/services/document_engine/editor.py
+++ b/src/note/services/document_engine/editor.py
@@ -1,0 +1,248 @@
+"""Atomic block-subtree operations for Tiptap documents."""
+
+import copy
+import json
+from collections import Counter
+
+from note.services.document_engine.errors import InvalidDocumentOperation
+from note.services.document_engine.registry import (
+    CREATABLE_TOP_LEVEL_NODES,
+    ID_CAPABLE_NODES,
+)
+from note.services.document_engine.validator import (
+    normalize_created_ids,
+    validate_created_node,
+    validate_stored_document,
+)
+
+_OPERATION_KEYS = {
+    "replace_block": frozenset({"op", "locator", "node"}),
+    "insert_after": frozenset({"op", "locator", "node"}),
+    "move_block": frozenset({"op", "locator", "after"}),
+    "delete_block": frozenset({"op", "locator"}),
+    "replace_note": frozenset({"op", "doc"}),
+}
+
+
+def apply_operations(
+    doc: dict, operations: object
+) -> tuple[dict, list[dict], list[dict]]:
+    """Apply all operations to a copy, or raise without mutating the input."""
+
+    if not isinstance(operations, list) or not operations:
+        raise InvalidDocumentOperation(
+            "operations must be a non-empty array", path="operations"
+        )
+    if (
+        any(
+            isinstance(operation, dict) and operation.get("op") == "replace_note"
+            for operation in operations
+        )
+        and len(operations) != 1
+    ):
+        raise InvalidDocumentOperation(
+            "replace_note must be the only operation in a request", path="operations"
+        )
+
+    working = copy.deepcopy(doc)
+    results = []
+    for operation_index, operation in enumerate(operations):
+        path = f"operations[{operation_index}]"
+        _validate_operation_shape(operation, path)
+        op = operation["op"]
+        if op == "replace_block":
+            result = _replace_block(working, operation, path)
+        elif op == "insert_after":
+            result = _insert_after(working, operation, path)
+        elif op == "move_block":
+            result = _move_block(working, operation, path)
+        elif op == "delete_block":
+            result = _delete_block(working, operation, path)
+        elif op == "replace_note":
+            working = _replace_note(working, operation["doc"], path=f"{path}.doc")
+            result = {"op": op, "status": "applied"}
+        else:  # Shape validation makes this unreachable.
+            raise AssertionError(f"Unhandled operation: {op}")
+        results.append({"operation_index": operation_index, **result})
+
+    normalized, id_warnings = normalize_created_ids(working)
+    validated, _changed, validation_warnings = validate_stored_document(normalized)
+    return validated, results, [*id_warnings, *validation_warnings]
+
+
+def replace_note(base_doc: dict, submitted_doc: object) -> dict:
+    """Validate full replacement with verbatim preservation for opaque blocks."""
+
+    return _replace_note(base_doc, submitted_doc, path="doc")
+
+
+def _replace_block(doc: dict, operation: dict, path: str) -> dict:
+    content = doc["content"]
+    index = _resolve_locator(content, operation["locator"], f"{path}.locator")
+    target = content[index]
+    if target["type"] not in CREATABLE_TOP_LEVEL_NODES:
+        raise InvalidDocumentOperation(
+            f"Opaque node type {target['type']!r} cannot be replaced",
+            path=f"{path}.locator",
+        )
+    replacement = validate_created_node(operation["node"], path=f"{path}.node")
+    target_id = target.get("attrs", {}).get("id")
+    if replacement["type"] in ID_CAPABLE_NODES and isinstance(target_id, str):
+        replacement.setdefault("attrs", {})["id"] = target_id
+    content[index] = replacement
+    return {
+        "op": "replace_block",
+        "status": "applied",
+        "locator": operation["locator"],
+        "index": index,
+    }
+
+
+def _insert_after(doc: dict, operation: dict, path: str) -> dict:
+    content = doc["content"]
+    locator = operation["locator"]
+    if locator == "doc:start":
+        insert_index = 0
+    else:
+        insert_index = _resolve_locator(content, locator, f"{path}.locator") + 1
+    node = validate_created_node(operation["node"], path=f"{path}.node")
+    content.insert(insert_index, node)
+    return {
+        "op": "insert_after",
+        "status": "applied",
+        "after": locator,
+        "index": insert_index,
+    }
+
+
+def _move_block(doc: dict, operation: dict, path: str) -> dict:
+    content = doc["content"]
+    locator = operation["locator"]
+    after = operation["after"]
+    if locator == after:
+        raise InvalidDocumentOperation(
+            "A block cannot be moved after itself", path=f"{path}.after"
+        )
+    source_index = _resolve_locator(content, locator, f"{path}.locator")
+    after_index = (
+        None
+        if after == "doc:start"
+        else _resolve_locator(content, after, f"{path}.after")
+    )
+    node = content.pop(source_index)
+    if after_index is None:
+        destination_index = 0
+    elif after_index > source_index:
+        destination_index = after_index
+    else:
+        destination_index = after_index + 1
+    content.insert(destination_index, node)
+    return {
+        "op": "move_block",
+        "status": "applied",
+        "locator": locator,
+        "after": after,
+        "from_index": source_index,
+        "index": destination_index,
+    }
+
+
+def _delete_block(doc: dict, operation: dict, path: str) -> dict:
+    content = doc["content"]
+    index = _resolve_locator(content, operation["locator"], f"{path}.locator")
+    content.pop(index)
+    return {
+        "op": "delete_block",
+        "status": "applied",
+        "locator": operation["locator"],
+        "index": index,
+    }
+
+
+def _replace_note(base_doc: dict, submitted_doc: object, *, path: str) -> dict:
+    validate_stored_document(submitted_doc)
+    candidate = copy.deepcopy(submitted_doc)
+    assert isinstance(candidate, dict)  # Validated above.
+    base_blocks = Counter(_canonical(node) for node in base_doc.get("content", []))
+    accepted = []
+    for index, node in enumerate(candidate.get("content", [])):
+        canonical = _canonical(node)
+        if base_blocks[canonical]:
+            base_blocks[canonical] -= 1
+            accepted.append(copy.deepcopy(node))
+            continue
+        try:
+            accepted.append(
+                validate_created_node(node, path=f"{path}.content[{index}]")
+            )
+        except InvalidDocumentOperation as exc:
+            raise InvalidDocumentOperation(
+                "Full-note replacement may only create whitelisted blocks or "
+                "preserve base blocks verbatim",
+                path=exc.path or f"{path}.content[{index}]",
+            ) from exc
+    return {"type": "doc", "content": accepted}
+
+
+def _validate_operation_shape(operation: object, path: str):
+    if not isinstance(operation, dict):
+        raise InvalidDocumentOperation("Every operation must be an object", path=path)
+    if any(not isinstance(key, str) for key in operation):
+        raise InvalidDocumentOperation(
+            "Operation field names must be strings", path=path
+        )
+    op = operation.get("op")
+    if not isinstance(op, str):
+        raise InvalidDocumentOperation(
+            "Document operation name must be a string", path=f"{path}.op"
+        )
+    expected_keys = _OPERATION_KEYS.get(op)
+    if expected_keys is None:
+        raise InvalidDocumentOperation(
+            f"Unsupported document operation: {op!r}", path=f"{path}.op"
+        )
+    missing = expected_keys - set(operation)
+    extra = set(operation) - expected_keys
+    if missing:
+        raise InvalidDocumentOperation(
+            f"Operation is missing fields: {sorted(missing)}", path=path
+        )
+    if extra:
+        raise InvalidDocumentOperation(
+            f"Operation has unsupported fields: {sorted(extra)}", path=path
+        )
+
+
+def _resolve_locator(content: list[dict], locator: object, path: str) -> int:
+    if not isinstance(locator, str) or not locator:
+        raise InvalidDocumentOperation("Locator must be a non-empty string", path=path)
+    if locator.startswith("i:"):
+        raw_index = locator[2:]
+        if not raw_index.isdigit():
+            raise InvalidDocumentOperation(
+                f"Malformed index locator: {locator!r}", path=path
+            )
+        index = int(raw_index)
+        if index >= len(content):
+            raise InvalidDocumentOperation(
+                f"Locator does not name a block: {locator!r}", path=path
+            )
+        return index
+    if locator == "doc:start":
+        raise InvalidDocumentOperation(
+            "doc:start may only be used as an insertion destination", path=path
+        )
+    matches = [
+        index
+        for index, node in enumerate(content)
+        if node.get("attrs", {}).get("id") == locator
+    ]
+    if len(matches) != 1:
+        raise InvalidDocumentOperation(
+            f"Locator does not uniquely name a block: {locator!r}", path=path
+        )
+    return matches[0]
+
+
+def _canonical(value: dict) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)

--- a/src/note/services/document_engine/engine.py
+++ b/src/note/services/document_engine/engine.py
@@ -1,0 +1,116 @@
+"""Public facade for the note document engine."""
+
+from note.services.document_engine.editor import apply_operations
+from note.services.document_engine.errors import InvalidDocumentOperation
+from note.services.document_engine.reader import derive_plain_text, read_document
+from note.services.document_engine.registry import (
+    EDITOR_SCHEMA_VERSION,
+    SCHEMA_FINGERPRINT,
+)
+from note.services.document_engine.validator import (
+    validate_schema_version,
+    validate_stored_document,
+)
+
+
+class NoteDocumentEngine:
+    """Stateless facade for validation, bounded reads, and atomic edits."""
+
+    schema_version = EDITOR_SCHEMA_VERSION
+    schema_fingerprint = SCHEMA_FINGERPRINT
+
+    def validate(self, payload: object) -> dict:
+        request = _request(payload, required={"doc"}, optional={"schema_version"})
+        validate_schema_version(request.get("schema_version"))
+        doc, changed, warnings = validate_stored_document(request["doc"])
+        return _result(
+            doc=doc,
+            plain_text=derive_plain_text(doc),
+            changed=changed,
+            warnings=warnings,
+            valid=True,
+        )
+
+    def read(self, payload: object) -> dict:
+        request = _request(
+            payload,
+            required={"doc"},
+            optional={"schema_version", "from", "limit"},
+        )
+        validate_schema_version(request.get("schema_version"))
+        doc, changed, warnings = validate_stored_document(request["doc"])
+        response = read_document(
+            doc, start=request.get("from", 0), limit=request.get("limit", 100)
+        )
+        return {
+            "schema_version": EDITOR_SCHEMA_VERSION,
+            "schema_fingerprint": SCHEMA_FINGERPRINT,
+            "changed": changed,
+            "warnings": warnings,
+            **response,
+        }
+
+    def apply(self, payload: object) -> dict:
+        request = _request(
+            payload,
+            required={"doc", "operations"},
+            optional={"schema_version"},
+        )
+        validate_schema_version(request.get("schema_version"))
+        base_doc, normalization_changed, base_warnings = validate_stored_document(
+            request["doc"]
+        )
+        result_doc, operation_results, edit_warnings = apply_operations(
+            base_doc, request["operations"]
+        )
+        return _result(
+            doc=result_doc,
+            plain_text=derive_plain_text(result_doc),
+            changed=result_doc != request["doc"],
+            normalization_changed=normalization_changed,
+            warnings=_deduplicate_warnings([*base_warnings, *edit_warnings]),
+            operation_results=operation_results,
+        )
+
+
+def _request(payload: object, *, required: set[str], optional: set[str]) -> dict:
+    if not isinstance(payload, dict):
+        raise InvalidDocumentOperation("Engine input must be an object", path="request")
+    if any(not isinstance(key, str) for key in payload):
+        raise InvalidDocumentOperation(
+            "Engine input field names must be strings", path="request"
+        )
+    missing = required - set(payload)
+    extra = set(payload) - required - optional
+    if missing:
+        raise InvalidDocumentOperation(
+            f"Engine input is missing fields: {sorted(missing)}", path="request"
+        )
+    if extra:
+        raise InvalidDocumentOperation(
+            f"Engine input has unsupported fields: {sorted(extra)}", path="request"
+        )
+    return payload
+
+
+def _result(*, doc: dict, plain_text: str, changed: bool, warnings: list, **extra):
+    return {
+        "schema_version": EDITOR_SCHEMA_VERSION,
+        "schema_fingerprint": SCHEMA_FINGERPRINT,
+        "doc": doc,
+        "plain_text": plain_text,
+        "changed": changed,
+        "warnings": warnings,
+        **extra,
+    }
+
+
+def _deduplicate_warnings(warnings: list[dict]) -> list[dict]:
+    deduplicated = []
+    seen = set()
+    for warning in warnings:
+        key = tuple(sorted((key, repr(value)) for key, value in warning.items()))
+        if key not in seen:
+            seen.add(key)
+            deduplicated.append(warning)
+    return deduplicated

--- a/src/note/services/document_engine/reader.py
+++ b/src/note/services/document_engine/reader.py
@@ -1,0 +1,140 @@
+"""Lossless bounded reads and text projection for Tiptap documents."""
+
+import copy
+import re
+
+from note.services.document_engine.errors import InvalidDocumentOperation
+from note.services.document_engine.registry import (
+    CREATABLE_TOP_LEVEL_NODES,
+    MAX_READ_BLOCKS,
+    PREVIEW_LENGTH,
+)
+
+_WHITESPACE = re.compile(r"\s+")
+_INLINE_CONTAINERS = frozenset(
+    {"paragraph", "heading", "detailsSummary", "figcaption", "quoteCaption"}
+)
+_BLOCK_CONTAINERS = frozenset(
+    {
+        "doc",
+        "listItem",
+        "taskItem",
+        "details",
+        "detailsContent",
+        "columns",
+        "column",
+        "blockquoteFigure",
+        "quote",
+        "figure",
+    }
+)
+
+
+def derive_plain_text(doc: dict) -> str:
+    """Derive readable text without using it to reconstruct canonical JSON."""
+
+    return _node_text(doc)
+
+
+def read_document(doc: dict, *, start: int = 0, limit: int = MAX_READ_BLOCKS) -> dict:
+    """Return a bounded top-level slice with stable locators and exact JSON."""
+
+    if isinstance(start, bool) or not isinstance(start, int) or start < 0:
+        raise InvalidDocumentOperation(
+            "from must be a non-negative integer", path="from"
+        )
+    if (
+        isinstance(limit, bool)
+        or not isinstance(limit, int)
+        or not 1 <= limit <= MAX_READ_BLOCKS
+    ):
+        raise InvalidDocumentOperation(
+            f"limit must be an integer from 1 through {MAX_READ_BLOCKS}", path="limit"
+        )
+
+    content = doc.get("content", [])
+    total = len(content)
+    end = min(start + limit, total)
+    selected = content[start:end] if start < total else []
+    blocks = []
+    for relative_index, node in enumerate(selected):
+        index = start + relative_index
+        node_text = _node_text(node)
+        blocks.append(
+            {
+                "locator": block_locator(node, index),
+                "index": index,
+                "node": copy.deepcopy(node),
+                "plain_text_preview": _preview(node_text),
+                "capabilities": block_capabilities(node),
+            }
+        )
+
+    has_more = end < total
+    return {
+        "doc": {"type": "doc", "content": copy.deepcopy(selected)},
+        "blocks": blocks,
+        "from": start,
+        "limit": limit,
+        "total": total,
+        "returned": len(selected),
+        "has_more": has_more,
+        "next_from": end if has_more else None,
+        "plain_text": _node_text({"type": "doc", "content": selected}),
+    }
+
+
+def block_locator(node: dict, index: int) -> str:
+    node_id = node.get("attrs", {}).get("id")
+    return node_id if isinstance(node_id, str) and node_id else f"i:{index}"
+
+
+def block_capabilities(node: dict) -> list[str]:
+    capabilities = ["insert_after", "move", "delete"]
+    if node.get("type") in CREATABLE_TOP_LEVEL_NODES:
+        capabilities.insert(0, "replace")
+    return capabilities
+
+
+def _preview(value: str) -> str:
+    compact = _WHITESPACE.sub(" ", value).strip()
+    if len(compact) <= PREVIEW_LENGTH:
+        return compact
+    return f"{compact[: PREVIEW_LENGTH - 1]}…"
+
+
+def _node_text(node: dict) -> str:
+    node_type = node.get("type")
+    if node_type == "text":
+        return node.get("text", "")
+    if node_type == "hardBreak":
+        return "\n"
+    if node_type == "imageBlock":
+        return _string_attr(node, "alt")
+    if node_type == "emoji":
+        return _string_attr(node, "name")
+    if node_type == "youtube":
+        return _string_attr(node, "src")
+
+    children = [_node_text(child) for child in node.get("content", [])]
+    if node_type in _INLINE_CONTAINERS or node_type == "codeBlock":
+        return "".join(children)
+    if node_type == "tableRow":
+        return "\t".join(children)
+    if node_type in {"table", "bulletList", "orderedList", "taskList"}:
+        return "\n".join(_nonempty_or_structural(children))
+    if node_type in {"tableCell", "tableHeader"} | _BLOCK_CONTAINERS:
+        return "\n".join(_nonempty_or_structural(children))
+
+    # Unknown nodes remain lossless in JSON. Generic recursive projection still
+    # exposes any ordinary text leaves they contain.
+    return "\n".join(_nonempty_or_structural(children))
+
+
+def _nonempty_or_structural(values: list[str]) -> list[str]:
+    return [value for value in values if value != ""]
+
+
+def _string_attr(node: dict, name: str) -> str:
+    value = node.get("attrs", {}).get(name)
+    return value if isinstance(value, str) else ""

--- a/src/note/tests/document_engine/test_editor.py
+++ b/src/note/tests/document_engine/test_editor.py
@@ -1,0 +1,239 @@
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from note.services.document_engine import InvalidDocumentOperation, NoteDocumentEngine
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class EditorTests(unittest.TestCase):
+    def setUp(self):
+        self.engine = NoteDocumentEngine()
+        raw_document = json.loads((FIXTURES / "editor_document.json").read_text())
+        self.document = self.engine.validate({"doc": raw_document})["doc"]
+
+    def test_replace_changes_only_the_target_block(self):
+        # Arrange
+        untouched = copy.deepcopy(self.document["content"][1:])
+        replacement = {
+            "type": "heading",
+            "attrs": {"level": 3},
+            "content": [{"type": "text", "text": "replacement-token"}],
+        }
+
+        # Act
+        result = self.engine.apply(
+            {
+                "doc": self.document,
+                "operations": [
+                    {
+                        "op": "replace_block",
+                        "locator": "heading-1",
+                        "node": replacement,
+                    }
+                ],
+            }
+        )
+
+        # Assert
+        changed = result["doc"]["content"][0]
+        self.assertEqual(changed["attrs"]["id"], "heading-1")
+        self.assertEqual(changed["attrs"]["level"], 3)
+        self.assertEqual(result["doc"]["content"][1:], untouched)
+        self.assertIn("replacement-token", result["plain_text"])
+
+    def test_invalid_later_operation_rejects_request_atomically(self):
+        # Arrange
+        original = copy.deepcopy(self.document)
+        operations = [
+            {
+                "op": "insert_after",
+                "locator": "doc:start",
+                "node": {"type": "paragraph", "content": []},
+            },
+            {
+                "op": "replace_block",
+                "locator": "table-1",
+                "node": {"type": "paragraph", "content": []},
+            },
+        ]
+
+        # Act / Assert
+        with self.assertRaises(InvalidDocumentOperation):
+            self.engine.apply({"doc": self.document, "operations": operations})
+        self.assertEqual(self.document, original)
+
+    def test_opaque_blocks_can_move_and_delete(self):
+        # Arrange
+        table = copy.deepcopy(self.document["content"][10])
+
+        # Act
+        moved = self.engine.apply(
+            {
+                "doc": self.document,
+                "operations": [
+                    {"op": "move_block", "locator": "table-1", "after": "heading-1"}
+                ],
+            }
+        )["doc"]
+        deleted = self.engine.apply(
+            {
+                "doc": moved,
+                "operations": [{"op": "delete_block", "locator": "table-1"}],
+            }
+        )["doc"]
+
+        # Assert
+        self.assertEqual(moved["content"][1], table)
+        self.assertNotIn(table, deleted["content"])
+
+    def test_move_resolves_index_destination_before_removing_source(self):
+        # Arrange
+        doc = {
+            "type": "doc",
+            "content": [
+                {"type": "horizontalRule"},
+                {"type": "imageBlock", "attrs": {"src": "one"}},
+                {"type": "youtube", "attrs": {"src": "two"}},
+            ],
+        }
+
+        # Act
+        result = self.engine.apply(
+            {
+                "doc": doc,
+                "operations": [{"op": "move_block", "locator": "i:1", "after": "i:2"}],
+            }
+        )["doc"]
+
+        # Assert
+        self.assertEqual(
+            [node["type"] for node in result["content"]],
+            ["horizontalRule", "youtube", "imageBlock"],
+        )
+
+    def test_created_attributes_are_canonicalized(self):
+        # Arrange
+        image = {
+            "type": "imageBlock",
+            "attrs": {"src": "https://example.test/new.png", "alt": "new image"},
+        }
+        paragraph = {
+            "type": "paragraph",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "linked",
+                    "marks": [
+                        {
+                            "type": "link",
+                            "attrs": {"href": "https://example.test/reference"},
+                        },
+                        {"type": "highlight", "attrs": {"color": "#AABBCC"}},
+                    ],
+                }
+            ],
+        }
+
+        # Act
+        result = self.engine.apply(
+            {
+                "doc": self.document,
+                "operations": [
+                    {"op": "insert_after", "locator": "doc:start", "node": image},
+                    {
+                        "op": "replace_block",
+                        "locator": "paragraph-1",
+                        "node": paragraph,
+                    },
+                ],
+            }
+        )["doc"]
+
+        # Assert
+        self.assertEqual(
+            result["content"][0]["attrs"],
+            {
+                "src": "https://example.test/new.png",
+                "width": "100%",
+                "align": "center",
+                "alt": "new image",
+            },
+        )
+        marks = result["content"][2]["content"][0]["marks"]
+        self.assertEqual(marks[0]["attrs"]["target"], "_blank")
+        self.assertEqual(marks[1]["attrs"]["color"], "#aabbcc")
+
+    def test_invalid_created_content_is_rejected(self):
+        invalid_nodes = [
+            {"type": "paragraph", "attrs": {"id": "model-id"}},
+            {"type": "heading", "attrs": {"level": 7}},
+            {"type": "imageBlock", "attrs": {"src": "http://example.test/a.png"}},
+            {
+                "type": "paragraph",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "styled",
+                        "marks": [{"type": "textStyle", "attrs": {"color": "red"}}],
+                    }
+                ],
+            },
+            {"type": "paragraph", "content": [{"type": "text", "text": ""}]},
+            {"type": "table", "attrs": {"id": "invented"}},
+        ]
+        for node in invalid_nodes:
+            with self.subTest(node=node):
+                # Arrange
+                operation = {
+                    "op": "insert_after",
+                    "locator": "doc:start",
+                    "node": node,
+                }
+
+                # Act / Assert
+                with self.assertRaises(InvalidDocumentOperation):
+                    self.engine.apply({"doc": self.document, "operations": [operation]})
+
+    def test_replace_note_preserves_verbatim_opaque_blocks(self):
+        # Arrange
+        submitted = {
+            "type": "doc",
+            "content": [
+                copy.deepcopy(self.document["content"][10]),
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "new-block"}],
+                },
+            ],
+        }
+
+        # Act
+        result = self.engine.apply(
+            {
+                "doc": self.document,
+                "operations": [{"op": "replace_note", "doc": submitted}],
+            }
+        )["doc"]
+
+        # Assert
+        self.assertEqual(result["content"][0], self.document["content"][10])
+        self.assertEqual(result["content"][1]["content"][0]["text"], "new-block")
+        self.assertIn("id", result["content"][1]["attrs"])
+
+    def test_replace_note_rejects_modified_opaque_blocks(self):
+        # Arrange
+        modified_table = copy.deepcopy(self.document["content"][10])
+        modified_table["content"][0]["content"][0]["attrs"]["style"] = "color:red"
+        submitted = {"type": "doc", "content": [modified_table]}
+
+        # Act / Assert
+        with self.assertRaises(InvalidDocumentOperation):
+            self.engine.apply(
+                {
+                    "doc": self.document,
+                    "operations": [{"op": "replace_note", "doc": submitted}],
+                }
+            )

--- a/src/note/tests/document_engine/test_reader.py
+++ b/src/note/tests/document_engine/test_reader.py
@@ -1,0 +1,50 @@
+import json
+import unittest
+from pathlib import Path
+
+from note.services.document_engine import InvalidDocumentOperation, NoteDocumentEngine
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class ReaderTests(unittest.TestCase):
+    def setUp(self):
+        self.engine = NoteDocumentEngine()
+        self.document = json.loads((FIXTURES / "editor_document.json").read_text())
+
+    def test_read_is_bounded_and_lossless(self):
+        # Arrange
+        expected = self.document["content"][1:3]
+
+        # Act
+        result = self.engine.read({"doc": self.document, "from": 1, "limit": 2})
+
+        # Assert
+        self.assertEqual(result["doc"]["content"], expected)
+        self.assertEqual([block["node"] for block in result["blocks"]], expected)
+        self.assertEqual(result["returned"], 2)
+        self.assertTrue(result["has_more"])
+        self.assertEqual(result["next_from"], 3)
+
+    def test_read_exposes_stable_and_index_locators(self):
+        # Arrange / Act
+        result = self.engine.read({"doc": self.document})
+        blocks = {block["node"]["type"]: block for block in result["blocks"]}
+
+        # Assert
+        self.assertEqual(blocks["heading"]["locator"], "heading-1")
+        self.assertEqual(blocks["horizontalRule"]["locator"], "i:3")
+        self.assertIn("replace", blocks["heading"]["capabilities"])
+        self.assertNotIn("replace", blocks["table"]["capabilities"])
+        self.assertEqual(
+            blocks["table"]["capabilities"], ["insert_after", "move", "delete"]
+        )
+
+    def test_read_rejects_invalid_bounds(self):
+        for start, limit in [(-1, 1), (0, 0), (0, 101), (True, 1)]:
+            # Arrange / Act / Assert
+            with (
+                self.subTest(start=start, limit=limit),
+                self.assertRaises(InvalidDocumentOperation),
+            ):
+                self.engine.read({"doc": self.document, "from": start, "limit": limit})

--- a/src/note/tests/document_engine/test_validator.py
+++ b/src/note/tests/document_engine/test_validator.py
@@ -3,19 +3,11 @@ import json
 import unittest
 from pathlib import Path
 
-from note.services.document_engine.errors import (
+from note.services.document_engine import (
+    EDITOR_SCHEMA_VERSION,
     DocumentSchemaMismatch,
     InvalidDocument,
-    InvalidDocumentOperation,
-)
-from note.services.document_engine.registry import (
-    EDITOR_SCHEMA_VERSION,
-    LEGACY_SCHEMA_VERSION,
-)
-from note.services.document_engine.validator import (
-    validate_created_node,
-    validate_schema_version,
-    validate_stored_document,
+    NoteDocumentEngine,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -23,6 +15,7 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 class ValidatorTests(unittest.TestCase):
     def setUp(self):
+        self.engine = NoteDocumentEngine()
         self.document = json.loads((FIXTURES / "editor_document.json").read_text())
 
     def test_golden_document_round_trips_without_loss(self):
@@ -30,12 +23,30 @@ class ValidatorTests(unittest.TestCase):
         original = copy.deepcopy(self.document)
 
         # Act
-        doc, changed, _warnings = validate_stored_document(self.document)
+        result = self.engine.validate({"doc": self.document})
 
         # Assert
-        self.assertFalse(changed)
-        self.assertEqual(doc, original)
+        self.assertTrue(result["valid"])
+        self.assertFalse(result["changed"])
+        self.assertEqual(result["doc"], original)
+        self.assertEqual(result["schema_version"], EDITOR_SCHEMA_VERSION)
         self.assertEqual(self.document, original)
+
+    def test_plain_text_covers_all_text_leaves_and_projected_attributes(self):
+        # Arrange
+        expected_text = _text_leaves(self.document)
+
+        # Act
+        plain_text = self.engine.validate({"doc": self.document})["plain_text"]
+
+        # Assert
+        for value in expected_text:
+            self.assertIn(value, plain_text)
+        self.assertIn("image-alt-token", plain_text)
+        self.assertIn("microscope", plain_text)
+        self.assertIn("https://www.youtube.com/watch?v=example", plain_text)
+        self.assertIn("table-header-token\ttable-cell-token", plain_text)
+        self.assertIn("  indented = True\n", plain_text)
 
     def test_unknown_types_warn_and_remain_verbatim(self):
         # Arrange
@@ -43,11 +54,13 @@ class ValidatorTests(unittest.TestCase):
         doc = {"type": "doc", "content": [unknown]}
 
         # Act
-        validated, _changed, warnings = validate_stored_document(doc)
+        result = self.engine.validate({"doc": doc})
 
         # Assert
-        self.assertEqual(validated["content"][0], unknown)
-        self.assertIn("unknown_node_type", {item["code"] for item in warnings})
+        self.assertEqual(result["doc"]["content"][0], unknown)
+        self.assertIn(
+            "unknown_node_type", {item["code"] for item in result["warnings"]}
+        )
 
     def test_unprojectable_known_attribute_warns_without_mutation(self):
         # Arrange
@@ -58,13 +71,13 @@ class ValidatorTests(unittest.TestCase):
         doc = {"type": "doc", "content": [image]}
 
         # Act
-        validated, _changed, warnings = validate_stored_document(doc)
+        result = self.engine.validate({"doc": doc})
 
         # Assert
-        self.assertEqual(validated["content"][0], image)
+        self.assertEqual(result["doc"]["content"][0], image)
         self.assertIn(
             "unprojectable_attribute",
-            {warning["code"] for warning in warnings},
+            {warning["code"] for warning in result["warnings"]},
         )
 
     def test_missing_and_duplicate_ids_are_repaired_deterministically(self):
@@ -79,27 +92,28 @@ class ValidatorTests(unittest.TestCase):
         }
 
         # Act
-        first, _first_changed, first_warnings = validate_stored_document(doc)
-        second, _second_changed, _second_warnings = validate_stored_document(doc)
-        ids = [node["attrs"]["id"] for node in first["content"]]
+        first = self.engine.validate({"doc": doc})
+        second = self.engine.validate({"doc": doc})
+        ids = [node["attrs"]["id"] for node in first["doc"]["content"]]
 
         # Assert
-        self.assertEqual(first, second)
+        self.assertEqual(first["doc"], second["doc"])
         self.assertEqual(len(ids), len(set(ids)))
         self.assertEqual(ids[0], "duplicate")
         self.assertEqual(
-            {warning["code"] for warning in first_warnings},
+            {warning["code"] for warning in first["warnings"]},
             {"duplicate_node_id", "missing_node_id"},
         )
 
     def test_legacy_and_current_versions_are_supported(self):
         # Arrange / Act
-        legacy = validate_schema_version(None)
-        current = validate_schema_version(EDITOR_SCHEMA_VERSION)
+        legacy = self.engine.validate({"schema_version": None, "doc": self.document})
+        current = self.engine.validate(
+            {"schema_version": EDITOR_SCHEMA_VERSION, "doc": self.document}
+        )
 
         # Assert
-        self.assertEqual(legacy, LEGACY_SCHEMA_VERSION)
-        self.assertEqual(current, EDITOR_SCHEMA_VERSION)
+        self.assertEqual(legacy["doc"], current["doc"])
 
     def test_unknown_schema_version_is_rejected(self):
         # Arrange / Act / Assert
@@ -108,7 +122,7 @@ class ValidatorTests(unittest.TestCase):
                 self.subTest(version=version),
                 self.assertRaises(DocumentSchemaMismatch),
             ):
-                validate_schema_version(version)
+                self.engine.validate({"schema_version": version, "doc": self.document})
 
     def test_malformed_document_is_rejected(self):
         malformed_documents = [
@@ -129,38 +143,11 @@ class ValidatorTests(unittest.TestCase):
         for doc in malformed_documents:
             # Arrange / Act / Assert
             with self.subTest(doc=doc), self.assertRaises(InvalidDocument):
-                validate_stored_document(doc)
+                self.engine.validate({"doc": doc})
 
-    def test_created_attributes_are_canonicalized(self):
-        # Arrange
-        image = {
-            "type": "imageBlock",
-            "attrs": {"src": "https://example.test/new.png", "alt": "new image"},
-        }
 
-        # Act
-        result = validate_created_node(image)
-
-        # Assert
-        self.assertEqual(
-            result["attrs"],
-            {
-                "src": "https://example.test/new.png",
-                "width": "100%",
-                "align": "center",
-                "alt": "new image",
-            },
-        )
-
-    def test_invalid_created_content_is_rejected(self):
-        invalid_nodes = [
-            {"type": "paragraph", "attrs": {"id": "model-id"}},
-            {"type": "heading", "attrs": {"level": 7}},
-            {"type": "imageBlock", "attrs": {"src": "http://example.test/a.png"}},
-            {"type": "paragraph", "content": [{"type": "text", "text": ""}]},
-            {"type": "table", "attrs": {"id": "invented"}},
-        ]
-        for node in invalid_nodes:
-            # Arrange / Act / Assert
-            with self.subTest(node=node), self.assertRaises(InvalidDocumentOperation):
-                validate_created_node(node)
+def _text_leaves(node: dict) -> list[str]:
+    values = [node["text"]] if node["type"] == "text" else []
+    for child in node.get("content", []):
+        values.extend(_text_leaves(child))
+    return values


### PR DESCRIPTION
## Summary

- add the stateless `NoteDocumentEngine` facade with `validate`, bounded `read`, and atomic `apply`
- add lossless top-level reads with stable locators, previews, capabilities, and continuation metadata
- add block replace, insert, move, and delete operations plus safe full-note replacement
- derive canonical result JSON and plain text together, with per-operation results and deduplicated warnings
- add reader, editor, preservation, opacity, atomicity, and replacement tests

## Why

This completes notebook assistant PR0.5 on top of the schema and validation foundation in #3921. Keeping it stacked lets reviewers evaluate runtime orchestration separately from the schema-safety rules.

## Impact

The runtime remains pure and in-process. No provider, agent, chat endpoint, or existing note view behavior is added.

## Dependency

This PR intentionally targets `agent/notebook-pr0-5-schema-foundation`. After #3921 merges, retarget this PR to `main`.

## Validation

- `PYTHONPATH=src .venv/bin/python -m unittest discover -s src/note/tests/document_engine -v` — 21 tests pass
- `uv run ruff format --check --diff src`
- `uv run ruff check src`
- combined branch tree matches the original complete PR0.5 implementation branch