### PR TITLE
Let a user stop the note assistant mid-turn

### DIFF
--- a/src/research_ai/services/agent/loop.py
+++ b/src/research_ai/services/agent/loop.py
@@ -187,6 +187,38 @@ class Agent:
                 raise
             logger.warning("agent recorder record_message failed", exc_info=True)
 
+    def _ensure_active(self) -> None:
+        """Stop if this run no longer owns its execution.
+
+        Called before each of the two expensive things an iteration does -- a
+        provider call and a tool call -- because every other stop point is a
+        durable write, and those come *after* the spending. Left to the writes
+        alone, a stopped run would pay for one more model request, or run a tool
+        and its side effects in full, before noticing.
+
+        It narrows those windows rather than closing them -- a cancellation
+        committing between this check and what follows still gets one call
+        through, and no probe here can prevent that. Correctness under a
+        concurrent turn is therefore not this check's job and must not be built
+        on it: a tool that mutates shared state guards its own write, the way
+        ``edit_note`` requires the version id it read and rejects the edit if the
+        document moved.
+
+        The check is optional (see ``AgentRecorder.is_active``) and its failure
+        is not a stop signal: a recorder that cannot answer must not be able to
+        halt a healthy run.
+        """
+        is_active = getattr(self.recorder, "is_active", None)
+        if is_active is None:
+            return
+        try:
+            active = is_active()
+        except Exception:  # noqa: BLE001 - an unanswerable check is not a stop
+            logger.warning("agent recorder is_active failed", exc_info=True)
+            return
+        if not active:
+            raise InterruptedError("agent execution is no longer running")
+
     def _record_terminal(self, hook: str, *args) -> None:
         """Best-effort terminal observation must not mask the run outcome."""
         if self.recorder is None:
@@ -257,6 +289,9 @@ class Agent:
         result_blocks: list[ToolResultBlock] = []
         stop = False
         for call in tool_calls:
+            # Per call, not once per turn: a turn can ask for several tools, and
+            # a cancellation landing partway through must not let the rest run.
+            self._ensure_active()
             logger.info(
                 "iter %d -> %s(%s)", iteration, call.name, _compact_args(call.input)
             )
@@ -299,6 +334,11 @@ class Agent:
         )
 
         for iteration in range(1, self.max_iterations + 1):
+            # Before spending on the model, not only before a tool: a provider
+            # call is the most expensive thing an iteration does and can hold the
+            # worker for the vendor SDK's whole retry budget, so a run that was
+            # stopped must not start another one.
+            self._ensure_active()
             turn = self._complete_turn(messages, rendered_tools, iteration)
             # The turn is replayed exactly as the provider sent it: reasoning
             # blocks are signed and must lead, and a server-side tool's result

--- a/src/research_ai/services/agent/recorder.py
+++ b/src/research_ai/services/agent/recorder.py
@@ -44,3 +44,14 @@ class AgentRecorder(Protocol):
     def on_run_failed(self, error: Exception) -> None:
         """The run failed; every message up to the failure was recorded."""
         ...
+
+    def is_active(self) -> bool:
+        """Whether this run still owns the work it is recording.
+
+        Optional. Recorders whose run can be cancelled from outside implement
+        this so the loop can stop *before* a tool call takes effect rather than
+        discovering it at the next write, which happens only after the side
+        effect. A recorder without it is treated as always active, so nothing is
+        required of observers that cannot be pre-empted.
+        """
+        ...

--- a/src/research_ai/services/agent_persistence/__init__.py
+++ b/src/research_ai/services/agent_persistence/__init__.py
@@ -1,5 +1,6 @@
 """Django persistence and read services for the provider-neutral agent core."""
 
