### PR TITLE
Push notebook chat turn events over WebSockets

### DIFF
--- a/src/research_ai/consumers.py
+++ b/src/research_ai/consumers.py
@@ -10,7 +10,9 @@ a client should refetch on any event and treat the socket as droppable.
 
 Admission mirrors the REST contract in ``notebook_chat_views`` and must be
 kept in sync with ``NOTEBOOK_CHAT_PERMISSIONS`` there: authentication
-(4401), the editor-or-moderator rollout gate (4403, the REST 403), and
+(4401 -- including a deactivated account, which ``TokenAuthMiddleware``
+still resolves from its lingering token but DRF's ``TokenAuthentication``
+refuses), the editor-or-moderator rollout gate (4403, the REST 403), and
 owner-scoped resolution of the note and conversation (4404, the REST 404).
 Resolution failures close with the same code whether the chat does not
 exist, belongs to someone else, or sits on an invisible note -- the group is
@@ -57,7 +59,10 @@ def _rejection_code(user, note_id: int, conversation_id: int) -> int | None:
 class NotebookChatConsumer(AsyncWebsocketConsumer):
     async def connect(self):
         user = self.scope.get("user")
-        if user is None or user.is_anonymous:
+        # ``is_active`` alongside ``is_anonymous``: deactivating an account
+        # must revoke this socket the same way DRF revokes the REST API,
+        # even while the account's auth token still resolves to a user.
+        if user is None or user.is_anonymous or not user.is_active:
             await self.close(code=CLOSE_UNAUTHENTICATED)
             return
 

--- a/src/research_ai/consumers.py
+++ b/src/research_ai/consumers.py
@@ -1,0 +1,88 @@
+"""WebSocket consumers for research AI features.
+
+``NotebookChatConsumer`` subscribes one client to one chat's turn events
+(``ws/notebook/notes/<note_id>/chats/<conversation_id>/``). Events are the
+small refetch nudges published by ``notebook_chat.events``; the payload the
+client receives is the event's ``data`` object verbatim (``conversation_id``,
+``execution_id``, ``kind``). The socket is a latency optimization over the
+``?activity=live`` polling projection, which remains the source of truth --
+a client should refetch on any event and treat the socket as droppable.
+
+Admission mirrors the REST contract in ``notebook_chat_views`` and must be
+kept in sync with ``NOTEBOOK_CHAT_PERMISSIONS`` there: authentication
+(4401), the editor-or-moderator rollout gate (4403, the REST 403), and
+owner-scoped resolution of the note and conversation (4404, the REST 404).
+Resolution failures close with the same code whether the chat does not
+exist, belongs to someone else, or sits on an invisible note -- the group is
+per-conversation and owner-only precisely because chats are private, unlike
+the org-wide room ``NoteConsumer`` uses for note notifications.
+"""
+
+import json
+
+from channels.db import database_sync_to_async
+from channels.generic.websocket import AsyncWebsocketConsumer
+
+from note.related_models.note_model import Note
+from research_ai.services.notebook_chat import NotebookChatService
+from research_ai.services.notebook_chat.events import conversation_group
+
+# Private-use WebSocket close codes (4000-4999), mapped to the REST statuses
+# the same request would have received.
+CLOSE_UNAUTHENTICATED = 4401
+CLOSE_FORBIDDEN = 4403
+CLOSE_NOT_FOUND = 4404
+
+
+@database_sync_to_async
+def _rejection_code(user, note_id: int, conversation_id: int) -> int | None:
+    """Why ``user`` may not watch this chat, or ``None`` to admit them.
+
+    One database hop covering the REST permission stack: the rollout gate
+    (``UserIsEditor | IsModerator``; ``ResearchAIPermission`` is the
+    authentication check the caller already made), then note visibility and
+    conversation ownership exactly as the views resolve them.
+    """
+    if not (user.moderator or user.is_hub_editor()):
+        return CLOSE_FORBIDDEN
+    note = Note.objects.filter(id=note_id, unified_document__is_removed=False).first()
+    if note is None or not note.permissions.has_user(user):
+        return CLOSE_NOT_FOUND
+    service = NotebookChatService()
+    if service.get_conversation(note, user, conversation_id) is None:
+        return CLOSE_NOT_FOUND
+    return None
+
+
+class NotebookChatConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        user = self.scope.get("user")
+        if user is None or user.is_anonymous:
+            await self.close(code=CLOSE_UNAUTHENTICATED)
+            return
+
+        kwargs = self.scope["url_route"]["kwargs"]
+        # The route constrains both to digits; the casts normalize away
+        # artifacts like leading zeros so the group name always matches the
+        # one the publisher derives from model ids.
+        note_id = int(kwargs["note_id"])
+        conversation_id = int(kwargs["conversation_id"])
+
+        rejection = await _rejection_code(user, note_id, conversation_id)
+        if rejection is not None:
+            await self.close(code=rejection)
+            return
+
+        self.group_name = conversation_group(conversation_id)
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        # The client offers ("Token", <key>) as subprotocols for
+        # TokenAuthMiddleware; echo the name back like the other consumers.
+        await self.accept(subprotocol="Token")
+
+    async def disconnect(self, close_code):
+        if hasattr(self, "group_name"):
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+
+    async def notebook_chat_event(self, event):
+        """Forward one published turn event to the client."""
+        await self.send(text_data=json.dumps(event["data"]))

--- a/src/research_ai/routing.py
+++ b/src/research_ai/routing.py
@@ -1,0 +1,10 @@
+from django.urls import re_path
+
+from . import consumers
+
+websocket_urlpatterns = [
+    re_path(
+        r"ws/notebook/notes/(?P<note_id>[0-9]+)/chats/(?P<conversation_id>[0-9]+)/$",
+        consumers.NotebookChatConsumer.as_asgi(),
+    )
+]

--- a/src/research_ai/services/agent/recorder.py
+++ b/src/research_ai/services/agent/recorder.py
@@ -40,20 +40,16 @@ class AgentRecorder(Protocol):
     def on_run_finished(self, result: AgentResult) -> bool | None:
         """The run completed; every message was already recorded.
 
-        A recorder that persists a terminal outcome reports whether this call
-        performed the transition itself: ``False`` means the run was already
-        sealed from elsewhere (cancelled, for instance) and the result was
-        discarded. Observers layered over such a recorder use the report to
-        stay silent about outcomes that never landed; the loop ignores it,
-        and recorders that do not track it return ``None``.
+        Returns whether this call performed the terminal transition itself
+        (``False`` if the run was already sealed elsewhere, ``None`` from
+        recorders that do not track it). The loop ignores the report.
         """
         ...
 
     def on_run_failed(self, error: Exception) -> bool | None:
         """The run failed; every message up to the failure was recorded.
 
-        Reports whether this call sealed the run, under the same contract as
-        ``on_run_finished``.
+        Reports its transition like ``on_run_finished``.
         """
         ...
 

