### PR TITLE
Bootstrap org-scoped preview CORS

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -193,6 +193,12 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https:\/\/(\w)*[-]*(researchhub+)([-](\w)*)*(.vercel.app){1}/",
 ]
 
+if STAGING:
+    # CodePress Live Dev Server preview origins (managed)
+    CORS_ALLOWED_ORIGIN_REGEXES.append(
+        r"^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$"
+    )
+
 # Health check
 
 HEALTH_CHECK_TOKEN = os.environ.get("HEALTH_CHECK_TOKEN", keys.HEALTH_CHECK_TOKEN)


### PR DESCRIPTION
## Summary
Enable ResearchHub’s staging API to accept requests from this organization’s Live Dev Server previews, so a frontend preview in another repository can call the backend without weakening production access or trusting previews from other organizations.

## Technical details
The repository is a standalone Django backend with django-cors-headers and an additional Coinbase route helper that both consume `CORS_ALLOWED_ORIGIN_REGEXES`. The change appends a CodePress-managed, fully anchored org-scoped regex under the existing literal `STAGING` environment gate in `src/researchhub/settings.py`: `^https://[0-9a-f]{32}-87d3f8ab798deaec\.preview\.codepress\.dev$`. Existing origins and regexes remain unchanged; no allow-all, credentials, private-network, proxy, or production configuration was added. Because no runnable frontend exists in this repository, no recipe or Dockerfile was authored.

## Changes
- Add the org-scoped Live Dev Server preview origin pattern to staging-only Django CORS settings.
- Preserve the existing CORS allowlist and leave credential/private-network behavior unchanged.

## Test plan
- [ ] Run the repository’s Python parser check against `src/researchhub/settings.py` and confirm it parses successfully.
- [ ] Exercise the new regex with a valid 32-hex-session org preview origin and an appended-host attack variant; confirm only the valid origin matches.
- [ ] After deploying staging, send a CORS preflight from a valid org-scoped preview origin and confirm the API returns the requested origin, while an origin outside the org-scoped pattern is not allowed.

## Open items
- The CORS edit takes effect only after the customer deploys the staging backend with this change.
- The previewed frontend lives outside this backend repository and must target the staging API for this allowance to be used.

## Authors
Generated with [CodePress](https://codepress.dev) · [View the chat session](https://codepress.dev/dashboard/researchhub/chat/3fc996d0-0a45-4066-bc8b-c2c5d6070f5a)

<!-- codepress-pr-source: cloud -->
<!-- codepress-pr-session: 3fc996d0-0a45-4066-bc8b-c2c5d6070f5a -->

<!-- codepress-delivery-status: status=unverified head=5fbf2057f167bb8d37f17f5a4a196fb220431ced reason=The current head is not backed by an exact-head verification PASS. (already surfaced for this stage and head; continuing advisory.) -->

<!-- codepress-bootstrap-delivery: cbdba2d4-8244-40e8-8a2c-682d1edfc3d2 -->
