### PR TITLE
Vendor frontend ProseMirror schemas with prosemirror-py loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     "stripe>=11.2.0,<12.0.0",
     "web3>=7.16.0",
     "xdk>=0.4.5",
+    "prosemirror>=0.6.1,<0.7",
 ]
 
 [dependency-groups]

--- a/src/utils/prosemirror/__init__.py
+++ b/src/utils/prosemirror/__init__.py
@@ -1,0 +1,51 @@
+"""ProseMirror schemas exported from the web frontend.
+
+The JSON specs under ``schemas/`` are generated in the ResearchHub/web repo
+by ``npm run schema:export`` from the same TipTap extension sets the editors
+run (see ``schemas/prosemirror/README.md`` there, and ``schemas/README.md``
+here for how to update the vendored copies). They let backend code parse,
+validate, and write editor documents against the exact schema the frontend
+enforces, via `prosemirror-py <https://github.com/fellowapp/prosemirror-py>`_.
+
+Usage::
+
+    from utils.prosemirror import COMMENT_EDITOR, parse_document
+
+    node = parse_document(COMMENT_EDITOR, comment_json)  # raises ValueError
+
+Schema validity is structural only: it guarantees known node/mark types,
+known attributes, and legal nesting — not that a mention's user id exists or
+that a link is safe. That remains application-level validation.
+"""
+
+import json
+from functools import cache
+from pathlib import Path
+
+from prosemirror.model import Node, Schema
+
+# Notebook notes and posts (web: components/Editor).
+BLOCK_EDITOR = "block-editor"
+# Comments, including review mode (web: components/Comment).
+COMMENT_EDITOR = "comment-editor"
+
+_SCHEMA_DIR = Path(__file__).parent / "schemas"
+
+
+@cache
+def get_schema(name: str) -> Schema:
+    """Return the exported ProseMirror schema ``name`` (cached per process)."""
+    with open(_SCHEMA_DIR / f"{name}.json") as f:
+        return Schema(json.load(f))
+
+
+def parse_document(schema_name: str, doc: dict) -> Node:
+    """Parse and validate a TipTap/ProseMirror document in JSON form.
+
+    Returns the parsed ``Node`` with attribute defaults filled in. Raises
+    ``ValueError`` if the document references unknown node/mark types or
+    attributes, or violates the schema's nesting rules.
+    """
+    node = Node.from_json(get_schema(schema_name), doc)
+    node.check()
+    return node

--- a/src/utils/prosemirror/__init__.py
+++ b/src/utils/prosemirror/__init__.py
@@ -13,10 +13,10 @@ Usage::
 
     node = parse_document(COMMENT_EDITOR, comment_json)  # raises ValueError
 
-Schema validity is structural only: it guarantees known node/mark types,
-required attributes, and legal nesting — not that a mention's user id exists
-or that a link is safe. That remains application-level validation. Note that
-unrecognized attributes are silently stripped rather than rejected.
+Schema validity is structural only: it guarantees a top-level ``doc`` node,
+known node/mark types and attributes, and legal nesting — not that a
+mention's user id exists or that a link is safe. That remains
+application-level validation.
 """
 
 from utils.prosemirror.loader import (

--- a/src/utils/prosemirror/__init__.py
+++ b/src/utils/prosemirror/__init__.py
@@ -19,36 +19,16 @@ or that a link is safe. That remains application-level validation. Note that
 unrecognized attributes are silently stripped rather than rejected.
 """
 
-import json
-from functools import cache
-from pathlib import Path
+from utils.prosemirror.loader import (
+    BLOCK_EDITOR,
+    COMMENT_EDITOR,
+    get_schema,
+    parse_document,
+)
 
-from prosemirror.model import Node, Schema
-
-# Notebook notes and posts (web: components/Editor).
-BLOCK_EDITOR = "block-editor"
-# Comments, including review mode (web: components/Comment).
-COMMENT_EDITOR = "comment-editor"
-
-_SCHEMA_DIR = Path(__file__).parent / "schemas"
-
-
-@cache
-def get_schema(name: str) -> Schema:
-    """Return the exported ProseMirror schema ``name`` (cached per process)."""
-    with open(_SCHEMA_DIR / f"{name}.json") as f:
-        return Schema(json.load(f))
-
-
-def parse_document(schema_name: str, doc: dict) -> Node:
-    """Parse and validate a TipTap/ProseMirror document in JSON form.
-
-    Returns the parsed ``Node`` with attribute defaults filled in and any
-    unrecognized attributes silently stripped (prosemirror-py ignores them
-    rather than rejecting). Raises ``ValueError`` if the document references
-    unknown node/mark types, omits a required attribute, or violates the
-    schema's nesting rules.
-    """
-    node = Node.from_json(get_schema(schema_name), doc)
-    node.check()
-    return node
+__all__ = [
+    "BLOCK_EDITOR",
+    "COMMENT_EDITOR",
+    "get_schema",
+    "parse_document",
+]

--- a/src/utils/prosemirror/__init__.py
+++ b/src/utils/prosemirror/__init__.py
@@ -14,8 +14,9 @@ Usage::
     node = parse_document(COMMENT_EDITOR, comment_json)  # raises ValueError
 
 Schema validity is structural only: it guarantees known node/mark types,
-known attributes, and legal nesting — not that a mention's user id exists or
-that a link is safe. That remains application-level validation.
+required attributes, and legal nesting — not that a mention's user id exists
+or that a link is safe. That remains application-level validation. Note that
+unrecognized attributes are silently stripped rather than rejected.
 """
 
 import json
@@ -42,9 +43,11 @@ def get_schema(name: str) -> Schema:
 def parse_document(schema_name: str, doc: dict) -> Node:
     """Parse and validate a TipTap/ProseMirror document in JSON form.
 
-    Returns the parsed ``Node`` with attribute defaults filled in. Raises
-    ``ValueError`` if the document references unknown node/mark types or
-    attributes, or violates the schema's nesting rules.
+    Returns the parsed ``Node`` with attribute defaults filled in and any
+    unrecognized attributes silently stripped (prosemirror-py ignores them
+    rather than rejecting). Raises ``ValueError`` if the document references
+    unknown node/mark types, omits a required attribute, or violates the
+    schema's nesting rules.
     """
     node = Node.from_json(get_schema(schema_name), doc)
     node.check()

--- a/src/utils/prosemirror/loader.py
+++ b/src/utils/prosemirror/loader.py
@@ -24,12 +24,42 @@ def get_schema(name: str) -> Schema:
 def parse_document(schema_name: str, doc: dict) -> Node:
     """Parse and validate a TipTap/ProseMirror document in JSON form.
 