--- a/src/research_ai/services/agent/recorder.py
+++ b/src/research_ai/services/agent/recorder.py
@@ -37,12 +37,24 @@ class AgentRecorder(Protocol):
         """
         ...
 
-    def on_run_finished(self, result: AgentResult) -> None:
-        """The run completed; every message was already recorded."""
+    def on_run_finished(self, result: AgentResult) -> bool | None:
+        """The run completed; every message was already recorded.
+
+        A recorder that persists a terminal outcome reports whether this call
+        performed the transition itself: ``False`` means the run was already
+        sealed from elsewhere (cancelled, for instance) and the result was
+        discarded. Observers layered over such a recorder use the report to
+        stay silent about outcomes that never landed; the loop ignores it,
+        and recorders that do not track it return ``None``.
+        """
         ...
 
-    def on_run_failed(self, error: Exception) -> None:
-        """The run failed; every message up to the failure was recorded."""
+    def on_run_failed(self, error: Exception) -> bool | None:
+        """The run failed; every message up to the failure was recorded.
+
+        Reports whether this call sealed the run, under the same contract as
+        ``on_run_finished``.
+        """
         ...
 
     def is_active(self) -> bool:

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -299,7 +299,13 @@ class DatabaseAgentRecorder:
             )
             execution.save(update_fields=update_fields)
 
-    def on_run_finished(self, result) -> None:
+    def on_run_finished(self, result) -> bool:
+        """Seal the run as ``SUCCEEDED`` and publish its answer to the chat.
+
+        Returns whether this call performed the transition. ``False`` means
+        the execution was already terminal -- cancellation won the race --
+        so the result was discarded and nothing was published.
+        """
         now = timezone.now()
         final_output, _truncated, _size = serialize_final_output(result.final_text)
         transitioned = False
@@ -331,7 +337,7 @@ class DatabaseAgentRecorder:
             terminal = _is_terminal(execution.status)
         self.terminal_observed = terminal
         if not transitioned:
-            return
+            return False
         # Publish what the model actually answered, not the snapshot trimmed to
         # fit the execution row: chat content is unbounded text, so truncating
         # it here would drop the tail of a successful response for good.
@@ -342,8 +348,15 @@ class DatabaseAgentRecorder:
                 logger.warning(
                     "failed to publish agent response to chat", exc_info=True
                 )
+        return True
 
-    def on_run_failed(self, error: Exception) -> None:
+    def on_run_failed(self, error: Exception) -> bool:
+        """Seal the run as ``FAILED`` (``INTERRUPTED`` for an interruption).
+
+        Returns whether this call performed the transition, exactly as
+        ``on_run_finished`` does; an execution sealed from outside leaves
+        nothing here to record, only to report.
+        """
         now = timezone.now()
         raw_stop_reason = getattr(error, "stop_reason", "") or ""
         stop_reason = _safe_exception_message(raw_stop_reason)
@@ -367,6 +380,7 @@ class DatabaseAgentRecorder:
             if isinstance(error, InterruptedError)
             else AgentExecution.Status.FAILED
         )
+        transitioned = False
         with transaction.atomic():
             execution = AgentExecution.objects.select_for_update().get(
                 id=self.execution.id
@@ -397,8 +411,10 @@ class DatabaseAgentRecorder:
                         "updated_date",
                     ]
                 )
+                transitioned = True
             terminal = _is_terminal(execution.status)
         self.terminal_observed = terminal
+        return transitioned
 
     def publish_assistant_output(self, text: str | None = None) -> bool:
         """Publish or repair the canonical assistant message idempotently."""

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -300,12 +300,7 @@ class DatabaseAgentRecorder:
             execution.save(update_fields=update_fields)
 
     def on_run_finished(self, result) -> bool:
-        """Seal the run as ``SUCCEEDED`` and publish its answer to the chat.
-
-        Returns whether this call performed the transition. ``False`` means
-        the execution was already terminal -- cancellation won the race --
-        so the result was discarded and nothing was published.
-        """
+        """Seal the run as ``SUCCEEDED``; ``False`` if it was already terminal."""
         now = timezone.now()
         final_output, _truncated, _size = serialize_final_output(result.final_text)
         transitioned = False
@@ -351,12 +346,7 @@ class DatabaseAgentRecorder:
         return True
 
     def on_run_failed(self, error: Exception) -> bool:
-        """Seal the run as ``FAILED`` (``INTERRUPTED`` for an interruption).
-
-        Returns whether this call performed the transition, exactly as
-        ``on_run_finished`` does; an execution sealed from outside leaves
-        nothing here to record, only to report.
-        """
+        """Seal as ``FAILED``/``INTERRUPTED``; ``False`` if already terminal."""
         now = timezone.now()
         raw_stop_reason = getattr(error, "stop_reason", "") or ""
         stop_reason = _safe_exception_message(raw_stop_reason)

--- a/src/research_ai/services/notebook_chat/__init__.py
+++ b/src/research_ai/services/notebook_chat/__init__.py
@@ -1,6 +1,10 @@
 """The notebook chat assistant flow."""
 
 from research_ai.services.notebook_chat.config import NotebookChatConfig
+from research_ai.services.notebook_chat.events import (
+    ConversationEventPublisher,
+    conversation_group,
+)
 from research_ai.services.notebook_chat.service import (
     ACTIVITY_ALL,
     ACTIVITY_LIVE,
@@ -16,8 +20,10 @@ __all__ = [
     "ACTIVITY_ALL",
     "ACTIVITY_LIVE",
     "WORKFLOW",
+    "ConversationEventPublisher",
     "NotebookChatConfig",
     "NotebookChatService",
     "NotebookWebSearchToolset",
     "compose_notebook_toolset",
+    "conversation_group",
 ]

--- a/src/research_ai/services/notebook_chat/events.py
+++ b/src/research_ai/services/notebook_chat/events.py
@@ -66,10 +66,8 @@ class ConversationEventPublisher:
     def publish(self, conversation_id: int, execution_id: int, kind: str) -> None:
         """Emit ``kind`` for ``execution_id`` once the current transaction commits.
 
-        Outside a transaction this sends immediately (``on_commit`` semantics),
-        which is the worker path: the recorder's writes commit before its hooks
-        return. ``robust`` because a lost nudge costs one poll interval, while
-        an exception here could otherwise cancel sibling commit callbacks.
+        Sends immediately when no transaction is active. ``robust`` so a
+        failed send cannot cancel sibling commit callbacks.
         """
         transaction.on_commit(
             lambda: self._send(conversation_id, execution_id, kind),
@@ -104,19 +102,11 @@ class ConversationEventPublisher:
 class PublishingRecorder:
     """Wraps a turn's recorder to publish an event after each durable write.
 
-    The wrapped recorder stays the authority on persistence and its contracts
-    (``requires_durable_messages``, ``is_active``, ``terminal_observed`` --
-    everything undefined here is delegated). This wrapper only appends a
-    post-write nudge, and only for writes that actually landed: publish after
-    the wrapped call returns, never when it raises, and never when a terminal
-    hook reports that it performed no transition of its own. A cancelled run
-    therefore emits nothing on its way down --
-    whether it unwinds through a refused write (``InterruptedError``) into
-    the failure hook or races cancellation to the finish hook, the row was
-    sealed from outside and the hook finds nothing left to record. The
-    sealing path (cancellation) already published the authoritative event;
-    announcing ``turn_failed`` or ``turn_finished`` over it would hand
-    subscribers a contradiction.
+    Everything undefined here is delegated to the wrapped recorder. Events
+    fire only for writes that landed: never when the wrapped call raises,
+    and never when a terminal hook reports it performed no transition --
+    that run was sealed from outside (cancelled), and the sealing path
+    already published the authoritative event.
     """
 
     def __init__(
@@ -143,22 +133,13 @@ class PublishingRecorder:
         self._publish(TURN_PROGRESS)
 
     def on_run_finished(self, result) -> None:
-        # Only an explicit ``False`` report suppresses the event: it means the
-        # hook found the row already sealed from outside and discarded the
-        # result, so the sealing path's event stands alone. A recorder that
-        # does not track transitions returns ``None`` and keeps its events.
-        # On a real finish the wrapped hook also publishes the assistant's
-        # reply to the chat before returning, so this event's refetch already
-        # sees the answer.
+        # Only an explicit False suppresses; None (a recorder that does not
+        # track transitions) keeps the event.
         if self._recorder.on_run_finished(result) is False:
             return
         self._publish(TURN_FINISHED)
 
     def on_run_failed(self, error: Exception) -> None:
-        # Same rule as the finish hook. A report of no transition here is the
-        # cancelled run's own unwinding reaching this hook (an interruption,
-        # or a late failure) after cancellation already sealed the row and
-        # told the subscribers.
         if self._recorder.on_run_failed(error) is False:
             return
         self._publish(TURN_FAILED)

--- a/src/research_ai/services/notebook_chat/events.py
+++ b/src/research_ai/services/notebook_chat/events.py
@@ -1,0 +1,147 @@
+"""Turn-lifecycle push events for notebook chat WebSocket clients.
+
+The polling projection (``?activity=live``) is the source of truth for a
+chat's state; its weakness is latency, not correctness -- a client learns of
+progress only at its next poll. This module closes that gap by publishing a
+small event to a per-conversation channel-layer group at every point a turn's
+durable state changes, so a subscribed client can refetch immediately instead
+of waiting out its interval.
+
+Two properties keep this layer simple and safe to lose:
+
+- **Events carry identifiers, never state.** A client reacts to any event the
+  same way -- refetch the conversation -- so a dropped, duplicated, or
+  reordered event can never show wrong data, only later data. Polling remains
+  the repair path; the socket is purely a latency optimization.
+- **Emission is post-commit and best-effort.** Every publish is deferred with
+  ``transaction.on_commit(robust=True)``, so an event can never describe a
+  write the triggered refetch cannot yet see, and a failing channel layer can
+  never break the write it narrates (or starve later commit callbacks, such
+  as the one that queues the worker task).
+
+The group is scoped to one conversation because chats are private to their
+creator: the consumer admits only the owner, so events never reach an
+org-wide room the way note notifications do.
+"""
+
+import logging
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from django.db import transaction
+
+logger = logging.getLogger(__name__)
+
+# Channel-layer message type; Channels routes it to the consumer handler of
+# the same name.
+EVENT_TYPE = "notebook_chat_event"
+
+# Event kinds, in rough lifecycle order. ``TURN_PROGRESS`` fires on every
+# durable trace append (assistant turns and tool results alike); the terminal
+# kinds are advisory -- the refetch, not the kind, is what a client should
+# trust for the execution's final status.
+TURN_QUEUED = "turn_queued"
+TURN_PROGRESS = "turn_progress"
+TURN_FINISHED = "turn_finished"
+TURN_FAILED = "turn_failed"
+TURN_CANCELLED = "turn_cancelled"
+
+
+def conversation_group(conversation_id: int | str) -> str:
+    """The channel-layer group carrying one chat's turn events."""
+    return f"notebook_chat_{conversation_id}"
+
+
+class ConversationEventPublisher:
+    """Publishes turn events to a conversation's channel-layer group.
+
+    The channel layer is injectable for tests; by default each send resolves
+    the configured layer at publish time, so a worker process that never
+    serves WebSockets still publishes through the shared Redis backend.
+    """
+
+    def __init__(self, channel_layer=None):
+        self._channel_layer = channel_layer
+
+    def publish(self, conversation_id: int, execution_id: int, kind: str) -> None:
+        """Emit ``kind`` for ``execution_id`` once the current transaction commits.
+
+        Outside a transaction this sends immediately (``on_commit`` semantics),
+        which is the worker path: the recorder's writes commit before its hooks
+        return. ``robust`` because a lost nudge costs one poll interval, while
+        an exception here could otherwise cancel sibling commit callbacks.
+        """
+        transaction.on_commit(
+            lambda: self._send(conversation_id, execution_id, kind),
+            robust=True,
+        )
+
+    def _send(self, conversation_id: int, execution_id: int, kind: str) -> None:
+        try:
+            layer = self._channel_layer or get_channel_layer()
+            if layer is None:
+                return
+            async_to_sync(layer.group_send)(
+                conversation_group(conversation_id),
+                {
+                    "type": EVENT_TYPE,
+                    "data": {
+                        "conversation_id": conversation_id,
+                        "execution_id": execution_id,
+                        "kind": kind,
+                    },
+                },
+            )
+        except Exception:  # noqa: BLE001 - push is best-effort by contract
+            logger.warning(
+                "notebook chat event publish failed (conversation=%s kind=%s)",
+                conversation_id,
+                kind,
+                exc_info=True,
+            )
+
+
+class PublishingRecorder:
+    """Wraps a turn's recorder to publish an event after each durable write.
+
+    The wrapped recorder stays the authority on persistence and its contracts
+    (``requires_durable_messages``, ``is_active``, ``terminal_observed`` --
+    everything undefined here is delegated). This wrapper only appends a
+    post-write nudge: publish after the wrapped call returns, never when it
+    raises, so an event always narrates a write that actually landed. A
+    cancelled run's refused write (``InterruptedError``) therefore emits
+    nothing -- the cancel path already published its own event.
+    """
+
+    def __init__(
+        self,
+        recorder,
+        publisher: ConversationEventPublisher,
+        *,
+        conversation_id: int,
+        execution_id: int,
+    ):
+        self._recorder = recorder
+        self._publisher = publisher
+        self._conversation_id = conversation_id
+        self._execution_id = execution_id
+
+    def __getattr__(self, name):
+        return getattr(self._recorder, name)
+
+    def _publish(self, kind: str) -> None:
+        self._publisher.publish(self._conversation_id, self._execution_id, kind)
+
+    def record_message(self, message, *, turn=None) -> None:
+        self._recorder.record_message(message, turn=turn)
+        self._publish(TURN_PROGRESS)
+
+    def on_run_finished(self, result) -> None:
+        # The wrapped hook also publishes the assistant's reply to the chat
+        # before returning, so this event's refetch already sees the answer.
+        self._recorder.on_run_finished(result)
+        self._publish(TURN_FINISHED)
+
+    def on_run_failed(self, error: Exception) -> None:
+        self._recorder.on_run_failed(error)
+        self._publish(TURN_FAILED)

