### PR TITLE
Restrict paper updates to moderators and editors

### DIFF
--- a/src/paper/permissions.py
+++ b/src/paper/permissions.py
@@ -1,15 +1,30 @@
+from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 
 from user.models import Author
-from utils.permissions import AuthorizationBasedPermission, RuleBasedPermission
+from utils.permissions import AuthorizationBasedPermission
 
 
-class UpdatePaper(RuleBasedPermission):
-    message = "Not enough reputation to update paper."
+class UpdatePaper(BasePermission):
+    """
+    Restrict paper writes to site moderators and hub editors.
+    """
 
-    def satisfies_rule(self, request: Request) -> bool:
-        """Return whether the requester may update a paper."""
-        return request.user.reputation >= 1 and not request.user.is_suspended
+    message = "Only moderators and hub editors can update papers."
+
+    def has_permission(self, request: Request, view) -> bool:
+        """Return whether the requester may write to papers at all."""
+        # Other write actions declare their own permissions.
+        # `delete_user_vote` does not, so gating by HTTP method blocks removing a vote.
+        if getattr(view, "action", None) not in ("partial_update", "update"):
+            return True
+
+        user = request.user
+        return (
+            user.is_authenticated
+            and not user.is_suspended
+            and user.is_moderator_or_editor()
+        )
 
 
 class IsAuthor(AuthorizationBasedPermission):

--- a/src/paper/tests/test_permissions.py
+++ b/src/paper/tests/test_permissions.py
@@ -2,7 +2,7 @@ import random
 
 from rest_framework.test import APITestCase
 
-from user.tests.helpers import create_random_authenticated_user
+from user.tests.helpers import create_hub_editor, create_random_authenticated_user
 
 from .helpers import create_paper
 
@@ -15,28 +15,127 @@ class PaperPermissionsIntegrationTests(APITestCase):
         self.flag_reason = "Inappropriate"
 
     def test_can_flag_paper_with_minimum_reputation(self):
+        # Arrange
         user = self.create_user_with_reputation(50)
+
+        # Act
         response = self.get_flag_response(user)
+
+        # Assert
         self.assertContains(response, self.flag_reason, status_code=201)
 
-    def test_can_update_paper_with_minimum_reputation(self):
-        user = self.create_user_with_reputation(1)
-        response = self.get_patch_response(user, self.paper)
+    def test_moderator_can_update_paper(self):
+        # Arrange
+        moderator = create_random_authenticated_user(
+            self.random_generator.random(), moderator=True
+        )
+
+        # Act
+        response = self.get_patch_response(moderator, self.paper)
+
+        # Assert
         self.assertEqual(response.status_code, 200)
 
-    def test_can_not_update_paper_below_minimum_reputation(self):
-        user = self.create_user_with_reputation(0)
+    def test_hub_editor_can_update_paper(self):
+        # Arrange
+        editor, _ = create_hub_editor(self.random_generator.random(), "Test Hub")
+
+        # Act
+        response = self.get_patch_response(editor, self.paper)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+
+    def test_regular_user_can_not_update_paper(self):
+        # Arrange
+        user = create_random_authenticated_user(self.random_generator.random())
+
+        # Act
         response = self.get_patch_response(user, self.paper)
+
+        # Assert
         self.assertEqual(response.status_code, 403)
 
+    def test_uploader_can_not_update_own_paper(self):
+        # Arrange
+        uploader = create_random_authenticated_user(self.random_generator.random())
+        paper = create_paper(title="Uploaded Paper", uploaded_by=uploader)
+
+        # Act
+        response = self.get_patch_response(uploader, paper)
+
+        # Assert
+        self.assertEqual(response.status_code, 403)
+
+    def test_suspended_moderator_can_not_update_paper(self):
+        # Arrange
+        moderator = create_random_authenticated_user(
+            self.random_generator.random(), moderator=True
+        )
+        moderator.is_suspended = True
+        moderator.save()
+
+        # Act
+        response = self.get_patch_response(moderator, self.paper)
+
+        # Assert
+        self.assertEqual(response.status_code, 403)
+
+    def test_anonymous_user_can_not_update_paper(self):
+        # Arrange
+        url = self.base_url + f"{self.paper.id}/"
+
+        # Act
+        response = self.client.patch(
+            url, {"title": "Patched Paper Title"}, format="multipart"
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_regular_user_can_still_read_paper(self):
+        # Arrange
+        user = create_random_authenticated_user(self.random_generator.random())
+        self.client.force_authenticate(user)
+
+        # Act
+        response = self.client.get(self.base_url + f"{self.paper.id}/")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+
+    def test_regular_user_can_remove_own_vote(self):
+        # Arrange
+        # `delete_user_vote` has no `permission_classes` of its own, so it falls
+        # back to the viewset's. It must not be caught by the update gate.
+        user = create_random_authenticated_user(self.random_generator.random())
+        self.client.force_authenticate(user)
+        self.client.post(f"{self.base_url}{self.paper.id}/upvote/", {}, format="json")
+
+        # Act
+        response = self.client.delete(f"{self.base_url}{self.paper.id}/user_vote/")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+
     def test_can_upvote_paper_with_minimum_reputation(self):
+        # Arrange
         user = self.create_user_with_reputation(1)
+
+        # Act
         response = self.get_upvote_response(user)
+
+        # Assert
         self.assertEqual(response.status_code, 201)
 
     def test_can_downvote_paper_with_minimum_reputation(self):
+        # Arrange
         user = self.create_user_with_reputation(25)
+
+        # Act
         response = self.get_downvote_response(user)
+
+        # Assert
         self.assertEqual(response.status_code, 201)
 
     def create_user_with_reputation(self, reputation):

--- a/src/paper/tests/tests.py
+++ b/src/paper/tests/tests.py
@@ -24,7 +24,7 @@ class PaperPatchTest(APITestCase):
         form = {
             "title": updated_title,
         }
-        user = create_random_authenticated_user("paper_patch")
+        user = create_random_authenticated_user("paper_patch", moderator=True)
         url = f"{self.base_url}{paper.id}/?make_public=true"
         self.client.force_authenticate(user)
         response = self.client.patch(url, form, format="json")


### PR DESCRIPTION
`UpdatePaper` extended `RuleBasedPermission`, which implements only `has_permission`, so `check_object_permissions` fell through to `BasePermission`'s default of `True` and any authenticated account could edit any paper.
The reputation rule it did enforce was not a barrier either since all accounts start at reputation 100.