### PR TITLE
Keep the container id a streamed turn discloses

### DIFF
--- a/src/research_ai/services/agent/providers/claude_platform.py
+++ b/src/research_ai/services/agent/providers/claude_platform.py
@@ -525,9 +525,14 @@ class ClaudePlatformProvider(LLMProvider):
         container = None
         with self._client.messages.stream(**kwargs) as stream:
             for event in stream:
-                event_container = getattr(event, "container", None)
-                if event_container is not None:
-                    container = event_container
+                # The SDK declares it on the event's ``delta``; an id the API
+                # sends elsewhere lands on the event itself as a model extra.
+                delta = getattr(event, "delta", None)
+                disclosed = getattr(delta, "container", None) or getattr(
+                    event, "container", None
+                )
+                if disclosed is not None:
+                    container = disclosed
             response = stream.get_final_message()
         if container is not None:
             response.container = container

--- a/src/research_ai/services/agent/providers/claude_platform.py
+++ b/src/research_ai/services/agent/providers/claude_platform.py
@@ -476,8 +476,7 @@ class ClaudePlatformProvider(LLMProvider):
                 # Streamed so a turn's wall clock is bounded by chunk gaps,
                 # not the whole emission -- a full-budget turn legitimately
                 # outlives any sane whole-request timeout.
-                with self._client.messages.stream(**kwargs) as stream:
-                    response = stream.get_final_message()
+                response = self._stream_turn(kwargs)
             except Exception as e:
                 logger.exception("Claude Platform complete failed")
                 raise ProviderError(f"Claude Platform complete failed: {e}") from e
@@ -514,6 +513,25 @@ class ClaudePlatformProvider(LLMProvider):
         return turn
 
     # -- private helpers --------------------------------------------------
