### PR TITLE
Fix access control gaps in note content and template endpoints

### DIFF
--- a/src/note/tests/test_note_api.py
+++ b/src/note/tests/test_note_api.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from rest_framework.test import APITestCase
 
 from invite.related_models.note_invitation import NoteInvitation
-from note.models import Note
+from note.models import Note, NoteTemplate
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
 from researchhub_access_group.models import Permission
 from researchhub_document.models import ResearchhubUnifiedDocument
@@ -79,6 +79,38 @@ class NoteTests(APITestCase):
         # Assert
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["count"], 0)
+
+    def test_user_cannot_list_other_users_note_contents(self):
+        # Arrange
+        response = self.client.post(
+            "/api/note/",
+            {
+                "grouping": "PRIVATE",
+                "title": "TEST",
+            },
+        )
+        note = response.data
+        response = self.client.post(
+            "/api/note_content/",
+            {
+                "full_src": "private note body",
+                "note": note["id"],
+                "plain_text": "private note body",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+        other_user = get_user_model().objects.create_user(
+            username="other2", password=uuid.uuid4().hex, email="other2@researchhub.com"
+        )
+
+        # Act
+        self.client.force_authenticate(other_user)
+        response = self.client.get("/api/note_content/")
+
+        # Assert
+        self.assertEqual(response.status_code, 405)
+        self.assertNotIn("private note body", str(response.data))
 
     def test_org_member_can_list_org_notes(self):
         # Arrange
@@ -877,6 +909,118 @@ class NoteTests(APITestCase):
 
         self.assertEqual(delete_response.status_code, 403)
         self.assertEqual(delete_response.data["is_removed"], False)
+
+    def test_user_cannot_list_other_orgs_note_templates(self):
+        # Arrange
+        response = self.client.post(
+            "/api/note_template/",
+            {
+                "full_src": "org template body",
+                "is_default": False,
+                "organization": self.org["id"],
+                "name": "ORG TEMPLATE",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        template = response.data
+
+        other_user = get_user_model().objects.create_user(
+            username="other3", password=uuid.uuid4().hex, email="other3@researchhub.com"
+        )
+
+        # Act
+        self.client.force_authenticate(other_user)
+        list_response = self.client.get("/api/note_template/")
+        retrieve_response = self.client.get(f"/api/note_template/{template['id']}/")
+
+        # Assert
+        self.assertEqual(list_response.status_code, 200)
+        self.assertNotIn("ORG TEMPLATE", str(list_response.data))
+        self.assertEqual(retrieve_response.status_code, 404)
+
+    def test_user_cannot_delete_other_orgs_note_template(self):
+        # Arrange
+        response = self.client.post(
+            "/api/note_template/",
+            {
+                "full_src": "org template body",
+                "is_default": False,
+                "organization": self.org["id"],
+                "name": "ORG TEMPLATE",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        template = response.data
+
+        other_user = get_user_model().objects.create_user(
+            username="other4", password=uuid.uuid4().hex, email="other4@researchhub.com"
+        )
+
+        # Act
+        self.client.force_authenticate(other_user)
+        response = self.client.post(f"/api/note_template/{template['id']}/delete/")
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(NoteTemplate.objects.get(id=template["id"]).is_removed)
+
+    def test_any_user_can_list_default_note_templates(self):
+        # Arrange
+        response = self.client.post(
+            "/api/note_template/",
+            {
+                "full_src": "default template body",
+                "is_default": True,
+                "name": "DEFAULT TEMPLATE",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+        other_user = get_user_model().objects.create_user(
+            username="other5", password=uuid.uuid4().hex, email="other5@researchhub.com"
+        )
+
+        # Act
+        self.client.force_authenticate(other_user)
+        response = self.client.get("/api/note_template/")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("DEFAULT TEMPLATE", str(response.data))
+
+    def test_org_member_can_delete_org_note_template(self):
+        # Arrange
+        response = self.client.post(
+            "/api/note_template/",
+            {
+                "full_src": "org template body",
+                "is_default": False,
+                "organization": self.org["id"],
+                "name": "ORG TEMPLATE",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        template = response.data
+
+        member_user = get_user_model().objects.create_user(
+            username="member2",
+            password=uuid.uuid4().hex,
+            email="member2@researchhub.com",
+        )
+        Permission.objects.create(
+            access_type="MEMBER",
+            content_type=self.organization_ct,
+            object_id=self.org["id"],
+            user=member_user,
+        )
+
+        # Act
+        self.client.force_authenticate(member_user)
+        response = self.client.post(f"/api/note_template/{template['id']}/delete/")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(NoteTemplate.objects.get(id=template["id"]).is_removed)
 
     def test_note_content_json_functionality(self):
         # Create workspace note

--- a/src/note/views/note_template_view.py
+++ b/src/note/views/note_template_view.py
@@ -1,4 +1,5 @@
 from django.core.files.base import ContentFile
+from django.db.models import Q
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -6,10 +7,6 @@ from rest_framework.viewsets import ModelViewSet
 
 from note.models import NoteTemplate
 from note.serializers import NoteTemplateSerializer
-from researchhub_access_group.permissions import (
-    HasEditingPermission,
-    HasOrgEditingPermission,
-)
 from user.models import Organization
 
 
@@ -19,6 +16,19 @@ class NoteTemplateViewSet(ModelViewSet):
     permission_classes = [IsAuthenticated]
     serializer_class = NoteTemplateSerializer
     http_method_names = ["get", "head", "options", "post"]
+
+    def get_queryset(self):
+        user = self.request.user
+        return (
+            self.queryset.filter(
+                Q(is_default=True)
+                | Q(created_by=user)
+                | Q(organization__permissions__user=user)
+            )
+            .filter(is_removed=False)
+            .distinct()
+            .order_by("-created_date")
+        )
 
     def create(self, request, *args, **kwargs):
         user = request.user
@@ -57,15 +67,11 @@ class NoteTemplateViewSet(ModelViewSet):
         full_src_file = ContentFile(data.encode())
         return file_name, full_src_file
 
-    @action(
-        detail=True,
-        methods=["post", "delete"],
-        permission_classes=[HasOrgEditingPermission | HasEditingPermission],
-    )
+    @action(detail=True, methods=["post", "delete"])
     def delete(self, request, pk=None):
-        template = NoteTemplate.objects.get(id=pk)
+        template = self.get_object()
 
-        if template.is_default:
+        if template.is_default or not self._can_delete(request.user, template):
             status_code = 403
         else:
             template.is_removed = True
@@ -74,3 +80,13 @@ class NoteTemplateViewSet(ModelViewSet):
 
         serializer = self.serializer_class(template)
         return Response(serializer.data, status=status_code)
+
+    def _can_delete(self, user, template):
+        # Mirrors the create authorization: creator, or org admin/member.
+        if template.created_by == user:
+            return True
+        organization = template.organization
+        return organization is not None and (
+            organization.org_has_admin_user(user)
+            or organization.org_has_member_user(user)
+        )

--- a/src/note/views/note_view.py
+++ b/src/note/views/note_view.py
@@ -6,9 +6,15 @@ from django.db.models import Q, QuerySet
 from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.mixins import (
+    CreateModelMixin,
+    DestroyModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+)
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from hub.models import Hub
 from invite.models import NoteInvitation
@@ -518,7 +524,15 @@ class NoteViewSet(ModelViewSet):
         return Response(serializer.data, status=200)
 
 
-class NoteContentViewSet(ModelViewSet):
+class NoteContentViewSet(
+    CreateModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+    DestroyModelMixin,
+    GenericViewSet,
+):
+    # No ListModelMixin: the queryset is unscoped and permissions are only
+    # checked per object in get_object, so a list action would expose every note.
     ordering = "-created_date"
     queryset = NoteContent.objects.all()
     permission_classes = [IsAuthenticated, HasEditingPermission]


### PR DESCRIPTION
NoteContentViewSet: remove the list action. The queryset was unscoped and permissions were only checked per object, so GET /api/note_content/ returned every note's content to any authenticated user.

NoteTemplateViewSet: scope list/retrieve to default templates, own templates, and templates of the user's organizations (excluding removed ones), and enforce delete authorization (creator or org admin/member). Previously any authenticated user could read any template and soft-delete any non-default template, since the delete action never invoked its declared permission classes.