### PR TITLE
Allow multiple notebook chats per note

### DIFF
--- a/src/research_ai/migrations/0024_agentconversation_title.py
+++ b/src/research_ai/migrations/0024_agentconversation_title.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("research_ai", "0023_alter_proposaldraft_status"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="agentconversation",
+            name="title",
+            field=models.CharField(
+                blank=True,
+                db_comment=(
+                    "User-visible conversation name. Blank until the workflow "
+                    "derives one (typically from the first message) or the "
+                    "user sets it."
+                ),
+                default="",
+                max_length=255,
+            ),
+            preserve_default=False,
+        ),
+    ]

--- a/src/research_ai/models/agent.py
+++ b/src/research_ai/models/agent.py
@@ -24,6 +24,14 @@ class AgentConversation(DefaultModel):
             "such as proposal_draft or notebook_chat."
         ),
     )
+    title = models.CharField(
+        max_length=255,
+        blank=True,
+        db_comment=(
+            "User-visible conversation name. Blank until the workflow derives "
+            "one (typically from the first message) or the user sets it."
+        ),
+    )
     next_trace_sequence = models.PositiveBigIntegerField(default=1)
     next_chat_sequence = models.PositiveBigIntegerField(default=1)
 

--- a/src/research_ai/serializers.py
+++ b/src/research_ai/serializers.py
@@ -1024,6 +1024,27 @@ class NotebookChatMessageCreateSerializer(serializers.Serializer):
     message = serializers.CharField(max_length=20000)
 
 
+class NotebookChatCreateSerializer(serializers.Serializer):
+    """
+    Request body for creating a chat on a note.
+
+    The title is optional: a chat created without one is named from its
+    first message.
+    """
+
+    title = serializers.CharField(
+        max_length=255, required=False, allow_blank=True, default=""
+    )
+
+
+class NotebookChatUpdateSerializer(serializers.Serializer):
+    """
+    Request body for renaming a chat.
+    """
+
+    title = serializers.CharField(max_length=255)
+
+
 class ProposalDraftCreateSerializer(serializers.Serializer):
     """
     Request body for enqueueing a proposal-drafting job.

--- a/src/research_ai/services/agent_persistence/chat_service.py
+++ b/src/research_ai/services/agent_persistence/chat_service.py
@@ -297,6 +297,7 @@ class AgentChatService:
         ]
         return {
             "conversation_id": conversation.id,
+            "title": conversation.title,
             "messages": messages,
             "executions": executions,
         }

--- a/src/research_ai/services/agent_persistence/conversation_service.py
+++ b/src/research_ai/services/agent_persistence/conversation_service.py
@@ -16,11 +16,30 @@ class AgentConversationService:
         *,
         user=None,
         workflow: str = "",
+        title: str = "",
     ) -> AgentConversation:
         return AgentConversation.objects.create(
             user=user,
             workflow=workflow,
+            title=title,
         )
+
+    def set_title(self, conversation: AgentConversation, title: str) -> None:
+        conversation.title = title
+        conversation.save(update_fields=["title", "updated_date"])
+
+    def set_title_if_blank(self, conversation: AgentConversation, title: str) -> None:
+        """Set a derived title unless one exists, without clobbering a rename.
+
+        Filtered update rather than read-then-save: a concurrent rename and a
+        first-message derivation race here, and the user's explicit title must
+        win no matter which lands first.
+        """
+        updated = AgentConversation.objects.filter(id=conversation.id, title="").update(
+            title=title
+        )
+        if updated:
+            conversation.title = title
 
     def add_human_message(
         self, conversation: AgentConversation, content: str

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -1,7 +1,12 @@
 """The notebook chat assistant: research + note edits driven by user feedback.
 
-One conversation per (note, user), workflow ``notebook_chat``. A turn is
-split across two processes:
+A user can keep any number of chats on a note, workflow ``notebook_chat``.
+Each chat is its own ``AgentConversation`` -- resolved by id, never by
+position -- with its own context lineage and its own busy check, so turns in
+different chats on the same note may run concurrently. That is safe by
+construction: note edits are optimistic-concurrency guarded and versioned
+(see ``NoteToolset``), so parallel agents can at worst reject each other's
+stale writes, never corrupt the note. A turn is split across two processes:
 
 - ``submit_message`` (request path) resolves the conversation, appends the
   user's message, and creates a ``PENDING`` execution via
@@ -29,10 +34,16 @@ import logging
 from datetime import timedelta
 
 from django.db import transaction
+from django.db.models import Exists, OuterRef, Subquery
+from django.db.models.functions import Left
 from django.utils import timezone
 
 from note.related_models.note_model import Note