-    Returns the parsed ``Node`` with attribute defaults filled in and any
-    unrecognized attributes silently stripped (prosemirror-py ignores them
-    rather than rejecting). Raises ``ValueError`` if the document references
-    unknown node/mark types, omits a required attribute, or violates the
-    schema's nesting rules.
+    Returns the parsed ``Node`` with attribute defaults filled in. Raises
+    ``ValueError`` if the root is not the schema's top-level ``doc`` node, if
+    the document references unknown node/mark types or attributes, omits a
+    required attribute, or violates the schema's nesting rules.
     """
-    node = Node.from_json(get_schema(schema_name), doc)
+    schema = get_schema(schema_name)
+    node = Node.from_json(schema, doc)
+    if node.type is not schema.top_node_type:
+        raise ValueError(
+            f"expected top-level {schema.top_node_type.name!r} node,"
+            f" got {node.type.name!r}"
+        )
+    _reject_unknown_attrs(schema, doc)
     node.check()
     return node
+
+
+def _reject_unknown_attrs(schema: Schema, node_json: dict) -> None:
+    # Node.from_json() drops attribute keys the schema doesn't declare, so a
+    # misspelled key would otherwise pass validation and lose its data.
+    unknown = set(node_json.get("attrs") or ()) - set(
+        schema.nodes[node_json["type"]].attrs
+    )
+    if unknown:
+        raise ValueError(
+            f"unknown attributes on node {node_json['type']!r}: "
+            + ", ".join(sorted(unknown))
+        )
+    for mark_json in node_json.get("marks") or ():
+        unknown = set(mark_json.get("attrs") or ()) - set(
+            schema.marks[mark_json["type"]].attrs
+        )
+        if unknown:
+            raise ValueError(
+                f"unknown attributes on mark {mark_json['type']!r}: "
+                + ", ".join(sorted(unknown))
+            )
+    for child in node_json.get("content") or ():
+        _reject_unknown_attrs(schema, child)

--- a/src/utils/prosemirror/loader.py
+++ b/src/utils/prosemirror/loader.py
@@ -1,0 +1,35 @@
+"""Loader for the vendored ProseMirror schemas; see the package docstring."""
+
+import json
+from functools import cache
+from pathlib import Path
+
+from prosemirror.model import Node, Schema
+
+# Notebook notes and posts (web: components/Editor).
+BLOCK_EDITOR = "block-editor"
+# Comments, including review mode (web: components/Comment).
+COMMENT_EDITOR = "comment-editor"
+
+_SCHEMA_DIR = Path(__file__).parent / "schemas"
+
+
+@cache
+def get_schema(name: str) -> Schema:
+    """Return the exported ProseMirror schema ``name`` (cached per process)."""
+    with open(_SCHEMA_DIR / f"{name}.json") as f:
+        return Schema(json.load(f))
+
+
+def parse_document(schema_name: str, doc: dict) -> Node:
+    """Parse and validate a TipTap/ProseMirror document in JSON form.
+
+    Returns the parsed ``Node`` with attribute defaults filled in and any
+    unrecognized attributes silently stripped (prosemirror-py ignores them
+    rather than rejecting). Raises ``ValueError`` if the document references
+    unknown node/mark types, omits a required attribute, or violates the
+    schema's nesting rules.
+    """
+    node = Node.from_json(get_schema(schema_name), doc)
+    node.check()
+    return node

--- a/src/utils/prosemirror/loader.py
+++ b/src/utils/prosemirror/loader.py
@@ -26,19 +26,24 @@ def parse_document(schema_name: str, doc: dict) -> Node:
     """Parse and validate a TipTap/ProseMirror document in JSON form.
 
     Returns the parsed ``Node`` with attribute defaults filled in. Raises
-    ``ValueError`` if the root is not the schema's top-level ``doc`` node, if
-    the document references unknown node/mark types, JSON keys, or
-    attributes, omits a required attribute, or violates the schema's nesting
-    rules.
+    ``ValueError`` if the document JSON is structurally malformed, if the
+    root is not the schema's top-level ``doc`` node, if the document
+    references unknown node/mark types, JSON keys, or attributes, omits a
+    required attribute, or violates the schema's nesting rules.
     """
     schema = get_schema(schema_name)
-    node = Node.from_json(schema, doc)
+    try:
+        node = Node.from_json(schema, doc)
+        _reject_unknown_keys(schema, doc)
+    except (AttributeError, KeyError, TypeError) as e:
+        # prosemirror-py leaks these for malformed shapes (a node missing
+        # "type", non-dict nodes or attrs); keep the ValueError contract.
+        raise ValueError(f"malformed document JSON: {e!r}") from e
     if node.type is not schema.top_node_type:
         raise ValueError(
             f"expected top-level {schema.top_node_type.name!r} node,"
             f" got {node.type.name!r}"
         )
-    _reject_unknown_keys(schema, doc)
     node.check()
     return node
 

--- a/src/utils/prosemirror/loader.py
+++ b/src/utils/prosemirror/loader.py
@@ -1,6 +1,7 @@
 """Loader for the vendored ProseMirror schemas; see the package docstring."""
 
 import json
+from collections.abc import Iterable
 from functools import cache
 from pathlib import Path
 
@@ -26,8 +27,9 @@ def parse_document(schema_name: str, doc: dict) -> Node:
 
     Returns the parsed ``Node`` with attribute defaults filled in. Raises
     ``ValueError`` if the root is not the schema's top-level ``doc`` node, if
-    the document references unknown node/mark types or attributes, omits a
-    required attribute, or violates the schema's nesting rules.
+    the document references unknown node/mark types, JSON keys, or
+    attributes, omits a required attribute, or violates the schema's nesting
+    rules.
     """
     schema = get_schema(schema_name)
     node = Node.from_json(schema, doc)
@@ -36,30 +38,42 @@ def parse_document(schema_name: str, doc: dict) -> Node:
             f"expected top-level {schema.top_node_type.name!r} node,"
             f" got {node.type.name!r}"
         )
-    _reject_unknown_attrs(schema, doc)
+    _reject_unknown_keys(schema, doc)
     node.check()
     return node
 
 