--- a/src/research_ai/services/notebook_chat/events.py
+++ b/src/research_ai/services/notebook_chat/events.py
@@ -109,8 +109,12 @@ class PublishingRecorder:
     everything undefined here is delegated). This wrapper only appends a
     post-write nudge: publish after the wrapped call returns, never when it
     raises, so an event always narrates a write that actually landed. A
-    cancelled run's refused write (``InterruptedError``) therefore emits
-    nothing -- the cancel path already published its own event.
+    cancelled run therefore emits nothing on its way down: its refused write
+    raises ``InterruptedError``, and the failure hook that error reaches is
+    likewise suppressed -- in both cases the execution was sealed from
+    outside, and the sealing path (cancellation) already published the
+    authoritative event. Announcing ``turn_failed`` over it would hand
+    subscribers a contradiction.
     """
 
     def __init__(
@@ -144,4 +148,9 @@ class PublishingRecorder:
 
     def on_run_failed(self, error: Exception) -> None:
         self._recorder.on_run_failed(error)
-        self._publish(TURN_FAILED)
+        # An interruption is not this run's own failure: the loop raises it
+        # when the execution stopped being ours -- sealed from outside, by
+        # cancellation in this flow -- and the wrapped hook leaves such a row
+        # untouched. Whoever sealed it already told the subscribers.
+        if not isinstance(error, InterruptedError):
+            self._publish(TURN_FAILED)

--- a/src/research_ai/services/notebook_chat/events.py
+++ b/src/research_ai/services/notebook_chat/events.py
@@ -77,8 +77,6 @@ class ConversationEventPublisher:
     def _send(self, conversation_id: int, execution_id: int, kind: str) -> None:
         try:
             layer = self._channel_layer or get_channel_layer()
-            if layer is None:
-                return
             async_to_sync(layer.group_send)(
                 conversation_group(conversation_id),
                 {

--- a/src/research_ai/services/notebook_chat/events.py
+++ b/src/research_ai/services/notebook_chat/events.py
@@ -107,13 +107,15 @@ class PublishingRecorder:
     The wrapped recorder stays the authority on persistence and its contracts
     (``requires_durable_messages``, ``is_active``, ``terminal_observed`` --
     everything undefined here is delegated). This wrapper only appends a
-    post-write nudge: publish after the wrapped call returns, never when it
-    raises, so an event always narrates a write that actually landed. A
-    cancelled run therefore emits nothing on its way down: its refused write
-    raises ``InterruptedError``, and the failure hook that error reaches is
-    likewise suppressed -- in both cases the execution was sealed from
-    outside, and the sealing path (cancellation) already published the
-    authoritative event. Announcing ``turn_failed`` over it would hand
+    post-write nudge, and only for writes that actually landed: publish after
+    the wrapped call returns, never when it raises, and never when a terminal
+    hook reports that it performed no transition of its own. A cancelled run
+    therefore emits nothing on its way down --
+    whether it unwinds through a refused write (``InterruptedError``) into
+    the failure hook or races cancellation to the finish hook, the row was
+    sealed from outside and the hook finds nothing left to record. The
+    sealing path (cancellation) already published the authoritative event;
+    announcing ``turn_failed`` or ``turn_finished`` over it would hand
     subscribers a contradiction.
     """
 
@@ -141,16 +143,22 @@ class PublishingRecorder:
         self._publish(TURN_PROGRESS)
 
     def on_run_finished(self, result) -> None:
-        # The wrapped hook also publishes the assistant's reply to the chat
-        # before returning, so this event's refetch already sees the answer.
-        self._recorder.on_run_finished(result)
+        # Only an explicit ``False`` report suppresses the event: it means the
+        # hook found the row already sealed from outside and discarded the
+        # result, so the sealing path's event stands alone. A recorder that
+        # does not track transitions returns ``None`` and keeps its events.
+        # On a real finish the wrapped hook also publishes the assistant's
+        # reply to the chat before returning, so this event's refetch already
+        # sees the answer.
+        if self._recorder.on_run_finished(result) is False:
+            return
         self._publish(TURN_FINISHED)
 
     def on_run_failed(self, error: Exception) -> None:
-        self._recorder.on_run_failed(error)
-        # An interruption is not this run's own failure: the loop raises it
-        # when the execution stopped being ours -- sealed from outside, by
-        # cancellation in this flow -- and the wrapped hook leaves such a row
-        # untouched. Whoever sealed it already told the subscribers.
-        if not isinstance(error, InterruptedError):
-            self._publish(TURN_FAILED)
+        # Same rule as the finish hook. A report of no transition here is the
+        # cancelled run's own unwinding reaching this hook (an interruption,
+        # or a late failure) after cancellation already sealed the row and
+        # told the subscribers.
+        if self._recorder.on_run_failed(error) is False:
+            return
+        self._publish(TURN_FAILED)

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -398,12 +398,9 @@ class NotebookChatService:
         # After prepare_turn so a refused turn (busy, for instance) names
         # nothing; the filtered update keeps a concurrent rename authoritative.
         self.conversations.set_title_if_blank(conversation, _derive_title(text))
-        # Nudge before scheduling: both defer to the same commit -- and under
-        # autocommit, the production request path, run right here in this
-        # order -- so subscribers always see turn_queued before anything the
-        # scheduled worker can publish, and before the failure published when
-        # a broker refusal fails the turn synchronously inside the scheduling
-        # step. The queued row itself is already committed either way.
+        # Publish before scheduling: under autocommit both run immediately in
+        # this order, keeping turn_queued ahead of anything the worker or a
+        # synchronous broker refusal publishes.
         self.events.publish(conversation.id, execution.id, TURN_QUEUED)
         transaction.on_commit(lambda: self._schedule_turn(execution.id))
         return execution

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -69,6 +69,12 @@ from research_ai.services.notebook_chat.activity import (
     public_activity,
 )
 from research_ai.services.notebook_chat.config import NotebookChatConfig
