### PR TITLE
Associate RFP to Proposal Pre-Publish

### DIFF
--- a/src/note/migrations/0011_note_selected_grant.py
+++ b/src/note/migrations/0011_note_selected_grant.py
@@ -1,0 +1,24 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("note", "0010_notecontent_created_by_notecontent_created_via_and_more"),
+        ("purchase", "0060_alter_rscexchangerate_price_source"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="note",
+            name="selected_grant",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="draft_notes",
+                to="purchase.grant",
+            ),
+        ),
+    ]

--- a/src/note/related_models/note_model.py
+++ b/src/note/related_models/note_model.py
@@ -24,6 +24,13 @@ class Note(DefaultModel):
     organization = models.ForeignKey(
         Organization, null=True, related_name="created_notes", on_delete=models.SET_NULL
     )
+    selected_grant = models.ForeignKey(
+        "purchase.Grant",
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+        related_name="draft_notes",
+    )
     title = models.TextField(blank=True, default="")
     unified_document = models.OneToOneField(
         ResearchhubUnifiedDocument, related_name="note", on_delete=models.CASCADE

--- a/src/note/services/note_grant_service.py
+++ b/src/note/services/note_grant_service.py
@@ -1,0 +1,37 @@
+from rest_framework.exceptions import NotFound
+from rest_framework.serializers import IntegerField, ValidationError
+
+from purchase.models import Grant
+from researchhub_document.models import ResearchhubPost
+from researchhub_document.related_models.constants.document_type import PREREGISTRATION
+from user.models import User
+
+
+def resolve_selected_grant(
+    grant_id: object,
+    document_type: str | None,
+    user: User,
+) -> Grant | None:
+    """Resolve a visible, active grant for a preregistration note."""
+    if document_type != PREREGISTRATION:
+        raise ValidationError(
+            {"selected_grant": "Only preregistration notes can select a grant."}
+        )
+    if grant_id is None:
+        return None
+
+    validated_grant_id = IntegerField(min_value=1).run_validation(grant_id)
+    visible_document_ids = ResearchhubPost.objects.visible_to(user).values(
+        "unified_document_id"
+    )
+    grant = Grant.objects.filter(
+        id=validated_grant_id,
+        unified_document_id__in=visible_document_ids,
+    ).first()
+    if grant is None:
+        raise NotFound("Grant not found.")
+    if not grant.is_active():
+        raise ValidationError(
+            {"selected_grant": "Grant is no longer accepting applications."}
+        )
+    return grant

--- a/src/note/views/note_view.py
+++ b/src/note/views/note_view.py
@@ -26,6 +26,7 @@ from note.serializers import (
     NoteContentSerializer,
     NoteSerializer,
 )
+from note.services.note_grant_service import resolve_selected_grant
 from researchhub.pagination import MediumPageLimitPagination
 from researchhub.settings import TESTING
 from researchhub_access_group.constants import (
@@ -173,12 +174,19 @@ class NoteViewSet(ModelViewSet):
             created_by = user
             organization = user.organization
 
+        selected_grant = None
+        if "selected_grant" in data:
+            selected_grant = resolve_selected_grant(
+                data.get("selected_grant"), document_type, user
+            )
+
         unified_doc = self._create_unified_doc(request)
         self._create_permission(created_by, organization, unified_doc, grouping)
 
         note_kwargs = {
             "created_by": created_by,
             "organization": organization,
+            "selected_grant": selected_grant,
             "unified_document": unified_doc,
             "title": title,
         }
@@ -248,6 +256,7 @@ class NoteViewSet(ModelViewSet):
     def update(self, request, *args, **kwargs):
         user = request.user
         partial = kwargs.pop("partial", False)
+        data = request.data.copy()
         note = self.get_object()
         permissions = note.unified_document.permissions
         is_admin = permissions.has_admin_user(user)
@@ -256,9 +265,25 @@ class NoteViewSet(ModelViewSet):
         if not (is_admin or is_editor):
             return Response({"data": "Invalid permissions"}, status=403)
 
-        serializer = self.get_serializer(note, data=request.data, partial=partial)
+        selection_requested = "selected_grant" in data
+        if selection_requested:
+            if hasattr(note, "post"):
+                return Response(
+                    {"detail": "Published notes cannot change grants."},
+                    status=status.HTTP_409_CONFLICT,
+                )
+            selected_grant_id = data.get("selected_grant")
+            data.pop("selected_grant")
+            selected_grant = resolve_selected_grant(
+                selected_grant_id, note.document_type, user
+            )
+
+        serializer = self.get_serializer(note, data=data, partial=partial)
         serializer.is_valid(raise_exception=True)
-        self.perform_update(serializer)
+        if selection_requested:
+            serializer.save(selected_grant=selected_grant)
+        else:
+            self.perform_update(serializer)
 
         if getattr(note, "_prefetched_objects_cache", None):
             # If 'prefetch_related' has been applied to a queryset, we need to

--- a/src/research_ai/prompts/notebook_chat_prompts.py
+++ b/src/research_ai/prompts/notebook_chat_prompts.py
@@ -6,12 +6,23 @@ edit_note with full-document replaces. The user prompt is the user's chat
 message verbatim, so there is no user-prompt builder here.
 """
 
+from note.models import Note
 from research_ai.prompts._loader import load_template
 
 
-def build_notebook_chat_system_prompt(note) -> str:
-    """The system prompt for a conversation attached to ``note``."""
+def build_notebook_chat_system_prompt(note: Note) -> str:
+    """Build the system prompt for a conversation attached to ``note``."""
     template = load_template("notebook_chat_system.txt")
-    return template.replace("{{NOTE_ID}}", str(note.id)).replace(
-        "{{NOTE_TITLE}}", str(note.title or "Untitled")
+    grant_context = ""
+    if note.selected_grant_id is not None:
+        grant = note.selected_grant
+        grant_context = (
+            "## Selected funding opportunity\n\n"
+            f"Grant ID: {grant.id}\n\n"
+            f"RFP context:\n{grant.get_llm_context_text()}"
+        )
+    return (
+        template.replace("{{NOTE_ID}}", str(note.id))
+        .replace("{{NOTE_TITLE}}", str(note.title or "Untitled"))
+        .replace("{{GRANT_CONTEXT}}", grant_context)
     )

--- a/src/research_ai/prompts/notebook_chat_system.txt
+++ b/src/research_ai/prompts/notebook_chat_system.txt
@@ -7,6 +7,8 @@ and revise the note itself, guided by their feedback.
 You are attached to note {{NOTE_ID}} ("{{NOTE_TITLE}}"). Every read_note and
 edit_note call must use this note id; you have no access to other notes.
 
+{{GRANT_CONTEXT}}
+
 ## What you can do
 
 - **Answer and research.** Use search_institutions, search_authors, get_author,

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -1,4 +1,5 @@
 import json
+from decimal import Decimal
 from unittest.mock import Mock, patch
 
 from django.contrib.auth import get_user_model
@@ -6,6 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, TransactionTestCase
 
 from note.tests.helpers import create_note
+from purchase.models import Grant
 from research_ai.models import (
     AgentConversation,
     AgentExecution,
@@ -35,7 +37,12 @@ from research_ai.tests.agent.persistence_test_helpers import (
 from research_ai.tests.notebook_chat.test_notebook_chat_events import FakeChannelLayer
 from researchhub_access_group.constants import ADMIN
 from researchhub_access_group.models import Permission
+from researchhub_document.helpers import create_post
 from researchhub_document.models import ResearchhubUnifiedDocument
+from researchhub_document.related_models.constants.document_type import (
+    GRANT,
+    PREREGISTRATION,
+)
 
 EDITED_DOC = {
     "type": "doc",
@@ -96,9 +103,34 @@ class NotebookChatServiceTests(TestCase):
             execution = self.service.submit_message(self.note, conversation, text)
         return execution, delay
 
-    def test_submit_message_prepares_turn_and_schedules_task(self):
+    def test_submit_message_prepares_turn_and_schedules_task(self) -> None:
+        """Submitting a turn snapshots its note and selected grant context."""
+        # Arrange
+        grant_post = create_post(
+            title="Notebook chat grant",
+            created_by=self.user,
+            document_type=GRANT,
+        )
+        grant = Grant.objects.create(
+            created_by=self.user,
+            unified_document=grant_post.unified_document,
+            amount=Decimal("25000.00"),
+            currency="USD",
+            organization="Prompt Foundation",
+            description="Notebook chat grant requirements",
+            status=Grant.OPEN,
+        )
+        self.note.document_type = PREREGISTRATION
+        self.note.selected_grant = grant
+        self.note.save(update_fields=["document_type", "selected_grant"])
+
         # Act
-        execution, delay = self._submit()
+        with patch.object(
+            Grant,
+            "get_llm_context_text",
+            return_value="Unique notebook chat RFP text.",
+        ):
+            execution, delay = self._submit()
 
         # Assert
         conversation = execution.conversation
@@ -109,6 +141,8 @@ class NotebookChatServiceTests(TestCase):
         self.assertEqual(execution.status, AgentExecution.Status.PENDING)
         self.assertIn(str(self.note.id), execution.system_prompt)
         self.assertIn(self.note.title, execution.system_prompt)
+        self.assertIn(f"Grant ID: {grant.id}", execution.system_prompt)
+        self.assertIn("Unique notebook chat RFP text.", execution.system_prompt)
         self.assertEqual(execution.configuration["note_id"], self.note.id)
         self.assertEqual(execution.trigger_message.content, "Please add a summary.")
         delay.assert_called_once_with(execution.id)


### PR DESCRIPTION
## Overview ##

This PR creates the selected_grant_id field on the note to associate the selected RFP to the proposal before publishing the proposal, and connects this information to the Notebook Chat.