### PR TITLE
Bootstrap CodePress preview CORS for org-scoped previews

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -193,6 +193,12 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
 ]
 
+if STAGING:
+    # CodePress Live Dev Server preview origins (managed)
+    CORS_ALLOWED_ORIGIN_REGEXES.append(
+        r"^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$"
+    )
+
 # Health check
 
 HEALTH_CHECK_TOKEN = os.environ.get("HEALTH_CHECK_TOKEN", keys.HEALTH_CHECK_TOKEN)


### PR DESCRIPTION
## Summary
Enables ResearchHub’s staging API to accept requests from this organization’s Live Dev Server preview origins, so a frontend preview can call the backend after the change is deployed to staging. This repository is backend-only, so no frontend recipe or Dockerfile was added.

## Technical details
Added a staging-gated entry to `src/researchhub/settings.py` using Django’s existing `CORS_ALLOWED_ORIGIN_REGEXES` surface. The appended managed pattern is anchored to `https://[0-9a-f]{32}-87d3f8ab798deaec.preview.codepress.dev`, preserving the existing allowlist and limiting trust to this organization’s preview hosts. The `STAGING` gate keeps the allowance out of production; the repository contains no credentialed or private-network CORS setting, and the custom Coinbase CORS path reuses the same origin settings without emitting credential headers. The backend-only shape means there is no frontend API environment variable to prefill in this repository.

## Changes
- Add the org-scoped CodePress preview origin regex to staging CORS settings.
- Leave existing origins and production CORS behavior unchanged.

## Test plan
- [ ] Run `uv run ruff check src/researchhub/settings.py`.
- [ ] Parse `src/researchhub/settings.py` with Python’s AST parser.
- [ ] Deploy the branch to staging, issue a preflight from an origin matching the org-scoped pattern, and verify `Access-Control-Allow-Origin` echoes that origin without granting private-network access.

## Open items
- The CORS change takes effect only after the customer deploys staging with this commit.
- The previewed frontend is in another repository and must target this backend’s staging deployment; no backend URL was confidently declared in this API-only repository.

## Authors
Generated with [CodePress](https://codepress.dev) · [View the chat session](https://codepress.dev/dashboard/researchhub/chat/95822a33-4dfd-401e-8ec0-770dc91b2e96)

<!-- codepress-pr-source: cloud -->
<!-- codepress-pr-session: 95822a33-4dfd-401e-8ec0-770dc91b2e96 -->