+from research_ai.services.notebook_chat.events import (
+    TURN_CANCELLED,
+    TURN_QUEUED,
+    ConversationEventPublisher,
+    PublishingRecorder,
+)
 from research_ai.services.notebook_chat.toolset import (
     NotebookWebSearchToolset,
     compose_notebook_toolset,
@@ -115,7 +121,9 @@ class NotebookChatService:
 
     Runtime collaborators are injectable for tests; in production they default
     to the settings-configured generator provider, OpenAlex client, Brave web
-    search, and database persistence services.
+    search, database persistence services, and the channel-layer event
+    publisher (see ``events``) that nudges subscribed WebSocket clients as a
+    turn advances.
     """
 
     def __init__(
@@ -130,6 +138,7 @@ class NotebookChatService:
         context_service: AgentContextService | None = None,
         cancel_service: AgentExecutionCancelService | None = None,
         config: NotebookChatConfig | None = None,
+        event_publisher: ConversationEventPublisher | None = None,
     ):
         self._provider = provider
         self._oa_client = oa_client
@@ -150,6 +159,9 @@ class NotebookChatService:
         )
         self.cancels = (
             AgentExecutionCancelService() if cancel_service is None else cancel_service
+        )
+        self.events = (
+            ConversationEventPublisher() if event_publisher is None else event_publisher
         )
         self._config = config
 
@@ -387,6 +399,9 @@ class NotebookChatService:
         # nothing; the filtered update keeps a concurrent rename authoritative.
         self.conversations.set_title_if_blank(conversation, _derive_title(text))
         transaction.on_commit(lambda: self._schedule_turn(execution.id))
+        # After the schedule registration, so the commit-time order is
+        # enqueue-then-nudge and a nudged refetch finds the turn queued.
+        self.events.publish(conversation.id, execution.id, TURN_QUEUED)
         return execution
 
     def cancel_active_turn(
@@ -413,7 +428,12 @@ class NotebookChatService:
         )
         if execution is None:
             return None
-        return execution if self.cancels.cancel(execution) else None
+        if not self.cancels.cancel(execution):
+            return None
+        # The worker's own writes stop publishing once the row is terminal
+        # (a refused write emits nothing), so the cancel is announced here.
+        self.events.publish(conversation.id, execution.id, TURN_CANCELLED)
+        return execution
 
     def _schedule_turn(self, execution_id: int) -> None:
         """Queue the worker turn, failing the execution if the broker refuses.
@@ -437,7 +457,7 @@ class NotebookChatService:
                 else None
             )
             if recorder is not None:
-                recorder.on_run_failed(exc)
+                self._publishing_recorder(recorder, execution).on_run_failed(exc)
 
     # -- worker path ------------------------------------------------------
 
@@ -463,6 +483,10 @@ class NotebookChatService:
                 execution.status,
             )
             return {"execution_id": execution.id, "skipped": True}
+        # Every durable write and terminal transition below flows through the
+        # recorder, so wrapping it here is what pushes the whole turn's
+        # progress to subscribed clients.
+        recorder = self._publishing_recorder(recorder, execution)
         try:
             return self._run_turn(execution, recorder)
         except Exception as exc:
@@ -531,6 +555,17 @@ class NotebookChatService:
             "iterations": result.iterations,
             "final_text": result.final_text,
         }
