### PR TITLE
Simplify message utils

### DIFF
--- a/src/mailing_list/lib.py
+++ b/src/mailing_list/lib.py
@@ -29,7 +29,7 @@ def send_email(
     sender: str = DEFAULT_SENDER,
     reply_to: str | None = None,
     cc: list[str] | None = None,
-) -> dict[str, list[str]]:
+) -> None:
     """
     Send notification email, skipping addresses that have opted out.
 
@@ -64,7 +64,7 @@ def send_email(
                 extra={"recipient": recipient},
             )
 
-    return deliver_email(
+    deliver_email(
         recipients=recipients,
         template=template,
         subject=subject,
@@ -87,14 +87,14 @@ def send_transactional_email(
     sender: str = DEFAULT_SENDER,
     reply_to: str | None = None,
     cc: list[str] | None = None,
-) -> dict[str, list[str]]:
+) -> None:
     """
     Send transactional email that ignores notification opt-outs.
 
     Transactional emails can include email confirmation, password reset, and others.
     Opting out of other notifications must not lock someone out of their own account.
     """
-    return deliver_email(
+    deliver_email(
         recipients=recipients,
         template=template,
         subject=subject,

--- a/src/mailing_list/tests/test_lib.py
+++ b/src/mailing_list/tests/test_lib.py
@@ -33,30 +33,28 @@ class SendEmailTests(TestCase):
 
     def test_sends_to_recipient_without_a_suppression_record(self):
         # Act
-        result = self._send(["good@example.com"])
+        self._send(["good@example.com"])
 
         # Assert
-        self.assertEqual(result["success"], ["good@example.com"])
         self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ["good@example.com"])
 
     def test_accepts_a_single_recipient_string(self):
         # Act
-        result = self._send("good@example.com")
+        self._send("good@example.com")
 
         # Assert
-        self.assertEqual(result["success"], ["good@example.com"])
         self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ["good@example.com"])
 
     def test_excludes_opted_out_recipient(self):
         # Arrange
         EmailOptOut.add("optout@example.com")
 
         # Act
-        result = self._send(["optout@example.com"])
+        self._send(["optout@example.com"])
 
         # Assert
-        self.assertEqual(result["success"], [])
-        self.assertIn("optout@example.com", result["exclude"])
         self.assertEqual(len(mail.outbox), 0)
 
     def test_excludes_opted_out_recipient_regardless_of_casing(self):
@@ -64,10 +62,9 @@ class SendEmailTests(TestCase):
         EmailOptOut.add("optout@example.com")
 
         # Act
-        result = self._send(["OptOut@Example.com"])
+        self._send(["OptOut@Example.com"])
 
         # Assert
-        self.assertEqual(result["success"], [])
         self.assertEqual(len(mail.outbox), 0)
 
     def test_sends_only_to_unsuppressed_recipients_in_a_mixed_list(self):
@@ -75,11 +72,9 @@ class SendEmailTests(TestCase):
         EmailOptOut.add("optout@example.com")
 
         # Act
-        result = self._send(["optout@example.com", "good@example.com"])
+        self._send(["optout@example.com", "good@example.com"])
 
         # Assert
-        self.assertEqual(result["success"], ["good@example.com"])
-        self.assertIn("optout@example.com", result["exclude"])
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, ["good@example.com"])
 
@@ -163,11 +158,11 @@ class SendTransactionalEmailTests(TestCase):
         EmailOptOut.add("optout@example.com")
 
         # Act
-        result = self._send(["optout@example.com"])
+        self._send(["optout@example.com"])
 
         # Assert
-        self.assertEqual(result["success"], ["optout@example.com"])
         self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ["optout@example.com"])
 
     def test_does_not_set_unsubscribe_headers(self):
         # Act

--- a/src/researchhub_comment/tests/test_tasks.py
+++ b/src/researchhub_comment/tests/test_tasks.py
@@ -53,7 +53,6 @@ class SendAuthorUpdateEmailNotificationsTaskTests(TestCase):
         """
         # Arrange
         follower_ids = [self.follower1.id, self.follower2.id]
-        mock_send_email.return_value = {"success": [], "failure": [], "exclude": []}
 
         # Act
         send_author_update_email_notifications(self.comment.id, follower_ids)
@@ -103,7 +102,6 @@ class SendAuthorUpdateEmailNotificationsTaskTests(TestCase):
         """
         # Arrange
         follower_ids = [self.follower1.id]
-        mock_send_email.return_value = {"success": [], "failure": [], "exclude": []}
 
         # Act
         send_author_update_email_notifications(self.comment.id, follower_ids)
@@ -140,7 +138,6 @@ class SendAuthorUpdateEmailNotificationsTaskTests(TestCase):
         follower3 = create_random_default_user("follower3")
 
         follower_ids = [self.follower1.id, self.follower2.id, follower3.id]
-        mock_send_email.return_value = {"success": [], "failure": [], "exclude": []}
 
         # Act
         send_author_update_email_notifications(self.comment.id, follower_ids)

--- a/src/utils/message.py
+++ b/src/utils/message.py
@@ -23,29 +23,6 @@ def is_valid_email(email: str) -> bool:
     return email in settings.EMAIL_WHITELIST
 
 
-def _filter_recipients(
-    recipients: list[str],
-    suppressed_emails: set[str] | None = None,
-) -> tuple[list[str], list[str]]:
-    """Partition recipients into sendable and excluded lists.
-
-    Args:
-        recipients: List of email addresses to filter.
-        suppressed_emails: Optional pre-computed set of emails to exclude.
-
-    Returns:
-        (sendable, excluded) – two lists of email addresses.
-    """
-    sendable = [r for r in recipients if is_valid_email(r)]
-    excluded = list(set(recipients) - set(sendable))
-
-    if sendable and suppressed_emails:
-        excluded.extend(suppressed_emails & set(sendable))
-        sendable = [r for r in sendable if r not in suppressed_emails]
-
-    return sendable, excluded
-
-
 def _render_body(
     template: str | None, html_template: str | None, context: dict[str, Any]
 ) -> tuple[str, str | None]:
@@ -82,11 +59,14 @@ def deliver_email(
     cc: list[str] | None = None,
     suppressed_emails: set[str] | None = None,
     unsubscribe_urls: dict[str, UnsubscribeUrls] | None = None,
-) -> dict[str, list[str]]:
+) -> None:
     """Low-level email delivery: render templates, set headers, and send.
 
     Callers should prefer ``mailing_list.lib.send_email`` which automatically
     looks up suppressed addresses before delegating here.
