### PR TITLE
Author Position Service items and Ordering

### DIFF
--- a/src/researchhub_document/migrations/0082_researchhubpostauthor_ordering.py
+++ b/src/researchhub_document/migrations/0082_researchhubpostauthor_ordering.py
@@ -1,0 +1,25 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("researchhub_document", "0081_researchhubpostauthor_position"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="researchhubpostauthor",
+            options={"ordering": ["position", "id"]},
+        ),
+        migrations.AlterField(
+            model_name="researchhubpostauthor",
+            name="researchhub_post",
+            field=models.ForeignKey(
+                db_column="researchhubpost_id",
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="author_links",
+                to="researchhub_document.researchhubpost",
+            ),
+        ),
+    ]

--- a/src/researchhub_document/related_models/researchhub_post_model.py
+++ b/src/researchhub_document/related_models/researchhub_post_model.py
@@ -3,7 +3,7 @@ import logging
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.storage import default_storage
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Exists, OuterRef, Q
 from django.utils.functional import cached_property
 
@@ -257,6 +257,14 @@ class ResearchhubPost(AbstractGenericReactionModel):
         return self.unified_document.hubs
 
     @property
+    def ordered_authors(self) -> list[Author]:
+        """Credited authors in byline order, excluding removed ones."""
+        links = self.author_links.filter(author__is_removed=False).select_related(
+            "author"
+        )
+        return [link.author for link in links]
+
+    @property
     def is_removed(self):
         return self.unified_document.is_removed
 
@@ -280,6 +288,20 @@ class ResearchhubPost(AbstractGenericReactionModel):
     def get_discussion_count(self):
         return self.rh_threads.get_discussion_count()
 
+    def replace_authors(self, author_ids: list[int]) -> None:
+        """Credit the given authors to this post in the order received."""
+        unique_author_ids = list(dict.fromkeys(author_ids))
+        with transaction.atomic():
+            self.author_links.all().delete()
+            ResearchhubPostAuthor.objects.bulk_create(
+                ResearchhubPostAuthor(
+                    researchhub_post=self,
+                    author_id=author_id,
+                    position=position,
+                )
+                for position, author_id in enumerate(unique_author_ids, start=1)
+            )
+
 
 class ResearchhubPostAuthor(models.Model):
     """An author credited on a post and the order they appear in."""
@@ -288,6 +310,7 @@ class ResearchhubPostAuthor(models.Model):
         ResearchhubPost,
         db_column="researchhubpost_id",
         on_delete=models.CASCADE,
+        related_name="author_links",
     )
     author = models.ForeignKey(
         Author,
@@ -297,4 +320,6 @@ class ResearchhubPostAuthor(models.Model):
 
     class Meta:
         db_table = "researchhub_document_researchhubpost_authors"
+        # Legacy links have no position, which Postgres sorts last.
+        ordering = ["position", "id"]
         unique_together = ("researchhub_post", "author")

--- a/src/researchhub_document/related_models/researchhub_post_model.py
+++ b/src/researchhub_document/related_models/researchhub_post_model.py
@@ -288,18 +288,23 @@ class ResearchhubPost(AbstractGenericReactionModel):
     def get_discussion_count(self):
         return self.rh_threads.get_discussion_count()
 
-    def replace_authors(self, author_ids: list[int]) -> None:
-        """Credit the given authors to this post in the order received."""
+    def reset_post_authors(self, author_ids: list[int]) -> None:
+        """Credit the given authors in the order received, dropping any others."""
         unique_author_ids = list(dict.fromkeys(author_ids))
         with transaction.atomic():
-            self.author_links.all().delete()
+            self.author_links.exclude(author_id__in=unique_author_ids).delete()
             ResearchhubPostAuthor.objects.bulk_create(
-                ResearchhubPostAuthor(
-                    researchhub_post=self,
-                    author_id=author_id,
-                    position=position,
-                )
-                for position, author_id in enumerate(unique_author_ids, start=1)
+                [
+                    ResearchhubPostAuthor(
+                        researchhub_post=self,
+                        author_id=author_id,
+                        position=position,
+                    )
+                    for position, author_id in enumerate(unique_author_ids, start=1)
+                ],
+                update_conflicts=True,
+                unique_fields=["researchhub_post", "author"],
+                update_fields=["position"],
             )
 
 

--- a/src/researchhub_document/services/journal_entry_service.py
+++ b/src/researchhub_document/services/journal_entry_service.py
@@ -31,7 +31,7 @@ from researchhub_document.related_models.constants.document_type import (
     REGISTERED_REPORT,
 )
 from researchhub_document.services.journey_service import JourneyService
-from user.models import Author, User
+from user.models import User
 from utils.doi import DOI
 
 
@@ -103,13 +103,13 @@ class JournalEntryService:
             unified_document__status=ResearchhubUnifiedDocument.APPROVED,
         ).filter(Exists(funded_fundraises), ~Exists(registered_reports))
 