+
+    def _publishing_recorder(
+        self, recorder, execution: AgentExecution
+    ) -> PublishingRecorder:
+        """Wrap ``recorder`` so its writes nudge the chat's WebSocket group."""
+        return PublishingRecorder(
+            recorder,
+            self.events,
+            conversation_id=execution.conversation_id,
+            execution_id=execution.id,
+        )
 
     def _turn_config(self, execution: AgentExecution) -> NotebookChatConfig:
         """The knobs this turn was submitted with, not today's settings.

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -398,10 +398,14 @@ class NotebookChatService:
         # After prepare_turn so a refused turn (busy, for instance) names
         # nothing; the filtered update keeps a concurrent rename authoritative.
         self.conversations.set_title_if_blank(conversation, _derive_title(text))
-        transaction.on_commit(lambda: self._schedule_turn(execution.id))
-        # After the schedule registration, so the commit-time order is
-        # enqueue-then-nudge and a nudged refetch finds the turn queued.
+        # Nudge before scheduling: both defer to the same commit -- and under
+        # autocommit, the production request path, run right here in this
+        # order -- so subscribers always see turn_queued before anything the
+        # scheduled worker can publish, and before the failure published when
+        # a broker refusal fails the turn synchronously inside the scheduling
+        # step. The queued row itself is already committed either way.
         self.events.publish(conversation.id, execution.id, TURN_QUEUED)
+        transaction.on_commit(lambda: self._schedule_turn(execution.id))
         return execution
 
     def cancel_active_turn(

--- a/src/research_ai/tests/agent/test_persistence_cancellation.py
+++ b/src/research_ai/tests/agent/test_persistence_cancellation.py
@@ -221,9 +221,8 @@ class AgentCancellationTests(TestCase):
         # Arrange
         recorder = self._running()
 
-        # Act & Assert: the hook that performs the transition says so; on the
-        # now-sealed row a repeat reports no transition. Event observers key
-        # on exactly this report to publish only outcomes that landed.
+        # Act & Assert: the hook that seals the run says so; a repeat on the
+        # sealed row reports no transition.
         self.assertTrue(recorder.on_run_failed(RuntimeError("boom")))
         self.assertFalse(recorder.on_run_failed(RuntimeError("boom")))
         recorder = self._running()
@@ -335,11 +334,9 @@ class AgentCancellationTests(TestCase):
             _finished_run(final_text="Here is the summary", stop_reason="end_turn")
         )
 
-        # Assert: the hook reports it sealed nothing -- what tells observers
-        # layered on the recorder to stay quiet about a finish that never
-        # landed -- and nothing was published, so the answer is gone from the
-        # context the next turn continues from; otherwise the model would
-        # resume as though it had already replied.
+        # Assert: the hook reports no transition, and nothing was published,
+        # so the answer is gone from the context the next turn continues from
+        # -- otherwise the model would resume as though it had already replied.
         self.assertFalse(transitioned)
         self.assertFalse(
             AgentConversationMessage.objects.filter(

--- a/src/research_ai/tests/agent/test_persistence_cancellation.py
+++ b/src/research_ai/tests/agent/test_persistence_cancellation.py
@@ -330,14 +330,13 @@ class AgentCancellationTests(TestCase):
 
         # Act
         self.cancels.cancel(recorder.execution)
-        transitioned = recorder.on_run_finished(
+        recorder.on_run_finished(
             _finished_run(final_text="Here is the summary", stop_reason="end_turn")
         )
 
-        # Assert: the hook reports no transition, and nothing was published,
-        # so the answer is gone from the context the next turn continues from
-        # -- otherwise the model would resume as though it had already replied.
-        self.assertFalse(transitioned)
+        # Assert: nothing was published, so the answer is gone from the context
+        # the next turn continues from -- otherwise the model would resume as
+        # though it had already replied.
         self.assertFalse(
             AgentConversationMessage.objects.filter(
                 generated_by_execution=recorder.execution,

--- a/src/research_ai/tests/agent/test_persistence_cancellation.py
+++ b/src/research_ai/tests/agent/test_persistence_cancellation.py
@@ -217,6 +217,20 @@ class AgentCancellationTests(TestCase):
         self.assertEqual(dispatched, ["read"])
         self.assertEqual(result.final_text, "done")
 
+    def test_terminal_hooks_report_whether_they_sealed_the_run(self):
+        # Arrange
+        recorder = self._running()
+
+        # Act & Assert: the hook that performs the transition says so; on the
+        # now-sealed row a repeat reports no transition. Event observers key
+        # on exactly this report to publish only outcomes that landed.
+        self.assertTrue(recorder.on_run_failed(RuntimeError("boom")))
+        self.assertFalse(recorder.on_run_failed(RuntimeError("boom")))
+        recorder = self._running()
+        result = _finished_run(final_text="done", stop_reason="end_turn")
+        self.assertTrue(recorder.on_run_finished(result))
+        self.assertFalse(recorder.on_run_finished(result))
+
     def test_cancelling_an_already_terminal_execution_reports_false(self):
         # Arrange
         recorder = self._running()
@@ -317,13 +331,16 @@ class AgentCancellationTests(TestCase):
 
         # Act
         self.cancels.cancel(recorder.execution)
-        recorder.on_run_finished(
+        transitioned = recorder.on_run_finished(
             _finished_run(final_text="Here is the summary", stop_reason="end_turn")
         )
 
-        # Assert: nothing was published, so the answer is gone from the context
-        # the next turn continues from -- otherwise the model would resume as
-        # though it had already replied.
+        # Assert: the hook reports it sealed nothing -- what tells observers
+        # layered on the recorder to stay quiet about a finish that never
+        # landed -- and nothing was published, so the answer is gone from the
+        # context the next turn continues from; otherwise the model would
+        # resume as though it had already replied.
+        self.assertFalse(transitioned)
         self.assertFalse(
             AgentConversationMessage.objects.filter(
                 generated_by_execution=recorder.execution,

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_consumer.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_consumer.py
@@ -54,7 +54,7 @@ class NotebookChatConsumerTests(TransactionTestCase):
             email="other@researchhub_test.com",
         )
 
-        self.note, _content = create_note(self.user, organization=None)
+        self.note = create_note(self.user, organization=None)[0]
         self._grant_note_access(self.user, self.note)
         self._grant_note_access(self.other_user, self.note)
         service = NotebookChatService()
@@ -64,8 +64,11 @@ class NotebookChatConsumerTests(TransactionTestCase):
         )
 
         # A second note the owner can view, with no chats on it.
-        self.other_note, _content = create_note(self.user, organization=None)
+        self.other_note = create_note(self.user, organization=None)[0]
         self._grant_note_access(self.user, self.other_note)
+
+        # A note the owner has no access to at all.
+        self.hidden_note = create_note(self.other_user, organization=None)[0]
 
     def _grant_note_access(self, user, note):
         Permission.objects.create(
@@ -111,6 +114,17 @@ class NotebookChatConsumerTests(TransactionTestCase):
 
         # Act
         _communicator, connected, code = await self._connect(self.other_user)
+
+        # Assert
+        self.assertFalse(connected)
+        self.assertEqual(code, CLOSE_NOT_FOUND)
+
+    async def test_an_invisible_note_reads_as_not_found(self):
+        # Act: the note exists but the user cannot view it; the close code
+        # matches a missing note's, so nothing about it leaks.
+        _communicator, connected, code = await self._connect(
+            self.user, note_id=self.hidden_note.id
+        )
 
         # Assert
         self.assertFalse(connected)

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_consumer.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_consumer.py
@@ -1,0 +1,173 @@
+import json
+from unittest.mock import patch
+
+from channels.layers import get_channel_layer
+from channels.routing import URLRouter
+from channels.testing import WebsocketCommunicator
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.contenttypes.models import ContentType
+from django.test import TransactionTestCase
+
+import research_ai.routing
+from note.tests.helpers import create_note
+from research_ai.consumers import (
+    CLOSE_FORBIDDEN,
+    CLOSE_NOT_FOUND,
+    CLOSE_UNAUTHENTICATED,
+)
+from research_ai.services.notebook_chat import NotebookChatService
+from research_ai.services.notebook_chat.events import EVENT_TYPE, conversation_group
+from researchhub_access_group.constants import ADMIN
+from researchhub_access_group.models import Permission
+from researchhub_document.models import ResearchhubUnifiedDocument
+
+application = URLRouter(research_ai.routing.websocket_urlpatterns)
+
+
+class NotebookChatConsumerTests(TransactionTestCase):
+    """Admission mirrors the REST contract; events are forwarded verbatim.
+
+    The communicator's scope user is set directly, standing in for what
+    ``TokenAuthMiddlewareStack`` resolves in production. All database
+    arrangement lives in ``setUp``: the async test bodies must not touch the
+    ORM synchronously, and the consumer does its own reads through
+    ``database_sync_to_async`` -- which also forces ``TransactionTestCase``
+    here, because its connection cleanup closes the wrapping transaction a
+    plain ``TestCase`` keeps open across the whole test.
+    """
+
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="owner@researchhub_test.com",
+            password="password",
+            email="owner@researchhub_test.com",
+        )
+        # The rollout gate admits editors or moderators; the flag is the
+        # cheapest way through it for tests.
+        self.user.moderator = True
+        self.user.save(update_fields=["moderator"])
+        self.other_user = user_model.objects.create_user(
+            username="other@researchhub_test.com",
+            password="password",
+            email="other@researchhub_test.com",
+        )
+
+        self.note, _content = create_note(self.user, organization=None)
+        self._grant_note_access(self.user, self.note)
+        self._grant_note_access(self.other_user, self.note)
+        service = NotebookChatService()
+        self.conversation = service.create_conversation(self.note, self.user)
+        self.other_conversation = service.create_conversation(
+            self.note, self.other_user
+        )
+
+        # A second note the owner can view, with no chats on it.
+        self.other_note, _content = create_note(self.user, organization=None)
+        self._grant_note_access(self.user, self.other_note)
+
+    def _grant_note_access(self, user, note):
+        Permission.objects.create(
+            access_type=ADMIN,
+            content_type=ContentType.objects.get_for_model(ResearchhubUnifiedDocument),
+            object_id=note.unified_document.id,
+            user=user,
+        )
+
+    async def _connect(self, user, *, note_id=None, conversation_id=None):
+        note_id = self.note.id if note_id is None else note_id
+        conversation_id = (
+            self.conversation.id if conversation_id is None else conversation_id
+        )
+        communicator = WebsocketCommunicator(
+            application, f"/ws/notebook/notes/{note_id}/chats/{conversation_id}/"
+        )
+        communicator.scope["user"] = user
+        connected, detail = await communicator.connect()
+        return communicator, connected, detail
+
+    async def test_anonymous_connection_is_rejected(self):
+        # Act
+        _communicator, connected, code = await self._connect(AnonymousUser())
+
+        # Assert
+        self.assertFalse(connected)
+        self.assertEqual(code, CLOSE_UNAUTHENTICATED)
+
+    async def test_user_outside_the_rollout_gate_is_rejected(self):
+        # Act: authenticated, but neither editor nor moderator.
+        _communicator, connected, code = await self._connect(self.other_user)
+
+        # Assert
+        self.assertFalse(connected)
+        self.assertEqual(code, CLOSE_FORBIDDEN)
+
+    async def test_someone_elses_conversation_reads_as_not_found(self):
+        # Arrange: a moderator who can view the note but does not own the
+        # chat; like the REST API, ownership failures leak nothing.
+        self.other_user.moderator = True
+        await self.other_user.asave(update_fields=["moderator"])
+
+        # Act
+        _communicator, connected, code = await self._connect(self.other_user)
+
+        # Assert
+        self.assertFalse(connected)
+        self.assertEqual(code, CLOSE_NOT_FOUND)
+
+    async def test_conversation_on_another_note_reads_as_not_found(self):
+        # Act: a note the owner can view, but the chat lives on a different
+        # one -- the (note, conversation) pair must not resolve.
+        _communicator, connected, code = await self._connect(
+            self.user, note_id=self.other_note.id
+        )
+
+        # Assert
+        self.assertFalse(connected)
+        self.assertEqual(code, CLOSE_NOT_FOUND)
+
+    async def test_hub_editor_passes_the_rollout_gate(self):
+        # Arrange: not a moderator; the gate's other branch admits editors.
+        user_model = get_user_model()
+
+        # Act
+        with patch.object(user_model, "is_hub_editor", return_value=True):
+            communicator, connected, _detail = await self._connect(
+                self.other_user, conversation_id=self.other_conversation.id
+            )
+
+        # Assert
+        self.assertTrue(connected)
+        await communicator.disconnect()
+
+    async def test_owner_connects_and_receives_published_events(self):
+        # Arrange
+        communicator, connected, subprotocol = await self._connect(self.user)
+        self.assertTrue(connected)
+        self.assertEqual(subprotocol, "Token")
+
+        # Act: an event lands on the conversation's group, shaped exactly as
+        # ``ConversationEventPublisher`` sends it.
+        await get_channel_layer().group_send(
+            conversation_group(self.conversation.id),
+            {
+                "type": EVENT_TYPE,
+                "data": {
+                    "conversation_id": self.conversation.id,
+                    "execution_id": 5,
+                    "kind": "turn_progress",
+                },
+            },
+        )
+
+        # Assert: the client receives the data object verbatim.
+        self.assertEqual(
+            json.loads(await communicator.receive_from()),
+            {
+                "conversation_id": self.conversation.id,
+                "execution_id": 5,
+                "kind": "turn_progress",
+            },
+        )
+        await communicator.disconnect()

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_consumer.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_consumer.py
@@ -98,6 +98,19 @@ class NotebookChatConsumerTests(TransactionTestCase):
         self.assertFalse(connected)
         self.assertEqual(code, CLOSE_UNAUTHENTICATED)
 
+    async def test_deactivated_account_is_rejected(self):
+        # Arrange: the account is disabled but its token still resolves, the
+        # state the auth middleware hands over for a lingering token.
+        self.user.is_active = False
+        await self.user.asave(update_fields=["is_active"])
+
+        # Act
+        _communicator, connected, code = await self._connect(self.user)
+
+        # Assert: deactivation revokes the socket like it revokes the REST API.
+        self.assertFalse(connected)
+        self.assertEqual(code, CLOSE_UNAUTHENTICATED)
+
     async def test_user_outside_the_rollout_gate_is_rejected(self):
         # Act: authenticated, but neither editor nor moderator.
         _communicator, connected, code = await self._connect(self.other_user)

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_events.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_events.py
@@ -110,7 +110,10 @@ class PublishingRecorderTests(unittest.TestCase):
         self.publisher.publish.assert_called_once_with(7, 9, TURN_PROGRESS)
 
     def test_terminal_hooks_forward_then_publish(self):
-        # Arrange
+        # Arrange: the wrapped recorder reports that each hook performed its
+        # terminal transition itself.
+        self.wrapped.on_run_finished.return_value = True
+        self.wrapped.on_run_failed.return_value = True
         result, error = object(), RuntimeError("boom")
 
         # Act
@@ -125,18 +128,37 @@ class PublishingRecorderTests(unittest.TestCase):
             [(7, 9, TURN_FINISHED), (7, 9, TURN_FAILED)],
         )
 
-    def test_an_interrupted_run_publishes_no_failure(self):
-        # Arrange: interruption means the execution was sealed from outside
-        # (cancelled), and the sealing path already announced it.
-        error = InterruptedError("agent execution is no longer running")
+    def test_terminal_hooks_that_did_not_transition_publish_nothing(self):
+        # Arrange: each hook finds the execution already sealed from outside
+        # (cancelled) and reports performing no transition of its own.
+        self.wrapped.on_run_finished.return_value = False
+        self.wrapped.on_run_failed.return_value = False
 
         # Act
-        self.recorder.on_run_failed(error)
+        self.recorder.on_run_finished(object())
+        self.recorder.on_run_failed(InterruptedError("no longer running"))
 
         # Assert: forwarded for persistence, but no contradictory event on
         # top of the turn_cancelled the subscribers already received.
-        self.wrapped.on_run_failed.assert_called_once_with(error)
+        self.wrapped.on_run_finished.assert_called_once()
+        self.wrapped.on_run_failed.assert_called_once()
         self.publisher.publish.assert_not_called()
+
+    def test_a_recorder_without_a_transition_report_keeps_its_events(self):
+        # Arrange: only an explicit False suppresses; a recorder that does
+        # not track transitions returns None and stays fully announced.
+        self.wrapped.on_run_finished.return_value = None
+        self.wrapped.on_run_failed.return_value = None
+
+        # Act
+        self.recorder.on_run_finished(object())
+        self.recorder.on_run_failed(RuntimeError("boom"))
+
+        # Assert
+        self.assertEqual(
+            [call.args for call in self.publisher.publish.call_args_list],
+            [(7, 9, TURN_FINISHED), (7, 9, TURN_FAILED)],
+        )
 
     def test_a_refused_write_publishes_nothing(self):
         # Arrange: the run was cancelled, so the durable write is refused.

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_events.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_events.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from django.test import TestCase
 
@@ -8,7 +8,6 @@ from research_ai.services.notebook_chat.events import (
     TURN_FAILED,
     TURN_FINISHED,
     TURN_PROGRESS,
-    TURN_QUEUED,
     ConversationEventPublisher,
     PublishingRecorder,
     conversation_group,
@@ -73,20 +72,6 @@ class ConversationEventPublisherTests(TestCase):
         ):
             publisher.publish(12, 34, TURN_FINISHED)
 
-    def test_publish_without_a_configured_layer_is_a_noop(self):
-        # Arrange
-        publisher = ConversationEventPublisher()
-
-        # Act & Assert: no layer resolved at send time means silently no push.
-        with (
-            patch(
-                "research_ai.services.notebook_chat.events.get_channel_layer",
-                return_value=None,
-            ),
-            self.captureOnCommitCallbacks(execute=True),
-        ):
-            publisher.publish(1, 2, TURN_QUEUED)
-
 
 class PublishingRecorderTests(unittest.TestCase):
     """Pure delegation tests; no Django machinery involved."""
@@ -143,22 +128,6 @@ class PublishingRecorderTests(unittest.TestCase):
         self.wrapped.on_run_finished.assert_called_once()
         self.wrapped.on_run_failed.assert_called_once()
         self.publisher.publish.assert_not_called()
-
-    def test_a_recorder_without_a_transition_report_keeps_its_events(self):
-        # Arrange: only an explicit False suppresses; a recorder that does
-        # not track transitions returns None and stays fully announced.
-        self.wrapped.on_run_finished.return_value = None
-        self.wrapped.on_run_failed.return_value = None
-
-        # Act
-        self.recorder.on_run_finished(object())
-        self.recorder.on_run_failed(RuntimeError("boom"))
-
-        # Assert
-        self.assertEqual(
-            [call.args for call in self.publisher.publish.call_args_list],
-            [(7, 9, TURN_FINISHED), (7, 9, TURN_FAILED)],
-        )
 
     def test_a_refused_write_publishes_nothing(self):
         # Arrange: the run was cancelled, so the durable write is refused.

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_events.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_events.py
@@ -125,6 +125,19 @@ class PublishingRecorderTests(unittest.TestCase):
             [(7, 9, TURN_FINISHED), (7, 9, TURN_FAILED)],
         )
 
+    def test_an_interrupted_run_publishes_no_failure(self):
+        # Arrange: interruption means the execution was sealed from outside
+        # (cancelled), and the sealing path already announced it.
+        error = InterruptedError("agent execution is no longer running")
+
+        # Act
+        self.recorder.on_run_failed(error)
+
+        # Assert: forwarded for persistence, but no contradictory event on
+        # top of the turn_cancelled the subscribers already received.
+        self.wrapped.on_run_failed.assert_called_once_with(error)
+        self.publisher.publish.assert_not_called()
+
     def test_a_refused_write_publishes_nothing(self):
         # Arrange: the run was cancelled, so the durable write is refused.
         self.wrapped.record_message.side_effect = InterruptedError("cancelled")

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_events.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_events.py
@@ -1,0 +1,149 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from research_ai.services.notebook_chat.events import (
+    EVENT_TYPE,
+    TURN_FAILED,
+    TURN_FINISHED,
+    TURN_PROGRESS,
+    TURN_QUEUED,
+    ConversationEventPublisher,
+    PublishingRecorder,
+    conversation_group,
+)
+
+
+class FakeChannelLayer:
+    """Records group_send calls; optionally fails like a down Redis."""
+
+    def __init__(self, error: Exception | None = None):
+        self.sent = []
+        self._error = error
+
+    async def group_send(self, group, message):
+        if self._error is not None:
+            raise self._error
+        self.sent.append((group, message))
+
+
+class ConversationEventPublisherTests(TestCase):
+    def test_publish_sends_to_the_conversation_group_after_commit(self):
+        # Arrange
+        layer = FakeChannelLayer()
+        publisher = ConversationEventPublisher(channel_layer=layer)
+
+        # Act
+        with self.captureOnCommitCallbacks(execute=True):
+            publisher.publish(12, 34, TURN_PROGRESS)
+            # Deferred: nothing may be pushed before the transaction commits,
+            # or a nudged refetch could read state that is not visible yet.
+            self.assertEqual(layer.sent, [])
+
+        # Assert
+        self.assertEqual(
+            layer.sent,
+            [
+                (
+                    conversation_group(12),
+                    {
+                        "type": EVENT_TYPE,
+                        "data": {
+                            "conversation_id": 12,
+                            "execution_id": 34,
+                            "kind": TURN_PROGRESS,
+                        },
+                    },
+                )
+            ],
+        )
+
+    def test_publish_survives_a_failing_channel_layer(self):
+        # Arrange
+        layer = FakeChannelLayer(error=RuntimeError("redis down"))
+        publisher = ConversationEventPublisher(channel_layer=layer)
+
+        # Act & Assert: the failure is logged, never raised into the caller.
+        with (
+            self.assertLogs(
+                "research_ai.services.notebook_chat.events", level="WARNING"
+            ),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            publisher.publish(12, 34, TURN_FINISHED)
+
+    def test_publish_without_a_configured_layer_is_a_noop(self):
+        # Arrange
+        publisher = ConversationEventPublisher()
+
+        # Act & Assert: no layer resolved at send time means silently no push.
+        with (
+            patch(
+                "research_ai.services.notebook_chat.events.get_channel_layer",
+                return_value=None,
+            ),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            publisher.publish(1, 2, TURN_QUEUED)
+
+
+class PublishingRecorderTests(unittest.TestCase):
+    """Pure delegation tests; no Django machinery involved."""
+
+    def setUp(self):
+        self.wrapped = Mock()
+        self.publisher = Mock()
+        self.recorder = PublishingRecorder(
+            self.wrapped, self.publisher, conversation_id=7, execution_id=9
+        )
+
+    def test_record_message_forwards_then_publishes_progress(self):
+        # Arrange
+        message, turn = object(), object()
+
+        # Act
+        self.recorder.record_message(message, turn=turn)
+
+        # Assert
+        self.wrapped.record_message.assert_called_once_with(message, turn=turn)
+        self.publisher.publish.assert_called_once_with(7, 9, TURN_PROGRESS)
+
+    def test_terminal_hooks_forward_then_publish(self):
+        # Arrange
+        result, error = object(), RuntimeError("boom")
+
+        # Act
+        self.recorder.on_run_finished(result)
+        self.recorder.on_run_failed(error)
+
+        # Assert
+        self.wrapped.on_run_finished.assert_called_once_with(result)
+        self.wrapped.on_run_failed.assert_called_once_with(error)
+        self.assertEqual(
+            [call.args for call in self.publisher.publish.call_args_list],
+            [(7, 9, TURN_FINISHED), (7, 9, TURN_FAILED)],
+        )
+
+    def test_a_refused_write_publishes_nothing(self):
+        # Arrange: the run was cancelled, so the durable write is refused.
+        self.wrapped.record_message.side_effect = InterruptedError("cancelled")
+
+        # Act & Assert: the exception propagates and no event narrates a
+        # write that never landed.
+        with self.assertRaises(InterruptedError):
+            self.recorder.record_message(object())
+        self.publisher.publish.assert_not_called()
+
+    def test_everything_else_is_delegated_to_the_wrapped_recorder(self):
+        # Arrange
+        self.wrapped.is_active.return_value = False
+        self.wrapped.terminal_observed = True
+        self.wrapped.requires_durable_messages = True
+
+        # Act & Assert: the loop's optional-contract lookups reach the
+        # wrapped recorder untouched.
+        self.assertFalse(self.recorder.is_active())
+        self.assertTrue(self.recorder.terminal_observed)
+        self.assertTrue(self.recorder.requires_durable_messages)
+        self.publisher.publish.assert_not_called()

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -746,27 +746,6 @@ class NotebookChatEventEmissionTests(TestCase):
         self.assertIsNone(cancelled)
         self.publisher.publish.assert_not_called()
 
-    def test_failed_enqueue_publishes_turn_failed_after_turn_queued(self):
-        # Act: the broker refuses the task after the turn committed.
-        with (
-            patch(
-                "research_ai.tasks.run_notebook_chat_turn_task.delay",
-                side_effect=RuntimeError("broker down"),
-            ),
-            self.captureOnCommitCallbacks(execute=True),
-        ):
-            execution = self.service.submit_message(self.note, self.conversation, "Hi")
-
-        # Assert: subscribers saw the turn appear, then fail -- never a
-        # silently stuck spinner.
-        self.assertEqual(
-            self._events(self.publisher),
-            [
-                (self.conversation.id, execution.id, TURN_QUEUED),
-                (self.conversation.id, execution.id, TURN_FAILED),
-            ],
-        )
-
 
 class NotebookChatEventSendOrderTests(TransactionTestCase):
     """Send order under autocommit, where ``on_commit`` runs immediately.
