### PR TITLE
Bootstrap CodePress preview CORS

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -193,6 +193,12 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
 ]
 
+if STAGING:
+    # CodePress Live Dev Server preview origins (managed)
+    CORS_ALLOWED_ORIGIN_REGEXES.append(
+        r"^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$"
+    )
+
 # Health check
 
 HEALTH_CHECK_TOKEN = os.environ.get("HEALTH_CHECK_TOKEN", keys.HEALTH_CHECK_TOKEN)


### PR DESCRIPTION
## Summary
This prepares the ResearchHub staging API to accept requests from this organization’s Live Dev Server previews. Because this repository is backend-only, the bootstrap adds the preview CORS support without creating frontend recipe files; the allowance becomes active after the staging backend deploys, and the separate frontend must target that staging API.

## Technical details
Added a CodePress-managed, org-scoped anchored origin regex to `src/researchhub/settings.py` only when `APP_ENV` identifies the staging environment. The existing Django `django-cors-headers` allowlist, middleware ordering, and all existing origins remain unchanged. The pattern accepts exactly `https://<32 lowercase hex session>-87d3f8ab798deaec.preview.codepress.dev`, so it does not trust extra subdomains or suffix attacks. No credential or private-network CORS setting was enabled; the existing route-specific Coinbase CORS decorator was inspected and emits no such headers. No frontend was discovered, so no `.codepress/dev-server/recipe.json` or Dockerfile was authored.

## Changes
- Add the org-scoped CodePress preview origin regex to staging-only Django CORS settings.
- Keep production CORS unchanged and preserve the existing allowlist.

## Test plan
- [ ] Run `python -c 'from pathlib import Path; compile(Path("src/researchhub/settings.py").read_text(), "src/researchhub/settings.py", "exec")'` from the repository root.
- [ ] Run the staging Django checks and issue a CORS preflight from an origin matching `https://<32-hex-session>-87d3f8ab798deaec.preview.codepress.dev`; verify the origin is allowed without an `Access-Control-Allow-Credentials` or private-network header.
- [ ] Deploy the change to staging, point the preview frontend at the staging API, and verify an authenticated API request from that preview origin.

## Open items
- The CORS change takes effect only after the staging backend is deployed.
- The previewed frontend lives outside this backend repository and must target this staging API for the allowance to be used.

## Authors
Generated with [CodePress](https://codepress.dev) · [View the chat session](https://codepress.dev/dashboard/researchhub/chat/81aa766e-932d-4a70-8d90-f3994d714ec1)

<!-- codepress-pr-source: cloud -->
<!-- codepress-pr-session: 81aa766e-932d-4a70-8d90-f3994d714ec1 -->