### PR TITLE
Bootstrap org-scoped preview CORS

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -193,6 +193,12 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
 ]
 
+if STAGING:
+    # CodePress Live Dev Server preview origins (managed)
+    CORS_ALLOWED_ORIGIN_REGEXES.append(
+        r"^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$"
+    )
+
 # Health check
 
 HEALTH_CHECK_TOKEN = os.environ.get("HEALTH_CHECK_TOKEN", keys.HEALTH_CHECK_TOKEN)


### PR DESCRIPTION
## Summary
Prepares ResearchHub’s staging API to receive browser requests from this organization’s CodePress Live Dev Server previews. This repository is backend-only, so the bootstrap adds the staging CORS support without creating frontend dev-server files.

## Technical details
`src/researchhub/settings.py` appends a CodePress-managed `CORS_ALLOWED_ORIGIN_REGEXES` entry only when the existing `STAGING` flag is true. The entry is anchored to the org-scoped preview shape `^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$`, preserving the existing whitelist and regexes while rejecting other organizations, multi-label hosts, and suffix attacks. It uses the repository’s existing `django-cors-headers` configuration and is also visible to the existing Coinbase endpoint origin check, without enabling credentials, private-network access, or allow-all behavior.

## Changes
- Add a managed, org-scoped preview-origin regex to staging CORS settings.
- Keep production and non-staging settings unchanged.

## Test plan
- [ ] Run the repository pre-commit checks; verify Ruff check and Ruff format pass for the change.
- [ ] Evaluate the regex with an org-scoped preview origin and confirm wrong-org, multi-label, and hostile-suffix origins do not match.
- [ ] After deploying staging, send a CORS preflight with an org-scoped CodePress preview Origin and verify the API returns the matching Access-Control-Allow-Origin header while production remains unchanged.

## Open items
- The change takes effect only after the staging backend is deployed.
- The frontend preview, which lives outside this backend-only repository, must target the staging API for this allowance to be used.

## Authors
Generated with [CodePress](https://codepress.dev) · [View the chat session](https://codepress.dev/dashboard/researchhub/chat/878ccbcf-fc8a-4c7e-b823-e87c987e17bc)

<!-- codepress-pr-source: cloud -->
<!-- codepress-pr-session: 878ccbcf-fc8a-4c7e-b823-e87c987e17bc -->