### PR TITLE
Fix concurrency grouping for deployments

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -24,7 +24,7 @@ on:
         default: main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.deploy_env }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.deploy_env || 'staging' }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
Make sure that there are no concurrent deployments to the same environment.