### PR TITLE
Fix Django settings initialization order in ASGI

### DIFF
--- a/src/researchhub/asgi.py
+++ b/src/researchhub/asgi.py
@@ -9,6 +9,8 @@ defined in the ASGI_APPLICATION setting.
 
 import os
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "researchhub.settings")
+
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 
@@ -24,8 +26,6 @@ import note.routing
 import notification.routing
 from researchhub.settings import CELERY_WORKER
 from researchhub.token_auth import TokenAuthMiddlewareStack
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "researchhub.settings")
 
 # Wrap Django ASGI application with Elastic APM middleware.
 # This is necessary to capture transaction data for performance monitoring.


### PR DESCRIPTION
Set `DJANGO_SETTINGS_MODULE` before initializing Django so the ASGI entrypoint does not rely on Celery package import side effects.