### PR TITLE
Bootstrap CodePress preview CORS

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -193,6 +193,12 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
 ]
 
+if STAGING:
+    # CodePress Live Dev Server preview origins (managed)
+    CORS_ALLOWED_ORIGIN_REGEXES.append(
+        r"^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$"
+    )
+
 # Health check
 
 HEALTH_CHECK_TOKEN = os.environ.get("HEALTH_CHECK_TOKEN", keys.HEALTH_CHECK_TOKEN)


### PR DESCRIPTION
## Summary
This backend-only bootstrap lets ResearchHub's staging API accept requests from this organization's CodePress Live Dev Server previews. The change is staged for deployment and will support a previewed frontend once staging is deployed with it and that frontend points at the staging API; no frontend recipe or Dockerfile was added because this repository has no runnable frontend.

## Technical details
`src/researchhub/settings.py` keeps the existing `django-cors-headers` allowlist and appends a CodePress-managed regex only when the repository's real `STAGING` flag is active (`APP_ENV` contains `staging`). The regex is anchored to exactly `https://[0-9a-f]{32}-87d3f8ab798deaec.preview.codepress.dev`, preserving the single-label, HTTPS-only, org-scoped boundary. Existing origins and CORS methods/headers are untouched; the change does not enable credentials or private-network access. The repository's custom route-level Coinbase CORS helper also derives approval from these settings and does not emit credential or private-network headers. Because the repo is backend-only, no `recipe.json`, Dockerfile, env prefill, or social-auth edit was appropriate.

## Changes
- Add the org-scoped CodePress preview origin regex to the staging-only Django CORS configuration.

## Test plan
- [ ] Run the focused syntax and regex checks for `src/researchhub/settings.py` and verify matching org preview origins are accepted while suffix/prefix attacks are rejected.
- [ ] Deploy staging with this commit, issue a CORS preflight from a matching CodePress preview origin, and verify the API returns the origin without adding credentialed or private-network access.
- [ ] Confirm a production `APP_ENV` does not append the managed preview regex.

## Authors
Generated with [CodePress](https://codepress.dev) · [View the chat session](https://codepress.dev/dashboard/researchhub/chat/d7357e0b-c9ff-4681-a1bd-ed7415f016ea)

<!-- codepress-pr-source: cloud -->
<!-- codepress-pr-session: d7357e0b-c9ff-4681-a1bd-ed7415f016ea -->