-def _reject_unknown_attrs(schema: Schema, node_json: dict) -> None:
-    # Node.from_json() drops attribute keys the schema doesn't declare, so a
-    # misspelled key would otherwise pass validation and lose its data.
-    unknown = set(node_json.get("attrs") or ()) - set(
-        schema.nodes[node_json["type"]].attrs
+# The JSON object keys Node.from_json() reads for each node kind.
+_NODE_KEYS = frozenset(("type", "attrs", "content", "marks"))
+_TEXT_NODE_KEYS = frozenset(("type", "text", "marks"))
+_MARK_KEYS = frozenset(("type", "attrs"))
+
+
+def _reject_unknown_keys(schema: Schema, node_json: dict) -> None:
+    # Node.from_json() ignores JSON keys and attribute names it doesn't
+    # recognize ("contents", "usrId"), so a misspelling would otherwise pass
+    # validation and silently drop the data under it.
+    node_type = schema.nodes[node_json["type"]]
+    node_keys = _TEXT_NODE_KEYS if node_type.is_text else _NODE_KEYS
+    _reject_unknown(node_json, node_keys, f"keys on node {node_type.name!r}")
+    _reject_unknown(
+        node_json.get("attrs"),
+        node_type.attrs,
+        f"attributes on node {node_type.name!r}",
     )
-    if unknown:
-        raise ValueError(
-            f"unknown attributes on node {node_json['type']!r}: "
-            + ", ".join(sorted(unknown))
-        )
     for mark_json in node_json.get("marks") or ():
-        unknown = set(mark_json.get("attrs") or ()) - set(
-            schema.marks[mark_json["type"]].attrs
+        mark_type = schema.marks[mark_json["type"]]
+        _reject_unknown(mark_json, _MARK_KEYS, f"keys on mark {mark_type.name!r}")
+        _reject_unknown(
+            mark_json.get("attrs"),
+            mark_type.attrs,
+            f"attributes on mark {mark_type.name!r}",
         )
-        if unknown:
-            raise ValueError(
-                f"unknown attributes on mark {mark_json['type']!r}: "
-                + ", ".join(sorted(unknown))
-            )
     for child in node_json.get("content") or ():
-        _reject_unknown_attrs(schema, child)
+        _reject_unknown_keys(schema, child)
+
+
+def _reject_unknown(found: dict | None, allowed: Iterable[str], what: str) -> None:
+    unknown = set(found or ()) - set(allowed)
+    if unknown:
+        raise ValueError(f"unknown {what}: " + ", ".join(sorted(unknown)))

--- a/src/utils/prosemirror/loader.py
+++ b/src/utils/prosemirror/loader.py
@@ -52,6 +52,8 @@ def parse_document(schema_name: str, doc: dict) -> Node:
 _NODE_KEYS = frozenset(("type", "attrs", "content", "marks"))
 _TEXT_NODE_KEYS = frozenset(("type", "text", "marks"))
 _MARK_KEYS = frozenset(("type", "attrs"))
+# The container type each of those keys must hold when present.
+_CONTAINER_TYPES = {"attrs": dict, "marks": list, "content": list}
 
 
 def _reject_unknown_keys(schema: Schema, node_json: dict) -> None:
@@ -59,22 +61,24 @@ def _reject_unknown_keys(schema: Schema, node_json: dict) -> None:
     # recognize ("contents", "usrId"), so a misspelling would otherwise pass
     # validation and silently drop the data under it.
     node_type = schema.nodes[node_json["type"]]
+    what = f"node {node_type.name!r}"
     node_keys = _TEXT_NODE_KEYS if node_type.is_text else _NODE_KEYS
-    _reject_unknown(node_json, node_keys, f"keys on node {node_type.name!r}")
+    _reject_unknown(node_json, node_keys, f"keys on {what}")
     _reject_unknown(
-        node_json.get("attrs"),
+        _get_container(node_json, "attrs", what),
         node_type.attrs,
-        f"attributes on node {node_type.name!r}",
+        f"attributes on {what}",
     )
-    for mark_json in node_json.get("marks") or ():
+    for mark_json in _get_container(node_json, "marks", what) or ():
         mark_type = schema.marks[mark_json["type"]]
-        _reject_unknown(mark_json, _MARK_KEYS, f"keys on mark {mark_type.name!r}")
+        mark_what = f"mark {mark_type.name!r}"
+        _reject_unknown(mark_json, _MARK_KEYS, f"keys on {mark_what}")
         _reject_unknown(
-            mark_json.get("attrs"),
+            _get_container(mark_json, "attrs", mark_what),
             mark_type.attrs,
-            f"attributes on mark {mark_type.name!r}",
+            f"attributes on {mark_what}",
         )
-    for child in node_json.get("content") or ():
+    for child in _get_container(node_json, "content", what) or ():
         _reject_unknown_keys(schema, child)
 
 
@@ -82,3 +86,16 @@ def _reject_unknown(found: dict | None, allowed: Iterable[str], what: str) -> No
     unknown = set(found or ()) - set(allowed)
     if unknown:
         raise ValueError(f"unknown {what}: " + ", ".join(sorted(unknown)))
+
+
+def _get_container(json_obj: dict, key: str, what: str) -> dict | list | None:
+    # Falsy wrong-typed containers ([], "", false) would read as absent both
+    # here and in Node.from_json(); require the proper type. None stays
+    # allowed as the JSON convention for an absent optional field.
+    value = json_obj.get(key)
+    if value is not None and not isinstance(value, _CONTAINER_TYPES[key]):
+        raise ValueError(
+            f"malformed {key} on {what}: expected "
+            f"{_CONTAINER_TYPES[key].__name__}, got {type(value).__name__}"
+        )
+    return value

--- a/src/utils/prosemirror/schemas/README.md
+++ b/src/utils/prosemirror/schemas/README.md
@@ -1,0 +1,27 @@
+# ProseMirror schemas (vendored from ResearchHub/web)
+
+Generated artifacts — **do not edit by hand**. The source of truth is the
+[ResearchHub/web](https://github.com/ResearchHub/web) repo, which generates
+these from the TipTap extension sets the editors actually run.
+
+| File | Covers |
+| --- | --- |
+| `block-editor.json` | Notebook notes, posts (`components/Editor`) |
+| `comment-editor.json` | Comments, incl. review mode (`components/Comment`) |
+
+Load them via `utils.prosemirror.get_schema` / `parse_document`.
+
+## Updating
+
+When editor extensions change in the web repo (its schema export is
+byte-deterministic, so a diff means a real schema change):
+
+```bash
+# in ResearchHub/web
+npm run schema:export
+cp schemas/prosemirror/*.json <backend>/src/utils/prosemirror/schemas/
+```
+
+Then run `utils` tests here. See `schemas/prosemirror/README.md` in the web
+repo for what the export contains and its intentional deviations (DOM-only
+fields stripped, permissive `doc` node, review-mode and AI-node supersets).

--- a/src/utils/prosemirror/schemas/block-editor.json
+++ b/src/utils/prosemirror/schemas/block-editor.json
@@ -1,0 +1,402 @@
+{
+  "topNode": "doc",
+  "nodes": {
+    "paragraph": {
+      "content": "inline*",
+      "group": "block",
+      "attrs": {
+        "id": {
+          "default": null
+        },
+        "class": {
+          "default": null
+        },
+        "textAlign": {
+          "default": null
+        }
+      }
+    },
+    "doc": {
+      "content": "(block|columns)+"
+    },
+    "columns": {
+      "content": "column column",
+      "group": "columns",
+      "defining": true,
+      "isolating": true,
+      "attrs": {
+        "layout": {
+          "default": "two-column"
+        }
+      }
+    },
+    "taskList": {
+      "content": "taskItem+",
+      "group": "block list"
+    },
+    "taskItem": {
+      "content": "paragraph block*",
+      "defining": true,
+      "attrs": {
+        "checked": {
+          "default": false
+        }
+      }
+    },
+    "column": {
+      "content": "block+",
+      "isolating": true,
+      "attrs": {
+        "position": {
+          "default": ""
+        }
+      }
+    },
+    "heading": {
+      "content": "inline*",
+      "group": "block",
+      "defining": true,
+      "attrs": {
+        "id": {
+          "default": null
+        },
+        "data-toc-id": {
+          "default": null
+        },
+        "textAlign": {
+          "default": null
+        },
+        "level": {
+          "default": 1
+        }
+      }
+    },
+    "horizontalRule": {
+      "group": "block"
+    },
+    "bulletList": {
+      "content": "listItem+",
+      "group": "block list"
+    },
+    "hardBreak": {
+      "group": "inline",
+      "inline": true,
+      "selectable": false,
+      "linebreakReplacement": true
+    },
+    "listItem": {
+      "content": "paragraph block*",
+      "defining": true
+    },
+    "orderedList": {
+      "content": "listItem+",
+      "group": "block list",
+      "attrs": {
+        "start": {
+          "default": 1
+        },
+        "type": {
+          "default": null
+        }
+      }
+    },
+    "text": {
+      "group": "inline"
+    },
+    "details": {
+      "allowGapCursor": false,
+      "content": "detailsSummary detailsContent",
+      "group": "block",
+      "defining": true,
+      "isolating": true,
+      "attrs": {
+        "open": {
+          "default": false
+        }
+      }
+    },
+    "detailsContent": {
+      "content": "block+",
+      "selectable": false,
+      "defining": true
+    },
+    "detailsSummary": {
+      "content": "text*",
+      "selectable": false,
+      "defining": true,
+      "isolating": true
+    },
+    "codeBlock": {
+      "content": "text*",
+      "marks": "",
+      "group": "block",
+      "code": true,
+      "defining": true,
+      "attrs": {
+        "id": {
+          "default": null
+        },
+        "language": {
+          "default": "javascript"
+        }
+      }
+    },
+    "tableOfContentsNode": {
+      "group": "block",
+      "inline": false,
+      "atom": true,
+      "selectable": true,
+      "draggable": true
+    },
+    "imageUpload": {
+      "group": "block",
+      "inline": false,
+      "selectable": true,
+      "draggable": true,
+      "defining": true,
+      "isolating": true
+    },
+    "imageBlock": {
+      "group": "block",
+      "inline": false,
+      "draggable": true,
+      "defining": true,
+      "isolating": true,
+      "attrs": {
+        "src": {
+          "default": ""
+        },
+        "width": {
+          "default": "100%"
+        },
+        "align": {
+          "default": "center"
+        },
+        "alt": {
+          "default": null
+        }
+      }
+    },
+    "emoji": {
+      "group": "inline",
+      "inline": true,
+      "selectable": false,
+      "attrs": {
+        "name": {
+          "default": null
+        }
+      }
+    },
+    "blockMath": {
+      "group": "block",
+      "atom": true,
+      "attrs": {
+        "latex": {
+          "default": ""
+        }
+      }
+    },
+    "inlineMath": {
+      "group": "inline",
+      "inline": true,
+      "atom": true,
+      "attrs": {
+        "latex": {
+          "default": ""
+        }
+      }
+    },
+    "table": {
+      "tableRole": "table",
+      "content": "tableRow+",
+      "group": "block",
+      "isolating": true,
+      "attrs": {
+        "id": {
+          "default": null
+        }
+      }
+    },
+    "tableCell": {
+      "tableRole": "cell",
+      "content": "block+",
+      "isolating": true,
+      "attrs": {
+        "colspan": {
+          "default": 1
+        },
+        "rowspan": {
+          "default": 1
+        },
+        "colwidth": {
+          "default": null
+        },
+        "style": {
+          "default": null
+        }
+      }
+    },
+    "tableHeader": {
+      "tableRole": "header_cell",
+      "content": "block+",
+      "isolating": true,
+      "attrs": {
+        "colspan": {
+          "default": 1
+        },
+        "rowspan": {
+          "default": 1
+        },
+        "colwidth": {
+          "default": null
+        },
+        "style": {
+          "default": null
+        }
+      }
+    },
+    "tableRow": {
+      "allowGapCursor": false,
+      "tableRole": "row",
+      "content": "tableCell*"
+    },
+    "figcaption": {
+      "content": "inline*",
+      "marks": "link",
+      "selectable": false,
+      "draggable": false
+    },
+    "blockquoteFigure": {
+      "content": "quote quoteCaption",
+      "group": "block",
+      "selectable": true,
+      "draggable": true,
+      "defining": true,
+      "isolating": true
+    },
+    "quote": {
+      "content": "paragraph+",
+      "marks": "",
+      "defining": true
+    },
+    "quoteCaption": {
+      "content": "text*",
+      "group": "block",
+      "defining": true,
+      "isolating": true
+    },
+    "youtube": {
+      "group": "block",
+      "inline": false,
+      "draggable": true,
+      "attrs": {
+        "src": {
+          "default": null
+        },
+        "start": {
+          "default": 0
+        },
+        "width": {
+          "default": 640
+        },
+        "height": {
+          "default": 480
+        }
+      }
+    },
+    "figure": {
+      "content": "block*",
+      "group": "block",
+      "attrs": {
+        "originalContent": {
+          "default": ""
+        },
+        "class": {
+          "default": ""
+        }
+      }
+    },
+    "aiWriter": {
+      "group": "block",
+      "draggable": true,
+      "attrs": {
+        "id": {
+          "default": null
+        },
+        "authorId": {
+          "default": null
+        },
+        "authorName": {
+          "default": null
+        }
+      }
+    },
+    "aiImage": {
+      "group": "block",
+      "draggable": true,
+      "attrs": {
+        "id": {
+          "default": null
+        },
+        "authorId": {
+          "default": null
+        },
+        "authorName": {
+          "default": null
+        }
+      }
+    }
+  },
+  "marks": {
+    "link": {
+      "inclusive": false,
+      "attrs": {
+        "href": {
+          "default": null
+        },
+        "target": {
+          "default": "_blank"
+        },
+        "rel": {
+          "default": "noopener noreferrer nofollow"
+        },
+        "class": {
+          "default": "link"
+        },
+        "title": {
+          "default": null
+        }
+      }
+    },
+    "textStyle": {
+      "attrs": {
+        "fontSize": {
+          "default": null
+        },
+        "fontFamily": {
+          "default": null
+        },
+        "color": {
+          "default": null
+        }
+      }
+    },
+    "bold": {},
+    "code": {
+      "excludes": "_",
+      "code": true
+    },
+    "italic": {},
+    "strike": {},
+    "highlight": {
+      "attrs": {
+        "color": {
+          "default": null
+        }
+      }
+    },
+    "underline": {},
+    "subscript": {},
+    "superscript": {}
+  }
+}

--- a/src/utils/prosemirror/schemas/comment-editor.json
+++ b/src/utils/prosemirror/schemas/comment-editor.json
@@ -1,0 +1,202 @@
+{
+  "topNode": "doc",
+  "nodes": {
+    "paragraph": {
+      "content": "inline*",
+      "group": "block"
+    },
+    "mention": {
+      "group": "inline",
+      "inline": true,
+      "atom": true,
+      "selectable": false,
+      "attrs": {
+        "id": {
+          "default": null
+        },
+        "label": {
+          "default": null
+        },
+        "mentionSuggestionChar": {
+          "default": "@"
+        },
+        "entityType": {
+          "default": null
+        },
+        "displayName": {
+          "default": null
+        },
+        "userId": {
+          "default": null
+        },
+        "authorProfileId": {
+          "default": null
+        },
+        "doi": {
+          "default": null
+        }
+      }
+    },
+    "blockquote": {
+      "content": "block+",
+      "group": "block",
+      "defining": true
+    },
+    "bulletList": {
+      "content": "listItem+",
+      "group": "block list"
+    },
+    "doc": {
+      "content": "block+"
+    },
+    "hardBreak": {
+      "group": "inline",
+      "inline": true,
+      "selectable": false,
+      "linebreakReplacement": true
+    },
+    "heading": {
+      "content": "inline*",
+      "group": "block",
+      "defining": true,
+      "attrs": {
+        "level": {
+          "default": 1
+        }
+      }
+    },
+    "horizontalRule": {
+      "group": "block"
+    },
+    "listItem": {
+      "content": "paragraph block*",
+      "defining": true
+    },
+    "orderedList": {
+      "content": "listItem+",
+      "group": "block list",
+      "attrs": {
+        "start": {
+          "default": 1
+        },
+        "type": {
+          "default": null
+        }
+      }
+    },
+    "text": {
+      "group": "inline"
+    },
+    "richLink": {
+      "group": "inline",
+      "inline": true,
+      "atom": true,
+      "selectable": true,
+      "draggable": false,
+      "attrs": {
+        "url": {
+          "default": null
+        },
+        "kind": {
+          "default": null
+        },
+        "videoId": {
+          "default": null
+        },
+        "tweetId": {
+          "default": null
+        },
+        "linkedinUrn": {
+          "default": null
+        }
+      }
+    },
+    "image": {
+      "group": "block",
+      "inline": false,
+      "draggable": true,
+      "attrs": {
+        "src": {
+          "default": null
+        },
+        "alt": {
+          "default": null
+        },
+        "title": {
+          "default": null
+        },
+        "width": {
+          "default": null
+        },
+        "height": {
+          "default": null
+        }
+      }
+    },
+    "codeBlock": {
+      "content": "text*",
+      "marks": "",
+      "group": "block",
+      "code": true,
+      "defining": true,
+      "attrs": {
+        "language": {
+          "default": "javascript"
+        }
+      }
+    },
+    "sectionHeader": {
+      "group": "block",
+      "atom": true,
+      "selectable": false,
+      "draggable": false,
+      "attrs": {
+        "sectionId": {
+          "default": null
+        },
+        "title": {
+          "default": null
+        },
+        "description": {
+          "default": null
+        },
+        "rating": {
+          "default": 0
+        }
+      }
+    }
+  },
+  "marks": {
+    "link": {
+      "inclusive": true,
+      "attrs": {
+        "href": {
+          "default": null
+        },
+        "target": {
+          "default": "_blank"
+        },
+        "rel": {
+          "default": "noopener noreferrer nofollow"
+        },
+        "class": {
+          "default": "text-blue-600 hover:text-blue-800 cursor-pointer relative group"
+        },
+        "title": {
+          "default": null
+        },
+        "noRichPreview": {
+          "default": false
+        }
+      }
+    },
+    "bold": {},
+    "code": {
+      "excludes": "_",
+      "code": true
+    },
+    "italic": {},
+    "strike": {},
+    "underline": {}
+  }
+}

--- a/src/utils/tests/test_prosemirror.py
+++ b/src/utils/tests/test_prosemirror.py
@@ -156,6 +156,65 @@ class ProseMirrorSchemaTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "bogus"):
             parse_document(COMMENT_EDITOR, doc)
 
+    def test_misspelled_content_key_rejected(self):
+        # Arrange
+        # from_json would ignore "contents" and build an empty paragraph.
+        doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "contents": [{"type": "text", "text": "lost"}],
+                }
+            ],
+        }
+
+        # Act & Assert
+        with self.assertRaisesRegex(ValueError, "keys on node 'paragraph': contents"):
+            parse_document(COMMENT_EDITOR, doc)
+
+    def test_misspelled_marks_key_rejected(self):
+        # Arrange
+        doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {"type": "text", "text": "x", "mark": [{"type": "bold"}]}
+                    ],
+                }
+            ],
+        }
+
+        # Act & Assert
+        with self.assertRaisesRegex(ValueError, "keys on node 'text': mark"):
+            parse_document(COMMENT_EDITOR, doc)
+
+    def test_misspelled_mark_attrs_key_rejected(self):
+        # Arrange
+        doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "x",
+                            "marks": [
+                                {"type": "link", "attr": {"href": "https://a.b"}}
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        # Act & Assert
+        with self.assertRaisesRegex(ValueError, "keys on mark 'link': attr"):
+            parse_document(COMMENT_EDITOR, doc)
+
     def test_unknown_node_type_rejected(self):
         # Arrange
         # imageBlock exists in the block schema but not the comment schema.

--- a/src/utils/tests/test_prosemirror.py
+++ b/src/utils/tests/test_prosemirror.py
@@ -79,7 +79,21 @@ class ProseMirrorSchemaTests(unittest.TestCase):
         doc.check()
         self.assertIsNone(doc.child(2).attrs["alt"])
 
-    def test_unknown_attributes_stripped_not_rejected(self):
+    def test_non_document_root_rejected(self):
+        # Arrange
+        fragment = {
+            "type": "paragraph",
+            "content": [{"type": "text", "text": "not a doc"}],
+        }
+
+        # Act & Assert
+        with self.assertRaisesRegex(ValueError, "expected top-level 'doc'"):
+            parse_document(COMMENT_EDITOR, fragment)
+
+    def test_unknown_node_attribute_rejected(self):
+        # Arrange
+        # prosemirror-py would silently drop the misspelled key, leaving a
+        # mention whose real id attribute is None.
         doc = {
             "type": "doc",
             "content": [
@@ -88,17 +102,46 @@ class ProseMirrorSchemaTests(unittest.TestCase):
                     "content": [
                         {
                             "type": "mention",
-                            "attrs": {"id": "1", "label": "x", "bogus": "dropped"},
+                            "attrs": {"usrId": "1", "label": "x"},
                         }
                     ],
                 }
             ],
         }
