### PR TITLE
Bootstrap CodePress preview CORS for staging

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -193,6 +193,12 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
 ]
 
+if STAGING:
+    # CodePress Live Dev Server preview origins (managed)
+    CORS_ALLOWED_ORIGIN_REGEXES.append(
+        r"^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$"
+    )
+
 # Health check
 
 HEALTH_CHECK_TOKEN = os.environ.get("HEALTH_CHECK_TOKEN", keys.HEALTH_CHECK_TOKEN)


### PR DESCRIPTION
## Summary
CodePress previews need a safe way to call ResearchHub’s staging API from their per-session browser origin. This change enables that path only in staging, so production does not trust preview origins and existing application origins remain unchanged.

## Technical details
The repository is a standalone Django backend with no runnable frontend, so this bootstrap intentionally adds no Live Dev Server recipe or Dockerfile. In `src/researchhub/settings.py`, the existing `django-cors-headers` regex allowlist now appends a CodePress-managed, org-scoped pattern only when `APP_ENV` selects staging: `^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$`. The pattern is anchored, HTTPS-only, limited to one 32-character hex session label and this organization key, and does not change credentials or private-network settings. Existing allowlist entries are preserved.

## Changes
- Add a managed, staging-only org-scoped preview-origin regex to the Django CORS configuration.

## Test plan
- [ ] Run `python3 -m py_compile src/researchhub/settings.py` and `git diff --check`.
- [ ] Deploy staging from this commit, then send a CORS preflight with an origin matching `https://<32-hex-session>-87d3f8ab798deaec.preview.codepress.dev`; verify the API allows that origin while existing application origins still work.
- [ ] Confirm a production process (`APP_ENV=production`) does not include the managed preview regex.

## Open items
- The CORS change becomes live only after the backend is deployed to staging; the frontend must target that staging API.
- Because this repo is backend-only, the separate frontend repository still needs its own Live Dev Server bootstrap if preview artifacts are required.

## Authors
Generated with [CodePress](https://codepress.dev) · [View the chat session](https://codepress.dev/dashboard/researchhub/chat/441b45f9-5b2e-48f7-9c50-f72f9af27859)

<!-- codepress-pr-source: cloud -->
<!-- codepress-pr-session: 441b45f9-5b2e-48f7-9c50-f72f9af27859 -->