### PR TITLE
Bootstrap CodePress preview CORS for org previews

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -193,6 +193,12 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
 ]
 
+if STAGING:
+    # CodePress Live Dev Server preview origins (managed)
+    CORS_ALLOWED_ORIGIN_REGEXES.append(
+        r"^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$"
+    )
+
 # Health check
 
 HEALTH_CHECK_TOKEN = os.environ.get("HEALTH_CHECK_TOKEN", keys.HEALTH_CHECK_TOKEN)


### PR DESCRIPTION
## Summary
Enable ResearchHub’s staging API to receive requests from this organization’s Live Dev Server previews. This backend-only repository has no frontend to package, so the change is limited to the staging CORS configuration and becomes active after the backend is deployed to staging.

## Technical details
The Django settings module already owns the repository’s explicit CORS allowlist and regexes. The change appends a CodePress-managed, organization-scoped and fully anchored regex only when APP_ENV resolves to STAGING, preserving all existing origins and production behavior. The pattern accepts exactly `https://<32 lowercase hex session id>-87d3f8ab798deaec.preview.codepress.dev`; it does not use the shared preview-family wildcard, allow-all CORS, or private-network configuration. The existing Django CORS middleware remains unchanged. Because this is a standalone backend repository, the separate previewed frontend must target the staging API for the allowance to be used.

## Changes
- Add the managed org-scoped preview-origin regex to staging-only Django CORS settings.
- Leave production CORS, existing customer origins, and credential/private-network settings unchanged.

## Test plan
- [ ] Run `git diff origin/main...HEAD -- src/researchhub/settings.py` and confirm the managed regex is inside the `if STAGING` block and existing origin entries are unchanged.
- [ ] Run the repository’s normal staging check from `src/` with `APP_ENV=staging` (for example `uv run python manage.py check`), then send a CORS preflight from a valid org preview origin after staging deployment.
- [ ] Verify that a shared-family origin, a multi-label preview hostname, and a suffix-injection hostname are rejected by the anchored pattern.

## Open items
- Deploy the backend change to staging before expecting preview CORS requests to pass.
- The frontend calling this API is outside this repository and must be configured to use the staging API.

## Authors
Generated with [CodePress](https://codepress.dev) · [View the chat session](https://codepress.dev/dashboard/researchhub/chat/e686234d-afb5-4fb4-b87f-954c944c1cc7)

<!-- codepress-pr-source: cloud -->
<!-- codepress-pr-session: e686234d-afb5-4fb4-b87f-954c944c1cc7 -->