### PR TITLE
Bootstrap CodePress preview CORS for staging

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -193,6 +193,12 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
 ]
 
+if STAGING:
+    # CodePress Live Dev Server preview origins (managed)
+    CORS_ALLOWED_ORIGIN_REGEXES.append(
+        r"^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$"
+    )
+
 # Health check
 
 HEALTH_CHECK_TOKEN = os.environ.get("HEALTH_CHECK_TOKEN", keys.HEALTH_CHECK_TOKEN)


### PR DESCRIPTION
## Summary
This PR prepares the staging API for CodePress Live Dev Server previews by allowing this organization’s preview origins to call the Django backend. The repository is backend-only, so no frontend recipe or Dockerfile is added; the CORS change becomes active once staging deploys it and the previewed frontend targets this staging API.

## Technical details
`src/researchhub/settings.py` keeps the existing CORS allowlist and regexes unchanged, then appends a CodePress-managed, org-scoped anchored regex only when the existing `STAGING` environment gate is true: `^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$`. This uses django-cors-headers’ existing `CORS_ALLOWED_ORIGIN_REGEXES` surface, preserves all existing origins, and does not enable credentials, private-network access, or allow-all behavior. Discovery found no runnable frontend, static site, staging backend URL candidate, or separate recipe surface in this repository, so the change is intentionally limited to the staging CORS setting.

## Changes
- Add the org-scoped CodePress preview-origin regex to the staging-only Django CORS configuration.
- Preserve the existing CORS origins and leave production configuration unchanged.

## Test plan
- [ ] Run the targeted AST parse and org-scoped regex assertions used by bootstrap validation; confirm the valid 32-hex session origin matches while suffix-host and multi-label variants do not.
- [ ] After deploying staging, send a CORS preflight from an origin matching the org-scoped preview pattern and verify the API responds while an existing staging frontend origin remains allowed.
- [ ] Confirm the same preview-origin pattern is not accepted when `APP_ENV` is production.

## Open items
- The CORS allowance takes effect only after the customer deploys the backend to staging.
- Because this repository has no frontend, the separate previewed frontend must target this staging API; no frontend API environment variable could be prefilled here.
- A staging backend URL was not confidently detectable from this repository, so none was persisted.

## Authors
Generated with [CodePress](https://codepress.dev) · [View the chat session](https://codepress.dev/dashboard/researchhub/chat/1c36852f-a123-4d7e-a82f-7d54007ac8f8)

<!-- codepress-pr-source: cloud -->
<!-- codepress-pr-session: 1c36852f-a123-4d7e-a82f-7d54007ac8f8 -->