### PR TITLE
Update links in email templates

### DIFF
--- a/src/mailing_list/lib.py
+++ b/src/mailing_list/lib.py
@@ -8,7 +8,6 @@ from mailing_list.models import EmailOptOut
 from mailing_list.services import EmailSubscriptionService
 from researchhub.settings import (
     ASSETS_BASE_URL,
-    BASE_FRONTEND_URL,
 )
 from utils.message import UnsubscribeUrls, deliver_email
 
@@ -16,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 base_email_context = {
     "assets_base_url": ASSETS_BASE_URL,
-    "update_subscription": BASE_FRONTEND_URL + "/user/settings/",
 }
 
 DEFAULT_SENDER = f"ResearchHub <{settings.DEFAULT_FROM_EMAIL}>"

--- a/src/templates/flagged_and_removed_content.html
+++ b/src/templates/flagged_and_removed_content.html
@@ -112,7 +112,7 @@
       <div class="footer">
         {% if opt_out %}
         <a class="footer-link" href="{{ opt_out }}"
-          >Unsubscribe from this list</a
+          >Unsubscribe</a
         >
         {% endif %}
         <a class="footer-link" href="{{ update_subscription }}"

--- a/src/templates/flagged_and_removed_content.html
+++ b/src/templates/flagged_and_removed_content.html
@@ -115,9 +115,6 @@
           >Unsubscribe</a
         >
         {% endif %}
-        <a class="footer-link" href="{{ update_subscription }}"
-          >Update subscription preferences</a
-        >
       </div>
     </div>
     <div style="display: none">{% now "U" %}</div>

--- a/src/templates/general_branded_email.html
+++ b/src/templates/general_branded_email.html
@@ -33,7 +33,7 @@
     </div>
     <div class="footer">
       {% if opt_out %}
-      <a href="{{ opt_out }}">Unsubscribe or change how frequently I get updated</a>
+      <a href="{{ opt_out }}">Unsubscribe</a>
       {% endif %}
     </div>
 </body>

--- a/src/templates/general_email_message.html
+++ b/src/templates/general_email_message.html
@@ -34,7 +34,7 @@
     </div>
     <div class="footer">
       {% if opt_out %}
-      <a href="{{opt_out}}">Unsubscribe or change how frequently I get updated</a>
+      <a href="{{opt_out}}">Unsubscribe</a>
       {% endif %}
     </div>
 </body>

--- a/src/templates/note_invite.html
+++ b/src/templates/note_invite.html
@@ -75,7 +75,7 @@
       <div class="footer">
         {% if opt_out %}
         <a class="footer-link" href="{{ opt_out }}"
-          >Unsubscribe from this list</a
+          >Unsubscribe</a
         >
         {% endif %}
         <a class="footer-link" href="{{ update_subscription }}"

--- a/src/templates/note_invite.html
+++ b/src/templates/note_invite.html
@@ -78,9 +78,6 @@
           >Unsubscribe</a
         >
         {% endif %}
-        <a class="footer-link" href="{{ update_subscription }}"
-          >Update subscription preferences</a
-        >
       </div>
     </div>
     <div style="display: none">{% now "U" %}</div>

--- a/src/templates/organization_invite.html
+++ b/src/templates/organization_invite.html
@@ -79,9 +79,6 @@
           >Unsubscribe</a
         >
         {% endif %}
-        <a class="footer-link" href="{{ update_subscription }}"
-          >Update subscription preferences</a
-        >
       </div>
     </div>
     <div style="display: none">{% now "U" %}</div>

--- a/src/templates/organization_invite.html
+++ b/src/templates/organization_invite.html
@@ -76,7 +76,7 @@
       <div class="footer">
         {% if opt_out %}
         <a class="footer-link" href="{{ opt_out }}"
-          >Unsubscribe from this list</a
+          >Unsubscribe</a
         >
         {% endif %}
         <a class="footer-link" href="{{ update_subscription }}"

--- a/src/templates/support_receipt.html
+++ b/src/templates/support_receipt.html
@@ -115,7 +115,7 @@
     </div>
     <div class="footer">
       {% if opt_out %}
-      <a class="footer-link" href="{{opt_out}}">Unsubscribe from this list</a>
+      <a class="footer-link" href="{{opt_out}}">Unsubscribe</a>
       {% endif %}
       <a class="footer-link" href="{{update_subscription}}">Update subscription preferences</a>
     </div>

--- a/src/templates/support_receipt.html
+++ b/src/templates/support_receipt.html
@@ -117,7 +117,6 @@
       {% if opt_out %}
       <a class="footer-link" href="{{opt_out}}">Unsubscribe</a>
       {% endif %}
-      <a class="footer-link" href="{{update_subscription}}">Update subscription preferences</a>
     </div>
     <div style="display: none">{% now "U" %}</div>
   </body>

--- a/src/templates/support_receipt.txt
+++ b/src/templates/support_receipt.txt
@@ -29,5 +29,5 @@ Amount Paid
 {{amount}}
 
 {% if opt_out %}
-{{opt_out}} Unsubscribe or change how frequently I get updated
+{{opt_out}} Unsubscribe
 {% endif %}


### PR DESCRIPTION
- Standardize language for unsubscribe link (just "Unsubscribe").
- Remove link to email preferences that doesn't exist.