### PR TITLE
Fix venv within devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,7 +50,6 @@
 				"git.blame.statusBarItem.enabled": true,
 				"python.analysis.autoImportCompletions": true,
 				"python.analysis.indexing": true,
-				"python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
 				"python.terminal.activateEnvironment": true,
 				"python.useEnvironmentsExtension": true,
 				"remote.autoForwardPorts": false


### PR DESCRIPTION
Remove the default interpreter path setting since it conflicts with the Python environment extension.