+
+    def _stream_turn(self, kwargs: dict) -> Any:
+        """Stream one turn, restoring the container the SDK accumulator drops.
+
+        Anthropic discloses the code-execution container on ``message_delta``,
+        and the accumulator behind ``get_final_message`` copies only stop and
+        usage fields off that event -- so the id every later request needs to
+        resume the container reaches this process only through the events.
+        """
+        container = None
+        with self._client.messages.stream(**kwargs) as stream:
+            for event in stream:
+                event_container = getattr(event, "container", None)
+                if event_container is not None:
+                    container = event_container
+            response = stream.get_final_message()
+        if container is not None:
+            response.container = container
+        return response
 
     def _render_messages(
         self, messages: list[Message], *, cache_last: bool = False

--- a/src/research_ai/tests/agent/test_claude_platform_provider.py
+++ b/src/research_ai/tests/agent/test_claude_platform_provider.py
@@ -8,6 +8,7 @@ from anthropic.types import (
     CodeExecutionToolResultBlock,
     Container,
     EncryptedCodeExecutionResultBlock,
+    RawMessageDeltaEvent,
     RedactedThinkingBlock,
     ServerToolUseBlock,
     Usage,
@@ -46,14 +47,18 @@ from research_ai.services.agent.types import (
 class _FakeStream:
     """Stands in for the SDK's ``MessageStreamManager`` context manager."""
 
-    def __init__(self, response):
+    def __init__(self, response, events=()):
         self._response = response
+        self._events = list(events)
 
     def __enter__(self):
         return self
 
     def __exit__(self, *exc_info):
         return False
+
+    def __iter__(self):
+        return iter(self._events)
 
     def get_final_message(self):
         return self._response
@@ -68,7 +73,25 @@ class FakeMessages:
 
     def stream(self, **kwargs):
         self.calls.append(deepcopy(kwargs))
-        return _FakeStream(self._responses.pop(0))
+        response = self._responses.pop(0)
+        if getattr(response, "container", None) is None:
+            return _FakeStream(response)
+        # Faithful to the SDK: the container arrives on ``message_delta`` and
+        # is never accumulated onto the final message.
+        return _FakeStream(
+            response.model_copy(update={"container": None}),
+            [
+                RawMessageDeltaEvent(
+                    type="message_delta",
+                    delta={
+                        "stop_reason": response.stop_reason,
+                        "stop_sequence": None,
+                    },
+                    usage={"output_tokens": response.usage.output_tokens},
+                    container=response.container,
+                )
+            ],
+        )
 
 
 class FakeAnthropicClient:
@@ -475,6 +498,9 @@ class CompleteAndParseTests(SimpleTestCase):
             def __exit__(self, *exc_info):
                 return False
 
+            def __iter__(self):
+                raise ValueError("connection reset")
+
             def get_final_message(self):
                 raise ValueError("connection reset")
 
@@ -681,6 +707,41 @@ class ServerSideToolTests(SimpleTestCase):
         self.assertEqual(
             replayed_result["content"]["encrypted_stdout"],
             "enc-stdout",
+        )
+
+    def test_container_disclosed_only_by_a_stream_event_is_recorded(self):
+        # Arrange: Anthropic reports the container on ``message_delta``, which
+        # the SDK never accumulates onto the final message -- reading the final
+        # message alone loses the id every later request needs.
+        container = Container(
+            id="container_123",
+            expires_at=datetime(2099, 1, 1, tzinfo=UTC),
+        )
+        delta = RawMessageDeltaEvent(
+            type="message_delta",
+            delta={"stop_reason": "tool_use", "stop_sequence": None},
+            usage={"output_tokens": 3},
+            container=container,
+        )
+
+        class DeltaOnlyMessages:
+            def stream(self, **kwargs):
+                return _FakeStream(_build_response([], stop_reason="tool_use"), [delta])
+
+        class DeltaOnlyClient:
+            messages = DeltaOnlyMessages()
+
+        provider = ClaudePlatformProvider(
+            client=DeltaOnlyClient(), model_id="claude-opus-5"
+        )
+
+        # Act
+        turn = _complete(provider)
+
+        # Assert
+        self.assertEqual(
+            turn.provider_state["anthropic"]["container"]["id"],
+            "container_123",
         )
 
     def test_code_execution_container_and_tool_caller_replay_on_followup(self):

--- a/src/research_ai/tests/agent/test_claude_platform_provider.py
+++ b/src/research_ai/tests/agent/test_claude_platform_provider.py
@@ -80,17 +80,7 @@ class FakeMessages:
         # is never accumulated onto the final message.
         return _FakeStream(
             response.model_copy(update={"container": None}),
-            [
-                RawMessageDeltaEvent(
-                    type="message_delta",
-                    delta={
-                        "stop_reason": response.stop_reason,
-                        "stop_sequence": None,
-                    },
-                    usage={"output_tokens": response.usage.output_tokens},
-                    container=response.container,
-                )
-            ],
+            [_build_container_delta(response.container, response.stop_reason)],
         )
 
 
@@ -117,6 +107,25 @@ def _build_response(
         stop_reason=stop_reason,
         stop_details=stop_details,
         usage=usage or Usage(input_tokens=10, output_tokens=3),
+    )
+
+
+def _build_container_delta(container, stop_reason="tool_use"):
+    """The ``message_delta`` disclosing a container, in the SDK's wire shape.
+
+    Deserialized rather than constructed: the container is a field of the
+    event's ``delta``, and the SDK's models accept undeclared top-level keys.
+    """
+    return RawMessageDeltaEvent.model_validate(
+        {
+            "type": "message_delta",
+            "delta": {
+                "container": container.model_dump(mode="json"),
+                "stop_reason": stop_reason,
+                "stop_sequence": None,
+            },
+            "usage": {"output_tokens": 3},
+        }
     )
 
 
@@ -717,12 +726,7 @@ class ServerSideToolTests(SimpleTestCase):
             id="container_123",
             expires_at=datetime(2099, 1, 1, tzinfo=UTC),
         )
-        delta = RawMessageDeltaEvent(
-            type="message_delta",
-            delta={"stop_reason": "tool_use", "stop_sequence": None},
-            usage={"output_tokens": 3},
-            container=container,
-        )
+        delta = _build_container_delta(container)
 
         class DeltaOnlyMessages:
             def stream(self, **kwargs):


### PR DESCRIPTION
## Problem

Staging notebook runs fail with:

```
anthropic.BadRequestError: Error code: 400 - container_id is required when
there are pending tool uses generated by code execution with tools.
```

Anthropic reports the code-execution container on the `message_delta` event. The SDK's stream accumulator copies `stop_reason`, `stop_sequence`, `stop_details`, and usage off that event and nothing else — `anthropic/lib/streaming/_messages.py` never mentions `container`. Verified against the installed 0.120.0: feeding a `message_delta` carrying a container to `accumulate_event` yields a final message whose `container` is `None`.

So since the provider moved from `messages.create` to `messages.stream` (`8bfcd4527`), `_parse_turn` has read `response.container` as `None` on every turn. No container id was ever recorded in `provider_state`, `_container_id()` returned `None` for every conversation, and `container` was never sent on any request — so the first request owing results to paused code execution (what web-search dynamic filtering runs) was rejected outright.

## Fix

Read the container off the stream events and put it back on the final message, reassembling what the non-streaming call returned. Everything downstream — `_parse_turn`, both continuation log lines, `_response_missing_required_container` — reads `response.container` and is unchanged.

## Tests

`_FakeStream` is now iterable, and `FakeMessages` delivers a container via a real `RawMessageDeltaEvent` with the final message stripped — so the existing container tests (follow-up replay, multi-hop, continuation logging) exercise the shape the API actually sends rather than one it never produces. Added a focused test that builds the stream directly, so it holds even if the fake changes.

Reverting the provider change turns 5 of these red, including the new one.

Full `research_ai` suite: 972 tests, and the 65 errors are identical with and without this change (`ProposalDraft.model_ref` NOT NULL violations that reproduce on a clean tree).

## Rollout notes

- This repairs turns produced after deploy. Conversations that ran between Aug 12 and now have no container id anywhere in their persisted history, so any caught mid-code-execution stay unresumable and need a fresh conversation.
- The preflight guard in `complete()` surfaced this as a raw 400 rather than its named `ProviderError`, because it measures only the newest assistant message and two proxy signals. Left alone here — with the container recorded again, the case it guards should stop arising.