### PR TITLE
Report per-execution progress on the chat representation

### DIFF
--- a/src/research_ai/services/agent_persistence/chat_service.py
+++ b/src/research_ai/services/agent_persistence/chat_service.py
@@ -42,6 +42,20 @@ def _has_publishable_output(execution: AgentExecution) -> bool:
     return isinstance(text, str) and bool(text)
 
 
+def _max_iterations(execution: AgentExecution) -> int | None:
+    """The iteration ceiling this attempt was submitted with, if it recorded one.
+
+    Read from the execution's own configuration snapshot rather than current
+    settings, so a client rendering "step 4 of 30" shows the bound the run is
+    actually held to and not one a later settings change invented.
+    """
+    configuration = execution.configuration
+    if not isinstance(configuration, dict):
+        return None
+    value = configuration.get("max_iterations")
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
 @dataclass(frozen=True)
 class PreparedAgentExecution:
     execution: AgentExecution
@@ -259,6 +273,15 @@ class AgentChatService:
                 "retry_of_id": execution.retry_of_id,
                 "context_parent_id": execution.context_parent_id,
                 "stop_reason": execution.stop_reason,
+                # Progress signals. ``last_activity_at`` is the run's heartbeat
+                # -- the recorder stamps it on every durable write -- so a
+                # client can tell a turn that is working slowly from one that
+                # has gone quiet, well before the liveness sweep reclaims it.
+                "started_at": execution.started_at,
+                "finished_at": execution.finished_at,
+                "last_activity_at": execution.last_activity_at,
+                "iterations": execution.iterations,
+                "max_iterations": _max_iterations(execution),
                 "assistant_message_pending": (
                     execution.status == AgentExecution.Status.SUCCEEDED
                     and execution.publish_output_to_chat

--- a/src/research_ai/tests/agent/test_persistence_chat.py
+++ b/src/research_ai/tests/agent/test_persistence_chat.py
@@ -178,8 +178,9 @@ class AgentChatPersistenceTests(AgentPersistenceTestCase):
         # Act
         representation = chat.representation(self.conversation)
 
-        # Assert
-        self.assertNotIn("secret token", json.dumps(representation))
+        # Assert: default=str because the representation carries the progress
+        # timestamps as datetimes, which DRF renders on the way out.
+        self.assertNotIn("secret token", json.dumps(representation, default=str))
         self.assertEqual(
             representation["executions"][0]["error"],
             {
@@ -187,6 +188,55 @@ class AgentChatPersistenceTests(AgentPersistenceTestCase):
                 "message": "The agent could not complete this request.",
             },
         )
+
+    def test_representation_reports_progress_for_a_finished_turn(self):
+        # Arrange
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(
+            self.conversation,
+            "Question",
+            configuration={"max_iterations": 12},
+        )
+
+        # Act
+        agent(FakeProvider([text_turn("Answer")]), prepared.recorder).run("Question")
+        (entry,) = chat.representation(self.conversation)["executions"]
+
+        # Assert: enough for a client to render elapsed time and "step N of M".
+        self.assertIsNotNone(entry["started_at"])
+        self.assertIsNotNone(entry["finished_at"])
+        self.assertIsNotNone(entry["last_activity_at"])
+        self.assertEqual(entry["iterations"], 1)
+        self.assertEqual(entry["max_iterations"], 12)
+
+    def test_max_iterations_is_absent_when_the_attempt_recorded_none(self):
+        # Arrange: max_iterations is read from the attempt's own configuration
+        # snapshot, so a run that never recorded one reports nothing rather
+        # than borrowing today's settings.
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+
+        # Act
+        agent(FakeProvider([text_turn("Answer")]), prepared.recorder).run("Question")
+        (entry,) = chat.representation(self.conversation)["executions"]
+
+        # Assert
+        self.assertIsNone(entry["max_iterations"])
+
+    def test_a_running_turn_reports_a_heartbeat_and_no_finish(self):
+        # Arrange: a turn in flight, no terminal hook called.
+        chat = AgentChatService()
+        chat.prepare_turn(self.conversation, "Question")
+
+        # Act
+        (entry,) = chat.representation(self.conversation)["executions"]
+
+        # Assert: last_activity_at is what lets a client tell a turn working
+        # slowly from one that has gone quiet.
+        self.assertEqual(entry["status"], AgentExecution.Status.RUNNING)
+        self.assertIsNotNone(entry["started_at"])
+        self.assertIsNotNone(entry["last_activity_at"])
+        self.assertIsNone(entry["finished_at"])
 
     def test_public_representation_costs_the_same_however_long_the_chat_is(self):
         # Arrange


### PR DESCRIPTION
A client watching a turn could see its status but not how far along it was. Every signal it needs was already recorded and simply not projected: when the attempt started and finished, its heartbeat, how many model turns it has taken, and the iteration ceiling it is held to.

max_iterations is read from the attempt's own configuration snapshot rather than current settings, so a settings change while a turn sat queued cannot make the number the client renders disagree with the bound the run is actually held to. An attempt that recorded no ceiling reports none instead of borrowing today's value.

last_activity_at is the one worth calling out: the recorder stamps it on every durable write, so it is what lets a client distinguish a turn working slowly from one that has gone quiet.