### PR TITLE
Bootstrap CodePress staging preview CORS

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -193,6 +193,12 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
 ]
 
+if STAGING:
+    # CodePress Live Dev Server preview origins (managed)
+    CORS_ALLOWED_ORIGIN_REGEXES.append(
+        r"^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$"
+    )
+
 # Health check
 
 HEALTH_CHECK_TOKEN = os.environ.get("HEALTH_CHECK_TOKEN", keys.HEALTH_CHECK_TOKEN)


### PR DESCRIPTION
## Summary
This prepares the ResearchHub API for CodePress Live Dev Server previews by allowing this organization’s preview sessions to call the staging API from a browser. The repository is backend-only, so there are no frontend recipe or Dockerfile artifacts to add; the change is limited to staging and does not affect production CORS.

## Technical details
The existing Django `django-cors-headers` configuration remains the source of truth. `src/researchhub/settings.py` now appends a managed, anchored regex only when the existing `STAGING` flag is true: `^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$`. This preserves every existing origin, matches only this organization’s 32-hex session hosts, and does not enable allow-all origins, credentials, or private-network access. Because this is a standalone backend repository with no runnable frontend, no `.codepress/dev-server/recipe.json`, Dockerfile, frontend environment prefill, or social-auth patch was applicable.

## Changes
- Add the org-scoped CodePress preview-origin regex to staging-only Django CORS settings.
- Preserve the existing allowlist and production behavior.

## Test plan
- [ ] Run `APP_ENV=staging uv run python -c 'import researchhub.settings as s; ...'` and verify the managed preview regex is present.
- [ ] Run `APP_ENV=production uv run python -c 'import researchhub.settings as s; ...'` and verify the preview regex is absent.
- [ ] Run `uv run ruff check src/researchhub/settings.py` and `git diff --check`.
- [ ] Deploy the change to staging, then verify a preflight from an org-scoped preview origin succeeds without changing production CORS.

## Open items
- The CORS allowance takes effect only after the backend is deployed to staging.
- The previewed frontend is in another repository and must target this staging API; this backend-only bootstrap cannot configure that frontend here.
- Live browser/API preview verification was not run in this backend-only bootstrap.

## Authors
Generated with [CodePress](https://codepress.dev) · [View the chat session](https://codepress.dev/dashboard/researchhub/chat/b4dc6e2e-5a33-43f6-aa56-88d887ac2f5e)

<!-- codepress-pr-source: cloud -->
<!-- codepress-pr-session: b4dc6e2e-5a33-43f6-aa56-88d887ac2f5e -->