### PR TITLE
Remove deprecated upvote count

### DIFF
--- a/src/user/related_models/author_model.py
+++ b/src/user/related_models/author_model.py
@@ -272,7 +272,6 @@ class Author(SoftDeletableModel):
 
     @property
     def achievements(self):
-        upvote_count = getattr(self.user, "upvote_count", 0)
         peer_review_count = getattr(self.user, "peer_review_count", 0)
         amount_funded = getattr(self.user, "amount_funded", 0)
         return {
@@ -287,14 +286,6 @@ class Author(SoftDeletableModel):
             "OPEN_SCIENCE_SUPPORTER": {
                 "value": amount_funded,
                 "milestones": [10, 1000, 10000],
-            },
-            "HIGHLY_UPVOTED": {
-                "value": upvote_count,
-                "milestones": [
-                    10,
-                    100,
-                    1000,
-                ],
             },
             "EXPERT_PEER_REVIEWER": {
                 "value": peer_review_count,

--- a/src/user/related_models/user_model.py
+++ b/src/user/related_models/user_model.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 
 from hub.models import Hub
 from purchase.related_models.balance_model import Balance
-from reputation.models import Distribution, PaidStatusModelMixin, Withdrawal
+from reputation.models import PaidStatusModelMixin, Withdrawal
 from researchhub.settings import BASE_FRONTEND_URL
 from researchhub_access_group.constants import (
     ASSISTANT_EDITOR,
@@ -500,21 +500,6 @@ class User(SoftDeletableModel, AbstractUser):
         author = self.author_profile
 
         author.calculate_hub_scores()
-
-    @property
-    def upvote_count(self):
-        from discussion.models import Vote
-
-        upvote_count = (
-            Distribution.objects.filter(
-                recipient=self,
-                proof_item_content_type=ContentType.objects.get_for_model(Vote),
-                reputation_amount=1,
-            ).aggregate(count=Count("id"))["count"]
-            or 0
-        )
-
-        return upvote_count
 
     @property
     def amount_funded(self):

--- a/src/user/serializers.py
+++ b/src/user/serializers.py
@@ -1080,7 +1080,6 @@ class DynamicAuthorProfileSerializer(DynamicModelFieldSerializer):
             "works_count": author.paper_count,
             "citation_count": author.citation_count,
             "two_year_mean_citedness": author.two_year_mean_citedness or 0,
-            "upvote_count": author.user.upvote_count if author.user else 0,
             "amount_funded": author.user.amount_funded if author.user else 0,
             "peer_review_count": author.user.peer_review_count if author.user else 0,
             "open_access_pct": author.open_access_pct,

--- a/src/user/tests/test_serializers.py
+++ b/src/user/tests/test_serializers.py
@@ -6,7 +6,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from django.utils import timezone
 
-from discussion.models import Vote
 from hub.models import Hub
 from paper.related_models.authorship_model import Authorship
 from paper.related_models.paper_model import Paper
@@ -53,12 +52,7 @@ class UserSerializersTests(TestCase):
 
         self.user_without_papers = create_user(email="email1@researchhub.com")
 
-        for i in range(50):
-            Distribution.objects.create(
-                recipient=self.user,
-                proof_item_content_type=ContentType.objects.get_for_model(Vote),
-                reputation_amount=1,
-            )
+        for _ in range(50):
             thread = RhCommentThreadModel.objects.create(
                 object_id=paper1.id,
                 content_type=ContentType.objects.get_for_model(Paper),
@@ -166,7 +160,6 @@ class UserSerializersTests(TestCase):
                 "citation_count": 30,
                 "peer_review_count": 50,
                 "two_year_mean_citedness": 0,
-                "upvote_count": 50,
                 "works_count": 2,
                 "open_access_pct": 0.0,
             },
@@ -186,7 +179,6 @@ class UserSerializersTests(TestCase):
                 "citation_count": 0,
                 "peer_review_count": 0,
                 "two_year_mean_citedness": 0,
-                "upvote_count": 0,
                 "works_count": 0,
                 "open_access_pct": 0.0,
             },


### PR DESCRIPTION
- Remove distribution-backed upvote counts from profiles.
- Remove related upvote achievement.