-    def get_registered_report_authors(self, proposal: ResearchhubPost) -> list[Author]:
-        """Return proposal authors or its creator for a registered report."""
-        authors = list(proposal.authors.all())
-        if authors:
-            return authors
+    def get_registered_report_author_ids(self, proposal: ResearchhubPost) -> list[int]:
+        """Return proposal author ids in byline order, or its creator's."""
+        author_ids = [author.id for author in proposal.ordered_authors]
+        if author_ids:
+            return author_ids
         if proposal.created_by is not None:
-            return [proposal.created_by.author_profile]
+            return [proposal.created_by.author_profile.id]
         return []
 
     def register_registered_report_doi(self, report: ResearchhubPost) -> None:
@@ -120,7 +120,7 @@ class JournalEntryService:
         )
         try:
             response = doi.register_doi_for_post(
-                list(report.authors.all()),
+                report.ordered_authors,
                 report.title,
                 report,
             )
@@ -280,10 +280,8 @@ class JournalEntryService:
         self, proposal: ResearchhubPost
     ) -> dict[str, object]:
         """Build registered report metadata to persist on a draft note."""
-        authors = self.get_registered_report_authors(proposal)
-        author_ids = [author.id for author in authors]
         return {
-            "author_ids": author_ids,
+            "author_ids": self.get_registered_report_author_ids(proposal),
             "image": proposal.image,
             "preview_img": proposal.preview_img,
             "proposal_id": proposal.id,

--- a/src/researchhub_document/tests/test_create_registered_report.py
+++ b/src/researchhub_document/tests/test_create_registered_report.py
@@ -62,6 +62,9 @@ class CreateRegisteredReportTests(APITestCase):
         """Verify a moderator can publish a report for an eligible proposal."""
         # Arrange
         proposal = self._create_completed_proposal(self.user)
+        coauthor = create_random_default_user("rr_coauthor")
+        proposal_authors = [coauthor.author_profile, self.user.author_profile]
+        proposal.replace_authors([author.id for author in proposal_authors])
         note = self._create_registered_report_note(proposal)
         payload = self._build_payload(proposal, note_id=note.id)
 
@@ -82,7 +85,7 @@ class CreateRegisteredReportTests(APITestCase):
             ResearchhubUnifiedDocument.APPROVED,
         )
         self.assertTrue(report.unified_document.is_public)
-        self.assertCountEqual(report.authors.all(), proposal.authors.all())
+        self.assertEqual(report.ordered_authors, proposal_authors)
         self.assertCountEqual(
             report.unified_document.hubs.all(),
             proposal.unified_document.hubs.all(),
@@ -96,7 +99,7 @@ class CreateRegisteredReportTests(APITestCase):
             version=report.version_number,
         )
         self.mock_doi.register_doi_for_post.assert_called_once_with(
-            list(report.authors.all()),
+            proposal_authors,
             report.title,
             report,
         )