-        node = parse_document(COMMENT_EDITOR, doc)
 
-        mention_json = node.to_json()["content"][0]["content"][0]
-        self.assertNotIn("bogus", mention_json["attrs"])
-        self.assertEqual(mention_json["attrs"]["id"], "1")
+        # Act & Assert
+        with self.assertRaisesRegex(ValueError, "usrId"):
+            parse_document(COMMENT_EDITOR, doc)
+
+    def test_unknown_mark_attribute_rejected(self):
+        # Arrange
+        doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "see docs",
+                            "marks": [
+                                {
+                                    "type": "link",
+                                    "attrs": {
+                                        "href": "https://example.com",
+                                        "bogus": 1,
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        # Act & Assert
+        with self.assertRaisesRegex(ValueError, "bogus"):
+            parse_document(COMMENT_EDITOR, doc)
 
     def test_unknown_node_type_rejected(self):
         # imageBlock exists in the block schema but not the comment schema.

--- a/src/utils/tests/test_prosemirror.py
+++ b/src/utils/tests/test_prosemirror.py
@@ -79,6 +79,27 @@ class ProseMirrorSchemaTests(unittest.TestCase):
         doc.check()
         self.assertIsNone(doc.child(2).attrs["alt"])
 
+    def test_unknown_attributes_stripped_not_rejected(self):
+        doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "mention",
+                            "attrs": {"id": "1", "label": "x", "bogus": "dropped"},
+                        }
+                    ],
+                }
+            ],
+        }
+        node = parse_document(COMMENT_EDITOR, doc)
+
+        mention_json = node.to_json()["content"][0]["content"][0]
+        self.assertNotIn("bogus", mention_json["attrs"])
+        self.assertEqual(mention_json["attrs"]["id"], "1")
+
     def test_unknown_node_type_rejected(self):
         # imageBlock exists in the block schema but not the comment schema.
         bad_doc = {"type": "doc", "content": [{"type": "imageBlock"}]}

