### PR TITLE
Fix Yarn signing key issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/python:3.13-trixie
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 
 # Remove Yarn apt source since the base image's signing key is stale.
 RUN rm -f /etc/apt/sources.list.d/yarn.list \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,9 @@ FROM mcr.microsoft.com/devcontainers/python:3.13-trixie
 
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+# Remove Yarn apt source since the base image's signing key is stale.
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends redis-tools
 
 # Install uv and add to PATH


### PR DESCRIPTION
The Yarn signing key in the base container is stale. Since this project doesn't rely on Yarn, its apt sources can be safely removed.