+from .cancel_service import AgentExecutionCancelService
 from .chat_service import AgentChatService, PreparedAgentExecution
 from .context_service import AgentContextService
 from .conversation_service import (
@@ -23,6 +24,7 @@ __all__ = [
     "AgentContextService",
     "AgentConversationBusyError",
     "AgentConversationService",
+    "AgentExecutionCancelService",
     "AgentExecutionService",
     "AgentRetentionService",
     "AgentRunDetails",

--- a/src/research_ai/services/agent_persistence/cancel_service.py
+++ b/src/research_ai/services/agent_persistence/cancel_service.py
@@ -1,0 +1,158 @@
+"""Cooperative cancellation for agent executions.
+
+A conversation permits one active execution, so one that never reaches a
+terminal status refuses every later turn as busy -- what happens when a worker
+dies before recording an outcome, or the broker never delivers a queued attempt.
+Cancelling unsticks it, and is deliberately the only way: no timeout is guessed
+at here, because one provider call can retry inside the vendor SDK for over an
+hour, so silence says nothing about whether a run is alive.
+
+It does not reach into the worker. The run stops before its next tool call,
+where the loop checks it still owns the execution, or at its next durable write,
+which refuses to extend a terminal execution. A ``PENDING`` execution needs
+neither: its claim is a conditional update, so a task delivered afterwards finds
+nothing left to claim.
+
+Stopping partway through leaves the record disagreeing with the conversation the
+user can see, in both directions, and cancelling reconciles the two. A turn
+cancelled before it ran never recorded the prompt that started it, though the
+chat shows it; a turn cancelled just after its last answer recorded that answer
+but never published it, and never will, because publication requires a
+``SUCCEEDED`` execution. Left alone, the next turn -- which continues from this
+execution's context -- would answer a conversation missing a message the user
+sent, or resume from one they never received.
+"""
+
+import logging
+
+from django.db import transaction
+from django.utils import timezone
+
+from research_ai.models import AgentContextMessage, AgentExecution
+from research_ai.services.agent.types import Message, TextBlock
+from research_ai.services.agent_persistence.content import serialize_context_message
+
+logger = logging.getLogger(__name__)
+
+CANCELLED_STOP_REASON = "cancelled"
+
+
+class AgentExecutionCancelService:
+    """Cancels executions on request."""
+
+    def cancel(self, execution: AgentExecution) -> bool:
+        """Mark an active execution ``CANCELLED``; report whether it landed.
+
+        No error fields are written: a cancellation is the user's own decision,
+        not a failure, and the status alone says so. Returns ``False`` when the
+        execution already reached a terminal state, which is the ordinary race
+        of cancelling a turn that was finishing anyway.
+        """
+        with transaction.atomic():
+            locked = (
+                AgentExecution.objects.select_for_update()
+                .filter(
+                    id=execution.id,
+                    status__in=[
+                        AgentExecution.Status.PENDING,
+                        AgentExecution.Status.RUNNING,
+                    ],
+                )
+                .first()
+            )
+            if locked is None:
+                return False
+            now = timezone.now()
+            locked.status = AgentExecution.Status.CANCELLED
+            locked.stop_reason = CANCELLED_STOP_REASON
+            locked.finished_at = now
+            locked.last_activity_at = now
+            if locked.started_at is not None:
+                locked.duration_ms = max(
+                    0, round((now - locked.started_at).total_seconds() * 1000)
+                )
+            locked.save(
+                update_fields=[
+                    "status",
+                    "stop_reason",
+                    "finished_at",
+                    "last_activity_at",
+                    "duration_ms",
+                    "updated_date",
+                ]
+            )
+            self._preserve_trigger_prompt(locked)
+            self._drop_unpublished_answer(locked)
+        execution.refresh_from_db()
+        return True
+
+    def _drop_unpublished_answer(self, execution: AgentExecution) -> None:
+        """Forget a final answer this turn recorded but never delivered.
+
+        The mirror of :meth:`_preserve_trigger_prompt`. A run cancelled between
+        recording its closing assistant turn and transitioning to ``SUCCEEDED``
+        keeps that answer in its context but never publishes it -- publication
+        requires ``SUCCEEDED``, so not even the repair path will pick it up later.
+        The next turn would then continue from a reply the user never saw, and
+        answer as though it had already said something it never did.
+
+        Only a *closing* answer goes. An assistant turn holding tool calls is
+        load-bearing lineage: a later turn seals its open calls, and dropping it
+        would leave tool results with nothing to attach to.
+
+        Nothing here needs to ask whether the answer was published. Publishing
+        requires a ``SUCCEEDED`` execution, and a succeeded one is terminal, so
+        the caller has already returned before reaching this -- an answer that
+        was delivered is one this method never sees.
+        """
+        if not execution.publish_output_to_chat:
+            # No chat to diverge from -- a headless workflow's context is only
+            # ever read by the model, so there is no answer "the user missed".
+            return
+        last = execution.context_messages.order_by("-sequence").first()
+        if last is None or last.role != "assistant":
+            return
+        blocks = last.content if isinstance(last.content, list) else []
+        if any(
+            isinstance(block, dict) and block.get("type") == "tool_use"
+            for block in blocks
+        ):
+            return
+        last.delete()
+        logger.info(
+            "dropped an unpublished answer from a cancelled turn",
+            extra={"execution_id": execution.id},
+        )
+
+    def _preserve_trigger_prompt(self, execution: AgentExecution) -> None:
+        """Seed the context with the prompt this turn never got to record.
+
+        A cancelled execution is a continuation parent, and reconstruction reads
+        context rows only -- so whatever is missing here the model never sees
+        again. A ``RUNNING`` turn already recorded its seed prompt, but one
+        cancelled while still ``PENDING`` never ran, and its prompt lives only in
+        the chat message that triggered it. Left alone, the next turn would
+        inherit a conversation with a user message visible on screen and absent
+        from the model's view of it.
+        """
+        if execution.context_messages.exists():
+            return
+        trigger = execution.trigger_message
+        if trigger is None or not (trigger.content or "").strip():
+            return
+        content, provider_state, is_compacted, original_size = (
+            serialize_context_message(
+                Message(role="user", content=[TextBlock(text=trigger.content)])
+            )
+        )
+        AgentContextMessage.objects.create(
+            execution=execution,
+            sequence=execution.next_context_sequence,
+            role="user",
+            content=content,
+            provider_state=provider_state,
+            is_compacted=is_compacted,
+            original_size_bytes=original_size if is_compacted else None,
+        )
+        execution.next_context_sequence += 1
+        execution.save(update_fields=["next_context_sequence", "updated_date"])

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -78,11 +78,21 @@ def _apply_turn_metrics(
     execution: AgentExecution,
     turn: AssistantTurn | None,
     trace_fields: dict,
+    *,
+    sealed: bool = False,
 ) -> list[str]:
+    """Fold one turn's metrics into the execution; return the fields to save.
+
+    ``sealed`` marks an execution that already reached a terminal status. Its
+    work counters are still true and still accumulate -- the tokens were really
+    spent -- but ``stop_reason`` is not its last turn's stop reason any more, it
+    is why the run ended, and that answer is already written.
+    """
     if turn is None:
         return []
     execution.iterations += 1
-    execution.stop_reason = turn.stop_reason.value
+    if not sealed:
+        execution.stop_reason = turn.stop_reason.value
     execution.input_tokens = _add_optional(
         execution.input_tokens, trace_fields["input_tokens"]
     )
@@ -98,15 +108,17 @@ def _apply_turn_metrics(
     execution.total_latency_ms = _add_optional(
         execution.total_latency_ms, turn.latency_ms
     )
-    return [
+    fields = [
         "iterations",
-        "stop_reason",
         "input_tokens",
         "output_tokens",
         "cache_read_tokens",
         "cache_write_tokens",
         "total_latency_ms",
     ]
+    if not sealed:
+        fields.append("stop_reason")
+    return fields
 
 
 class DatabaseAgentRecorder:
@@ -145,6 +157,21 @@ class DatabaseAgentRecorder:
                 system_prompt=system_prompt,
                 last_activity_at=timezone.now(),
             )
+
+    def is_active(self) -> bool:
+        """Whether this execution is still ours to advance.
+
+        The agent loop calls this before each tool call so a run cancelled from
+        elsewhere stops before the tool takes effect. One indexed read per tool
+        call, against a model turn that costs seconds at minimum.
+        """
+        return AgentExecution.objects.filter(
+            id=self.execution.id,
+            status__in=[
+                AgentExecution.Status.PENDING,
+                AgentExecution.Status.RUNNING,
+            ],
+        ).exists()
 
     def _provenance(self, message: Message) -> str:
         if message.role == "assistant":
@@ -254,14 +281,22 @@ class DatabaseAgentRecorder:
             conversation.next_trace_sequence += 1
             conversation.save(update_fields=["next_trace_sequence", "updated_date"])
 
+            # The trace row above is history and always lands -- the turn really
+            # happened. The execution's lifecycle fields are not: cancellation
+            # can commit between this method and the context write that preceded
+            # it, and a sealed run's outcome must not be reopened by a write that
+            # was already in flight when someone stopped it. Advancing
+            # ``last_activity_at`` past ``finished_at`` would be incoherent on
+            # its own.
+            sealed = _is_terminal(execution.status)
             execution.next_message_sequence += 1
-            execution.last_activity_at = now
-            update_fields = [
-                "next_message_sequence",
-                "last_activity_at",
-                "updated_date",
-            ]
-            update_fields.extend(_apply_turn_metrics(execution, turn, turn_fields))
+            update_fields = ["next_message_sequence", "updated_date"]
+            if not sealed:
+                execution.last_activity_at = now
+                update_fields.append("last_activity_at")
+            update_fields.extend(
+                _apply_turn_metrics(execution, turn, turn_fields, sealed=sealed)
+            )
             execution.save(update_fields=update_fields)
 
     def on_run_finished(self, result) -> None:

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -44,6 +44,7 @@ from research_ai.services.agent_persistence import (
     AgentChatService,
     AgentContextService,
     AgentConversationService,
+    AgentExecutionCancelService,
     NoteAgentConversationService,
 )
 from research_ai.services.agent_persistence.activity import conversation_tool_events
@@ -80,6 +81,7 @@ class NotebookChatService:
         conversation_service: AgentConversationService | None = None,
         note_conversation_service: NoteAgentConversationService | None = None,
         context_service: AgentContextService | None = None,
+        cancel_service: AgentExecutionCancelService | None = None,
         config: NotebookChatConfig | None = None,
     ):
         self._provider = provider
@@ -98,6 +100,9 @@ class NotebookChatService:
         )
         self.contexts = (
             AgentContextService() if context_service is None else context_service
+        )
+        self.cancels = (
+            AgentExecutionCancelService() if cancel_service is None else cancel_service
         )
         self._config = config
 
@@ -181,6 +186,33 @@ class NotebookChatService:
         execution = prepared.execution
         transaction.on_commit(lambda: self._schedule_turn(execution.id))
         return execution
+
+    def cancel_active_turn(self, note: Note, user) -> AgentExecution | None:
+        """Stop the conversation's in-flight turn; ``None`` if none was running.
+
+        Cancellation is cooperative: the worker is not interrupted here, it
+        notices at its next durable write and unwinds. So this returns as soon
+        as the intent is recorded, and the turn's status is ``CANCELLED`` from
+        that moment even though a model call may still be in flight. Nothing
+        the worker does afterwards can revive the row -- every terminal
+        transition in the recorder is guarded on ``RUNNING``.
+        """
+        conversation = self.get_conversation(note, user)
+        if conversation is None:
+            return None
+        execution = (
+            conversation.executions.filter(
+                status__in=[
+                    AgentExecution.Status.PENDING,
+                    AgentExecution.Status.RUNNING,
+                ]
+            )
+            .order_by("-attempt")
+            .first()
+        )
+        if execution is None:
+            return None
+        return execution if self.cancels.cancel(execution) else None
 
     def _schedule_turn(self, execution_id: int) -> None:
         """Queue the worker turn, failing the execution if the broker refuses.

--- a/src/research_ai/tests/agent/test_persistence_cancellation.py
+++ b/src/research_ai/tests/agent/test_persistence_cancellation.py
@@ -1,0 +1,396 @@
+"""Cooperative cancellation of an agent execution."""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from research_ai.models import (
+    AgentConversation,
+    AgentConversationMessage,
+    AgentExecution,
+)
+from research_ai.services.agent.loop import AgentResult
+from research_ai.services.agent.tools import Tool
+from research_ai.services.agent.types import (
+    AssistantTurn,
+    Message,
+    StopReason,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
+from research_ai.services.agent_persistence import (
+    AgentChatService,
+    AgentContextService,
+    AgentExecutionCancelService,
+    AgentExecutionService,
+    DatabaseAgentRecorder,
+)
+from research_ai.services.agent_persistence.content import serialize_trace_message
+from research_ai.tests.agent.persistence_test_helpers import (
+    FakeProvider,
+    agent,
+    text_turn,
+    tool_turn,
+)
+
+
+def _finished_run(*, final_text, stop_reason, iterations=1):
+    """The subset of AgentResult the recorder's terminal hook reads."""
+    return AgentResult(
+        messages=[],
+        final_text=final_text,
+        stop_reason=stop_reason,
+        iterations=iterations,
+    )
+
+
+class AgentCancellationTests(TestCase):
+    def setUp(self):
+        self.conversation = AgentConversation.objects.create(workflow="notebook_chat")
+        self.cancels = AgentExecutionCancelService()
+
+    def _running(self):
+        return AgentExecutionService().start(
+            self.conversation, provider="fake", model="fake-model-v1"
+        )
+
+    def _chat_turn(self, text="Summarize the note"):
+        """A claimed turn that publishes its answer, as a real chat turn does.
+
+        ``start`` defaults to not publishing, so anything about the divergence
+        between chat and context has to come through here or it proves nothing.
+        """
+        prepared = AgentChatService().prepare_turn(
+            self.conversation, text, pending=True
+        )
+        self.assertTrue(prepared.execution.publish_output_to_chat)
+        return AgentExecutionService().claim_pending(prepared.execution)
+
+    def test_cancelling_a_running_execution_records_no_failure(self):
+        # Arrange
+        recorder = self._running()
+
+        # Act
+        cancelled = self.cancels.cancel(recorder.execution)
+
+        # Assert: a cancellation is the user's decision, not an error, so the
+        # status carries it and the error fields stay empty.
+        self.assertTrue(cancelled)
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
+        self.assertEqual(execution.stop_reason, "cancelled")
+        self.assertEqual(execution.error_type, "")
+        self.assertIsNotNone(execution.finished_at)
+
+    def test_cancelling_stops_the_worker_at_its_next_durable_write(self):
+        # Arrange: a run in flight, cancelled from another process.
+        recorder = self._running()
+        self.cancels.cancel(recorder.execution)
+
+        # Act & Assert: the recorder refuses to extend a terminal execution, so
+        # the loop unwinds instead of appending to context nobody will replay.
+        with self.assertRaises(InterruptedError):
+            recorder.record_message(
+                Message(role="assistant", content=[TextBlock(text="still going")])
+            )
+
+    def test_cancelling_stops_the_run_before_a_tool_takes_effect(self):
+        # Arrange: a turn that asked for two tools. Cancellation lands after the
+        # assistant message is recorded and before dispatch -- the window where
+        # the next durable write is not until *after* the tools have run.
+        recorder = self._running()
+        dispatched = []
+
+        def _tool(_args):
+            dispatched.append("edit")
+            return {"ok": True}
+
+        tools = [
+            Tool("edit_note", "edit", {"type": "object"}, _tool),
+            Tool("read_note", "read", {"type": "object"}, _tool),
+        ]
+        provider = FakeProvider(
+            [
+                AssistantTurn(
+                    text_blocks=[TextBlock(text="editing now")],
+                    tool_calls=[
+                        ToolUseBlock(id="c1", name="edit_note", input={}),
+                        ToolUseBlock(id="c2", name="read_note", input={}),
+                    ],
+                    stop_reason=StopReason.TOOL_USE,
+                ),
+                text_turn("done"),
+            ]
+        )
+        cancels = self.cancels
+
+        original = DatabaseAgentRecorder.record_message
+
+        def _cancel_after_assistant_turn(self_recorder, message, *, turn=None):
+            original(self_recorder, message, turn=turn)
+            if turn is not None:
+                cancels.cancel(self_recorder.execution)
+
+        # Act
+        with (
+            patch.object(
+                DatabaseAgentRecorder, "record_message", _cancel_after_assistant_turn
+            ),
+            self.assertRaises(InterruptedError),
+        ):
+            agent(provider, recorder, tools).run("Edit the note")
+
+        # Assert: the note was never touched. Cancellation frees the
+        # conversation at once, so a tool running past it could write the same
+        # document as the replacement turn.
+        self.assertEqual(dispatched, [])
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
+
+    def test_a_cancelled_run_does_not_pay_for_another_provider_call(self):
+        # Arrange: a turn that called a tool. The cancel lands *after* the tool
+        # result was durably recorded, so every write this turn made saw a live
+        # execution and none of them refused -- the next thing the run would do
+        # is ask the model again.
+        recorder = self._running()
+        dispatched = []
+        tools = [
+            Tool(
+                "read_note",
+                "read",
+                {"type": "object"},
+                lambda _a: dispatched.append("read") or {"ok": True},
+            )
+        ]
+        provider = FakeProvider([tool_turn("c1", "read_note", {}), text_turn("done")])
+        cancels = self.cancels
+        original = DatabaseAgentRecorder.record_message
+
+        def _cancel_after_tool_result(self_recorder, message, *, turn=None):
+            original(self_recorder, message, turn=turn)
+            if any(isinstance(block, ToolResultBlock) for block in message.content):
+                cancels.cancel(self_recorder.execution)
+
+        # Act
+        with (
+            patch.object(
+                DatabaseAgentRecorder, "record_message", _cancel_after_tool_result
+            ),
+            self.assertRaises(InterruptedError),
+        ):
+            agent(provider, recorder, tools).run("Read the note")
+
+        # Assert: the tool ran -- the cancel really did land after the turn was
+        # under way -- and the second model request was never made. A provider
+        # call is the costliest thing an iteration does and can hold the worker
+        # for the vendor SDK's entire retry budget, so waiting for the next
+        # durable write to notice would be paid for in tokens and in a worker
+        # nobody is waiting on.
+        self.assertEqual(dispatched, ["read"])
+        self.assertEqual(len(provider.calls), 1)
+
+    def test_a_recorder_that_cannot_answer_does_not_halt_a_healthy_run(self):
+        # Arrange: is_active is advisory -- a failing check must not be able to
+        # stop a run that is fine.
+        recorder = self._running()
+        dispatched = []
+        tools = [
+            Tool(
+                "read_note",
+                "read",
+                {"type": "object"},
+                lambda _a: dispatched.append("read") or {"ok": True},
+            )
+        ]
+        provider = FakeProvider([tool_turn("c1", "read_note", {}), text_turn("done")])
+
+        # Act
+        with patch.object(
+            DatabaseAgentRecorder,
+            "is_active",
+            side_effect=RuntimeError("database hiccup"),
+        ):
+            result = agent(provider, recorder, tools).run("Read the note")
+
+        # Assert
+        self.assertEqual(dispatched, ["read"])
+        self.assertEqual(result.final_text, "done")
+
+    def test_cancelling_an_already_terminal_execution_reports_false(self):
+        # Arrange
+        recorder = self._running()
+        self.cancels.cancel(recorder.execution)
+
+        # Act
+        again = self.cancels.cancel(recorder.execution)
+
+        # Assert: the ordinary race of stopping a turn that already stopped.
+        self.assertFalse(again)
+
+    def test_a_trace_write_already_in_flight_cannot_reopen_the_outcome(self):
+        # Arrange: recording a message writes durable context first, then the
+        # optional trace. Cancellation commits in the gap between the two, so
+        # the context write saw a live execution and the trace write finds a
+        # terminal one -- and it is holding the turn's own stop reason.
+        recorder = self._running()
+        traced_before = recorder.execution.messages.count()
+
+        def _cancel_then_serialize(message):
+            self.cancels.cancel(recorder.execution)
+            return serialize_trace_message(message)
+
+        # Act: patched where the recorder reads it, since it binds the symbol at
+        # import time.
+        with patch(
+            "research_ai.services.agent_persistence.recorder.serialize_trace_message",
+            _cancel_then_serialize,
+        ):
+            recorder.record_message(
+                Message(role="assistant", content=[TextBlock(text="mid-flight")]),
+                turn=text_turn("mid-flight"),
+            )
+
+        # Assert: the trace row still lands -- the turn really happened -- but
+        # the cancellation stands. Overwriting stop_reason here would report a
+        # CANCELLED execution as having stopped for `end_turn`, and moving
+        # last_activity_at would push it past finished_at.
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
+        self.assertEqual(execution.stop_reason, "cancelled")
+        self.assertGreater(execution.messages.count(), traced_before)
+        self.assertIsNotNone(execution.finished_at)
+        self.assertLessEqual(execution.last_activity_at, execution.finished_at)
+
+    def test_cancelling_a_queued_turn_keeps_its_prompt_in_the_model_context(self):
+        # Arrange: a turn cancelled while still PENDING never ran, so the worker
+        # never recorded its seed prompt as context. That prompt is on screen in
+        # the chat, and a cancelled execution is a continuation parent whose
+        # context the next turn inherits -- so without it the model would answer
+        # a conversation missing a message the user can see.
+        prepared = AgentChatService().prepare_turn(
+            self.conversation, "Summarize the note", pending=True
+        )
+        self.assertEqual(prepared.execution.context_messages.count(), 0)
+
+        # Act
+        self.cancels.cancel(prepared.execution)
+
+        # Assert
+        contexts = AgentContextService().for_continuation(
+            self.conversation, include_partial=True
+        )
+        self.assertEqual(len(contexts), 1)
+        self.assertEqual(contexts[0].role, "user")
+        self.assertIn("Summarize the note", str(contexts[0].content))
+
+    def test_cancelling_a_running_turn_does_not_duplicate_its_prompt(self):
+        # Arrange: a turn that did run recorded its own seed prompt, so the
+        # rescue above must not add a second copy of it.
+        prepared = AgentChatService().prepare_turn(
+            self.conversation, "Summarize the note", pending=True
+        )
+        recorder = AgentExecutionService().claim_pending(prepared.execution)
+        recorder.record_message(
+            Message(role="user", content=[TextBlock(text="Summarize the note")])
+        )
+
+        # Act
+        self.cancels.cancel(recorder.execution)
+
+        # Assert
+        self.assertEqual(recorder.execution.context_messages.count(), 1)
+
+    def test_cancelling_forgets_an_answer_the_user_never_received(self):
+        # Arrange: the run recorded its closing answer, then the cancel landed
+        # before ``on_run_finished`` could transition and publish it. Publication
+        # requires SUCCEEDED, so that answer is never delivered -- not even by the
+        # repair path.
+        recorder = self._chat_turn()
+        recorder.record_message(
+            Message(role="user", content=[TextBlock(text="Summarize the note")])
+        )
+        recorder.record_message(
+            Message(role="assistant", content=[TextBlock(text="Here is the summary")]),
+            turn=text_turn("Here is the summary"),
+        )
+
+        # Act
+        self.cancels.cancel(recorder.execution)
+        recorder.on_run_finished(
+            _finished_run(final_text="Here is the summary", stop_reason="end_turn")
+        )
+
+        # Assert: nothing was published, so the answer is gone from the context
+        # the next turn continues from -- otherwise the model would resume as
+        # though it had already replied.
+        self.assertFalse(
+            AgentConversationMessage.objects.filter(
+                generated_by_execution=recorder.execution,
+            ).exists()
+        )
+        contexts = AgentContextService().for_continuation(
+            self.conversation, include_partial=True
+        )
+        self.assertEqual([message.role for message in contexts], ["user"])
+
+    def test_cancelling_keeps_an_answer_the_user_did_receive(self):
+        # Arrange: the run finished and published before anyone pressed stop, so
+        # the answer is on screen and must stay in the context behind it. What
+        # protects it is that a succeeded execution is terminal and cancelling
+        # stops there -- the trim never runs at all. Pinned because moving the
+        # trim ahead of that early return would silently retract a delivered
+        # answer from the model's view of the conversation.
+        recorder = self._chat_turn()
+        recorder.record_message(
+            Message(role="assistant", content=[TextBlock(text="Here is the summary")]),
+            turn=text_turn("Here is the summary"),
+        )
+        recorder.on_run_finished(
+            _finished_run(final_text="Here is the summary", stop_reason="end_turn")
+        )
+
+        # Act
+        self.cancels.cancel(recorder.execution)
+
+        # Assert: the cancel is a no-op on a finished turn, and the delivered
+        # answer survives.
+        self.assertEqual(recorder.execution.context_messages.count(), 1)
+
+    def test_cancelling_keeps_an_assistant_turn_that_opened_tool_calls(self):
+        # Arrange: an assistant turn holding tool calls is lineage, not an
+        # answer. A later turn seals its open calls, so dropping it would leave
+        # tool results attached to nothing.
+        recorder = self._chat_turn()
+        recorder.record_message(
+            Message(
+                role="assistant",
+                content=[
+                    TextBlock(text="reading the note"),
+                    ToolUseBlock(id="c1", name="read_note", input={}),
+                ],
+            ),
+            turn=tool_turn("c1", "read_note", {}),
+        )
+
+        # Act
+        self.cancels.cancel(recorder.execution)
+
+        # Assert
+        self.assertEqual(recorder.execution.context_messages.count(), 1)
+
+    def test_cancelling_frees_the_conversation_for_the_next_turn(self):
+        # Arrange: one active execution per conversation is enforced, so an
+        # execution that never reaches a terminal status refuses every later
+        # turn on that conversation. Cancelling is what unsticks it -- including
+        # when the worker that owned it died without landing an outcome.
+        recorder = self._running()
+
+        # Act
+        self.cancels.cancel(recorder.execution)
+
+        # Assert
+        prepared = AgentChatService().prepare_turn(
+            self.conversation, "Never mind, try this instead.", pending=True
+        )
+        self.assertEqual(prepared.execution.status, AgentExecution.Status.PENDING)

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_views.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_views.py
@@ -64,6 +64,7 @@ class NotebookChatViewTests(APITestCase):
         )
         self.chat_url = f"/api/research_ai/notebook/notes/{self.note.id}/chat/"
         self.messages_url = f"{self.chat_url}messages/"
