### PR TITLE
Bootstrap CodePress preview CORS for org previews

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -193,6 +193,12 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
 ]
 
+if STAGING:
+    # CodePress Live Dev Server preview origins (managed)
+    CORS_ALLOWED_ORIGIN_REGEXES.append(
+        r"^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$"
+    )
+
 # Health check
 
 HEALTH_CHECK_TOKEN = os.environ.get("HEALTH_CHECK_TOKEN", keys.HEALTH_CHECK_TOKEN)


### PR DESCRIPTION
## Summary
This repository is a standalone Django API, so the bootstrap adds the Live Dev Server’s org-scoped preview access to its staging environment. The change keeps production and the existing application origins untouched; previews can use the API after the staging deployment includes this commit and the separate frontend points at that staging API.

## Technical details
`src/researchhub/settings.py` keeps the existing `CORS_ALLOWED_ORIGIN_REGEXES` entries and appends one CodePress-managed, anchored regex only when the repository’s actual `STAGING` flag is true (`APP_ENV` contains `staging`). The pattern is the org-scoped form `^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$`, so it accepts exactly one session origin for this organization and rejects nested labels, HTTP, and unrelated preview hosts. No credentials or private-network CORS settings were enabled, and no existing origins or middleware were replaced. Discovery found no runnable frontend, package manifest, or static site in this backend-only repository, so no frontend recipe or Dockerfile was authored.

## Changes
- Add a managed org-scoped preview-origin regex to the staging-gated Django CORS settings.
- Leave production settings and all existing CORS origins unchanged.

## Test plan
- [ ] Run the existing Django validation in the staging deployment environment with `APP_ENV=staging`.
- [ ] Send an OPTIONS preflight with `Origin: https://<32-hex-session>-87d3f8ab798deaec.preview.codepress.dev` and verify the API returns the matching `Access-Control-Allow-Origin` after staging deploy.
- [ ] Verify an HTTP origin, a nested preview subdomain, and a preview host with a different org key do not receive the new allowlist match.

## Open items
- The CORS change takes effect only after the backend is deployed to staging.
- Because this repo has no frontend, the previewed frontend in its own repository must target this staging API for the allowance to be used.

## Authors
Generated with [CodePress](https://codepress.dev) · [View the chat session](https://codepress.dev/dashboard/researchhub/chat/a2632dec-b0d3-4978-b963-64d554717b45)

<!-- codepress-pr-source: cloud -->
<!-- codepress-pr-session: a2632dec-b0d3-4978-b963-64d554717b45 -->