@@ -796,10 +775,18 @@ class NotebookChatEventSendOrderTests(TransactionTestCase):
             "research_ai.tasks.run_notebook_chat_turn_task.delay",
             side_effect=RuntimeError("broker down"),
         ):
-            service.submit_message(note, conversation, "Hello")
+            execution = service.submit_message(note, conversation, "Hello")
 
-        # Assert: queued goes out before the refusal's failure.
+        # Assert: queued goes out before the refusal's failure, each naming
+        # this conversation and execution.
         self.assertEqual(
-            [message["data"]["kind"] for _group, message in layer.sent],
-            [TURN_QUEUED, TURN_FAILED],
+            [message["data"] for _group, message in layer.sent],
+            [
+                {
+                    "conversation_id": conversation.id,
+                    "execution_id": execution.id,
+                    "kind": kind,
+                }
+                for kind in (TURN_QUEUED, TURN_FAILED)
+            ],
         )

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -14,6 +14,13 @@ from research_ai.models import (
 from research_ai.services.agent_persistence import AgentConversationBusyError
 from research_ai.services.notebook_chat import WORKFLOW, NotebookChatService
 from research_ai.services.notebook_chat.config import NotebookChatConfig
+from research_ai.services.notebook_chat.events import (
+    TURN_CANCELLED,
+    TURN_FAILED,
+    TURN_FINISHED,
+    TURN_PROGRESS,
+    TURN_QUEUED,
+)
 from research_ai.services.notebook_chat.service import TITLE_MAX_CHARS
 from research_ai.tests.agent.persistence_test_helpers import (
     FakeProvider,
@@ -523,3 +530,148 @@ class NotebookChatResolutionTests(TestCase):
         self.assertEqual(idle["title"], "")
         self.assertIsNone(idle["last_message_preview"])
         self.assertFalse(idle["has_active_turn"])
+
+
+class NotebookChatEventEmissionTests(TestCase):
+    """Where the service nudges the chat's WebSocket group.
+
+    The publisher is a Mock: the contract under test is which lifecycle
+    points emit which kind, always naming the right conversation and
+    execution. Commit deferral, group naming, and delivery are the
+    publisher's and consumer's own tests.
+    """
+
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="owner@researchhub_test.com",
+            password="password",
+            email="owner@researchhub_test.com",
+        )
+        self.note = create_note(self.user, organization=None)[0]
+        Permission.objects.create(
+            access_type=ADMIN,
+            content_type=ContentType.objects.get_for_model(ResearchhubUnifiedDocument),
+            object_id=self.note.unified_document.id,
+            user=self.user,
+        )
+        self.publisher = Mock()
+        self.service = _make_service(event_publisher=self.publisher)
+        self.conversation = self.service.create_conversation(self.note, self.user)
+
+    def _submit(self, text="Please add a summary."):
+        with (
+            patch("research_ai.tasks.run_notebook_chat_turn_task.delay"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            return self.service.submit_message(self.note, self.conversation, text)
+
+    @staticmethod
+    def _events(publisher):
+        return [call.args for call in publisher.publish.call_args_list]
+
+    def test_submit_message_publishes_turn_queued(self):
+        # Act
+        execution = self._submit()
+
+        # Assert
+        self.publisher.publish.assert_called_once_with(
+            self.conversation.id, execution.id, TURN_QUEUED
+        )
+
+    def test_run_turn_publishes_progress_then_finished(self):
+        # Arrange
+        execution = self._submit()
+        run_publisher = Mock()
+        runner = _make_service(
+            provider=FakeProvider([text_turn("Done.")]),
+            event_publisher=run_publisher,
+        )
+
+        # Act
+        runner.run_turn(execution.id)
+
+        # Assert: every durable write nudged, the settled turn last, and each
+        # event names this conversation and execution.
+        events = self._events(run_publisher)
+        kinds = [kind for _, _, kind in events]
+        self.assertIn(TURN_PROGRESS, kinds)
+        self.assertEqual(kinds[-1], TURN_FINISHED)
+        for conversation_id, execution_id, _ in events:
+            self.assertEqual(conversation_id, self.conversation.id)
+            self.assertEqual(execution_id, execution.id)
+
+    def test_run_turn_provider_failure_publishes_turn_failed(self):
+        # Arrange
+        execution = self._submit()
+        run_publisher = Mock()
+        runner = _make_service(
+            provider=FakeProvider([RuntimeError("provider exploded")]),
+            event_publisher=run_publisher,
+        )
+
+        # Act
+        runner.run_turn(execution.id)
+
+        # Assert
+        kinds = [kind for _, _, kind in self._events(run_publisher)]
+        self.assertEqual(kinds[-1], TURN_FAILED)
+        self.assertNotIn(TURN_FINISHED, kinds)
+
+    def test_run_turn_duplicate_delivery_publishes_nothing(self):
+        # Arrange: another worker already claimed this execution.
+        execution = self._submit()
+        self.assertIsNotNone(self.service.chat.executions.claim_pending(execution))
+        run_publisher = Mock()
+        runner = _make_service(event_publisher=run_publisher)
+
+        # Act
+        result = runner.run_turn(execution.id)
+
+        # Assert: a skipped delivery changed nothing, so it announces nothing.
+        self.assertTrue(result["skipped"])
+        run_publisher.publish.assert_not_called()
+
+    def test_cancel_active_turn_publishes_turn_cancelled(self):
+        # Arrange
+        execution = self._submit()
+
+        # Act
+        with self.captureOnCommitCallbacks(execute=True):
+            cancelled = self.service.cancel_active_turn(self.conversation)
+
+        # Assert
+        self.assertIsNotNone(cancelled)
+        self.assertEqual(
+            self.publisher.publish.call_args.args,
+            (self.conversation.id, execution.id, TURN_CANCELLED),
+        )
+
+    def test_cancel_without_active_turn_publishes_nothing(self):
+        # Act
+        cancelled = self.service.cancel_active_turn(self.conversation)
+
+        # Assert
+        self.assertIsNone(cancelled)
+        self.publisher.publish.assert_not_called()
+
+    def test_failed_enqueue_publishes_turn_failed_after_turn_queued(self):
+        # Act: the broker refuses the task after the turn committed.
+        with (
+            patch(
+                "research_ai.tasks.run_notebook_chat_turn_task.delay",
+                side_effect=RuntimeError("broker down"),
+            ),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            execution = self.service.submit_message(self.note, self.conversation, "Hi")
+
+        # Assert: subscribers saw the turn appear, then fail -- never a
+        # silently stuck spinner.
+        self.assertEqual(
+            self._events(self.publisher),
+            [
+                (self.conversation.id, execution.id, TURN_QUEUED),
+                (self.conversation.id, execution.id, TURN_FAILED),
+            ],
+        )

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -769,20 +769,15 @@ class NotebookChatEventEmissionTests(TestCase):
 
 
 class NotebookChatEventSendOrderTests(TransactionTestCase):
-    """Send order as production sees it: autocommit, no wrapping transaction.
+    """Send order under autocommit, where ``on_commit`` runs immediately.
 
-    Here ``on_commit`` runs its callback at registration time, so submitting
-    a message schedules the worker -- and can fail the turn -- while
-    ``submit_message`` is still on the stack. That interleaving is invisible
-    to the ``TestCase`` suites above: their wrapping transaction defers every
-    callback to one commit point, where either registration order sends
-    queued first. Only out here does the real wire order get pinned.
+    The ``TestCase`` suites above cannot see this interleaving: their
+    wrapping transaction defers every callback to one commit point.
     """
 
     def test_a_refused_broker_sends_queued_before_failed(self):
-        # Arrange: a real publisher over a recording layer, so the order
-        # events leave the process is what is asserted -- not the order the
-        # service called publish().
+        # Arrange: a real publisher over a recording layer, so send order --
+        # not publish() call order -- is what is asserted.
         user = get_user_model().objects.create_user(
             username="owner@researchhub_test.com",
             password="password",
@@ -803,8 +798,7 @@ class NotebookChatEventSendOrderTests(TransactionTestCase):
         ):
             service.submit_message(note, conversation, "Hello")
 
-        # Assert: queued left the process before the failure did -- a
-        # terminal event may never be followed by its own turn's queued.
+        # Assert: queued goes out before the refusal's failure.
         self.assertEqual(
             [message["data"]["kind"] for _group, message in layer.sent],
             [TURN_QUEUED, TURN_FAILED],

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 
 from note.tests.helpers import create_note
 from research_ai.models import (
@@ -23,6 +23,7 @@ from research_ai.services.notebook_chat.events import (
     TURN_FINISHED,
     TURN_PROGRESS,
     TURN_QUEUED,
+    ConversationEventPublisher,
 )
 from research_ai.services.notebook_chat.service import TITLE_MAX_CHARS
 from research_ai.tests.agent.persistence_test_helpers import (
@@ -30,6 +31,7 @@ from research_ai.tests.agent.persistence_test_helpers import (
     text_turn,
     tool_turn,
 )
+from research_ai.tests.notebook_chat.test_notebook_chat_events import FakeChannelLayer
 from researchhub_access_group.constants import ADMIN
 from researchhub_access_group.models import Permission
 from researchhub_document.models import ResearchhubUnifiedDocument
@@ -763,4 +765,47 @@ class NotebookChatEventEmissionTests(TestCase):
                 (self.conversation.id, execution.id, TURN_QUEUED),
                 (self.conversation.id, execution.id, TURN_FAILED),
             ],
+        )
+
+
+class NotebookChatEventSendOrderTests(TransactionTestCase):
+    """Send order as production sees it: autocommit, no wrapping transaction.
+
+    Here ``on_commit`` runs its callback at registration time, so submitting
+    a message schedules the worker -- and can fail the turn -- while
+    ``submit_message`` is still on the stack. That interleaving is invisible
+    to the ``TestCase`` suites above: their wrapping transaction defers every
+    callback to one commit point, where either registration order sends
+    queued first. Only out here does the real wire order get pinned.
+    """
+
+    def test_a_refused_broker_sends_queued_before_failed(self):
+        # Arrange: a real publisher over a recording layer, so the order
+        # events leave the process is what is asserted -- not the order the
+        # service called publish().
+        user = get_user_model().objects.create_user(
+            username="owner@researchhub_test.com",
+            password="password",
+            email="owner@researchhub_test.com",
+        )
+        note = create_note(user, organization=None)[0]
+        layer = FakeChannelLayer()
+        service = _make_service(
+            event_publisher=ConversationEventPublisher(channel_layer=layer)
+        )
+        conversation = service.create_conversation(note, user)
+
+        # Act: the broker refuses, failing the turn synchronously inside the
+        # scheduling step.
+        with patch(
+            "research_ai.tasks.run_notebook_chat_turn_task.delay",
+            side_effect=RuntimeError("broker down"),
+        ):
+            service.submit_message(note, conversation, "Hello")
+
+        # Assert: queued left the process before the failure did -- a
+        # terminal event may never be followed by its own turn's queued.
+        self.assertEqual(
+            [message["data"]["kind"] for _group, message in layer.sent],
+            [TURN_QUEUED, TURN_FAILED],
         )

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -11,7 +11,10 @@ from research_ai.models import (
     AgentExecution,
     NoteAgentConversation,
 )
-from research_ai.services.agent_persistence import AgentConversationBusyError
+from research_ai.services.agent_persistence import (
+    AgentConversationBusyError,
+    DatabaseAgentRecorder,
+)
 from research_ai.services.notebook_chat import WORKFLOW, NotebookChatService
 from research_ai.services.notebook_chat.config import NotebookChatConfig
 from research_ai.services.notebook_chat.events import (
@@ -652,6 +655,39 @@ class NotebookChatEventEmissionTests(TestCase):
         kinds = [kind for _, _, kind in self._events(run_publisher)]
         self.assertNotIn(TURN_FAILED, kinds)
         self.assertNotIn(TURN_FINISHED, kinds)
+
+    def test_cancelled_just_before_the_finish_publishes_no_finished(self):
+        # Arrange: the narrowest cancellation window -- after the closing
+        # assistant message was durably recorded, before the terminal hook
+        # runs. The recorder discards the finish, so no event may claim it.
+        execution = self._submit()
+        run_publisher = Mock()
+        runner = _make_service(
+            provider=FakeProvider([text_turn("Almost made it.")]),
+            event_publisher=run_publisher,
+        )
+        original = DatabaseAgentRecorder.on_run_finished
+
+        def _cancel_then_finish(recorder, result):
+            AgentExecution.objects.filter(id=recorder.execution.id).update(
+                status=AgentExecution.Status.CANCELLED
+            )
+            return original(recorder, result)
+
+        # Act
+        with patch.object(
+            DatabaseAgentRecorder, "on_run_finished", _cancel_then_finish
+        ):
+            runner.run_turn(execution.id)
+
+        # Assert: the cancellation stands and neither terminal kind was
+        # pushed over the turn_cancelled the cancel path already published.
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
+        kinds = [kind for _, _, kind in self._events(run_publisher)]
+        self.assertIn(TURN_PROGRESS, kinds)
+        self.assertNotIn(TURN_FINISHED, kinds)
+        self.assertNotIn(TURN_FAILED, kinds)
 
     def test_run_turn_duplicate_delivery_publishes_nothing(self):
         # Arrange: another worker already claimed this execution.

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -647,6 +647,24 @@ class NotebookChatEventEmissionTests(TestCase):
             (self.conversation.id, execution.id, TURN_CANCELLED),
         )
 
+    def test_cancel_that_lost_the_race_publishes_nothing(self):
+        # Arrange: the turn goes terminal between the scan and the
+        # transition, so the cancel service refuses it.
+        self._submit()
+        cancel_publisher = Mock()
+        cancels = Mock()
+        cancels.cancel.return_value = False
+        service = _make_service(
+            event_publisher=cancel_publisher, cancel_service=cancels
+        )
+
+        # Act
+        cancelled = service.cancel_active_turn(self.conversation)
+
+        # Assert: no event may announce a cancellation that did not happen.
+        self.assertIsNone(cancelled)
+        cancel_publisher.publish.assert_not_called()
+
     def test_cancel_without_active_turn_publishes_nothing(self):
         # Act
         cancelled = self.service.cancel_active_turn(self.conversation)

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -532,6 +532,20 @@ class NotebookChatResolutionTests(TestCase):
         self.assertFalse(idle["has_active_turn"])
 
 
+class CancellingProvider(FakeProvider):
+    """Seals the execution mid-turn, like a cancel landing during the call."""
+
+    def __init__(self, turns, execution_id):
+        super().__init__(turns)
+        self.execution_id = execution_id
+
+    def complete(self, **kwargs):
+        AgentExecution.objects.filter(id=self.execution_id).update(
+            status=AgentExecution.Status.CANCELLED
+        )
+        return super().complete(**kwargs)
+
+
 class NotebookChatEventEmissionTests(TestCase):
     """Where the service nudges the chat's WebSocket group.
 
@@ -616,6 +630,27 @@ class NotebookChatEventEmissionTests(TestCase):
         # Assert
         kinds = [kind for _, _, kind in self._events(run_publisher)]
         self.assertEqual(kinds[-1], TURN_FAILED)
+        self.assertNotIn(TURN_FINISHED, kinds)
+
+    def test_cancelled_mid_run_turn_publishes_no_failure(self):
+        # Arrange: the cancel lands while the model call is in flight, so the
+        # worker's next durable write is refused. Subscribers already got
+        # turn_cancelled from the cancel path; nothing here may contradict it.
+        execution = self._submit()
+        run_publisher = Mock()
+        runner = _make_service(
+            provider=CancellingProvider([text_turn("Too late.")], execution.id),
+            event_publisher=run_publisher,
+        )
+
+        # Act
+        runner.run_turn(execution.id)
+
+        # Assert: the turn stays cancelled and no terminal event was pushed.
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
+        kinds = [kind for _, _, kind in self._events(run_publisher)]
+        self.assertNotIn(TURN_FAILED, kinds)
         self.assertNotIn(TURN_FINISHED, kinds)
 
     def test_run_turn_duplicate_delivery_publishes_nothing(self):

--- a/src/researchhub/asgi.py
+++ b/src/researchhub/asgi.py
@@ -22,6 +22,7 @@ from django.conf import settings
 
 import note.routing
 import notification.routing
+import research_ai.routing
 from researchhub.settings import CELERY_WORKER
 from researchhub.token_auth import TokenAuthMiddlewareStack
 
@@ -46,6 +47,7 @@ if not CELERY_WORKER:
                 [
                     *note.routing.websocket_urlpatterns,
                     *notification.routing.websocket_urlpatterns,
+                    *research_ai.routing.websocket_urlpatterns,
                 ]
             )
         )


### PR DESCRIPTION
Publish best-effort refetch nudges to a per-conversation channel-layer group as a turn advances: queued, per-write progress, finished, failed, cancelled. Events carry identifiers only; the ?activity=live projection stays the source of truth and polling remains the repair path.

The consumer at ws/notebook/notes/<note_id>/chats/<conversation_id>/ mirrors the REST contract: 4401 unauthenticated, 4403 outside the editor/moderator gate, 4404 for anything that is not the requester's own chat on a visible note.