--- a/src/utils/tests/test_prosemirror.py
+++ b/src/utils/tests/test_prosemirror.py
@@ -240,6 +240,54 @@ class ProseMirrorSchemaTests(unittest.TestCase):
             ):
                 parse_document(COMMENT_EDITOR, doc)
 
+    def test_falsy_non_container_values_rejected(self):
+        # Arrange
+        # Falsy wrong-typed containers would otherwise read as absent and
+        # normalize instead of failing.
+        def wrap(inner):
+            return {
+                "type": "doc",
+                "content": [{"type": "paragraph", "content": [inner]}],
+            }
+
+        malformed = {
+            "attrs as list": wrap({"type": "mention", "attrs": []}),
+            "attrs as string": wrap({"type": "mention", "attrs": ""}),
+            "attrs as bool": wrap({"type": "mention", "attrs": False}),
+            "marks as bool": wrap({"type": "text", "text": "x", "marks": False}),
+            "content as bool": {
+                "type": "doc",
+                "content": [{"type": "paragraph", "content": False}],
+            },
+        }
+
+        # Act & Assert
+        for name, doc in malformed.items():
+            with (
+                self.subTest(name),
+                self.assertRaisesRegex(ValueError, "malformed"),
+            ):
+                parse_document(COMMENT_EDITOR, doc)
+
+    def test_null_containers_treated_as_absent(self):
+        # Arrange
+        doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "attrs": None,
+                    "content": [{"type": "text", "text": "x", "marks": None}],
+                }
+            ],
+        }
+
+        # Act
+        node = parse_document(COMMENT_EDITOR, doc)
+
+        # Assert
+        self.assertEqual(node.child(0).child(0).text, "x")
+
     def test_unknown_node_type_rejected(self):
         # Arrange
         # imageBlock exists in the block schema but not the comment schema.