--- a/src/researchhub_document/tests/test_create_registered_report.py
+++ b/src/researchhub_document/tests/test_create_registered_report.py
@@ -64,7 +64,7 @@ class CreateRegisteredReportTests(APITestCase):
         proposal = self._create_completed_proposal(self.user)
         coauthor = create_random_default_user("rr_coauthor")
         proposal_authors = [coauthor.author_profile, self.user.author_profile]
-        proposal.replace_authors([author.id for author in proposal_authors])
+        proposal.reset_post_authors([author.id for author in proposal_authors])
         note = self._create_registered_report_note(proposal)
         payload = self._build_payload(proposal, note_id=note.id)
 

--- a/src/researchhub_document/tests/test_view.py
+++ b/src/researchhub_document/tests/test_view.py
@@ -16,7 +16,11 @@ from purchase.models import Grant, GrantApplication
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
 from researchhub_access_group.models import Permission
 from researchhub_document.helpers import create_post
-from researchhub_document.models import ResearchhubUnifiedDocument, ResearchJourney
+from researchhub_document.models import (
+    ResearchhubPost,
+    ResearchhubUnifiedDocument,
+    ResearchJourney,
+)
 from researchhub_document.related_models.constants.document_type import (
     GRANT,
     PREREGISTRATION,
@@ -236,14 +240,16 @@ class ViewTests(APITestCase):
         self.assertEqual(doc_response.status_code, 400)
 
     def test_user_can_create_post_with_multiple_authors(self):
+        """Verify creating a post credits its authors in the submitted order."""
+        # Arrange
         note = create_note(self.admin_user, self.organization)
-
         self.client.force_authenticate(self.admin_user)
 
+        # Act
         doc_response = self.client.post(
             "/api/researchhubpost/",
             {
-                "authors": [self.admin_author.id, self.member_author.id],
+                "authors": [self.member_author.id, self.admin_author.id],
                 "created_by": self.admin_user.id,
                 "document_type": "DISCUSSION",
                 "full_src": "body",
@@ -259,7 +265,10 @@ class ViewTests(APITestCase):
             },
         )
 
+        # Assert
         self.assertEqual(doc_response.status_code, 200)
+        post = ResearchhubPost.objects.get(id=doc_response.data["id"])
+        self.assertEqual(post.ordered_authors, [self.member_author, self.admin_author])
 
     def test_user_can_create_post_with_non_members(self):
         note = create_note(self.admin_user, self.organization)
@@ -367,13 +376,14 @@ class ViewTests(APITestCase):
         self.assertEqual(updated_response.data["image_url"], "/updatedImagePath1")
 
     def test_author_can_update_post_with_non_members(self):
+        """Verify updating a post recredits its authors in the submitted order."""
+        # Arrange
         note = create_note(self.admin_user, self.organization)
-
         self.client.force_authenticate(self.admin_user)
-
         doc_response = self.client.post(
             "/api/researchhubpost/",
             {
+                "authors": [self.admin_author.id, self.non_member_author.id],
                 "document_type": "DISCUSSION",
                 "created_by": self.admin_user.id,
                 "full_src": "body",
@@ -391,10 +401,11 @@ class ViewTests(APITestCase):
 
         self.assertEqual(doc_response.status_code, 200)
 
+        # Act
         updated_response = self.client.post(
             "/api/researchhubpost/",
             {
-                "authors": [self.admin_author.id, self.non_member_author.id],
+                "authors": [self.non_member_author.id, self.admin_author.id],
                 "post_id": doc_response.data["id"],
                 "document_type": "DISCUSSION",
                 "created_by": self.admin_user.id,
@@ -410,7 +421,12 @@ class ViewTests(APITestCase):
             },
         )
 
+        # Assert
         self.assertEqual(updated_response.status_code, 200)
+        post = ResearchhubPost.objects.get(id=doc_response.data["id"])
+        self.assertEqual(
+            post.ordered_authors, [self.non_member_author, self.admin_author]
+        )
 
     def test_author_cannot_update_post_without_self_in_authors(self):
         # Arrange

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -323,11 +323,10 @@ class ResearchhubPostViewSet(
                         serializer.validated_data["full_json"],
                         created_by=created_by,
                     )
-                    authors = (
-                        serializer.validated_data.get("authors")
-                        or journal_entry_service.get_registered_report_author_ids(
-                            registered_report_proposal
-                        )
+                    authors = serializer.validated_data.get(
+                        "authors"
+                    ) or journal_entry_service.get_registered_report_author_ids(
+                        registered_report_proposal
                     )
                     if image is None:
                         image = registered_report_proposal.image

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -63,7 +63,7 @@ from researchhub_document.services.unified_document_share_link_service import (
     get_shared_unified_document_id,
 )
 from user.content_moderation_mixin import ContentModerationActionsMixin
-from user.models import User
+from user.models import Author, User
 from user.services.risk_score_service import RiskScoreService
 from utils.throttles import THROTTLE_CLASSES
 
@@ -190,6 +190,14 @@ class ResearchhubPostViewSet(
                 400,
             )
         return None
+
+    def _validate_author_ids(self, author_ids: list[int]) -> None:
+        """Reject author identifiers that do not belong to an existing author."""
+        known_ids = Author.objects.filter(id__in=author_ids).values_list(
+            "id", flat=True
+        )
+        if missing_ids := sorted(set(author_ids) - set(known_ids)):
+            raise serializers.ValidationError(f"Unknown author IDs: {missing_ids}")
 
     def get_queryset(self):
         request = self.request
@@ -392,7 +400,8 @@ class ResearchhubPostViewSet(
                 )
                 file_name = f"RH-POST-{document_type}-USER-{created_by.id}.txt"
                 full_src_file = ContentFile(data["full_src"].encode())
-                rh_post.replace_authors(authors)
+                self._validate_author_ids(authors)
+                rh_post.reset_post_authors(authors)
                 self.add_upvote(created_by, rh_post)
                 if registered_report_proposal is not None:
                     journey_service.attach_stage(
@@ -587,7 +596,7 @@ class ResearchhubPostViewSet(
         try:
             data = request.data
 
-            authors = data.get("authors", [])
+            authors = data.get("authors")
             rh_post_id = data.get("post_id", None)
             rh_post = ResearchhubPost.objects.get(id=rh_post_id)
             if rh_post.document_type == REGISTERED_REPORT:
@@ -630,8 +639,9 @@ class ResearchhubPostViewSet(
                     post_id=post.id,
                 )
 
-            if type(authors) is list:
-                rh_post.replace_authors(authors)
+            if isinstance(authors, list):
+                self._validate_author_ids(authors)
+                rh_post.reset_post_authors(authors)
 
             if type(hubs) is list:
                 unified_doc = post.unified_document

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -323,10 +323,12 @@ class ResearchhubPostViewSet(
                         serializer.validated_data["full_json"],
                         created_by=created_by,
                     )
-                    if not authors:
-                        authors = journal_entry_service.get_registered_report_authors(
+                    authors = (
+                        serializer.validated_data.get("authors")
+                        or journal_entry_service.get_registered_report_author_ids(
                             registered_report_proposal
                         )
+                    )
                     if image is None:
                         image = registered_report_proposal.image
                     if preview_img is None:
@@ -391,7 +393,7 @@ class ResearchhubPostViewSet(
                 )
                 file_name = f"RH-POST-{document_type}-USER-{created_by.id}.txt"
                 full_src_file = ContentFile(data["full_src"].encode())
-                rh_post.authors.set(authors)
+                rh_post.replace_authors(authors)
                 self.add_upvote(created_by, rh_post)
                 if registered_report_proposal is not None:
                     journey_service.attach_stage(
@@ -630,7 +632,7 @@ class ResearchhubPostViewSet(
                 )
 
             if type(authors) is list:
-                rh_post.authors.set(authors)
+                rh_post.replace_authors(authors)
 
             if type(hubs) is list:
                 unified_doc = post.unified_document


### PR DESCRIPTION
## Overview ##

This PR adds basic service items for author positioning, such as setting author positioning properly for create/updating works.  It also fixes issues that would have arose with registered reports using this new system, and sets proper ordering.  