+
+    Sends are best-effort: a recipient that fails is logged and skipped so one
+    bad address cannot abort the rest of the batch.
 
     Args:
         recipients: Email address string or list of addresses.
@@ -103,9 +83,6 @@ def deliver_email(
         suppressed_emails: Optional set of email addresses to exclude.
         unsubscribe_urls: Optional recipient-to-URL-pair mapping for signed
             human-facing links and one-click unsubscribe headers.
-
-    Returns:
-        ``{"success": [...], "failure": [...], "exclude": [...]}``.
     """
     subject = subject.replace("\n", "").replace("\r", "")
 
@@ -115,13 +92,12 @@ def deliver_email(
     if not settings.PRODUCTION:
         subject = "[Staging] " + subject
 
-    sendable, excluded = _filter_recipients(recipients, suppressed_emails)
-    result = {"success": [], "failure": [], "exclude": excluded}
+    for recipient in recipients:
+        if not is_valid_email(recipient):
+            continue
+        if suppressed_emails and recipient in suppressed_emails:
+            continue
 
-    if not sendable:
-        return result
-
-    for recipient in sendable:
         context = email_context.copy()
         urls = unsubscribe_urls.get(recipient) if unsubscribe_urls is not None else None
         if urls:
@@ -143,13 +119,9 @@ def deliver_email(
             if html_message:
                 msg.attach_alternative(html_message, "text/html")
             msg.send(fail_silently=False)
-            result["success"].append(recipient)
         except Exception:
             logger.exception("Email send failed to %s", recipient)
-            result["failure"].append(recipient)
 
         # Stagger sends based on AWS SES limit
         # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/manage-sending-limits.html
         sleep(0.2)
-
-    return result

--- a/src/utils/message.py
+++ b/src/utils/message.py
@@ -17,7 +17,10 @@ class UnsubscribeUrls:
     one_click: str
 
 
-def is_valid_email(email: str) -> bool:
+def _is_allowed_recipient(email: str) -> bool:
+    """
+    Return whether the email is allowed for sending in the current environment.
+    """
     if settings.TESTING or settings.PRODUCTION:
         return True
     return email in settings.EMAIL_WHITELIST
@@ -93,7 +96,7 @@ def deliver_email(
         subject = "[Staging] " + subject
 
     for recipient in recipients:
-        if not is_valid_email(recipient):
+        if not _is_allowed_recipient(recipient):
             continue
         if suppressed_emails and recipient in suppressed_emails:
             continue

--- a/src/utils/tests/test_message.py
+++ b/src/utils/tests/test_message.py
@@ -1,24 +1,24 @@
 from django.core import mail
 from django.test import TestCase, override_settings
 
-from utils.message import UnsubscribeUrls, deliver_email, is_valid_email
+from utils.message import UnsubscribeUrls, _is_allowed_recipient, deliver_email
 
 TEMPLATE_TXT = "general_email_message.txt"
 TEMPLATE_HTML = "general_email_message.html"
 BASE_CONTEXT = {"action": {"message": "hello"}, "subject": "Test"}
 
 
-class IsValidEmailTests(TestCase):
-    def test_allows_any_email_in_test_mode(self):
-        self.assertTrue(is_valid_email("anyone@example.com"))
+class IsAllowedRecipientTests(TestCase):
+    def test_allows_any_valid_email_in_test_mode(self):
+        self.assertTrue(_is_allowed_recipient("anyone@example.com"))
 
     @override_settings(TESTING=False, EMAIL_WHITELIST=["a@example.com"])
     def test_allows_whitelisted_email(self):
-        self.assertTrue(is_valid_email("a@example.com"))
+        self.assertTrue(_is_allowed_recipient("a@example.com"))
 
     @override_settings(TESTING=False, EMAIL_WHITELIST=["other@example.com"])
     def test_rejects_non_whitelisted_email(self):
-        self.assertFalse(is_valid_email("blocked@example.com"))
+        self.assertFalse(_is_allowed_recipient("blocked@example.com"))
 
 
 @override_settings(

--- a/src/utils/tests/test_message.py
+++ b/src/utils/tests/test_message.py
@@ -39,22 +39,20 @@ class DeliverEmailTests(TestCase):
 
     def test_sends_to_valid_recipient(self):
         # Act
-        result = self._send()
+        self._send()
 
         # Assert
-        self.assertEqual(result["success"], ["user@example.com"])
         self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ["user@example.com"])
 
     def test_excludes_suppressed_emails(self):
         # Act
-        result = self._send(
+        self._send(
             recipients=["bounced@example.com"],
             suppressed_emails={"bounced@example.com"},
         )
 
         # Assert
-        self.assertEqual(result["success"], [])
-        self.assertIn("bounced@example.com", result["exclude"])
         self.assertEqual(len(mail.outbox), 0)
 
     def test_sets_precedence_bulk(self):


### PR DESCRIPTION
- Don't return results that are ignored by callers anyway.
- Rename misleading `is_valid_email` method and make it private.