+        self.cancel_url = f"{self.chat_url}cancel/"
 
     def _post_message(self, text="Summarize the note"):
         with patch("research_ai.tasks.run_notebook_chat_turn_task.delay") as delay:
@@ -164,6 +165,71 @@ class NotebookChatViewTests(APITestCase):
 
         # Assert
         self.assertEqual(second.status_code, 409)
+
+    def test_cancel_stops_the_running_turn_and_frees_the_conversation(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        posted, _delay = self._post_message()
+
+        # Act
+        response = self.client.post(self.cancel_url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["cancelled"])
+        self.assertEqual(response.data["execution_id"], posted.data["execution_id"])
+        execution = AgentExecution.objects.get(id=posted.data["execution_id"])
+        self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
+        # The whole point: the user can send the next message immediately.
+        again, _delay = self._post_message("Try this instead")
+        self.assertEqual(again.status_code, 202)
+
+    def test_cancel_with_nothing_running_succeeds_and_reports_nothing(self):
+        # Arrange: the client cannot know which side of the race it is on when
+        # the user clicks stop, so this is a success, not an error.
+        self.client.force_authenticate(self.owner)
+
+        # Act
+        response = self.client.post(self.cancel_url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["cancelled"])
+        self.assertIsNone(response.data["execution_id"])
+
+    def test_cancel_requires_note_access(self):
+        # Arrange
+        self.client.force_authenticate(self.outsider)
+
+        # Act
+        response = self.client.post(self.cancel_url)
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_cancel_is_scoped_to_the_requesting_users_conversation(self):
+        # Arrange: two people each have a turn running on the same note. Each
+        # holds their own conversation, so stop must reach one and not the other.
+        self.client.force_authenticate(self.owner)
+        owners, _delay = self._post_message()
+        self.client.force_authenticate(self.viewer)
+        viewers, _delay = self._post_message("Summarize it for me too")
+        self.assertNotEqual(owners.data["execution_id"], viewers.data["execution_id"])
+
+        # Act
+        response = self.client.post(self.cancel_url)
+
+        # Assert: the viewer stopped their own turn and left the owner's running.
+        self.assertTrue(response.data["cancelled"])
+        self.assertEqual(response.data["execution_id"], viewers.data["execution_id"])
+        self.assertEqual(
+            AgentExecution.objects.get(id=viewers.data["execution_id"]).status,
+            AgentExecution.Status.CANCELLED,
+        )
+        self.assertEqual(
+            AgentExecution.objects.get(id=owners.data["execution_id"]).status,
+            AgentExecution.Status.PENDING,
+        )
 
     def test_get_chat_without_conversation_returns_empty(self):
         # Arrange

--- a/src/research_ai/urls.py
+++ b/src/research_ai/urls.py
@@ -21,6 +21,7 @@ from research_ai.views.expert_finder_views import (
     InvitedExpertOverviewView,
 )
 from research_ai.views.notebook_chat_views import (
+    NotebookChatCancelView,
     NotebookChatMessageView,
     NotebookChatView,
 )
@@ -109,5 +110,9 @@ urlpatterns = [
     path(
         "notebook/notes/<int:note_id>/chat/messages/",
         NotebookChatMessageView.as_view(),
+    ),
+    path(
+        "notebook/notes/<int:note_id>/chat/cancel/",
+        NotebookChatCancelView.as_view(),
     ),
 ]

--- a/src/research_ai/views/notebook_chat_views.py
+++ b/src/research_ai/views/notebook_chat_views.py
@@ -88,3 +88,26 @@ class NotebookChatMessageView(APIView):
             },
             status=status.HTTP_202_ACCEPTED,
         )