--- a/src/utils/tests/test_prosemirror.py
+++ b/src/utils/tests/test_prosemirror.py
@@ -215,6 +215,31 @@ class ProseMirrorSchemaTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "keys on mark 'link': attr"):
             parse_document(COMMENT_EDITOR, doc)
 
+    def test_malformed_json_rejected_with_value_error(self):
+        # Arrange
+        # Shapes where prosemirror-py itself raises KeyError/AttributeError,
+        # which parse_document must translate to the advertised ValueError.
+        def wrap(inner):
+            return {
+                "type": "doc",
+                "content": [{"type": "paragraph", "content": [inner]}],
+            }
+
+        malformed = {
+            "node missing type": wrap({"text": "no type"}),
+            "text node missing text": wrap({"type": "text"}),
+            "non-dict content item": wrap(5),
+            "non-dict attrs": wrap({"type": "mention", "attrs": 5}),
+        }
+
+        # Act & Assert
+        for name, doc in malformed.items():
+            with (
+                self.subTest(name),
+                self.assertRaisesRegex(ValueError, "malformed document JSON"),
+            ):
+                parse_document(COMMENT_EDITOR, doc)
+
     def test_unknown_node_type_rejected(self):
         # Arrange
         # imageBlock exists in the block schema but not the comment schema.

