### PR TITLE
Replace standalone scripts with `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL := help
 
 CELERY_QUEUES := \
+	agents \
 	bluesky_metrics \
 	bounties \
 	caches \
@@ -9,7 +10,6 @@ CELERY_QUEUES := \
 	elastic_search \
 	external_reporting \
 	github_metrics \
-	hot_score \
 	hubs \
 	logs \
 	notifications \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: start-celery test
+
+CELERY_QUEUES := \
+	bluesky_metrics \
+	bounties \
+	caches \
+	contributions \
+	default \
+	elastic_search \
+	external_reporting \
+	github_metrics \
+	hot_score \
+	hubs \
+	logs \
+	notifications \
+	paper_metadata \
+	paper_metrics \
+	paper_misc \
+	pull_papers \
+	purchases \
+	reputation \
+	x_metrics
+
+test:
+	cd src && uv run manage.py test --keepdb
+
+start-celery:
+	cd src && uv run celery -A researchhub worker \
+		-Q "$$(echo $(CELERY_QUEUES) | tr ' ' ',')" \
+		-l info \
+		--prefetch-multiplier=1 \
+		-P prefork \
+		--concurrency=1 \
+		--beat

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-.PHONY: help start-celery test
-
 .DEFAULT_GOAL := help
 
 CELERY_QUEUES := \
@@ -23,12 +21,15 @@ CELERY_QUEUES := \
 	reputation \
 	x_metrics
 
+.PHONY: help
 help: ## Show this help
 	@awk -F':.*## ' '/^[a-zA-Z_-]+:.*##/ {printf "  %-14s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
+.PHONY: test
 test: ## Run the Django test suite
 	cd src && uv run manage.py test --keepdb
 
+.PHONY: start-celery
 start-celery: ## Run the Celery worker with beat
 	cd src && uv run celery \
 		--app=researchhub \

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,12 @@ test:
 	cd src && uv run manage.py test --keepdb
 
 start-celery:
-	cd src && uv run celery -A researchhub worker \
-		-Q "$$(echo $(CELERY_QUEUES) | tr ' ' ',')" \
-		-l info \
+	cd src && uv run celery \
+		--app=researchhub \
+		worker \
+		--queues "$$(echo $(CELERY_QUEUES) | tr ' ' ',')" \
+		--loglevel=info \
 		--prefetch-multiplier=1 \
-		-P prefork \
+		--pool=prefork \
 		--concurrency=1 \
 		--beat

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: start-celery test
+.PHONY: help start-celery test
+
+.DEFAULT_GOAL := help
 
 CELERY_QUEUES := \
 	bluesky_metrics \
@@ -21,10 +23,13 @@ CELERY_QUEUES := \
 	reputation \
 	x_metrics
 
-test:
+help: ## Show this help
+	@awk -F':.*## ' '/^[a-zA-Z_-]+:.*##/ {printf "  %-14s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+test: ## Run the Django test suite
 	cd src && uv run manage.py test --keepdb
 
-start-celery:
+start-celery: ## Run the Celery worker with beat
 	cd src && uv run celery \
 		--app=researchhub \
 		worker \

--- a/src/start-celery.sh
+++ b/src/start-celery.sh
@@ -1,7 +1,0 @@
-celery -A researchhub worker \
-    -Q default,paper_metadata,caches,hot_score,elastic_search,external_reporting,notifications,paper_metrics,x_metrics,github_metrics,bluesky_metrics,paper_misc,pull_papers,logs,purchases,contributions,bounties,hubs,reputation \
-    -l info \
-    --prefetch-multiplier=1 \
-    -P prefork \
-    --concurrency=1 \
-    --beat

--- a/src/start-es.sh
+++ b/src/start-es.sh
@@ -1,9 +1,0 @@
-docker network create researchhub-network
-
-docker run \
-  --name researchhub-elasticsearch \
-  --network researchhub-network \
-  --publish 9200:9200 \
-  --publish 9300:9300 \
-  --env "discovery.type=single-node" \
-  docker.elastic.co/elasticsearch/elasticsearch:7.10.1

--- a/src/start-kibana.sh
+++ b/src/start-kibana.sh
@@ -1,8 +1,0 @@
-docker network create researchhub-network
-
-docker run \
-  --name researchhub-kibana \
-  --publish 5601:5601 \
-  --network researchhub-network \
-  --env "ELASTICSEARCH_HOSTS=http://researchhub-elasticsearch:9200" \
-  docker.elastic.co/kibana/kibana:7.4.1


### PR DESCRIPTION
Add `Makefile` with the following goals:
- `test`: Run all tests
- `start-celery`: Start Celery process locally
- `help`: Print help

Remove the standalone script for Celery and the deprecated ES scripts.