+
+
+class NotebookChatCancelView(APIView):
+    """Stop the note assistant's in-flight turn.
+
+    Idempotent by design: cancelling when nothing is running -- or when the
+    turn finished a moment earlier -- is a success reporting ``cancelled:
+    false``, not an error, because the client cannot know which side of that
+    race it is on when the user clicks stop.
+    """
+
+    permission_classes = [
+        IsAuthenticated,
+        ResearchAIPermission,
+        UserIsEditor | IsModerator,
+    ]
+
+    def post(self, request, note_id):
+        note = _get_viewable_note_or_404(note_id, request.user)
+        execution = NotebookChatService().cancel_active_turn(note, request.user)
+        if execution is None:
+            return Response({"cancelled": False, "execution_id": None})
+        return Response({"cancelled": True, "execution_id": execution.id})


### PR DESCRIPTION
A conversation permits one active execution, so a turn that never reaches a terminal status refuses every later turn on it as busy. That happens for real -- a worker dies between claiming an execution and recording its outcome, or the broker never delivers a queued attempt -- and until now the only way out was to wait for a run nobody was watching to finish or die.

Cancellation is the remedy, and deliberately the only one. An earlier draft of this branch also swept for stalled executions and reclaimed them on a timer; that is gone. The timeout was a guess, and sizing it meant answering how long a healthy run may stay quiet -- a question with no good answer when a single provider call can retry inside the vendor SDK for well over an hour and a tool handler can make several of those before returning. Every guess was either short enough to kill healthy runs or long enough to leave a stuck conversation stuck for an hour. Unsticking a conversation is a decision someone makes.