--- a/src/utils/tests/test_prosemirror.py
+++ b/src/utils/tests/test_prosemirror.py
@@ -1,0 +1,94 @@
+import unittest
+
+from utils.prosemirror import (
+    BLOCK_EDITOR,
+    COMMENT_EDITOR,
+    get_schema,
+    parse_document,
+)
+
+COMMENT_DOC = {
+    "type": "doc",
+    "content": [
+        {
+            "type": "sectionHeader",
+            "attrs": {"sectionId": "s1", "title": "Impact", "rating": 4},
+        },
+        {
+            "type": "paragraph",
+            "content": [
+                {"type": "text", "text": "Great work "},
+                {"type": "mention", "attrs": {"id": "123", "label": "Jane Doe"}},
+                {"type": "text", "text": ", see "},
+                {
+                    "type": "richLink",
+                    "attrs": {"url": "https://example.com/paper"},
+                },
+                {
+                    "type": "text",
+                    "marks": [{"type": "bold"}],
+                    "text": " (important)",
+                },
+            ],
+        },
+        {"type": "codeBlock", "content": [{"type": "text", "text": "print('hi')"}]},
+    ],
+}
+
+
+class ProseMirrorSchemaTests(unittest.TestCase):
+    def test_schemas_load_with_expected_types(self):
+        block = get_schema(BLOCK_EDITOR)
+        comment = get_schema(COMMENT_EDITOR)
+
+        for node_name in ("doc", "paragraph", "text", "imageBlock", "blockMath"):
+            self.assertIn(node_name, block.nodes)
+        for node_name in ("doc", "mention", "richLink", "sectionHeader"):
+            self.assertIn(node_name, comment.nodes)
+        for mark_name in ("bold", "italic", "link"):
+            self.assertIn(mark_name, block.marks)
+            self.assertIn(mark_name, comment.marks)
+
+    def test_get_schema_caches_instances(self):
+        self.assertIs(get_schema(COMMENT_EDITOR), get_schema(COMMENT_EDITOR))
+
+    def test_parse_document_round_trips_and_fills_defaults(self):
+        node = parse_document(COMMENT_EDITOR, COMMENT_DOC)
+
+        mention = node.child(1).child(1)
+        self.assertEqual(mention.attrs["id"], "123")
+        # Defaults the input omitted are filled in from the schema.
+        self.assertEqual(mention.attrs["mentionSuggestionChar"], "@")
+        self.assertEqual(node.child(2).attrs["language"], "javascript")
+
+        round_tripped = node.to_json()
+        self.assertEqual(round_tripped["type"], "doc")
+        self.assertEqual(len(round_tripped["content"]), 3)
+
+    def test_programmatic_document_construction(self):
+        block = get_schema(BLOCK_EDITOR)
+        doc = block.node(
+            "doc",
+            None,
+            [
+                block.node("heading", {"level": 1}, [block.text("My note")]),
+                block.node("paragraph", None, [block.text("Body text")]),
+                block.node("imageBlock", {"src": "https://example.com/img.png"}),
+            ],
+        )
+        doc.check()
+        self.assertIsNone(doc.child(2).attrs["alt"])
+
+    def test_unknown_node_type_rejected(self):
+        # imageBlock exists in the block schema but not the comment schema.
+        bad_doc = {"type": "doc", "content": [{"type": "imageBlock"}]}
+        with self.assertRaises(ValueError):
+            parse_document(COMMENT_EDITOR, bad_doc)
+
+    def test_invalid_nesting_rejected(self):
+        bad_doc = {
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "paragraph"}]}],
+        }
+        with self.assertRaises(ValueError):
+            parse_document(COMMENT_EDITOR, bad_doc)

--- a/src/utils/tests/test_prosemirror.py
+++ b/src/utils/tests/test_prosemirror.py
@@ -38,9 +38,11 @@ COMMENT_DOC = {
 
 class ProseMirrorSchemaTests(unittest.TestCase):
     def test_schemas_load_with_expected_types(self):
+        # Act
         block = get_schema(BLOCK_EDITOR)
         comment = get_schema(COMMENT_EDITOR)
 
+        # Assert
         for node_name in ("doc", "paragraph", "text", "imageBlock", "blockMath"):
             self.assertIn(node_name, block.nodes)
         for node_name in ("doc", "mention", "richLink", "sectionHeader"):
@@ -50,23 +52,32 @@ class ProseMirrorSchemaTests(unittest.TestCase):
             self.assertIn(mark_name, comment.marks)
 
     def test_get_schema_caches_instances(self):
-        self.assertIs(get_schema(COMMENT_EDITOR), get_schema(COMMENT_EDITOR))
+        # Act
+        first = get_schema(COMMENT_EDITOR)
+        second = get_schema(COMMENT_EDITOR)
+
+        # Assert
+        self.assertIs(first, second)
 
     def test_parse_document_round_trips_and_fills_defaults(self):
+        # Act
         node = parse_document(COMMENT_EDITOR, COMMENT_DOC)
+        round_tripped = node.to_json()
 
+        # Assert
         mention = node.child(1).child(1)
         self.assertEqual(mention.attrs["id"], "123")
         # Defaults the input omitted are filled in from the schema.
         self.assertEqual(mention.attrs["mentionSuggestionChar"], "@")
         self.assertEqual(node.child(2).attrs["language"], "javascript")
-
-        round_tripped = node.to_json()
         self.assertEqual(round_tripped["type"], "doc")
         self.assertEqual(len(round_tripped["content"]), 3)
 
     def test_programmatic_document_construction(self):
+        # Arrange
         block = get_schema(BLOCK_EDITOR)
+
+        # Act
         doc = block.node(
             "doc",
             None,
@@ -77,6 +88,8 @@ class ProseMirrorSchemaTests(unittest.TestCase):
             ],
         )
         doc.check()