-from research_ai.models import AgentConversation, AgentExecution
+from research_ai.models import (
+    AgentConversation,
+    AgentConversationMessage,
+    AgentExecution,
+)
 from research_ai.models.agent import AgentExecutionMessage
 from research_ai.prompts.notebook_chat_prompts import build_notebook_chat_system_prompt
 from research_ai.services.agent import (
@@ -85,6 +96,19 @@ ACTIVITY_LIVE = "live"
 # its worker unwinds, when trace rows can genuinely still land.
 ACTIVITY_SETTLED_GRACE = timedelta(seconds=60)
 
+# Derived chat titles are list labels, not documents: one collapsed line,
+# well under the model field's 255-char bound.
+TITLE_MAX_CHARS = 120
+
+# How much of a chat's newest message the listing carries as a preview,
+# truncated in the database so a 20k-character turn never rides along.
+LIST_PREVIEW_CHARS = 160
+
+
+def _derive_title(text: str) -> str:
+    """A list-friendly chat name from the first message: one bounded line."""
+    return " ".join(text.split())[:TITLE_MAX_CHARS].rstrip()
+
 
 class NotebookChatService:
     """Prepare and run notebook chat turns.
@@ -135,13 +159,65 @@ class NotebookChatService:
 
     # -- request path -----------------------------------------------------
 
-    def get_conversation(self, note: Note, user) -> AgentConversation | None:
-        """The user's existing notebook chat conversation on ``note``, if any."""
+    def get_conversation(
+        self, note: Note, user, conversation_id: int
+    ) -> AgentConversation | None:
+        """The user's notebook chat ``conversation_id`` on ``note``, if any.
+
+        Scoped to the note, the requesting user, and this workflow, so a
+        conversation id belonging to another user, another note, or another
+        workflow does not resolve -- the API turns that ``None`` into a 404.
+        """
         return (
             self.note_conversations.for_note(note)
-            .filter(workflow=WORKFLOW, user=user)
+            .filter(workflow=WORKFLOW, user=user, id=conversation_id)
             .first()
         )
+
+    def list_conversations(self, note: Note, user) -> list[dict]:
+        """The user's chats on ``note``, newest activity first.
+
+        A listing projection, deliberately not ``representation``: one query
+        with a bounded preview of each chat's newest message, instead of
+        walking every conversation's executions and running publication
+        repair. ``has_active_turn`` is what lets a chat picker show a spinner
+        without fetching any chat's full state.
+        """
+        last_message = (
+            AgentConversationMessage.objects.filter(
+                conversation=OuterRef("pk"), is_active=True
+            )
+            .order_by("-sequence")
+            .annotate(preview=Left("content", LIST_PREVIEW_CHARS))
+            .values("preview")[:1]
+        )
+        conversations = (
+            self.note_conversations.for_note(note)
+            .filter(workflow=WORKFLOW, user=user)
+            .annotate(
+                last_message_preview=Subquery(last_message),
+                has_active_turn=Exists(
+                    AgentExecution.objects.filter(
+                        conversation=OuterRef("pk"),
+                        status__in=[
+                            AgentExecution.Status.PENDING,
+                            AgentExecution.Status.RUNNING,
+                        ],
+                    )
+                ),
+            )
+        )
+        return [
+            {
+                "id": conversation.id,
+                "title": conversation.title,
+                "created_date": conversation.created_date,
+                "updated_date": conversation.updated_date,
+                "last_message_preview": conversation.last_message_preview,
+                "has_active_turn": conversation.has_active_turn,
+            }
+            for conversation in conversations
+        ]
 
     def representation(
         self, conversation: AgentConversation, *, activity_scope: str = ACTIVITY_ALL
@@ -251,29 +327,39 @@ class NotebookChatService:
             ids.add(executions[-1]["id"])
         return sorted(ids)
 
-    def get_or_create_conversation(self, note: Note, user) -> AgentConversation:
-        conversation = self.get_conversation(note, user)
-        if conversation is not None:
-            return conversation
+    def create_conversation(
+        self, note: Note, user, title: str = ""
+    ) -> AgentConversation:
+        """Create a new chat on ``note`` owned by ``user``.
+
+        Any number of chats per (note, user) is expected, so concurrent
+        creates are simply two new chats -- no serialization needed. Atomic so
+        a conversation never outlives a failed note attachment.
+        """
         with transaction.atomic():
-            # Serialize concurrent first messages on the note row: without
-            # this, each request creates its own conversation and the busy
-            # check in ``prepare_turn`` -- which locks per conversation --
-            # would happily run both turns against the note at once.
-            Note.objects.select_for_update().get(id=note.id)
-            conversation = self.get_conversation(note, user)
-            if conversation is not None:
-                return conversation
-            conversation = self.conversations.create(user=user, workflow=WORKFLOW)
+            conversation = self.conversations.create(
+                user=user, workflow=WORKFLOW, title=title
+            )
             self.note_conversations.attach(conversation, note)
-            return conversation
+        return conversation
 
-    def submit_message(self, note: Note, user, text: str) -> AgentExecution:
-        """Record the user's message and schedule the agent turn.
+    def rename_conversation(
+        self, conversation: AgentConversation, title: str
+    ) -> AgentConversation:
+        self.conversations.set_title(conversation, title)
+        return conversation
 
-        Raises ``ValueError`` on an empty or oversized message and lets
-        ``AgentConversationBusyError`` propagate when a turn is already
-        running on the conversation (the API maps it to a 409).
+    def submit_message(
+        self, note: Note, conversation: AgentConversation, text: str
+    ) -> AgentExecution:
+        """Record the user's message on ``conversation`` and schedule the turn.
+
+        ``conversation`` must have been resolved through ``get_conversation``
+        so it is known to belong to ``note``. A chat still untitled takes its
+        name from this message. Raises ``ValueError`` on an empty or oversized
+        message and lets ``AgentConversationBusyError`` propagate when a turn
+        is already running on this conversation (the API maps it to a 409);
+        other chats on the note are unaffected.
         """
         text = (text or "").strip()
         if not text:
@@ -282,7 +368,6 @@ class NotebookChatService:
         if len(text) > config.max_message_chars:
             raise ValueError(f"message exceeds {config.max_message_chars} characters")
 
-        conversation = self.get_or_create_conversation(note, user)
         prepared = self.chat.prepare_turn(
             conversation,
             text,
@@ -298,10 +383,15 @@ class NotebookChatService:
             system_prompt=build_notebook_chat_system_prompt(note),
         )
         execution = prepared.execution
+        # After prepare_turn so a refused turn (busy, for instance) names
+        # nothing; the filtered update keeps a concurrent rename authoritative.
+        self.conversations.set_title_if_blank(conversation, _derive_title(text))
         transaction.on_commit(lambda: self._schedule_turn(execution.id))
         return execution
 
-    def cancel_active_turn(self, note: Note, user) -> AgentExecution | None:
+    def cancel_active_turn(
+        self, conversation: AgentConversation
+    ) -> AgentExecution | None:
         """Stop the conversation's in-flight turn; ``None`` if none was running.
 
         Cancellation is cooperative: the worker is not interrupted here, it
@@ -311,9 +401,6 @@ class NotebookChatService:
         the worker does afterwards can revive the row -- every terminal
         transition in the recorder is guarded on ``RUNNING``.
         """
-        conversation = self.get_conversation(note, user)
-        if conversation is None:
-            return None
         execution = (
             conversation.executions.filter(
                 status__in=[

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
@@ -94,6 +94,7 @@ class NotebookChatActivityTests(TestCase):
             object_id=self.note.unified_document.id,
             user=self.user,
         )
+        self.conversation = _make_service().create_conversation(self.note, self.user)
 
     def _run_turn(
         self,
@@ -107,7 +108,7 @@ class NotebookChatActivityTests(TestCase):
             patch("research_ai.tasks.run_notebook_chat_turn_task.delay"),
             self.captureOnCommitCallbacks(execute=True),
         ):
-            execution = service.submit_message(self.note, self.user, text)
+            execution = service.submit_message(self.note, self.conversation, text)
         runner = _make_service(
             provider=FakeProvider(provider_turns),
             web_search_client=web_search_client,
@@ -361,7 +362,9 @@ class NotebookChatActivityTests(TestCase):
             patch("research_ai.tasks.run_notebook_chat_turn_task.delay"),
             self.captureOnCommitCallbacks(execute=True),
         ):
-            queued = _make_service().submit_message(self.note, self.user, "Rephrased.")
+            queued = _make_service().submit_message(
+                self.note, self.conversation, "Rephrased."
+            )
 
         # Act
         live = _make_service().representation(
@@ -942,7 +945,10 @@ class NotebookChatActivityViewTests(APITestCase):
             object_id=self.note.unified_document.id,
             user=self.owner,
         )
-        self.chat_url = f"/api/research_ai/notebook/notes/{self.note.id}/chat/"
+        chats_url = f"/api/research_ai/notebook/notes/{self.note.id}/chats/"
+        self.client.force_authenticate(self.owner)
+        created = self.client.post(chats_url, {}, format="json")
+        self.chat_url = f"{chats_url}{created.data['conversation_id']}/"
 
     def test_get_chat_includes_each_turns_activity(self):
         # Arrange: a submitted turn has no activity yet; a completed turn has

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -372,7 +372,7 @@ class NotebookChatTitleTests(TestCase):
             password="password",
             email="owner@researchhub_test.com",
         )
-        self.note, _content = create_note(self.user, organization=None)
+        self.note = create_note(self.user, organization=None)[0]
         Permission.objects.create(
             access_type=ADMIN,
             content_type=ContentType.objects.get_for_model(ResearchhubUnifiedDocument),
@@ -460,8 +460,8 @@ class NotebookChatResolutionTests(TestCase):
             email="other@researchhub_test.com",
         )
         unified_doc_ct = ContentType.objects.get_for_model(ResearchhubUnifiedDocument)
-        self.note, _content = create_note(self.user, organization=None)
-        self.other_note, _other = create_note(self.user, organization=None)
+        self.note = create_note(self.user, organization=None)[0]
+        self.other_note = create_note(self.user, organization=None)[0]
         for note in (self.note, self.other_note):
             Permission.objects.create(
                 access_type=ADMIN,

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -6,10 +6,15 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from note.tests.helpers import create_note
-from research_ai.models import AgentConversation, AgentExecution
+from research_ai.models import (
+    AgentConversation,
+    AgentExecution,
+    NoteAgentConversation,
+)
 from research_ai.services.agent_persistence import AgentConversationBusyError
 from research_ai.services.notebook_chat import WORKFLOW, NotebookChatService
 from research_ai.services.notebook_chat.config import NotebookChatConfig
+from research_ai.services.notebook_chat.service import TITLE_MAX_CHARS
 from research_ai.tests.agent.persistence_test_helpers import (
     FakeProvider,
     text_turn,
@@ -55,13 +60,15 @@ class NotebookChatServiceTests(TestCase):
             user=self.user,
         )
         self.service = _make_service()
+        self.conversation = self.service.create_conversation(self.note, self.user)
 
-    def _submit(self, text="Please add a summary."):
+    def _submit(self, text="Please add a summary.", conversation=None):
+        conversation = self.conversation if conversation is None else conversation
         with (
             patch("research_ai.tasks.run_notebook_chat_turn_task.delay") as delay,
             self.captureOnCommitCallbacks(execute=True),
         ):
-            execution = self.service.submit_message(self.note, self.user, text)
+            execution = self.service.submit_message(self.note, conversation, text)
         return execution, delay
 
     def test_submit_message_prepares_turn_and_schedules_task(self):
@@ -81,7 +88,7 @@ class NotebookChatServiceTests(TestCase):
         self.assertEqual(execution.trigger_message.content, "Please add a summary.")
         delay.assert_called_once_with(execution.id)
 
-    def test_submit_message_reuses_the_users_conversation_on_the_note(self):
+    def test_second_message_continues_the_same_conversation(self):
         # Arrange
         first, _delay = self._submit()
         first.status = AgentExecution.Status.SUCCEEDED
@@ -100,24 +107,22 @@ class NotebookChatServiceTests(TestCase):
 
         # Act & Assert
         with self.assertRaises(ValueError):
-            service.submit_message(self.note, self.user, "   ")
+            service.submit_message(self.note, self.conversation, "   ")
         with self.assertRaises(ValueError):
-            service.submit_message(self.note, self.user, "x" * 11)
+            service.submit_message(self.note, self.conversation, "x" * 11)
 
-    def test_first_message_race_reuses_the_concurrently_created_conversation(self):
-        # Arrange: another request created the conversation after this
-        # request's unlocked pre-check ran empty; the re-check under the note
-        # lock must pick it up instead of creating a duplicate.
-        existing = self.service.get_or_create_conversation(self.note, self.user)
-        with patch.object(
-            NotebookChatService, "get_conversation", side_effect=[None, existing]
-        ):
-            # Act
-            conversation = self.service.get_or_create_conversation(self.note, self.user)
+    def test_create_conversation_makes_a_new_chat_each_time(self):
+        # Act
+        second = self.service.create_conversation(self.note, self.user)
 
-        # Assert
-        self.assertEqual(conversation.id, existing.id)
-        self.assertEqual(AgentConversation.objects.count(), 1)
+        # Assert: both chats coexist on the note for the same user.
+        self.assertNotEqual(second.id, self.conversation.id)
+        self.assertEqual(
+            AgentConversation.objects.filter(
+                user=self.user, workflow=WORKFLOW, note_links__note=self.note
+            ).count(),
+            2,
+        )
 
     def test_submit_message_while_turn_is_running_raises_busy(self):
         # Arrange
@@ -125,7 +130,19 @@ class NotebookChatServiceTests(TestCase):
 
         # Act & Assert
         with self.assertRaises(AgentConversationBusyError):
-            self.service.submit_message(self.note, self.user, "again")
+            self.service.submit_message(self.note, self.conversation, "again")
+
+    def test_busy_chat_does_not_block_the_users_other_chats(self):
+        # Arrange: a turn is pending on the first chat.
+        self._submit()
+        second = self.service.create_conversation(self.note, self.user)
+
+        # Act
+        execution, _delay = self._submit("Different thread", conversation=second)
+
+        # Assert: each chat serializes its own turns independently.
+        self.assertEqual(execution.conversation_id, second.id)
+        self.assertEqual(execution.status, AgentExecution.Status.PENDING)
 
     def test_run_turn_edits_note_and_publishes_reply(self):
         # Arrange
@@ -266,7 +283,7 @@ class NotebookChatServiceTests(TestCase):
             ),
             self.captureOnCommitCallbacks(execute=True),
         ):
-            execution = self.service.submit_message(self.note, self.user, "Hi")
+            execution = self.service.submit_message(self.note, self.conversation, "Hi")
 
         # Assert: failed instead of holding the busy check forever.
         execution.refresh_from_db()
@@ -345,3 +362,164 @@ class NotebookChatServiceTests(TestCase):
         self.assertIn("First answer", texts)
         self.assertIn("Second question", texts)
         self.assertEqual(AgentConversation.objects.filter(user=self.user).count(), 1)
+
+
+class NotebookChatTitleTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="owner@researchhub_test.com",
+            password="password",
+            email="owner@researchhub_test.com",
+        )
+        self.note, _content = create_note(self.user, organization=None)
+        Permission.objects.create(
+            access_type=ADMIN,
+            content_type=ContentType.objects.get_for_model(ResearchhubUnifiedDocument),
+            object_id=self.note.unified_document.id,
+            user=self.user,
+        )
+        self.service = _make_service()
+        self.conversation = self.service.create_conversation(self.note, self.user)
+
+    def _submit(self, text, conversation=None):
+        conversation = self.conversation if conversation is None else conversation
+        with (
+            patch("research_ai.tasks.run_notebook_chat_turn_task.delay"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            return self.service.submit_message(self.note, conversation, text)
+
+    def test_first_message_titles_the_chat_as_one_bounded_line(self):
+        # Act
+        self._submit("Draft an\nabstract   for this note\n\nplease")
+
+        # Assert
+        self.conversation.refresh_from_db()
+        self.assertEqual(
+            self.conversation.title, "Draft an abstract for this note please"
+        )
+
+    def test_long_first_message_is_truncated_in_the_title(self):
+        # Act
+        self._submit("word " * 100)
+
+        # Assert
+        self.conversation.refresh_from_db()
+        self.assertLessEqual(len(self.conversation.title), TITLE_MAX_CHARS)
+        self.assertTrue(self.conversation.title.startswith("word word"))
+        self.assertFalse(self.conversation.title.endswith(" "))
+
+    def test_title_does_not_change_after_the_first_message(self):
+        # Arrange
+        first = self._submit("Original question")
+        AgentExecution.objects.filter(id=first.id).update(
+            status=AgentExecution.Status.SUCCEEDED
+        )
+
+        # Act
+        self._submit("A completely different follow-up")
+
+        # Assert
+        self.conversation.refresh_from_db()
+        self.assertEqual(self.conversation.title, "Original question")
+
+    def test_explicit_title_survives_the_first_message(self):
+        # Arrange
+        named = self.service.create_conversation(
+            self.note, self.user, title="Planning thread"
+        )
+
+        # Act
+        self._submit("Something unrelated", conversation=named)
+
+        # Assert
+        named.refresh_from_db()
+        self.assertEqual(named.title, "Planning thread")
+
+    def test_rename_conversation_updates_the_title(self):
+        # Act
+        self.service.rename_conversation(self.conversation, "Literature review")
+
+        # Assert
+        self.conversation.refresh_from_db()
+        self.assertEqual(self.conversation.title, "Literature review")
+
+
+class NotebookChatResolutionTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="owner@researchhub_test.com",
+            password="password",
+            email="owner@researchhub_test.com",
+        )
+        self.other_user = user_model.objects.create_user(
+            username="other@researchhub_test.com",
+            password="password",
+            email="other@researchhub_test.com",
+        )
+        unified_doc_ct = ContentType.objects.get_for_model(ResearchhubUnifiedDocument)
+        self.note, _content = create_note(self.user, organization=None)
+        self.other_note, _other = create_note(self.user, organization=None)
+        for note in (self.note, self.other_note):
+            Permission.objects.create(
+                access_type=ADMIN,
+                content_type=unified_doc_ct,
+                object_id=note.unified_document.id,
+                user=self.user,
+            )
+        self.service = _make_service()
+        self.conversation = self.service.create_conversation(self.note, self.user)
+
+    def test_get_conversation_resolves_the_users_chat_on_the_note(self):
+        # Act & Assert
+        self.assertEqual(
+            self.service.get_conversation(self.note, self.user, self.conversation.id),
+            self.conversation,
+        )
+
+    def test_get_conversation_rejects_other_users_notes_and_workflows(self):
+        # Arrange
+        other_users_chat = self.service.create_conversation(self.note, self.other_user)
+        other_notes_chat = self.service.create_conversation(self.other_note, self.user)
+        other_workflow = AgentConversation.objects.create(
+            user=self.user, workflow="proposal_draft"
+        )
+        NoteAgentConversation.objects.create(
+            note=self.note, conversation=other_workflow
+        )
+
+        # Act & Assert: none of them resolve for (note, user, notebook_chat).
+        for conversation in (other_users_chat, other_notes_chat, other_workflow):
+            self.assertIsNone(
+                self.service.get_conversation(self.note, self.user, conversation.id)
+            )
+
+    def test_list_conversations_projects_the_users_chats_newest_first(self):
+        # Arrange: a second chat with a pending turn; another user's chat that
+        # must stay invisible.
+        second = self.service.create_conversation(self.note, self.user)
+        with (
+            patch("research_ai.tasks.run_notebook_chat_turn_task.delay"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            self.service.submit_message(self.note, second, "Find related work")
+        self.service.create_conversation(self.note, self.other_user)
+
+        # Act
+        listing = self.service.list_conversations(self.note, self.user)
+
+        # Assert: the chat with the newest activity leads, carrying its
+        # derived title, message preview, and busy flag; the untouched chat
+        # reports none of those.
+        self.assertEqual(
+            [entry["id"] for entry in listing], [second.id, self.conversation.id]
+        )
+        active, idle = listing
+        self.assertEqual(active["title"], "Find related work")
+        self.assertEqual(active["last_message_preview"], "Find related work")
+        self.assertTrue(active["has_active_turn"])
+        self.assertEqual(idle["title"], "")
+        self.assertIsNone(idle["last_message_preview"])
+        self.assertFalse(idle["has_active_turn"])

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_views.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_views.py
@@ -62,65 +62,148 @@ class NotebookChatViewTests(APITestCase):
             object_id=self.note.unified_document.id,
             user=self.regular_user,
         )
-        self.chat_url = f"/api/research_ai/notebook/notes/{self.note.id}/chat/"
-        self.messages_url = f"{self.chat_url}messages/"
-        self.cancel_url = f"{self.chat_url}cancel/"
+        self.chats_url = f"/api/research_ai/notebook/notes/{self.note.id}/chats/"
 
-    def _post_message(self, text="Summarize the note"):
+    def _chat_url(self, conversation_id):
+        return f"{self.chats_url}{conversation_id}/"
+
+    def _create_chat(self, **payload):
+        return self.client.post(self.chats_url, payload, format="json")
+
+    def _create_chat_id(self):
+        response = self._create_chat()
+        self.assertEqual(response.status_code, 201)
+        return response.data["conversation_id"]
+
+    def _post_message(self, conversation_id, text="Summarize the note"):
         with patch("research_ai.tasks.run_notebook_chat_turn_task.delay") as delay:
             response = self.client.post(
-                self.messages_url, {"message": text}, format="json"
+                f"{self._chat_url(conversation_id)}messages/",
+                {"message": text},
+                format="json",
             )
         return response, delay
 
-    def test_post_message_starts_a_turn(self):
+    def _cancel(self, conversation_id):
+        return self.client.post(f"{self._chat_url(conversation_id)}cancel/")
+
+    # -- creating chats ---------------------------------------------------
+
+    def test_create_chat_returns_an_empty_representation(self):
         # Arrange
         self.client.force_authenticate(self.owner)
 
         # Act
-        response, _delay = self._post_message()
+        response = self._create_chat()
+
+        # Assert
+        self.assertEqual(response.status_code, 201)
+        self.assertIsNotNone(response.data["conversation_id"])
+        self.assertEqual(response.data["title"], "")
+        self.assertEqual(response.data["messages"], [])
+        self.assertEqual(response.data["executions"], [])
+
+    def test_create_chat_accepts_a_title(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+
+        # Act
+        response = self._create_chat(title="Methods discussion")
+
+        # Assert
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["title"], "Methods discussion")
+
+    def test_a_user_can_keep_several_chats_on_one_note(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+
+        # Act
+        first = self._create_chat_id()
+        second = self._create_chat_id()
+
+        # Assert
+        self.assertNotEqual(first, second)
+        listing = self.client.get(self.chats_url)
+        self.assertEqual(len(listing.data["chats"]), 2)
+
+    def test_create_chat_requires_note_access(self):
+        # Arrange
+        self.client.force_authenticate(self.outsider)
+
+        # Act
+        response = self._create_chat()
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    # -- sending messages -------------------------------------------------
+
+    def test_post_message_starts_a_turn(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
+
+        # Act
+        response, _delay = self._post_message(chat_id)
 
         # Assert
         self.assertEqual(response.status_code, 202)
         execution = AgentExecution.objects.get(id=response.data["execution_id"])
         self.assertEqual(execution.status, AgentExecution.Status.PENDING)
-        self.assertEqual(response.data["conversation_id"], execution.conversation_id)
+        self.assertEqual(response.data["conversation_id"], chat_id)
         self.assertEqual(execution.trigger_message.content, "Summarize the note")
 
     def test_post_message_as_viewer_is_allowed(self):
         # Arrange: viewers can chat; the edit tool refuses writes for them.
         self.client.force_authenticate(self.viewer)
+        chat_id = self._create_chat_id()
 
         # Act
-        response, _delay = self._post_message()
+        response, _delay = self._post_message(chat_id)
 
         # Assert
         self.assertEqual(response.status_code, 202)
 
-    def test_post_message_requires_note_access(self):
-        # Arrange
-        self.client.force_authenticate(self.outsider)
+    def test_post_message_to_another_users_chat_is_not_found(self):
+        # Arrange: the viewer knows the owner's chat id but must not reach it.
+        self.client.force_authenticate(self.owner)
+        owners_chat = self._create_chat_id()
+        self.client.force_authenticate(self.viewer)
 
         # Act
-        response, _delay = self._post_message()
+        response, _delay = self._post_message(owners_chat)
 
         # Assert
         self.assertEqual(response.status_code, 404)
         self.assertFalse(AgentExecution.objects.exists())
 
+    def test_post_message_to_unknown_chat_is_not_found(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+
+        # Act
+        response, _delay = self._post_message(999999)
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
     def test_deleted_note_chat_is_hidden(self):
         # Arrange: a chat exists, then the note is soft-deleted.
         self.client.force_authenticate(self.owner)
-        self._post_message()
+        chat_id = self._create_chat_id()
+        self._post_message(chat_id)
         self.note.unified_document.is_removed = True
         self.note.unified_document.save(update_fields=["is_removed"])
 
         # Act
-        get_response = self.client.get(self.chat_url)
-        post_response, _delay = self._post_message()
+        list_response = self.client.get(self.chats_url)
+        get_response = self.client.get(self._chat_url(chat_id))
+        post_response, _delay = self._post_message(chat_id)
 
         # Assert: same deletion boundary as NoteViewSet -- the note, its chat
         # history, and new turns are all gone (404, not the busy 409).
+        self.assertEqual(list_response.status_code, 404)
         self.assertEqual(get_response.status_code, 404)
         self.assertEqual(post_response.status_code, 404)
 
@@ -129,17 +212,18 @@ class NotebookChatViewTests(APITestCase):
         self.client.force_authenticate(self.regular_user)
 
         # Act
-        post_response, _delay = self._post_message()
-        get_response = self.client.get(self.chat_url)
+        create_response = self._create_chat()
+        list_response = self.client.get(self.chats_url)
 
         # Assert
-        self.assertEqual(post_response.status_code, 403)
-        self.assertEqual(get_response.status_code, 403)
-        self.assertFalse(AgentExecution.objects.exists())
+        self.assertEqual(create_response.status_code, 403)
+        self.assertEqual(list_response.status_code, 403)
 
     def test_post_message_requires_authentication(self):
         # Act
-        response = self.client.post(self.messages_url, {"message": "hi"}, format="json")
+        response = self.client.post(
+            f"{self._chat_url(1)}messages/", {"message": "hi"}, format="json"
+        )
 
         # Assert
         self.assertEqual(response.status_code, 401)
@@ -147,9 +231,10 @@ class NotebookChatViewTests(APITestCase):
     def test_post_empty_message_is_rejected(self):
         # Arrange
         self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
 
         # Act
-        response, _delay = self._post_message("")
+        response, _delay = self._post_message(chat_id, "")
 
         # Assert
         self.assertEqual(response.status_code, 400)
@@ -157,22 +242,40 @@ class NotebookChatViewTests(APITestCase):
     def test_post_while_turn_is_running_returns_conflict(self):
         # Arrange
         self.client.force_authenticate(self.owner)
-        first, _delay = self._post_message()
+        chat_id = self._create_chat_id()
+        first, _delay = self._post_message(chat_id)
         self.assertEqual(first.status_code, 202)
 
         # Act
-        second, _delay = self._post_message("another")
+        second, _delay = self._post_message(chat_id, "another")
 
         # Assert
         self.assertEqual(second.status_code, 409)
 
-    def test_cancel_stops_the_running_turn_and_frees_the_conversation(self):
-        # Arrange
+    def test_busy_chat_does_not_block_the_users_other_chats(self):
+        # Arrange: a turn is running in the first chat.
         self.client.force_authenticate(self.owner)
-        posted, _delay = self._post_message()
+        busy_chat = self._create_chat_id()
+        self._post_message(busy_chat)
+        other_chat = self._create_chat_id()
 
         # Act
-        response = self.client.post(self.cancel_url)
+        response, _delay = self._post_message(other_chat, "Separate thread")
+
+        # Assert: the 409 is per chat, not per note.
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.data["conversation_id"], other_chat)
+
+    # -- cancelling -------------------------------------------------------
+
+    def test_cancel_stops_the_running_turn_and_frees_the_chat(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
+        posted, _delay = self._post_message(chat_id)
+
+        # Act
+        response = self._cancel(chat_id)
 
         # Assert
         self.assertEqual(response.status_code, 200)
@@ -181,82 +284,107 @@ class NotebookChatViewTests(APITestCase):
         execution = AgentExecution.objects.get(id=posted.data["execution_id"])
         self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
         # The whole point: the user can send the next message immediately.
-        again, _delay = self._post_message("Try this instead")
+        again, _delay = self._post_message(chat_id, "Try this instead")
         self.assertEqual(again.status_code, 202)
 
     def test_cancel_with_nothing_running_succeeds_and_reports_nothing(self):
         # Arrange: the client cannot know which side of the race it is on when
         # the user clicks stop, so this is a success, not an error.
         self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
 
         # Act
-        response = self.client.post(self.cancel_url)
+        response = self._cancel(chat_id)
 
         # Assert
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.data["cancelled"])
         self.assertIsNone(response.data["execution_id"])
 
-    def test_cancel_requires_note_access(self):
-        # Arrange
-        self.client.force_authenticate(self.outsider)
-
-        # Act
-        response = self.client.post(self.cancel_url)
-
-        # Assert
-        self.assertEqual(response.status_code, 404)
-
-    def test_cancel_is_scoped_to_the_requesting_users_conversation(self):
-        # Arrange: two people each have a turn running on the same note. Each
-        # holds their own conversation, so stop must reach one and not the other.
+    def test_cancel_of_another_users_chat_is_not_found(self):
+        # Arrange: the owner's turn is running; the viewer aims stop at it.
         self.client.force_authenticate(self.owner)
-        owners, _delay = self._post_message()
+        owners_chat = self._create_chat_id()
+        posted, _delay = self._post_message(owners_chat)
         self.client.force_authenticate(self.viewer)
-        viewers, _delay = self._post_message("Summarize it for me too")
-        self.assertNotEqual(owners.data["execution_id"], viewers.data["execution_id"])
 
         # Act
-        response = self.client.post(self.cancel_url)
+        response = self._cancel(owners_chat)
 
-        # Assert: the viewer stopped their own turn and left the owner's running.
-        self.assertTrue(response.data["cancelled"])
-        self.assertEqual(response.data["execution_id"], viewers.data["execution_id"])
+        # Assert: not reachable, and the owner's turn is untouched.
+        self.assertEqual(response.status_code, 404)
         self.assertEqual(
-            AgentExecution.objects.get(id=viewers.data["execution_id"]).status,
-            AgentExecution.Status.CANCELLED,
-        )
-        self.assertEqual(
-            AgentExecution.objects.get(id=owners.data["execution_id"]).status,
+            AgentExecution.objects.get(id=posted.data["execution_id"]).status,
             AgentExecution.Status.PENDING,
         )
 
-    def test_get_chat_without_conversation_returns_empty(self):
-        # Arrange
+    def test_cancel_only_touches_the_addressed_chat(self):
+        # Arrange: the same user runs turns in two chats on the note.
         self.client.force_authenticate(self.owner)
+        first_chat = self._create_chat_id()
+        first_posted, _delay = self._post_message(first_chat)
+        second_chat = self._create_chat_id()
+        second_posted, _delay = self._post_message(second_chat)
 
         # Act
-        response = self.client.get(self.chat_url)
+        response = self._cancel(second_chat)
 
         # Assert
-        self.assertEqual(response.status_code, 200)
-        self.assertIsNone(response.data["conversation_id"])
-        self.assertEqual(response.data["messages"], [])
-        self.assertEqual(response.data["executions"], [])
-
-    def test_get_chat_returns_the_users_conversation(self):
-        # Arrange
-        self.client.force_authenticate(self.owner)
-        posted, _delay = self._post_message("What is this note about?")
-
-        # Act
-        response = self.client.get(self.chat_url)
-
-        # Assert
-        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["cancelled"])
         self.assertEqual(
-            response.data["conversation_id"], posted.data["conversation_id"]
+            AgentExecution.objects.get(id=second_posted.data["execution_id"]).status,
+            AgentExecution.Status.CANCELLED,
         )
+        self.assertEqual(
+            AgentExecution.objects.get(id=first_posted.data["execution_id"]).status,
+            AgentExecution.Status.PENDING,
+        )
+
+    # -- reading chats ----------------------------------------------------
+
+    def test_list_chats_starts_empty(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+
+        # Act
+        response = self.client.get(self.chats_url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["chats"], [])
+
+    def test_list_chats_shows_titles_previews_and_activity(self):
+        # Arrange: one busy chat named from its first message, one idle chat.
+        self.client.force_authenticate(self.owner)
+        idle_chat = self._create_chat_id()
+        busy_chat = self._create_chat_id()
+        self._post_message(busy_chat, "Compare the cited methods")
+
+        # Act
+        response = self.client.get(self.chats_url)
+
+        # Assert: newest activity first.
+        busy, idle = response.data["chats"]
+        self.assertEqual(busy["id"], busy_chat)
+        self.assertEqual(busy["title"], "Compare the cited methods")
+        self.assertEqual(busy["last_message_preview"], "Compare the cited methods")
+        self.assertTrue(busy["has_active_turn"])
+        self.assertEqual(idle["id"], idle_chat)
+        self.assertFalse(idle["has_active_turn"])
+
+    def test_get_chat_returns_its_representation(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
+        self._post_message(chat_id, "What is this note about?")
+
+        # Act
+        response = self.client.get(self._chat_url(chat_id))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["conversation_id"], chat_id)
+        self.assertEqual(response.data["title"], "What is this note about?")
         self.assertEqual(len(response.data["messages"]), 1)
         self.assertEqual(
             response.data["messages"][0]["content"], "What is this note about?"
@@ -267,26 +395,82 @@ class NotebookChatViewTests(APITestCase):
             AgentExecution.Status.PENDING,
         )
 
-    def test_get_chat_is_scoped_per_user(self):
-        # Arrange: the owner has a conversation; the viewer sees their own
-        # (empty) chat, not the owner's.
+    def test_get_unknown_chat_is_not_found(self):
+        # Arrange
         self.client.force_authenticate(self.owner)
-        self._post_message()
+
+        # Act
+        response = self.client.get(self._chat_url(999999))
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_chats_are_scoped_per_user(self):
+        # Arrange: the owner has a chat; the viewer neither lists nor reads it.
+        self.client.force_authenticate(self.owner)
+        owners_chat = self._create_chat_id()
         self.client.force_authenticate(self.viewer)
 
         # Act
-        response = self.client.get(self.chat_url)
+        listing = self.client.get(self.chats_url)
+        detail = self.client.get(self._chat_url(owners_chat))
 
         # Assert
-        self.assertEqual(response.status_code, 200)
-        self.assertIsNone(response.data["conversation_id"])
+        self.assertEqual(listing.status_code, 200)
+        self.assertEqual(listing.data["chats"], [])
+        self.assertEqual(detail.status_code, 404)
 
-    def test_get_chat_requires_note_access(self):
+    def test_list_chats_requires_note_access(self):
         # Arrange
         self.client.force_authenticate(self.outsider)
 
         # Act
-        response = self.client.get(self.chat_url)
+        response = self.client.get(self.chats_url)
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    # -- renaming ---------------------------------------------------------
+
+    def test_rename_chat(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
+
+        # Act
+        response = self.client.patch(
+            self._chat_url(chat_id), {"title": "Grant ideas"}, format="json"
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["title"], "Grant ideas")
+        detail = self.client.get(self._chat_url(chat_id))
+        self.assertEqual(detail.data["title"], "Grant ideas")
+
+    def test_rename_chat_rejects_a_blank_title(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
+
+        # Act
+        response = self.client.patch(
+            self._chat_url(chat_id), {"title": ""}, format="json"
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+
+    def test_rename_of_another_users_chat_is_not_found(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        owners_chat = self._create_chat_id()
+        self.client.force_authenticate(self.viewer)
+
+        # Act
+        response = self.client.patch(
+            self._chat_url(owners_chat), {"title": "Mine now"}, format="json"
+        )
 
         # Assert
         self.assertEqual(response.status_code, 404)

--- a/src/research_ai/urls.py
+++ b/src/research_ai/urls.py
@@ -22,8 +22,9 @@ from research_ai.views.expert_finder_views import (
 )
 from research_ai.views.notebook_chat_views import (
     NotebookChatCancelView,
+    NotebookChatDetailView,
+    NotebookChatListCreateView,
     NotebookChatMessageView,
-    NotebookChatView,
 )
 from research_ai.views.proposal_draft_views import (
     ProposalDraftCancelView,
@@ -109,15 +110,19 @@ urlpatterns = [
         ProposalDraftCancelView.as_view(),
     ),
     path(
-        "notebook/notes/<int:note_id>/chat/",
-        NotebookChatView.as_view(),
+        "notebook/notes/<int:note_id>/chats/",
+        NotebookChatListCreateView.as_view(),
     ),
     path(
-        "notebook/notes/<int:note_id>/chat/messages/",
+        "notebook/notes/<int:note_id>/chats/<int:conversation_id>/",
+        NotebookChatDetailView.as_view(),
+    ),
+    path(
+        "notebook/notes/<int:note_id>/chats/<int:conversation_id>/messages/",
         NotebookChatMessageView.as_view(),
     ),
     path(
-        "notebook/notes/<int:note_id>/chat/cancel/",
+        "notebook/notes/<int:note_id>/chats/<int:conversation_id>/cancel/",
         NotebookChatCancelView.as_view(),
     ),
 ]

--- a/src/research_ai/views/notebook_chat_views.py
+++ b/src/research_ai/views/notebook_chat_views.py
@@ -1,11 +1,17 @@
 """API for the notebook chat assistant.
 
+A user can keep any number of chats on a note; the collection lives at
+``notebook/notes/<note_id>/chats/`` and every other route addresses one chat
+by id. Chats are private to their creator: resolution is scoped to the
+requesting user, so another collaborator's chat id -- like a note the user
+cannot view -- is reported as 404 rather than 403, and nothing is leaked.
+
 Rollout is gated to hub editors and moderators for now (same gate as the
 proposal-draft views); within that group, access mirrors the note itself:
-anyone who can view the note can read the chat and send messages (the agent
-runs with the requester's permissions, so its edit tool refuses writes for
-viewers). A note the user cannot view is reported as 404 rather than 403 so
-its existence is not leaked -- the same contract as ``NoteToolset``.
+anyone who can view the note can chat on it (the agent runs with the
+requester's permissions, so its edit tool refuses writes for viewers). A note
+the user cannot view is likewise a 404 -- the same contract as
+``NoteToolset``.
 """
 
 import logging
@@ -18,8 +24,13 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from note.related_models.note_model import Note
+from research_ai.models import AgentConversation
 from research_ai.permissions import ResearchAIPermission
-from research_ai.serializers import NotebookChatMessageCreateSerializer
+from research_ai.serializers import (
+    NotebookChatCreateSerializer,
+    NotebookChatMessageCreateSerializer,
+    NotebookChatUpdateSerializer,
+)
 from research_ai.services.agent_persistence import AgentConversationBusyError
 from research_ai.services.notebook_chat import (
     ACTIVITY_ALL,
@@ -29,6 +40,12 @@ from research_ai.services.notebook_chat import (
 from user.permissions import IsModerator, UserIsEditor
 
 logger = logging.getLogger(__name__)
+
+NOTEBOOK_CHAT_PERMISSIONS = [
+    IsAuthenticated,
+    ResearchAIPermission,
+    UserIsEditor | IsModerator,
+]
 
 
 def _get_viewable_note_or_404(note_id: int, user) -> Note:
@@ -41,8 +58,41 @@ def _get_viewable_note_or_404(note_id: int, user) -> Note:
     return note
 
 
-class NotebookChatView(APIView):
-    """Read the user's assistant conversation on a note.
+def _get_conversation_or_404(
+    service: NotebookChatService, note: Note, user, conversation_id: int
+) -> AgentConversation:
+    conversation = service.get_conversation(note, user, conversation_id)
+    if conversation is None:
+        raise Http404
+    return conversation
+
+
+class NotebookChatListCreateView(APIView):
+    """List the user's chats on a note, or start a new one."""
+
+    permission_classes = NOTEBOOK_CHAT_PERMISSIONS
+
+    def get(self, request, note_id):
+        note = _get_viewable_note_or_404(note_id, request.user)
+        return Response(
+            {"chats": NotebookChatService().list_conversations(note, request.user)}
+        )
+
+    def post(self, request, note_id):
+        note = _get_viewable_note_or_404(note_id, request.user)
+        serializer = NotebookChatCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        service = NotebookChatService()
+        conversation = service.create_conversation(
+            note, request.user, title=serializer.validated_data["title"]
+        )
+        return Response(
+            service.representation(conversation), status=status.HTTP_201_CREATED
+        )
+
+
+class NotebookChatDetailView(APIView):
+    """Read or rename one chat.
 
     ``?activity=live`` is the polling form: it recomputes the activity feed
     only for turns the client may not yet hold settled -- active ones, and
@@ -55,18 +105,14 @@ class NotebookChatView(APIView):
     rather than correctness.
     """
 
-    permission_classes = [
-        IsAuthenticated,
-        ResearchAIPermission,
-        UserIsEditor | IsModerator,
-    ]
+    permission_classes = NOTEBOOK_CHAT_PERMISSIONS
 
-    def get(self, request, note_id):
+    def get(self, request, note_id, conversation_id):
         note = _get_viewable_note_or_404(note_id, request.user)
         service = NotebookChatService()
-        conversation = service.get_conversation(note, request.user)
-        if conversation is None:
-            return Response({"conversation_id": None, "messages": [], "executions": []})
+        conversation = _get_conversation_or_404(
+            service, note, request.user, conversation_id
+        )
         scope = (
             ACTIVITY_LIVE
             if request.query_params.get("activity") == ACTIVITY_LIVE
@@ -74,25 +120,37 @@ class NotebookChatView(APIView):
         )
         return Response(service.representation(conversation, activity_scope=scope))
 
+    def patch(self, request, note_id, conversation_id):
+        note = _get_viewable_note_or_404(note_id, request.user)
+        serializer = NotebookChatUpdateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        service = NotebookChatService()
+        conversation = _get_conversation_or_404(
+            service, note, request.user, conversation_id
+        )
+        service.rename_conversation(conversation, serializer.validated_data["title"])
+        return Response(
+            {"conversation_id": conversation.id, "title": conversation.title}
+        )
+
 
 class NotebookChatMessageView(APIView):
-    """Send a message to the note's assistant; the turn runs asynchronously."""
+    """Send a message to one chat; the turn runs asynchronously."""
 
-    permission_classes = [
-        IsAuthenticated,
-        ResearchAIPermission,
-        UserIsEditor | IsModerator,
-    ]
+    permission_classes = NOTEBOOK_CHAT_PERMISSIONS
 
-    def post(self, request, note_id):
+    def post(self, request, note_id, conversation_id):
         note = _get_viewable_note_or_404(note_id, request.user)
         serializer = NotebookChatMessageCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         service = NotebookChatService()
+        conversation = _get_conversation_or_404(
+            service, note, request.user, conversation_id
+        )
         try:
             execution = service.submit_message(
-                note, request.user, serializer.validated_data["message"]
+                note, conversation, serializer.validated_data["message"]
             )
         except AgentConversationBusyError:
             return Response(
@@ -111,7 +169,7 @@ class NotebookChatMessageView(APIView):
 
 
 class NotebookChatCancelView(APIView):
-    """Stop the note assistant's in-flight turn.
+    """Stop one chat's in-flight turn.
 
     Idempotent by design: cancelling when nothing is running -- or when the
     turn finished a moment earlier -- is a success reporting ``cancelled:
@@ -119,15 +177,15 @@ class NotebookChatCancelView(APIView):
     race it is on when the user clicks stop.
     """
 
-    permission_classes = [
-        IsAuthenticated,
-        ResearchAIPermission,
-        UserIsEditor | IsModerator,
-    ]
+    permission_classes = NOTEBOOK_CHAT_PERMISSIONS
 
-    def post(self, request, note_id):
+    def post(self, request, note_id, conversation_id):
         note = _get_viewable_note_or_404(note_id, request.user)
-        execution = NotebookChatService().cancel_active_turn(note, request.user)
+        service = NotebookChatService()
+        conversation = _get_conversation_or_404(
+            service, note, request.user, conversation_id
+        )
+        execution = service.cancel_active_turn(conversation)
         if execution is None:
             return Response({"cancelled": False, "execution_id": None})
         return Response({"cancelled": True, "execution_id": execution.id})


### PR DESCRIPTION
Replace the singleton chat with a collection: chats are created and addressed by id under notebook/notes/<id>/chats/, each with its own busy check so turns in different chats run independently. Conversations gain a title, named from the first message unless set explicitly, and the listing projects titles, previews, and activity in one query.