### PR TITLE
Make Amplitude event timestamps timezone-aware

### DIFF
--- a/src/analytics/interactions/amplitude_event_parser.py
+++ b/src/analytics/interactions/amplitude_event_parser.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from django.contrib.contenttypes.models import ContentType
@@ -128,8 +128,8 @@ class AmplitudeEventParser:
         """
         timestamp_ms = event.get(time_field)
         if timestamp_ms:
-            return datetime.fromtimestamp(timestamp_ms / 1000)
-        return datetime.now()
+            return datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC)
+        return datetime.now(UTC)
 
     def parse_amplitude_event(self, event: dict[str, Any]) -> AmplitudeEvent | None:
         """Parse an Amplitude event and return an AmplitudeEvent object."""

--- a/src/analytics/tests/test_amplitude_event_parser.py
+++ b/src/analytics/tests/test_amplitude_event_parser.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
@@ -162,7 +162,7 @@ class AmplitudeEventParserTests(TestCase):
 
         interaction = self.parser.parse_amplitude_event(event)
 
-        expected_datetime = datetime.fromtimestamp(timestamp_ms / 1000)
+        expected_datetime = datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC)
         self.assertEqual(interaction.event_timestamp, expected_datetime)
 
     def test_event_without_related_work_returns_none(self):


### PR DESCRIPTION
## Summary
Fixes the RuntimeWarning flood in the production worker logs:

> DateTimeField UserInteractions.event_timestamp received a naive datetime (2026-08-19 15:48:09.129100) while time zone support is active.

`AmplitudeEventParser._extract_timestamp` returned naive datetimes on both paths (`datetime.fromtimestamp(ms / 1000)` and the `datetime.now()` fallback), so every Amplitude webhook event processed by `process_amplitude_event` saved a naive value into `UserInteractions.event_timestamp`.

Both paths now return timezone-aware UTC datetimes. Amplitude timestamps are epoch milliseconds (UTC), so parsing with `tz=UTC` is correct regardless of the host's local timezone — previously `fromtimestamp` converted to server-local time, which only produced correct values because the prod hosts run UTC.

## Note for reviewers
`parse_amplitude_event` reads the `_time` field while `parse_bulk_impression_event` reads `time`. If prod payloads only carry `time`, single events always hit the current-time fallback and store ingest time rather than event time. Left as-is here since the existing tests codify `_time`, but it may be worth a follow-up.

## Testing
- `manage.py test analytics.tests.test_amplitude_event_parser analytics.tests.test_event_processor analytics.tests.test_tasks` — 59 tests pass
- `ruff check` and `ruff format --check` clean