### PR TITLE
Bootstrap CodePress preview CORS

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -193,6 +193,12 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
 ]
 
+if STAGING:
+    # CodePress Live Dev Server preview origins (managed)
+    CORS_ALLOWED_ORIGIN_REGEXES.append(
+        r"^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$"
+    )
+
 # Health check
 
 HEALTH_CHECK_TOKEN = os.environ.get("HEALTH_CHECK_TOKEN", keys.HEALTH_CHECK_TOKEN)


### PR DESCRIPTION
## Summary
Prepare the standalone ResearchHub backend for CodePress Live Dev Server previews by allowing this organization’s preview origins in the staging API only. The change preserves the existing origin policy and does not expose production to preview traffic; it becomes active after staging is deployed.

## Technical details
The Django settings module already uses django-cors-headers and maintains the existing CORS origin list/regexes. This change appends the exact org-scoped anchored preview regex `^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$` only when the real `STAGING` flag is true, with the required managed marker. It leaves production/base behavior, credentials, private-network access, and all existing origins untouched. The repository has no runnable frontend, so no dev-server recipe or Dockerfile was authored; the previewing frontend must target this staging API from its own repository.

## Changes
- Add a staging-gated, managed Django CORS regex for this organization’s CodePress preview origins.

## Test plan
- [ ] Run `uv run pre-commit run --config src/.pre-commit-config.yaml --files src/researchhub/settings.py`.
- [ ] Run `python3 -m py_compile src/researchhub/settings.py` and verify staging responses allow an origin matching the org-scoped pattern while production settings do not append it.

## Open items
- The CORS allowance takes effect only after the staging backend is deployed with this commit, and the previewing frontend must point to that staging API.

## Authors
Generated with [CodePress](https://codepress.dev) · [View the chat session](https://codepress.dev/dashboard/researchhub/chat/18863af0-4803-4321-960a-34594acd79be)

<!-- codepress-pr-source: cloud -->
<!-- codepress-pr-session: 18863af0-4803-4321-960a-34594acd79be -->