### PR TITLE
Narrate notebook chat turns and name what one is doing now

### DIFF
--- a/src/research_ai/services/agent_persistence/activity.py
+++ b/src/research_ai/services/agent_persistence/activity.py
@@ -55,15 +55,19 @@ class ToolCallEvent:
 class NarrationEvent:
     """Assistant prose from one text block of an assistant trace row.
 
-    ``from_final_turn`` marks text belonging to the execution's *last* assistant
-    message. On a run that succeeds, that text is the answer itself -- the same
-    string the chat publishes as an assistant message -- so a presenter must
-    drop it to avoid saying everything twice. A run that ends any other way
-    publishes nothing, and the flag then marks the only surviving account of
-    what the model last said, which a presenter should keep. While a run is
-    still going the flag is meaningless in practice: the last assistant message
-    is simply the newest thing the model said, nothing is published yet, and
-    showing it is the whole point.
+    ``from_final_turn`` marks text belonging to the execution's newest
+    *persisted* assistant message. On a run that succeeds, that text is
+    normally the answer itself -- the same string the chat publishes as an
+    assistant message -- so a presenter must drop it to avoid saying everything
+    twice. Normally, because trace writes are best-effort: when the answer's
+    own row was lost the flag lands on the newest surviving row instead, and a
+    presenter can only tell the two apart by checking the text against the
+    published answer. A run that ends any other way publishes nothing, and the
+    flag then marks the only surviving account of what the model last said,
+    which a presenter should keep. While a run is still going the flag is
+    meaningless in practice: the last assistant message is simply the newest
+    thing the model said, nothing is published yet, and showing it is the
+    whole point.
 
     The distinction cannot be drawn from the block alone. A turn that used the
     provider's own web search puts narration, the server-side call, and the

--- a/src/research_ai/services/agent_persistence/activity.py
+++ b/src/research_ai/services/agent_persistence/activity.py
@@ -45,6 +45,12 @@ class ToolCallEvent:
     result: dict | None = None
     is_error: bool = False
     finished_at: datetime | None = None
+    # A later assistant row exists, so this call is not what the run is doing
+    # now: a client dispatch returns before the loop asks the model to
+    # continue, and a server-side call's result rides in the later row itself,
+    # closing it. Open-and-stale therefore means the receipt was lost (trace
+    # writes are best-effort); the outcome stays unknown rather than guessed.
+    stale: bool = False
 
     @property
     def completed(self) -> bool:
@@ -117,8 +123,17 @@ class _Walk:
         event.finished_at = finished_at
 
     def begin_assistant_row(self, execution_id: int) -> None:
-        """A new assistant row demotes the previous one out of final position."""
+        """A new assistant row demotes what preceded it out of "current".
+
+        Earlier narration loses final-turn standing, and calls still open go
+        stale: the model does not get to speak again until its dispatches have
+        returned, so a call left open across this boundary is one whose result
+        row was lost, not one still running.
+        """
         self.pending_final[execution_id] = []
+        for event in self.events.get(execution_id, []):
+            if isinstance(event, ToolCallEvent) and not event.completed:
+                event.stale = True
 
     def narrate(self, execution_id: int, event: NarrationEvent) -> None:
         self.events.setdefault(execution_id, []).append(event)
@@ -140,7 +155,9 @@ def conversation_activity_events(
     is echoed by its ``tool_result``. A call whose result row never landed --
     the turn is still running, or it crashed or was truncated mid-flight --
     stays uncompleted rather than being guessed at; the presenter decides what
-    an open call means from the execution's own status.
+    an open call means from the execution's own status. An open call a later
+    assistant row has overtaken is additionally marked ``stale``: still of
+    unknown outcome, but demonstrably not what the run is doing now.
     """
     rows = AgentExecutionMessage.objects.filter(conversation=conversation).exclude(
         provenance__in=[

--- a/src/research_ai/services/agent_persistence/activity.py
+++ b/src/research_ai/services/agent_persistence/activity.py
@@ -1,10 +1,17 @@
-"""Tool-call events extracted from persisted execution traces.
+"""Activity events extracted from persisted execution traces.
 
 Trace rows (:class:`AgentExecutionMessage`) hold the model-protocol messages
 verbatim -- tool arguments, tool results, reasoning. None of that is user-safe
-API surface. This module reduces those rows to per-execution tool-call events:
-which tool ran, with what raw payloads, when, and whether it succeeded. A
-workflow presenter distills the raw payloads into public fields and drops the
+API surface. This module reduces those rows to per-execution events in
+conversation order:
+
+- :class:`ToolCallEvent` -- which tool ran, with what raw payloads, when, and
+  whether it succeeded.
+- :class:`NarrationEvent` -- assistant prose recorded mid-run, which is what
+  lets a long turn read as the agent explaining itself rather than as a
+  spinner.
+
+A workflow presenter distills the raw payloads into public fields and drops the
 rest; nothing here is shaped for a response body.
 
 Server-side tools (tools the provider ran itself, such as native web search)
@@ -45,11 +52,40 @@ class ToolCallEvent:
 
 
 @dataclass
+class NarrationEvent:
+    """Assistant prose from one text block of an assistant trace row.
+
+    ``from_final_turn`` marks text belonging to the execution's *last* assistant
+    message. That text is the answer itself -- the same string the chat
+    publishes as an assistant message once the run succeeds -- so a presenter
+    showing a finished turn must drop it to avoid saying everything twice.
+    While a run is still going the flag is meaningless in practice: the last
+    assistant message is simply the newest thing the model said, nothing is
+    published yet, and showing it is the whole point.
+
+    The distinction cannot be drawn from the block alone. A turn that used the
+    provider's own web search puts narration, the server-side call, and the
+    final answer in one assistant message, so "did this message make tool
+    calls" does not separate prose from answer -- only position does.
+    """
+
+    text: str
+    at: datetime
+    from_final_turn: bool = False
+
+
+ActivityEvent = ToolCallEvent | NarrationEvent
+
+
+@dataclass
 class _Walk:
     """Pairing state while trace rows stream by in conversation order."""
 
-    events: dict[int, list[ToolCallEvent]] = field(default_factory=dict)
+    events: dict[int, list[ActivityEvent]] = field(default_factory=dict)
     open_calls: dict[tuple[int, str], ToolCallEvent] = field(default_factory=dict)
+    # Narration from the newest assistant row seen per execution. It stays here
+    # until a later assistant row proves it was not the final turn.
+    pending_final: dict[int, list[NarrationEvent]] = field(default_factory=dict)
 
     def open(self, execution_id: int, call_id, event: ToolCallEvent) -> None:
         self.events.setdefault(execution_id, []).append(event)
@@ -74,41 +110,54 @@ class _Walk:
         event.is_error = is_error
         event.finished_at = finished_at
 
+    def begin_assistant_row(self, execution_id: int) -> None:
+        """A new assistant row demotes the previous one out of final position."""
+        self.pending_final[execution_id] = []
 
-def conversation_tool_events(
+    def narrate(self, execution_id: int, event: NarrationEvent) -> None:
+        self.events.setdefault(execution_id, []).append(event)
+        self.pending_final.setdefault(execution_id, []).append(event)
+
+    def finish(self) -> dict[int, list[ActivityEvent]]:
+        for narrations in self.pending_final.values():
+            for event in narrations:
+                event.from_final_turn = True
+        return self.events
+
+
+def conversation_activity_events(
     conversation: AgentConversation,
-) -> dict[int, list[ToolCallEvent]]:
-    """Ordered tool-call events per execution id, from one trace query.
+) -> dict[int, list[ActivityEvent]]:
+    """Ordered activity events per execution id, from one trace query.
 
-    Pairing follows the id-correlation invariant: a ``tool_use`` block's id is
-    echoed by its ``tool_result``. A call whose result row never landed -- the
-    turn is still running, or it crashed or was truncated mid-flight -- stays
-    uncompleted rather than being guessed at; the presenter decides what an
-    open call means from the execution's own status.
+    Tool pairing follows the id-correlation invariant: a ``tool_use`` block's id
+    is echoed by its ``tool_result``. A call whose result row never landed --
+    the turn is still running, or it crashed or was truncated mid-flight --
+    stays uncompleted rather than being guessed at; the presenter decides what
+    an open call means from the execution's own status.
     """
-    rows = (
-        AgentExecutionMessage.objects.filter(conversation=conversation)
-        .exclude(
-            provenance__in=[
-                AgentExecutionMessage.Provenance.HUMAN,
-                AgentExecutionMessage.Provenance.BACKEND,
-            ]
-        )
-        .order_by("sequence")
-        .values_list("execution_id", "content", "created_date")
+    rows = AgentExecutionMessage.objects.filter(conversation=conversation).exclude(
+        provenance__in=[
+            AgentExecutionMessage.Provenance.HUMAN,
+            AgentExecutionMessage.Provenance.BACKEND,
+        ]
     )
     walk = _Walk()
-    for execution_id, content, created in rows:
+    for execution_id, role, content, created in rows.order_by("sequence").values_list(
+        "execution_id", "role", "content", "created_date"
+    ):
         if not isinstance(content, list):
             continue
+        if role == "assistant":
+            walk.begin_assistant_row(execution_id)
         for block in content:
             if isinstance(block, dict):
-                _apply_block(walk, execution_id, block, created)
-    return walk.events
+                _apply_block(walk, execution_id, block, created, role=role)
+    return walk.finish()
 
 
 def _apply_block(
-    walk: _Walk, execution_id: int, block: dict, created: datetime
+    walk: _Walk, execution_id: int, block: dict, created: datetime, *, role: str
 ) -> None:
     block_type = block.get("type")
     if block_type == "tool_use":
@@ -132,6 +181,22 @@ def _apply_block(
         )
     elif block_type == "server_tool":
         _apply_server_block(walk, execution_id, block.get("data"), created)
+    elif block_type == "text" and role == "assistant":
+        _apply_text_block(walk, execution_id, block, created)
+
+
+def _apply_text_block(
+    walk: _Walk, execution_id: int, block: dict, created: datetime
+) -> None:
+    # A row too large to persist is replaced by a marker text block carrying
+    # ``_truncated``; that marker is written for an operator reading the trace,
+    # not for the user waiting on the turn.
+    if block.get("_truncated"):
+        return
+    text = block.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return
+    walk.narrate(execution_id, NarrationEvent(text=text.strip(), at=created))
 
 
 def _apply_server_block(

--- a/src/research_ai/services/agent_persistence/activity.py
+++ b/src/research_ai/services/agent_persistence/activity.py
@@ -56,12 +56,14 @@ class NarrationEvent:
     """Assistant prose from one text block of an assistant trace row.
 
     ``from_final_turn`` marks text belonging to the execution's *last* assistant
-    message. That text is the answer itself -- the same string the chat
-    publishes as an assistant message once the run succeeds -- so a presenter
-    showing a finished turn must drop it to avoid saying everything twice.
-    While a run is still going the flag is meaningless in practice: the last
-    assistant message is simply the newest thing the model said, nothing is
-    published yet, and showing it is the whole point.
+    message. On a run that succeeds, that text is the answer itself -- the same
+    string the chat publishes as an assistant message -- so a presenter must
+    drop it to avoid saying everything twice. A run that ends any other way
+    publishes nothing, and the flag then marks the only surviving account of
+    what the model last said, which a presenter should keep. While a run is
+    still going the flag is meaningless in practice: the last assistant message
+    is simply the newest thing the model said, nothing is published yet, and
+    showing it is the whole point.
 
     The distinction cannot be drawn from the block alone. A turn that used the
     provider's own web search puts narration, the server-side call, and the

--- a/src/research_ai/services/notebook_chat/activity.py
+++ b/src/research_ai/services/notebook_chat/activity.py
@@ -71,6 +71,7 @@ _MAX_SOURCES = 5
 # pathological turn cannot make every poll of this conversation huge.
 _MAX_NARRATION_CHARS = 4000
 
+PHASE_QUEUED = "queued"
 PHASE_USING_TOOL = "using_tool"
 PHASE_RESPONDING = "responding"
 PHASE_THINKING = "thinking"
@@ -95,31 +96,41 @@ def public_activity(
 
 
 def execution_phase(
-    events: Iterable[ActivityEvent], *, execution_active: bool
+    events: Iterable[ActivityEvent],
+    *,
+    execution_active: bool,
+    execution_claimed: bool,
 ) -> dict | None:
     """What a live turn is doing right now, or ``None`` once it is terminal.
 
-    Derived rather than stored: the trace rows already say it, and a separate
-    persisted phase would be one more thing a dead worker could leave lying
-    about the run's state.
+    A turn no worker has claimed yet is ``queued``: nothing is thinking, and
+    during a backlog that difference stays visible for a while. Everything
+    else is derived rather than stored: the trace rows already say it, and a
+    separate persisted phase would be one more thing a dead worker could leave
+    lying about the run's state.
     """
     if not execution_active:
         return None
+    if not execution_claimed:
+        return {"state": PHASE_QUEUED, "label": "Waiting to start"}
     ordered = list(events)
-    open_call = next(
-        (
-            event
-            for event in reversed(ordered)
-            if isinstance(event, ToolCallEvent) and not event.completed
-        ),
-        None,
-    )
-    if open_call is not None:
+    open_calls = [
+        event
+        for event in ordered
+        if isinstance(event, ToolCallEvent) and not event.completed
+    ]
+    if len(open_calls) == 1:
+        (call,) = open_calls
         return {
             "state": PHASE_USING_TOOL,
-            "label": _active_label(open_call.tool),
-            "tool": open_call.tool,
+            "label": _active_label(call.tool),
+            "tool": call.tool,
         }
+    if open_calls:
+        # One turn can dispatch several calls. They run in their emitted order
+        # but their results land as one batch, so mid-batch the trace cannot
+        # say which call is the current one -- naming any would be a guess.
+        return {"state": PHASE_USING_TOOL, "label": "Running tools"}
     if ordered and isinstance(ordered[-1], NarrationEvent):
         return {"state": PHASE_RESPONDING, "label": "Writing a response"}
     return {"state": PHASE_THINKING, "label": "Thinking"}

--- a/src/research_ai/services/notebook_chat/activity.py
+++ b/src/research_ai/services/notebook_chat/activity.py
@@ -1,20 +1,31 @@
 """User-safe activity feed for notebook chat turns.
 
-A curated projection of :func:`conversation_tool_events` into a fixed public
-shape -- tool, label, status, timestamps -- plus the enrichments the frontend
-renders: the note version an edit produced, so an open editor knows to reload,
-a human detail line (the search query or author searched for), and title/url
-``sources`` for citations. Sources come from every tool that yields citable
-items -- web search and the scholarly tools alike -- in one shape, so the
-frontend renders one citation list. Raw tool arguments and results never pass
-through: tool traffic includes whole note documents, paper full texts, and
-provider payloads, and tool error strings are written for the model, not the
-user.
+A curated projection of :func:`conversation_activity_events` into fixed public
+shapes. Tool calls carry tool, label, status and timestamps, plus the
+enrichments the frontend renders: the note version an edit produced, so an open
+editor knows to reload, a human detail line (the search query or author searched
+for), and title/url ``sources`` for citations. Sources come from every tool that
+yields citable items -- web search and the scholarly tools alike -- in one
+shape, so the frontend renders one citation list. Narration events carry the
+prose the model wrote between tool calls, which is what turns a slow turn from a
+spinner into a readable account of what the agent is doing.
+
+Raw tool arguments and results never pass through: tool traffic includes whole
+note documents, paper full texts, and provider payloads, and tool error strings
+are written for the model, not the user.
+
+Alongside the feed, :func:`execution_phase` reduces the same events to a single
+coarse "what is it doing right now" for a live turn, so a client has something
+to show without interpreting the event list itself.
 """
 
 from collections.abc import Iterable
 
-from research_ai.services.agent_persistence.activity import ToolCallEvent
+from research_ai.services.agent_persistence.activity import (
+    ActivityEvent,
+    NarrationEvent,
+    ToolCallEvent,
+)
 from research_ai.services.note_tools import EDIT_NOTE, READ_NOTE
 from research_ai.services.researcher_profile.openalex_tools import GET_WORK_FULLTEXT
 
@@ -34,6 +45,18 @@ _LABELS = {
     GET_AUTHOR_WORKS: "Fetched an author's publications",
     GET_WORK_FULLTEXT: "Read a paper",
 }
+# What each tool is doing while the call is still open, for the live phase.
+# Distinct from _LABELS, which reads as a completed step.
+_ACTIVE_LABELS = {
+    READ_NOTE: "Reading the note",
+    EDIT_NOTE: "Editing the note",
+    WEB_SEARCH: "Searching the web",
+    SEARCH_INSTITUTIONS: "Searching institutions",
+    SEARCH_AUTHORS: "Searching scholarly authors",
+    GET_AUTHOR: "Looking up an author",
+    GET_AUTHOR_WORKS: "Fetching an author's publications",
+    GET_WORK_FULLTEXT: "Reading a paper",
+}
 # The input field per tool whose value is the user's own kind of text -- safe
 # and meaningful to echo as the event detail.
 _DETAIL_INPUT_FIELDS = {
@@ -43,16 +66,76 @@ _DETAIL_INPUT_FIELDS = {
 }
 _MAX_DETAIL_CHARS = 200
 _MAX_SOURCES = 5
+# Narration between tool calls is a sentence or two in practice. The bound is
+# generous enough never to cut real narration, and only exists so one
+# pathological turn cannot make every poll of this conversation huge.
+_MAX_NARRATION_CHARS = 4000
+
+PHASE_USING_TOOL = "using_tool"
+PHASE_RESPONDING = "responding"
+PHASE_THINKING = "thinking"
 
 
 def public_activity(
-    events: Iterable[ToolCallEvent], *, execution_active: bool
+    events: Iterable[ActivityEvent], *, execution_active: bool
 ) -> list[dict]:
-    """Render events to the public shape; nothing raw passes through."""
-    return [_public_event(event, execution_active) for event in events]
+    """Render events to the public shapes; nothing raw passes through."""
+    public = []
+    for event in events:
+        if isinstance(event, NarrationEvent):
+            rendered = _public_narration(event, execution_active)
+        else:
+            rendered = _public_tool_call(event, execution_active)
+        if rendered is not None:
+            public.append(rendered)
+    return public
 
 
-def _public_event(event: ToolCallEvent, execution_active: bool) -> dict:
+def execution_phase(
+    events: Iterable[ActivityEvent], *, execution_active: bool
+) -> dict | None:
+    """What a live turn is doing right now, or ``None`` once it is terminal.
+
+    Derived rather than stored: the trace rows already say it, and a separate
+    persisted phase would be one more thing a dead worker could leave lying
+    about the run's state.
+    """
+    if not execution_active:
+        return None
+    ordered = list(events)
+    open_call = next(
+        (
+            event
+            for event in reversed(ordered)
+            if isinstance(event, ToolCallEvent) and not event.completed
+        ),
+        None,
+    )
+    if open_call is not None:
+        return {
+            "state": PHASE_USING_TOOL,
+            "label": _active_label(open_call.tool),
+            "tool": open_call.tool,
+        }
+    if ordered and isinstance(ordered[-1], NarrationEvent):
+        return {"state": PHASE_RESPONDING, "label": "Writing a response"}
+    return {"state": PHASE_THINKING, "label": "Thinking"}
+
+
+def _public_narration(event: NarrationEvent, execution_active: bool) -> dict | None:
+    # On a finished turn the final assistant text is published as the chat
+    # message, so echoing it here too would show the answer twice. While the
+    # turn is live nothing is published yet and this is the only way to read it.
+    if event.from_final_turn and not execution_active:
+        return None
+    return {
+        "type": "narration",
+        "text": event.text[:_MAX_NARRATION_CHARS],
+        "at": event.at,
+    }
+
+
+def _public_tool_call(event: ToolCallEvent, execution_active: bool) -> dict:
     public = {
         "type": "tool_call",
         "tool": event.tool,
@@ -80,6 +163,12 @@ def _label(tool: str) -> str:
     if tool in _LABELS:
         return _LABELS[tool]
     return f"Used {tool}" if tool else "Ran a tool"
+
+
+def _active_label(tool: str) -> str:
+    if tool in _ACTIVE_LABELS:
+        return _ACTIVE_LABELS[tool]
+    return f"Running {tool}" if tool else "Running a tool"
 
 
 def _status(event: ToolCallEvent, execution_active: bool) -> str:

--- a/src/research_ai/services/notebook_chat/activity.py
+++ b/src/research_ai/services/notebook_chat/activity.py
@@ -82,12 +82,13 @@ def public_activity(
     *,
     execution_active: bool,
     answer_published: bool,
+    published_answer: str | None,
 ) -> list[dict]:
     """Render events to the public shapes; nothing raw passes through."""
     public = []
     for event in events:
         if isinstance(event, NarrationEvent):
-            rendered = _public_narration(event, answer_published)
+            rendered = _public_narration(event, answer_published, published_answer)
         else:
             rendered = _public_tool_call(event, execution_active)
         if rendered is not None:
@@ -136,13 +137,27 @@ def execution_phase(
     return {"state": PHASE_THINKING, "label": "Thinking"}
 
 
-def _public_narration(event: NarrationEvent, answer_published: bool) -> dict | None:
+def _public_narration(
+    event: NarrationEvent, answer_published: bool, published_answer: str | None
+) -> dict | None:
     # Once the final assistant text is published as the chat message, echoing
     # it here too would show the answer twice. Until then it stays: on a live
     # turn nothing is published yet, and a turn that fails or is stopped never
     # publishes, leaving the feed as the only account of what the model last
     # said.
-    if event.from_final_turn and answer_published:
+    # The containment clause keeps the flag honest: trace writes are
+    # best-effort, so ``from_final_turn`` can land on the newest *surviving*
+    # row rather than the answer's own. Text the published answer does not
+    # contain is narration a lost final write left behind, and it stays. The
+    # answer joins its row's text blocks verbatim, so containment holds for
+    # every block that really is the answer. With no published text to check
+    # -- a regeneration replaced this answer -- position stands, keeping the
+    # replaced answer buried.
+    if (
+        event.from_final_turn
+        and answer_published
+        and (published_answer is None or event.text in published_answer)
+    ):
         return None
     return {
         "type": "narration",

--- a/src/research_ai/services/notebook_chat/activity.py
+++ b/src/research_ai/services/notebook_chat/activity.py
@@ -77,13 +77,16 @@ PHASE_THINKING = "thinking"
 
 
 def public_activity(
-    events: Iterable[ActivityEvent], *, execution_active: bool
+    events: Iterable[ActivityEvent],
+    *,
+    execution_active: bool,
+    answer_published: bool,
 ) -> list[dict]:
     """Render events to the public shapes; nothing raw passes through."""
     public = []
     for event in events:
         if isinstance(event, NarrationEvent):
-            rendered = _public_narration(event, execution_active)
+            rendered = _public_narration(event, answer_published)
         else:
             rendered = _public_tool_call(event, execution_active)
         if rendered is not None:
@@ -122,11 +125,13 @@ def execution_phase(
     return {"state": PHASE_THINKING, "label": "Thinking"}
 
 
-def _public_narration(event: NarrationEvent, execution_active: bool) -> dict | None:
-    # On a finished turn the final assistant text is published as the chat
-    # message, so echoing it here too would show the answer twice. While the
-    # turn is live nothing is published yet and this is the only way to read it.
-    if event.from_final_turn and not execution_active:
+def _public_narration(event: NarrationEvent, answer_published: bool) -> dict | None:
+    # Once the final assistant text is published as the chat message, echoing
+    # it here too would show the answer twice. Until then it stays: on a live
+    # turn nothing is published yet, and a turn that fails or is stopped never
+    # publishes, leaving the feed as the only account of what the model last
+    # said.
+    if event.from_final_turn and answer_published:
         return None
     return {
         "type": "narration",

--- a/src/research_ai/services/notebook_chat/activity.py
+++ b/src/research_ai/services/notebook_chat/activity.py
@@ -115,10 +115,12 @@ def execution_phase(
     if not execution_claimed:
         return {"state": PHASE_QUEUED, "label": "Waiting to start"}
     ordered = list(events)
+    # Stale open calls -- ones a later assistant row has overtaken -- are
+    # history whose receipt was lost, not what the turn is doing now.
     open_calls = [
         event
         for event in ordered
-        if isinstance(event, ToolCallEvent) and not event.completed
+        if isinstance(event, ToolCallEvent) and not event.completed and not event.stale
     ]
     if len(open_calls) == 1:
         (call,) = open_calls

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -133,6 +133,11 @@ class NotebookChatService:
         data = self.chat.representation(conversation)
         events = conversation_activity_events(conversation)
         active = {AgentExecution.Status.PENDING, AgentExecution.Status.RUNNING}
+        published_answers = {
+            message["execution_id"]: message["content"]
+            for message in data["messages"]
+            if message["execution_id"] is not None
+        }
         for execution in data["executions"]:
             execution_active = execution["status"] in active
             execution_events = events.get(execution["id"], [])
@@ -149,6 +154,10 @@ class NotebookChatService:
                     execution["status"] == AgentExecution.Status.SUCCEEDED
                     and not execution["assistant_message_pending"]
                 ),
+                # The published text itself, so the presenter can tell the
+                # answer's own trace row from older narration a lost final
+                # trace write left misflagged as the answer.
+                published_answer=published_answers.get(execution["id"]),
             )
             execution["phase"] = execution_phase(
                 execution_events,

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -46,9 +46,14 @@ from research_ai.services.agent_persistence import (
     AgentConversationService,
     NoteAgentConversationService,
 )
-from research_ai.services.agent_persistence.activity import conversation_tool_events
+from research_ai.services.agent_persistence.activity import (
+    conversation_activity_events,
+)
 from research_ai.services.note_tools import NoteToolset
-from research_ai.services.notebook_chat.activity import public_activity
+from research_ai.services.notebook_chat.activity import (
+    execution_phase,
+    public_activity,
+)
 from research_ai.services.notebook_chat.config import NotebookChatConfig
 from research_ai.services.notebook_chat.toolset import (
     NotebookWebSearchToolset,
@@ -121,14 +126,21 @@ class NotebookChatService:
         Activity is a notebook-chat presentation concern layered onto the
         workflow-neutral chat payload, so the generic service stays free of
         tool-specific knowledge.
+
+        ``phase`` is present on every execution and is ``None`` for terminal
+        ones, so a client reads "what is it doing" from one field either way.
         """
         data = self.chat.representation(conversation)
-        events = conversation_tool_events(conversation)
+        events = conversation_activity_events(conversation)
         active = {AgentExecution.Status.PENDING, AgentExecution.Status.RUNNING}
         for execution in data["executions"]:
+            execution_active = execution["status"] in active
+            execution_events = events.get(execution["id"], [])
             execution["activity"] = public_activity(
-                events.get(execution["id"], []),
-                execution_active=execution["status"] in active,
+                execution_events, execution_active=execution_active
+            )
+            execution["phase"] = execution_phase(
+                execution_events, execution_active=execution_active
             )
         return data
 

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -151,7 +151,13 @@ class NotebookChatService:
                 ),
             )
             execution["phase"] = execution_phase(
-                execution_events, execution_active=execution_active
+                execution_events,
+                execution_active=execution_active,
+                # A pending turn is waiting for a worker to claim it; only a
+                # claimed one has model work for the phase to describe.
+                execution_claimed=(
+                    execution["status"] == AgentExecution.Status.RUNNING
+                ),
             )
         return data
 

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -139,11 +139,15 @@ class NotebookChatService:
             execution["activity"] = public_activity(
                 execution_events,
                 execution_active=execution_active,
-                # Publication is success-gated: only a succeeded run's final
-                # text becomes the chat message. A failed, interrupted or
-                # cancelled run never publishes, so its feed keeps that text.
+                # The final text is dropped only while the chat truly carries
+                # it. Publication is success-gated, so any other terminal
+                # status keeps the text here, and a succeeded run stuck on
+                # publication repair (``assistant_message_pending``) keeps it
+                # too until the repair lands. A superseded run reports not
+                # pending, so an answer a regeneration replaced stays out.
                 answer_published=(
                     execution["status"] == AgentExecution.Status.SUCCEEDED
+                    and not execution["assistant_message_pending"]
                 ),
             )
             execution["phase"] = execution_phase(

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -137,7 +137,14 @@ class NotebookChatService:
             execution_active = execution["status"] in active
             execution_events = events.get(execution["id"], [])
             execution["activity"] = public_activity(
-                execution_events, execution_active=execution_active
+                execution_events,
+                execution_active=execution_active,
+                # Publication is success-gated: only a succeeded run's final
+                # text becomes the chat message. A failed, interrupted or
+                # cancelled run never publishes, so its feed keeps that text.
+                answer_published=(
+                    execution["status"] == AgentExecution.Status.SUCCEEDED
+                ),
             )
             execution["phase"] = execution_phase(
                 execution_events, execution_active=execution_active

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
@@ -12,6 +12,7 @@ from research_ai.models import (
     AgentExecution,
     AgentExecutionMessage,
 )
+from research_ai.services.agent_persistence.recorder import DatabaseAgentRecorder
 from research_ai.services.notebook_chat import NotebookChatService
 from research_ai.tests.agent.persistence_test_helpers import (
     FakeProvider,
@@ -405,6 +406,40 @@ class NotebookChatActivityProjectionTests(TestCase):
                 self._finish(status)
                 (narration,) = _narrations(self._entry()["activity"])
                 self.assertEqual(narration["text"], "Let me look into that.")
+
+    def test_succeeded_turn_stuck_on_publication_repair_keeps_its_text(self):
+        # Arrange: a succeeded run whose answer publication failed and whose
+        # on-read repair keeps failing, so the chat shows no assistant message.
+        self._add_trace_row(
+            1,
+            [{"type": "text", "text": "Here is the answer."}],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+        self.execution.status = AgentExecution.Status.SUCCEEDED
+        self.execution.publish_output_to_chat = True
+        self.execution.final_output = {"text": "Here is the answer."}
+        self.execution.save(
+            update_fields=["status", "publish_output_to_chat", "final_output"]
+        )
+
+        # Act: read while every repair attempt fails.
+        with (
+            patch.object(
+                DatabaseAgentRecorder,
+                "publish_assistant_output",
+                side_effect=Exception("db down"),
+            ),
+            self.assertLogs(
+                "research_ai.services.agent_persistence.chat_service", "WARNING"
+            ),
+        ):
+            entry = self._entry()
+
+        # Assert: until the answer actually lands as a chat message, the feed
+        # still carries the model's text rather than showing nothing at all.
+        self.assertTrue(entry["assistant_message_pending"])
+        (narration,) = _narrations(entry["activity"])
+        self.assertEqual(narration["text"], "Here is the answer.")
 
     def test_phase_names_the_open_tool_then_clears_when_terminal(self):
         # Arrange: a call whose result row has not landed.

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
@@ -522,6 +522,60 @@ class NotebookChatActivityProjectionTests(TestCase):
         self._finish(AgentExecution.Status.FAILED)
         self.assertIsNone(self._entry()["phase"])
 
+    def test_phase_moves_on_when_a_lost_result_leaves_a_call_open(self):
+        # Arrange: the call's result row was lost (trace writes are
+        # best-effort) and the model has since spoken again -- proof the
+        # dispatch finished, whatever its outcome was.
+        self._add_trace_row(
+            1,
+            [{"type": "tool_use", "id": "t1", "name": "read_note", "input": {}}],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+        self._add_trace_row(
+            2,
+            [{"type": "text", "text": "The note is long; summarizing."}],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+
+        # Act
+        entry = self._entry()
+
+        # Assert: the phase reports the newer work, while the feed keeps the
+        # call open rather than guessing an outcome for it.
+        self.assertEqual(entry["phase"]["state"], "responding")
+        (event,) = _tool_calls(entry["activity"])
+        self.assertEqual(event["status"], "in_progress")
+
+    def test_phase_names_the_current_call_despite_an_older_stale_one(self):
+        # Arrange: an open call whose result row was lost, then a later turn
+        # dispatching a single fresh call.
+        self._add_trace_row(
+            1,
+            [{"type": "tool_use", "id": "t1", "name": "read_note", "input": {}}],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+        self._add_trace_row(
+            2,
+            [
+                {
+                    "type": "tool_use",
+                    "id": "t2",
+                    "name": "web_search",
+                    "input": {"query": "anything"},
+                }
+            ],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+
+        # Act
+        phase = self._entry()["phase"]
+
+        # Assert: one call is genuinely current, so it is named rather than
+        # hidden behind the generic batch label.
+        self.assertEqual(phase["state"], "using_tool")
+        self.assertEqual(phase["tool"], "web_search")
+        self.assertEqual(phase["label"], "Searching the web")
+
     def test_phase_is_queued_until_a_worker_claims_the_turn(self):
         # Arrange: a submitted turn no worker has picked up; nothing is
         # thinking yet, and during a backlog this state can last a while.

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
@@ -367,7 +367,7 @@ class NotebookChatActivityProjectionTests(TestCase):
         self.execution.save(update_fields=["status"])
         self.assertEqual(self._single_event()["status"], "interrupted")
 
-    def test_live_turn_shows_its_newest_text_but_a_finished_turn_does_not(self):
+    def test_live_turn_shows_its_newest_text_but_a_succeeded_turn_does_not(self):
         # Arrange: the only assistant text so far, which is either narration in
         # progress or the answer, depending on whether the run is over.
         self._add_trace_row(
@@ -380,10 +380,31 @@ class NotebookChatActivityProjectionTests(TestCase):
         (narration,) = _narrations(self._entry()["activity"])
         self.assertEqual(narration["text"], "Let me look into that.")
 
-        # ...and once the run ends the same text is the published answer, so
-        # repeating it in the feed would show it twice.
+        # ...and once the run succeeds the same text is the published answer,
+        # so repeating it in the feed would show it twice.
         self._finish()
         self.assertEqual(_narrations(self._entry()["activity"]), [])
+
+    def test_unsuccessful_turn_keeps_its_newest_text(self):
+        # Arrange: text the model wrote on a turn that never got to publish
+        # an answer.
+        self._add_trace_row(
+            1,
+            [{"type": "text", "text": "Let me look into that."}],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+
+        # Act & Assert: with no published message to repeat, the feed is the
+        # only surviving account of what the model said.
+        for status in (
+            AgentExecution.Status.FAILED,
+            AgentExecution.Status.INTERRUPTED,
+            AgentExecution.Status.CANCELLED,
+        ):
+            with self.subTest(status=status):
+                self._finish(status)
+                (narration,) = _narrations(self._entry()["activity"])
+                self.assertEqual(narration["text"], "Let me look into that.")
 
     def test_phase_names_the_open_tool_then_clears_when_terminal(self):
         # Arrange: a call whose result row has not landed.

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
@@ -458,6 +458,44 @@ class NotebookChatActivityProjectionTests(TestCase):
         self._finish(AgentExecution.Status.FAILED)
         self.assertIsNone(self._entry()["phase"])
 
+    def test_phase_is_queued_until_a_worker_claims_the_turn(self):
+        # Arrange: a submitted turn no worker has picked up; nothing is
+        # thinking yet, and during a backlog this state can last a while.
+        self.execution.status = AgentExecution.Status.PENDING
+        self.execution.save(update_fields=["status"])
+
+        # Act & Assert
+        self.assertEqual(
+            self._entry()["phase"],
+            {"state": "queued", "label": "Waiting to start"},
+        )
+
+    def test_phase_stays_generic_while_a_batch_of_calls_is_open(self):
+        # Arrange: one assistant turn dispatched two calls. They run in order
+        # but their results land as one batch, so mid-batch the trace cannot
+        # say which call is the current one.
+        self._add_trace_row(
+            1,
+            [
+                {"type": "tool_use", "id": "t1", "name": "read_note", "input": {}},
+                {
+                    "type": "tool_use",
+                    "id": "t2",
+                    "name": "web_search",
+                    "input": {"query": "anything"},
+                },
+            ],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+
+        # Act
+        phase = self._entry()["phase"]
+
+        # Assert: a tool phase that names no specific call.
+        self.assertEqual(phase["state"], "using_tool")
+        self.assertEqual(phase["label"], "Running tools")
+        self.assertNotIn("tool", phase)
+
     def test_phase_is_thinking_once_the_tool_result_lands(self):
         # Arrange: the call completed and the model has not spoken since.
         self._add_trace_row(
@@ -634,6 +672,7 @@ class NotebookChatActivityViewTests(APITestCase):
             )
         before = self.client.get(self.chat_url)
         self.assertEqual(before.data["executions"][0]["activity"], [])
+        self.assertEqual(before.data["executions"][0]["phase"]["state"], "queued")
 
         _make_service(
             provider=FakeProvider(

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
@@ -34,6 +34,17 @@ PUBLIC_EVENT_KEYS = {
     "sources",
 }
 
+PUBLIC_NARRATION_KEYS = {"type", "text", "at"}
+
+
+def _tool_calls(activity):
+    return [event for event in activity if event["type"] == "tool_call"]
+
+
+def _narrations(activity):
+    return [event for event in activity if event["type"] == "narration"]
+
+
 EDITED_DOC = {
     "type": "doc",
     "content": [
@@ -123,9 +134,10 @@ class NotebookChatActivityTests(TestCase):
         # Assert
         self.note.refresh_from_db()
         self.assertEqual(
-            [event["tool"] for event in activity], (["read_note", "edit_note"])
+            [event["tool"] for event in _tool_calls(activity)],
+            (["read_note", "edit_note"]),
         )
-        read, edit = activity
+        read, edit = _tool_calls(activity)
         self.assertEqual(read["label"], "Read the note")
         self.assertEqual(read["status"], "succeeded")
         self.assertIsNotNone(read["started_at"])
@@ -158,8 +170,10 @@ class NotebookChatActivityTests(TestCase):
         activity = self._activity(execution)
 
         # Assert: fixed public shape only, and no document text leaks through.
-        for event in activity:
+        for event in _tool_calls(activity):
             self.assertLessEqual(set(event), PUBLIC_EVENT_KEYS)
+        for event in _narrations(activity):
+            self.assertLessEqual(set(event), PUBLIC_NARRATION_KEYS)
         serialized = json.dumps(activity, default=str)
         self.assertNotIn("Edited by the assistant", serialized)
 
@@ -186,7 +200,7 @@ class NotebookChatActivityTests(TestCase):
         activity = self._activity(execution)
 
         # Assert: the query is echoed and sources reduce to title/url pairs.
-        (event,) = activity
+        (event,) = _tool_calls(activity)
         self.assertEqual(event["label"], "Searched the web")
         self.assertEqual(event["status"], "succeeded")
         self.assertEqual(event["detail"], "perovskite stability")
@@ -232,7 +246,7 @@ class NotebookChatActivityTests(TestCase):
         activity = self._activity(execution)
 
         # Assert: names and citations surface; abstracts and metadata do not.
-        searched, looked_up, works, read_paper = activity
+        searched, looked_up, works, read_paper = _tool_calls(activity)
         self.assertEqual(searched["label"], "Searched scholarly authors")
         self.assertEqual(searched["detail"], "Jennifer Doudna")
         self.assertNotIn("sources", searched)
@@ -248,9 +262,36 @@ class NotebookChatActivityTests(TestCase):
         self.assertEqual(read_paper["label"], "Read a paper")
         self.assertEqual(read_paper["status"], "succeeded")
         self.assertEqual(read_paper["sources"], [expected_source])
-        for event in activity:
+        for event in _tool_calls(activity):
             self.assertLessEqual(set(event), PUBLIC_EVENT_KEYS)
         self.assertNotIn("abstract the user", json.dumps(activity, default=str))
+
+    def test_narration_interleaves_with_tool_calls_but_omits_the_answer(self):
+        # Arrange: the fake turns narrate ("calling read_note") before acting,
+        # then answer in plain text.
+        execution = self._run_turn(
+            [
+                tool_turn("t1", "read_note", {"note_id": self.note.id}),
+                text_turn("Here is the summary."),
+            ]
+        )
+
+        # Act
+        activity = self._activity(execution)
+
+        # Assert: narration precedes the call it explains, and the final answer
+        # is absent from the feed because the chat publishes it as a message.
+        self.assertEqual(
+            [
+                (event["type"], event.get("text") or event.get("tool"))
+                for event in activity
+            ],
+            [("narration", "calling read_note"), ("tool_call", "read_note")],
+        )
+        published = execution.conversation.chat_messages.filter(
+            role="ASSISTANT"
+        ).values_list("content", flat=True)
+        self.assertEqual(list(published), ["Here is the summary."])
 
     def test_failed_tool_call_reports_failed_without_error_text(self):
         # Arrange: web search is unconfigured, so the tool returns an error
@@ -266,7 +307,7 @@ class NotebookChatActivityTests(TestCase):
         activity = self._activity(execution)
 
         # Assert
-        (event,) = activity
+        (event,) = _tool_calls(activity)
         self.assertEqual(event["status"], "failed")
         self.assertNotIn("sources", event)
         self.assertNotIn("not configured", json.dumps(activity, default=str))
@@ -284,21 +325,30 @@ class NotebookChatActivityProjectionTests(TestCase):
             status=AgentExecution.Status.RUNNING,
         )
 
-    def _add_trace_row(self, sequence, content, provenance):
+    def _add_trace_row(self, sequence, content, provenance, role="assistant"):
         AgentExecutionMessage.objects.create(
             conversation=self.conversation,
             execution=self.execution,
             sequence=sequence,
             execution_sequence=sequence,
-            role="assistant",
+            role=role,
             provenance=provenance,
             content=content,
         )
 
+    def _finish(self, status=AgentExecution.Status.SUCCEEDED):
+        self.execution.status = status
+        self.execution.save(update_fields=["status"])
+
+    def _entry(self):
+        data = self.service.representation(self.conversation)
+        (execution,) = data["executions"]
+        return execution
+
     def _single_event(self):
         data = self.service.representation(self.conversation)
         (execution,) = data["executions"]
-        (event,) = execution["activity"]
+        (event,) = _tool_calls(execution["activity"])
         return event
 
     def test_open_call_is_in_progress_while_running_then_interrupted(self):
@@ -316,6 +366,100 @@ class NotebookChatActivityProjectionTests(TestCase):
         self.execution.status = AgentExecution.Status.FAILED
         self.execution.save(update_fields=["status"])
         self.assertEqual(self._single_event()["status"], "interrupted")
+
+    def test_live_turn_shows_its_newest_text_but_a_finished_turn_does_not(self):
+        # Arrange: the only assistant text so far, which is either narration in
+        # progress or the answer, depending on whether the run is over.
+        self._add_trace_row(
+            1,
+            [{"type": "text", "text": "Let me look into that."}],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+
+        # Act & Assert: while running it is the only way to see what was said...
+        (narration,) = _narrations(self._entry()["activity"])
+        self.assertEqual(narration["text"], "Let me look into that.")
+
+        # ...and once the run ends the same text is the published answer, so
+        # repeating it in the feed would show it twice.
+        self._finish()
+        self.assertEqual(_narrations(self._entry()["activity"]), [])
+
+    def test_phase_names_the_open_tool_then_clears_when_terminal(self):
+        # Arrange: a call whose result row has not landed.
+        self._add_trace_row(
+            1,
+            [{"type": "tool_use", "id": "t1", "name": "read_note", "input": {}}],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+
+        # Act & Assert
+        phase = self._entry()["phase"]
+        self.assertEqual(phase["state"], "using_tool")
+        self.assertEqual(phase["label"], "Reading the note")
+        self.assertEqual(phase["tool"], "read_note")
+
+        self._finish(AgentExecution.Status.FAILED)
+        self.assertIsNone(self._entry()["phase"])
+
+    def test_phase_is_thinking_once_the_tool_result_lands(self):
+        # Arrange: the call completed and the model has not spoken since.
+        self._add_trace_row(
+            1,
+            [{"type": "tool_use", "id": "t1", "name": "read_note", "input": {}}],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+        self._add_trace_row(
+            2,
+            [{"type": "tool_result", "tool_use_id": "t1", "content": {"ok": True}}],
+            AgentExecutionMessage.Provenance.TOOL,
+            role="user",
+        )
+
+        # Act & Assert
+        self.assertEqual(self._entry()["phase"]["state"], "thinking")
+
+    def test_phase_is_responding_while_the_model_writes(self):
+        # Arrange: a completed call, then prose.
+        self._add_trace_row(
+            1,
+            [{"type": "tool_use", "id": "t1", "name": "read_note", "input": {}}],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+        self._add_trace_row(
+            2,
+            [{"type": "tool_result", "tool_use_id": "t1", "content": {"ok": True}}],
+            AgentExecutionMessage.Provenance.TOOL,
+            role="user",
+        )
+        self._add_trace_row(
+            3,
+            [{"type": "text", "text": "Here is what the note says."}],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+
+        # Act & Assert
+        self.assertEqual(self._entry()["phase"]["state"], "responding")
+
+    def test_truncated_trace_marker_is_not_shown_as_narration(self):
+        # Arrange: the marker a row too large to persist leaves behind, which is
+        # written for an operator reading the trace.
+        self._add_trace_row(
+            1,
+            [
+                {
+                    "type": "text",
+                    "text": "[Trace message omitted because it exceeded the "
+                    "durable row limit.]",
+                    "_truncated": True,
+                    "omitted_blocks": 3,
+                }
+            ],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+
+        # Act & Assert
+        self.assertEqual(self._entry()["activity"], [])
 
     def test_server_side_web_search_blocks_produce_a_sourced_event(self):
         # Arrange: the provider ran web_search itself; request and result are
@@ -449,7 +593,7 @@ class NotebookChatActivityViewTests(APITestCase):
 
         # Assert
         (execution,) = response.data["executions"]
-        (event,) = execution["activity"]
+        (event,) = _tool_calls(execution["activity"])
         self.assertEqual(event["tool"], "read_note")
         self.assertEqual(event["label"], "Read the note")
         self.assertEqual(event["status"], "succeeded")

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
@@ -407,6 +407,70 @@ class NotebookChatActivityProjectionTests(TestCase):
                 (narration,) = _narrations(self._entry()["activity"])
                 self.assertEqual(narration["text"], "Let me look into that.")
 
+    def test_narration_survives_when_the_answers_trace_row_was_lost(self):
+        # Arrange: a tool-calling row landed, but the answer's own trace write
+        # failed (trace writes are best-effort), so the newest persisted
+        # assistant row is mid-run narration. The run still succeeded and its
+        # answer publishes from memory.
+        self._add_trace_row(
+            1,
+            [
+                {"type": "text", "text": "Let me read the note."},
+                {"type": "tool_use", "id": "t1", "name": "read_note", "input": {}},
+            ],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+        self._add_trace_row(
+            2,
+            [{"type": "tool_result", "tool_use_id": "t1", "content": {"ok": True}}],
+            AgentExecutionMessage.Provenance.TOOL,
+            role="user",
+        )
+        self.execution.status = AgentExecution.Status.SUCCEEDED
+        self.execution.publish_output_to_chat = True
+        self.execution.final_output = {"text": "The note covers perovskites."}
+        self.execution.save(
+            update_fields=["status", "publish_output_to_chat", "final_output"]
+        )
+
+        # Act: the read repairs the missing publication, then renders.
+        entry = self._entry()
+
+        # Assert: the published answer does not contain this narration, so
+        # suppressing it would erase words the chat never shows.
+        self.assertEqual(
+            list(
+                self.conversation.chat_messages.filter(role="ASSISTANT").values_list(
+                    "content", flat=True
+                )
+            ),
+            ["The note covers perovskites."],
+        )
+        (narration,) = _narrations(entry["activity"])
+        self.assertEqual(narration["text"], "Let me read the note.")
+
+    def test_published_answer_split_across_final_row_blocks_is_not_echoed(self):
+        # Arrange: a final row whose answer spans two text blocks; the chat
+        # publishes their verbatim join, so each block is part of the answer.
+        self._add_trace_row(
+            1,
+            [
+                {"type": "text", "text": "Searching now. "},
+                {"type": "text", "text": "Batteries improved."},
+            ],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+        self.execution.status = AgentExecution.Status.SUCCEEDED
+        self.execution.publish_output_to_chat = True
+        self.execution.final_output = {"text": "Searching now. Batteries improved."}
+        self.execution.save(
+            update_fields=["status", "publish_output_to_chat", "final_output"]
+        )
+
+        # Act & Assert: every block of the published answer stays out of the
+        # feed even though no single block equals the published string.
+        self.assertEqual(_narrations(self._entry()["activity"]), [])
+
     def test_succeeded_turn_stuck_on_publication_repair_keeps_its_text(self):
         # Arrange: a succeeded run whose answer publication failed and whose
         # on-read repair keeps failing, so the chat shows no assistant message.


### PR DESCRIPTION
A turn that ran four tools showed four labels and a spinner. The model's own account of what it was doing was already persisted in the trace and never surfaced.

Assistant text is now emitted as narration interleaved with the calls it explains, so a slow turn reads as prose. The final assistant text is excluded once the turn is terminal, because the chat publishes that as a message and showing it twice would be worse than not showing it at all. Position decides which text is the answer, not whether the message made tool calls: a turn using the provider's own web search puts narration, the server-side call and the answer in a single assistant message, so "did this message call tools" cannot separate them. While a run is live nothing is published yet, so its newest text is shown -- that is the whole point.

Alongside the feed, a derived phase reduces the same events to one coarse answer: which tool is open, or that the model is thinking or writing. It is derived rather than stored, because a persisted phase is one more thing a dead worker could leave lying about the state of a run.