## How it stops a run

Cooperative, in three places:

* **Before the next tool call.** The loop asks the recorder whether it still owns the execution. This check has to come first, because every other stop point is a write and writes land only *after* the tool has already run -- a turn cancelled between recording its tool calls and dispatching them would still edit the note, beside the replacement turn the user just sent.
* **At the next durable write.** The recorder refuses to extend a terminal execution and raises, so the run unwinds through its ordinary failure path.
* **Before the run starts at all.** A PENDING execution needs nothing special: the claim is a conditional update, so a task delivered after the cancel finds nothing to claim.

`is_active` is advisory. A recorder that cannot answer must not be able to halt a healthy run, so a failing check is not a stop signal -- there is a test for that -- and recorders that cannot be pre-empted need not implement it at all.

## The endpoint

`POST /api/research_ai/notebook/notes/<id>/chat/cancel/` is idempotent. Cancelling when nothing is running, or when the turn finished a moment earlier, reports `cancelled: false` with a 200 rather than an error, because the client cannot know which side of that race it is on when the user clicks stop. It is scoped to the caller's own conversation: two people chatting on one note each stop only their own turn.

No error fields are written. Stopping a turn is a decision, not a failure, and CANCELLED alone says so -- a status the context service already understood and nothing ever wrote.

## Frontend note

Because cancel is now the only way to recover a stranded conversation, stop needs to be offered whenever an execution is active -- including on a fresh page load, not just while the user is watching the turn they started.

## Testing

`cd src && uv run python manage.py test research_ai --keepdb` -- 846 tests pass. Ruff clean.