### PR TITLE
ActivityFeed. Fix cache-warm 

### DIFF
--- a/src/feed/views/activity_feed_view.py
+++ b/src/feed/views/activity_feed_view.py
@@ -238,6 +238,7 @@ class ActivityFeedViewSet(FeedViewMixin, ModelViewSet):
         wsgi_request = factory.get(
             "/api/activity_feed/",
             {"page": str(page), "page_size": str(page_size)},
+            HTTP_HOST="researchhub.com",
         )
         request = Request(wsgi_request)
         request.user = AnonymousUser()


### PR DESCRIPTION
Error:
<img width="692" height="135" alt="image" src="https://github.com/user-attachments/assets/e2ad7e3b-5f74-4f35-a41e-342a9f100329" />

## How?
- Fix cache-warm `APIRequestFactory` host to `researchhub.com` (allowed via `.researchhub.com`) to avoid `Invalid HTTP_HOST: testserver` during warm.