### PR TITLE
Add selected RFP tool to notebook chat

### DIFF
--- a/src/research_ai/prompts/notebook_chat_prompts.py
+++ b/src/research_ai/prompts/notebook_chat_prompts.py
@@ -7,11 +7,24 @@ message verbatim, so there is no user-prompt builder here.
 """
 
 from research_ai.prompts._loader import load_template
+from researchhub_document.related_models.constants.document_type import PREREGISTRATION
+
+_SELECTED_RFP_CAPABILITY = """## The selected RFP
+
+This preregistration may have a funding opportunity selected. When the user's
+request depends on that RFP's fit, requirements, budget, deadline, or wording,
+call read_selected_rfp before answering or editing. Do not use search_grants to
+guess which RFP is selected."""
 
 
 def build_notebook_chat_system_prompt(note) -> str:
     """The system prompt for a conversation attached to ``note``."""
     template = load_template("notebook_chat_system.txt")
-    return template.replace("{{NOTE_ID}}", str(note.id)).replace(
-        "{{NOTE_TITLE}}", str(note.title or "Untitled")
+    selected_rfp_capability = (
+        _SELECTED_RFP_CAPABILITY if note.document_type == PREREGISTRATION else ""
+    )
+    return (
+        template.replace("{{NOTE_ID}}", str(note.id))
+        .replace("{{NOTE_TITLE}}", str(note.title or "Untitled"))
+        .replace("{{SELECTED_RFP_CAPABILITY}}", selected_rfp_capability)
     )

--- a/src/research_ai/prompts/notebook_chat_system.txt
+++ b/src/research_ai/prompts/notebook_chat_system.txt
@@ -7,6 +7,8 @@ and revise the note itself, guided by their feedback.
 You are attached to note {{NOTE_ID}} ("{{NOTE_TITLE}}"). Every read_note and
 edit_note call must use this note id; you have no access to other notes.
 
+{{SELECTED_RFP_CAPABILITY}}
+
 ## What you can do
 
 - **Answer and research.** Use search_institutions, search_authors, get_author,

--- a/src/research_ai/services/notebook_chat/__init__.py
+++ b/src/research_ai/services/notebook_chat/__init__.py
@@ -5,7 +5,11 @@ from research_ai.services.notebook_chat.events import (
     ConversationEventPublisher,
     conversation_group,
 )
-from research_ai.services.notebook_chat.grant_tools import GrantSearchToolset
+from research_ai.services.notebook_chat.grant_tools import (
+    READ_SELECTED_RFP,
+    GrantSearchToolset,
+    SelectedRFPToolset,
+)
 from research_ai.services.notebook_chat.service import (
     ACTIVITY_ALL,
     ACTIVITY_LIVE,
@@ -20,12 +24,14 @@ from research_ai.services.notebook_chat.toolset import (
 __all__ = [
     "ACTIVITY_ALL",
     "ACTIVITY_LIVE",
+    "READ_SELECTED_RFP",
     "WORKFLOW",
     "ConversationEventPublisher",
     "GrantSearchToolset",
     "NotebookChatConfig",
     "NotebookChatService",
     "NotebookWebSearchToolset",
+    "SelectedRFPToolset",
     "compose_notebook_toolset",
     "conversation_group",
 ]

--- a/src/research_ai/services/notebook_chat/activity.py
+++ b/src/research_ai/services/notebook_chat/activity.py
@@ -30,7 +30,10 @@ from research_ai.services.agent_persistence.activity import (
     ToolCallEvent,
 )
 from research_ai.services.note_tools import EDIT_NOTE, READ_NOTE
-from research_ai.services.notebook_chat.grant_tools import SEARCH_GRANTS
+from research_ai.services.notebook_chat.grant_tools import (
+    READ_SELECTED_RFP,
+    SEARCH_GRANTS,
+)
 from research_ai.services.researcher_profile.openalex_tools import GET_WORK_FULLTEXT
 
 WEB_SEARCH = "web_search"
@@ -44,6 +47,7 @@ _LABELS = {
     EDIT_NOTE: "Edited the note",
     WEB_SEARCH: "Searched the web",
     SEARCH_GRANTS: "Searched grants",
+    READ_SELECTED_RFP: "Read the selected RFP",
     SEARCH_INSTITUTIONS: "Searched institutions",
     SEARCH_AUTHORS: "Searched scholarly authors",
     GET_AUTHOR: "Looked up an author",
@@ -57,6 +61,7 @@ _ACTIVE_LABELS = {
     EDIT_NOTE: "Editing the note",
     WEB_SEARCH: "Searching the web",
     SEARCH_GRANTS: "Searching grants",
+    READ_SELECTED_RFP: "Reading the selected RFP",
     SEARCH_INSTITUTIONS: "Searching institutions",
     SEARCH_AUTHORS: "Searching scholarly authors",
     GET_AUTHOR: "Looking up an author",
@@ -260,6 +265,9 @@ def _sources(event: ToolCallEvent) -> list[dict]:
         url_field = "url"
     elif event.tool == SEARCH_GRANTS:
         items = result.get("grants")
+        url_field = "url"
+    elif event.tool == READ_SELECTED_RFP:
+        items = [result]
         url_field = "url"
     elif event.tool == GET_AUTHOR_WORKS:
         items = result.get("works")

--- a/src/research_ai/services/notebook_chat/grant_tools.py
+++ b/src/research_ai/services/notebook_chat/grant_tools.py
@@ -2,16 +2,28 @@
 
 import logging
 
+from note.models import Note
 from purchase.services.grant_search_service import GrantSearchService
 from research_ai.constants import BASE_FRONTEND_URL
 from research_ai.services.agent import Tool, Toolset
+from researchhub_document.related_models.constants.document_type import PREREGISTRATION
 
 logger = logging.getLogger(__name__)
 
 SEARCH_GRANTS = "search_grants"
+READ_SELECTED_RFP = "read_selected_rfp"
 _MAX_QUERY_CHARS = 500
 _MAX_DESCRIPTION_CHARS = 3000
 _MAX_POST_CONTENT_CHARS = 3000
+_EMPTY_INPUT_SCHEMA = {"type": "object", "properties": {}}
+
+
+def _grant_url(grant, post=None) -> str | None:
+    if post is None:
+        post = grant.unified_document.posts.first()
+    if post is None or not post.id or not post.slug:
+        return None
+    return f"{BASE_FRONTEND_URL}/grant/{post.id}/{post.slug}"
 
 
 class GrantSearchToolset:
@@ -82,9 +94,6 @@ class GrantSearchToolset:
         title = (grant.short_title or "").strip()
         if not title and post is not None:
             title = (post.title or "").strip()
-        url = None
-        if post is not None and post.id and post.slug:
-            url = f"{BASE_FRONTEND_URL}/grant/{post.id}/{post.slug}"
         return {
             "id": grant.id,
             "title": title,
@@ -99,5 +108,80 @@ class GrantSearchToolset:
             "currency": grant.currency,
             "deadline": grant.end_date.isoformat() if grant.end_date else None,
             "application_visibility": grant.application_visibility,
-            "url": url,
+            "url": _grant_url(grant, post),
         }
+
+
+class SelectedRFPToolset:
+    """Read the RFP explicitly selected for one preregistration note."""
+
+    def __init__(self, *, note: Note, user):
+        self._note_id = note.id
+        self._user = user
+
+    def build_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name=READ_SELECTED_RFP,
+                description=(
+                    "Read the full RFP selected for this preregistration note. "
+                    "Use it before evaluating fit, requirements, budget, "
+                    "deadline, or revising the note for the selected funding "
+                    "opportunity. Returns structured grant terms and the full "
+                    "call text."
+                ),
+                input_schema=_EMPTY_INPUT_SCHEMA,
+                handler=self._read_selected_rfp,
+            )
+        ]
+
+    def as_toolset(self) -> Toolset:
+        return Toolset(self.build_tools())
+
+    def _read_selected_rfp(self, _args: dict) -> dict:
+        if self._user is None or not getattr(self._user, "is_authenticated", False):
+            return {"error": "selected RFP not found or not accessible"}
+
+        try:
+            note = (
+                Note.objects.select_related(
+                    "unified_document", "selected_grant__unified_document"
+                )
+                .prefetch_related("selected_grant__unified_document__posts")
+                .get(
+                    id=self._note_id,
+                    document_type=PREREGISTRATION,
+                    unified_document__is_removed=False,
+                )
+            )
+            if not note.permissions.has_user(self._user):
+                return {"error": "selected RFP not found or not accessible"}
+
+            grant = note.selected_grant
+            if grant is None:
+                return {"error": "this preregistration has no selected RFP"}
+            if grant.unified_document.is_removed or not (
+                grant.unified_document.is_visible_to_user(self._user)
+            ):
+                return {"error": "selected RFP not found or not accessible"}
+
+            post = grant.unified_document.posts.first()
+            title = (grant.short_title or "").strip()
+            if not title and post is not None:
+                title = (post.title or "").strip()
+            return {
+                "id": grant.id,
+                "title": title,
+                "organization": (grant.organization or "").strip(),
+                "rfp_text": grant.get_llm_context_text(),
+                "amount": str(grant.amount),
+                "currency": grant.currency,
+                "deadline": grant.end_date.isoformat() if grant.end_date else None,
+                "application_visibility": grant.application_visibility,
+                "url": _grant_url(grant, post),
+            }
+        except Note.DoesNotExist:
+            return {"error": "selected RFP not found or not accessible"}
+        except Exception:  # noqa: BLE001 - tool failures are model-readable
+            logger.exception("selected RFP read failed for note %s", self._note_id)
+            return {"error": "selected RFP is temporarily unavailable"}

--- a/src/research_ai/services/notebook_chat/grant_tools.py
+++ b/src/research_ai/services/notebook_chat/grant_tools.py
@@ -16,6 +16,7 @@ _MAX_QUERY_CHARS = 500
 _MAX_DESCRIPTION_CHARS = 3000
 _MAX_POST_CONTENT_CHARS = 3000
 _EMPTY_INPUT_SCHEMA = {"type": "object", "properties": {}}
+_SELECTED_RFP_NOT_ACCESSIBLE = "selected RFP not found or not accessible"
 
 
 def _grant_url(grant, post=None) -> str | None:
@@ -140,7 +141,7 @@ class SelectedRFPToolset:
 
     def _read_selected_rfp(self, _args: dict) -> dict:
         if self._user is None or not getattr(self._user, "is_authenticated", False):
-            return {"error": "selected RFP not found or not accessible"}
+            return {"error": _SELECTED_RFP_NOT_ACCESSIBLE}
 
         try:
             note = (
@@ -155,7 +156,7 @@ class SelectedRFPToolset:
                 )
             )
             if not note.permissions.has_user(self._user):
-                return {"error": "selected RFP not found or not accessible"}
+                return {"error": _SELECTED_RFP_NOT_ACCESSIBLE}
 
             grant = note.selected_grant
             if grant is None:
@@ -163,7 +164,7 @@ class SelectedRFPToolset:
             if grant.unified_document.is_removed or not (
                 grant.unified_document.is_visible_to_user(self._user)
             ):
-                return {"error": "selected RFP not found or not accessible"}
+                return {"error": _SELECTED_RFP_NOT_ACCESSIBLE}
 
             post = grant.unified_document.posts.first()
             title = (grant.short_title or "").strip()
@@ -181,7 +182,7 @@ class SelectedRFPToolset:
                 "url": _grant_url(grant, post),
             }
         except Note.DoesNotExist:
-            return {"error": "selected RFP not found or not accessible"}
+            return {"error": _SELECTED_RFP_NOT_ACCESSIBLE}
         except Exception:  # noqa: BLE001 - tool failures are model-readable
             logger.exception("selected RFP read failed for note %s", self._note_id)
             return {"error": "selected RFP is temporarily unavailable"}

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -75,12 +75,16 @@ from research_ai.services.notebook_chat.events import (
     ConversationEventPublisher,
     PublishingRecorder,
 )
-from research_ai.services.notebook_chat.grant_tools import GrantSearchToolset
+from research_ai.services.notebook_chat.grant_tools import (
+    GrantSearchToolset,
+    SelectedRFPToolset,
+)
 from research_ai.services.notebook_chat.toolset import (
     NotebookWebSearchToolset,
     compose_notebook_toolset,
 )
 from research_ai.services.researcher_profile.openalex_tools import OpenAlexToolset
+from researchhub_document.related_models.constants.document_type import PREREGISTRATION
 from utils.openalex import OpenAlex
 
 logger = logging.getLogger(__name__)
@@ -531,6 +535,11 @@ class NotebookChatService:
         toolset = compose_notebook_toolset(
             note_toolset=NoteToolset(user=conversation.user, note_ids={note.id}),
             grant_toolset=self._grant_toolset_factory(user=conversation.user),
+            selected_rfp_toolset=(
+                SelectedRFPToolset(note=note, user=conversation.user)
+                if note.document_type == PREREGISTRATION
+                else None
+            ),
             openalex_toolset=OpenAlexToolset(client=self._oa_client or OpenAlex()),
             web_search_toolset=NotebookWebSearchToolset(client=self._web_search_client),
             native_tool_names=provider.native_tool_names,

--- a/src/research_ai/services/notebook_chat/toolset.py
+++ b/src/research_ai/services/notebook_chat/toolset.py
@@ -93,6 +93,7 @@ def compose_notebook_toolset(
     *,
     note_toolset,
     grant_toolset,
+    selected_rfp_toolset=None,
     openalex_toolset,
     web_search_toolset,
     native_tool_names: frozenset[str] = frozenset(),
@@ -109,6 +110,8 @@ def compose_notebook_toolset(
     ]
     candidates.extend(web_search_toolset.build_tools())
     candidates.extend(grant_toolset.build_tools())
+    if selected_rfp_toolset is not None:
+        candidates.extend(selected_rfp_toolset.build_tools())
     candidates.extend(note_toolset.build_tools())
 
     toolset = Toolset()

--- a/src/research_ai/tests/notebook_chat/test_grant_tools.py
+++ b/src/research_ai/tests/notebook_chat/test_grant_tools.py
@@ -1,16 +1,27 @@
 from datetime import timedelta
 from decimal import Decimal
 
+from django.contrib.contenttypes.models import ContentType
+from django.core.files.base import ContentFile
 from django.test import TestCase
 from django.utils import timezone
 
+from note.tests.helpers import create_note
 from purchase.models import Grant
 from research_ai.services.notebook_chat.grant_tools import (
+    READ_SELECTED_RFP,
     SEARCH_GRANTS,
     GrantSearchToolset,
+    SelectedRFPToolset,
 )
+from researchhub_access_group.constants import ADMIN
+from researchhub_access_group.models import Permission
 from researchhub_document.helpers import create_post
-from researchhub_document.related_models.constants.document_type import GRANT
+from researchhub_document.models import ResearchhubUnifiedDocument
+from researchhub_document.related_models.constants.document_type import (
+    GRANT,
+    PREREGISTRATION,
+)
 from user.tests.helpers import create_random_authenticated_user
 
 
@@ -148,3 +159,99 @@ class GrantSearchToolsetTests(TestCase):
         # Assert
         self.assertEqual(missing, {"error": "query is required"})
         self.assertEqual(oversized, {"error": "query exceeds 500 characters"})
+
+
+class SelectedRFPToolsetTests(TestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("selected_rfp_user")
+        self.owner = create_random_authenticated_user("selected_rfp_owner")
+        self.note, _content = create_note(self.user, organization=None)
+        self.note.document_type = PREREGISTRATION
+        self.note.save(update_fields=["document_type"])
+        Permission.objects.create(
+            access_type=ADMIN,
+            content_type=ContentType.objects.get_for_model(ResearchhubUnifiedDocument),
+            object_id=self.note.unified_document_id,
+            user=self.user,
+        )
+
+    def _grant(self, *, is_public=True):
+        post = create_post(
+            created_by=self.owner,
+            document_type=GRANT,
+            title="Reproducibility RFP",
+        )
+        post.slug = "reproducibility-rfp"
+        post.discussion_src.save(
+            "rfp.md",
+            ContentFile(b"# Full call\nApplicants must publish their methods."),
+        )
+        post.save(update_fields=["slug"])
+        post.unified_document.is_public = is_public
+        post.unified_document.save(update_fields=["is_public"])
+        return Grant.objects.create(
+            created_by=self.owner,
+            unified_document=post.unified_document,
+            short_title="Reproducibility RFP",
+            organization="Research Foundation",
+            description="Funding for reproducible research.",
+            amount=Decimal("75000.00"),
+            currency="USD",
+            status=Grant.OPEN,
+            end_date=timezone.now() + timedelta(days=30),
+        )
+
+    def _read(self):
+        toolset = SelectedRFPToolset(note=self.note, user=self.user).as_toolset()
+        result, stop = toolset.dispatch(READ_SELECTED_RFP, {})
+        self.assertFalse(stop)
+        return result
+
+    def test_reads_selected_rfp_full_text_and_terms(self):
+        # Arrange
+        grant = self._grant()
+        self.note.selected_grant = grant
+        self.note.save(update_fields=["selected_grant"])
+
+        # Act
+        result = self._read()
+
+        # Assert
+        self.assertEqual(result["id"], grant.id)
+        self.assertEqual(result["title"], "Reproducibility RFP")
+        self.assertEqual(result["amount"], "75000.00")
+        self.assertIn("Funding for reproducible research.", result["rfp_text"])
+        self.assertIn("Applicants must publish their methods.", result["rfp_text"])
+        self.assertIn("/grant/", result["url"])
+
+    def test_reports_when_preregistration_has_no_selected_rfp(self):
+        # Act
+        result = self._read()
+
+        # Assert
+        self.assertEqual(result, {"error": "this preregistration has no selected RFP"})
+
+    def test_does_not_expose_an_rfp_the_user_can_no_longer_view(self):
+        # Arrange: model a grant becoming private after it was selected.
+        grant = self._grant(is_public=False)
+        self.note.selected_grant = grant
+        self.note.save(update_fields=["selected_grant"])
+
+        # Act
+        result = self._read()
+
+        # Assert
+        self.assertEqual(result, {"error": "selected RFP not found or not accessible"})
+
+    def test_refuses_a_non_preregistration_note(self):
+        # Arrange
+        grant = self._grant()
+        self.note.document_type = "NOTE"
+        self.note.selected_grant = grant
+        self.note.save(update_fields=["document_type", "selected_grant"])
+
+        # Act
+        result = self._read()
+
+        # Assert
+        self.assertEqual(result, {"error": "selected RFP not found or not accessible"})

--- a/src/research_ai/tests/notebook_chat/test_grant_tools.py
+++ b/src/research_ai/tests/notebook_chat/test_grant_tools.py
@@ -165,7 +165,7 @@ class SelectedRFPToolsetTests(TestCase):
     def setUp(self):
         self.user = create_random_authenticated_user("selected_rfp_user")
         self.owner = create_random_authenticated_user("selected_rfp_owner")
-        self.note, _content = create_note(self.user, organization=None)
+        self.note, _ = create_note(self.user, organization=None)
         self.note.document_type = PREREGISTRATION
         self.note.save(update_fields=["document_type"])
         Permission.objects.create(

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
@@ -782,6 +782,54 @@ class NotebookChatActivityProjectionTests(TestCase):
         self.execution.save(update_fields=["status"])
         self.assertEqual(self._single_event()["status"], "interrupted")
 
+    def test_selected_rfp_read_has_a_safe_label_and_source(self):
+        # Arrange
+        self._add_trace_row(
+            1,
+            [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "read_selected_rfp",
+                    "input": {},
+                }
+            ],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+        self._add_trace_row(
+            2,
+            [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "t1",
+                    "content": {
+                        "title": "Reproducibility RFP",
+                        "url": "https://example.org/rfp",
+                        "rfp_text": "Private full call text",
+                    },
+                }
+            ],
+            AgentExecutionMessage.Provenance.TOOL,
+            role="user",
+        )
+        self._finish()
+
+        # Act
+        event = self._single_event()
+
+        # Assert
+        self.assertEqual(event["label"], "Read the selected RFP")
+        self.assertEqual(
+            event["sources"],
+            [
+                {
+                    "title": "Reproducibility RFP",
+                    "url": "https://example.org/rfp",
+                }
+            ],
+        )
+        self.assertNotIn("Private full call text", json.dumps(event, default=str))
+
     def test_live_turn_shows_its_newest_text_but_a_succeeded_turn_does_not(self):
         # Arrange: the only assistant text so far, which is either narration in
         # progress or the answer, depending on whether the run is over.

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -36,6 +36,7 @@ from research_ai.tests.notebook_chat.test_notebook_chat_events import FakeChanne
 from researchhub_access_group.constants import ADMIN
 from researchhub_access_group.models import Permission
 from researchhub_document.models import ResearchhubUnifiedDocument
+from researchhub_document.related_models.constants.document_type import PREREGISTRATION
 
 EDITED_DOC = {
     "type": "doc",
@@ -109,9 +110,21 @@ class NotebookChatServiceTests(TestCase):
         self.assertEqual(execution.status, AgentExecution.Status.PENDING)
         self.assertIn(str(self.note.id), execution.system_prompt)
         self.assertIn(self.note.title, execution.system_prompt)
+        self.assertNotIn("read_selected_rfp", execution.system_prompt)
         self.assertEqual(execution.configuration["note_id"], self.note.id)
         self.assertEqual(execution.trigger_message.content, "Please add a summary.")
         delay.assert_called_once_with(execution.id)
+
+    def test_submit_message_mentions_selected_rfp_tool_for_preregistration(self):
+        # Arrange
+        self.note.document_type = PREREGISTRATION
+        self.note.save(update_fields=["document_type"])
+
+        # Act
+        execution, _delay = self._submit()
+
+        # Assert
+        self.assertIn("read_selected_rfp", execution.system_prompt)
 
     def test_second_message_continues_the_same_conversation(self):
         # Arrange
@@ -280,6 +293,40 @@ class NotebookChatServiceTests(TestCase):
         self.assertEqual(result["final_text"], "Done.")
         grant_toolset_factory.assert_called_once_with(user=self.user)
         grant_toolset.build_tools.assert_called_once_with()
+
+    def test_run_turn_passes_selected_rfp_toolset_for_preregistration(self):
+        # Arrange
+        self.note.document_type = PREREGISTRATION
+        self.note.save(update_fields=["document_type"])
+        execution, _delay = self._submit()
+        provider = FakeProvider([text_turn("Done.")])
+
+        # Act
+        with patch(
+            "research_ai.services.notebook_chat.service.SelectedRFPToolset"
+        ) as selected_rfp_toolset:
+            selected_rfp_toolset.return_value.build_tools.return_value = []
+            result = _make_service(provider=provider).run_turn(execution.id)
+
+        # Assert
+        self.assertEqual(result["final_text"], "Done.")
+        selected_rfp_toolset.assert_called_once_with(note=self.note, user=self.user)
+        selected_rfp_toolset.return_value.build_tools.assert_called_once_with()
+
+    def test_run_turn_omits_selected_rfp_toolset_for_other_notes(self):
+        # Arrange
+        execution, _delay = self._submit()
+        provider = FakeProvider([text_turn("Done.")])
+
+        # Act
+        with patch(
+            "research_ai.services.notebook_chat.service.SelectedRFPToolset"
+        ) as selected_rfp_toolset:
+            result = _make_service(provider=provider).run_turn(execution.id)
+
+        # Assert
+        self.assertEqual(result["final_text"], "Done.")
+        selected_rfp_toolset.assert_not_called()
 
     def test_run_turn_honors_the_recorded_iteration_limit(self):
         # Arrange: the turn was submitted with a one-iteration budget; the


### PR DESCRIPTION
## Summary

- add a permission-aware `read_selected_rfp` notebook tool that returns the selected grant's full RFP text and structured terms
- expose the tool and its prompt guidance only for preregistration notes
- add safe notebook activity labels and citation metadata without leaking raw RFP content
- cover selected-RFP reads, missing/inaccessible grants, conditional composition, prompt behavior, and activity projection

## Tests

- `uv run python manage.py test research_ai.tests.notebook_chat.test_grant_tools research_ai.tests.notebook_chat.test_notebook_chat_service research_ai.tests.notebook_chat.test_notebook_chat_activity` (92 tests)
- `uv run ruff check ...`
- `uv run ruff format --check --diff ...`
- `git diff --check`

No database migration is required.