+
+        # Assert
         self.assertIsNone(doc.child(2).attrs["alt"])
 
     def test_non_document_root_rejected(self):
@@ -144,15 +157,21 @@ class ProseMirrorSchemaTests(unittest.TestCase):
             parse_document(COMMENT_EDITOR, doc)
 
     def test_unknown_node_type_rejected(self):
+        # Arrange
         # imageBlock exists in the block schema but not the comment schema.
         bad_doc = {"type": "doc", "content": [{"type": "imageBlock"}]}
+
+        # Act & Assert
         with self.assertRaises(ValueError):
             parse_document(COMMENT_EDITOR, bad_doc)
 
     def test_invalid_nesting_rejected(self):
+        # Arrange
         bad_doc = {
             "type": "doc",
             "content": [{"type": "paragraph", "content": [{"type": "paragraph"}]}],
         }
+
+        # Act & Assert
         with self.assertRaises(ValueError):
             parse_document(COMMENT_EDITOR, bad_doc)

--- a/uv.lock
+++ b/uv.lock
@@ -749,6 +749,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cssselect"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/5a/6d6fcf922709391fac986f0a03ad4546f4f45b94d10aeb6c1ee041599993/cssselect-1.5.0.tar.gz", hash = "sha256:3cbe82dd7acbee9ba9e5723b5f9e4749826912f1fb31cd7f92aabed5fde15b15", size = 47598, upload-time = "2026-07-27T09:17:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/e9/6734502f67533a752ea8b1c8f7f227c94eecf300252ba8bf23e3e59d8a36/cssselect-1.5.0-py3-none-any.whl", hash = "sha256:1d1aded98e82bdde447ded990a191fd6916177c4f0c914fb62eccd58e2ffcdcc", size = 20797, upload-time = "2026-07-27T09:17:33.04Z" },
+]
+
+[[package]]
 name = "cssutils"
 version = "2.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2022,6 +2031,20 @@ wheels = [
 ]
 
 [[package]]
+name = "prosemirror"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cssselect" },
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/8a/36cd9224f70441fd66d428f7cad650923d949d0d9395cbae82aab6b78df5/prosemirror-0.6.1.tar.gz", hash = "sha256:eec45a4f35d03ddb58700199292646c34b334bbad385a21679fc7a8d181cd272", size = 76262, upload-time = "2026-02-21T15:43:01.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/6b/ff4f2362320c53ea989ef32e4ac978233b65ffb2e6e3131aea7860c740cb/prosemirror-0.6.1-py3-none-any.whl", hash = "sha256:f9d38313a72af1c579cbb87beac3a765f399416afc4567cb016aca53ec4cdae6", size = 67868, upload-time = "2026-02-21T15:43:00.3Z" },
+]
+
+[[package]]
 name = "psycopg"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2588,6 +2611,7 @@ dependencies = [
     { name = "openai" },
     { name = "opensearch-py" },
     { name = "pillow" },
+    { name = "prosemirror" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pyjwt" },
     { name = "pymupdf" },
@@ -2655,6 +2679,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.45.0" },
     { name = "opensearch-py", specifier = "==3.0.0" },
     { name = "pillow", specifier = ">=12.3.0" },
+    { name = "prosemirror", specifier = ">=0.6.1,<0.7" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.3,<4.0.0" },
     { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "pymupdf", specifier = ">=1.24.13,<2.0.0" },


### PR DESCRIPTION
## What

Vendors the ProseMirror schema JSON exported from [ResearchHub/web#1040](https://github.com/ResearchHub/web/pull/1040) and adds a loader, so backend code can parse, validate, and write TipTap editor documents against the **exact schema the frontend enforces**.

```python
from utils.prosemirror import COMMENT_EDITOR, parse_document

node = parse_document(COMMENT_EDITOR, comment_json)  # ValueError on unknown
                                                     # types/attrs, bad nesting
```

| File | Covers |
| --- | --- |
| `utils/prosemirror/schemas/block-editor.json` | Notebook notes, posts |
| `utils/prosemirror/schemas/comment-editor.json` | Comments, incl. review mode |

## How

- New dependency `prosemirror>=0.6.1,<0.7` ([prosemirror-py](https://github.com/fellowapp/prosemirror-py), Fellow's port of prosemirror-model/transform — pure Python; pulls in `cssselect`). Lock updated with a current uv (revision 3 format preserved; 25-line diff).
- `utils.prosemirror.get_schema()` returns a cached `Schema`; `parse_document()` = `Node.from_json()` + `check()`, plus explicit rejection of non-`doc` roots and of JSON or attribute keys the schema doesn't declare (prosemirror-py silently strips those); parser crashes on structurally malformed shapes (missing `type`, non-dict nodes) are translated to `ValueError` to keep the contract. Logic lives in `utils/prosemirror/loader.py`; the package `__init__` only re-exports.
- The schemas are **generated artifacts** — the web repo's `npm run schema:export` is the source of truth, and its output is byte-deterministic. Update flow is documented in `utils/prosemirror/schemas/README.md`. Schema validity is structural only (known types/attrs, legal nesting); semantic checks (does the mentioned user exist) stay app-level.

## Why

Primary consumer is agent/programmatic writing paths (e.g. `note_content_service`, AI peer-review comment services), which currently construct or walk TipTap JSON with no validation — errors surface only when the editor renders the doc. Wiring `parse_document` into those paths is a follow-up.

## Testing

- `utils.tests.test_prosemirror` (15 tests): both schemas load, a realistic review comment (mention + richLink + sectionHeader + marks + codeBlock) round-trips with attribute defaults filled in, programmatic doc construction works, and structurally malformed JSON (missing fields, wrong-typed `attrs`/`marks`/`content`), non-`doc` roots, unknown node types, misspelled structural keys (`contents`, `mark`, `attr`), unknown node/mark attribute keys, and invalid nesting raise `ValueError`.
- Ran via `uv run python -m unittest utils.tests.test_prosemirror` on Python 3.13 against the updated lock; ruff format/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



