### PR TITLE
Bootstrap staging preview CORS for Live Dev Server

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -193,6 +193,12 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
 ]
 
+if STAGING:
+    # CodePress Live Dev Server preview origins (managed)
+    CORS_ALLOWED_ORIGIN_REGEXES.append(
+        r"^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$"
+    )
+
 # Health check
 
 HEALTH_CHECK_TOKEN = os.environ.get("HEALTH_CHECK_TOKEN", keys.HEALTH_CHECK_TOKEN)


### PR DESCRIPTION
## Summary
Enable CodePress Live Dev Server previews to call the ResearchHub staging API from this organization’s preview origins. The backend-only repository now permits those previews in staging while leaving development and production behavior unchanged; no frontend recipe was created because this repository contains only the API.

## Technical details
`src/researchhub/settings.py` keeps the existing CORS allowlist and regexes intact, then appends a CodePress-managed regex only when the existing `STAGING` environment gate is active. The regex is anchored to HTTPS origins with exactly one 32-character lowercase hexadecimal session id and the fixed org key `87d3f8ab798deaec`, so it cannot match other organizations, extra subdomains, suffix attacks, or HTTP origins. The change does not enable credentials, private-network access, or allow-all CORS. Because this is a standalone backend, the separate frontend must target this staging API, and the allowance becomes live only after the staging deployment includes this commit.

## Changes
- Add the org-scoped CodePress preview-origin regex to the staging-only Django CORS configuration.
- Preserve the existing CORS origins and production/development behavior.

## Test plan
- [ ] Run `uv run ruff check src` and `uv run ruff format --check --diff src`.
- [ ] Run `uv run python -m compileall -q src`.
- [ ] Load the settings under staging, development, and production APP_ENV values; verify the exact preview regex is present only in staging, matches a valid org-scoped HTTPS origin, and rejects HTTP, extra-label, suffix-attack, and other-org origins.
- [ ] Deploy staging with this commit, point the separate frontend at the staging API, and verify a CORS preflight from a valid org-scoped preview origin succeeds without credentialed or private-network headers.

## Open items
- The backend change takes effect only after staging is deployed. The frontend lives in a separate repository and must target this staging API for previews to use the allowance.

## Authors
Generated with [CodePress](https://codepress.dev) · [View the chat session](https://codepress.dev/dashboard/researchhub/chat/e9d51b33-20ca-475b-ae45-08e5716f37c0)

<!-- codepress-pr-source: cloud -->
<!-- codepress-pr-session: e9d51b33-20ca-475b-ae45-08e5716f37c0 -->