### PR TITLE
Enable feed caching for moderators and hub editors

### DIFF
--- a/src/feed/activity_feed_cache.py
+++ b/src/feed/activity_feed_cache.py
@@ -33,6 +33,7 @@ def should_cache_activity_feed(request: Request) -> bool:
         or params.get("funder_id")
         or params.get("document_type")
         or params.get("content_type")
+        or params.get("include_hot_score_breakdown", "").lower() == "true"
     ):
         return False
 

--- a/src/feed/activity_feed_cache.py
+++ b/src/feed/activity_feed_cache.py
@@ -26,12 +26,6 @@ def activity_feed_cache_key(
 
 def should_cache_activity_feed(request: Request) -> bool:
     """Return whether this request may use the shared public activity-feed cache."""
-    user = request.user
-    if user.is_authenticated and (
-        getattr(user, "moderator", False) or user.is_hub_editor()
-    ):
-        return False
-
     params = request.query_params
     if (
         params.get("scope")

--- a/src/feed/cache_segment.py
+++ b/src/feed/cache_segment.py
@@ -6,7 +6,7 @@ from researchhub_document.related_models.researchhub_post_model import Researchh
 def get_feed_cache_segment(request: Request) -> tuple[str | None, bool]:
     """Return (suffix, should_cache) for grant/funding feed page caching.
 
-    suffix is ``:public`` or ``:viewer-{user_id}``.
+    suffix is ``:public``, ``:admin``, or ``:viewer-{user_id}``.
     """
     user = request.user
 
@@ -14,7 +14,7 @@ def get_feed_cache_segment(request: Request) -> tuple[str | None, bool]:
         return ":public", True
 
     if user.is_moderator_or_editor():
-        return ":public", True
+        return ":admin", True
 
     has_private_visibility = (
         ResearchhubPost.objects.visible_to(user)

--- a/src/feed/cache_segment.py
+++ b/src/feed/cache_segment.py
@@ -6,15 +6,9 @@ from researchhub_document.related_models.researchhub_post_model import Researchh
 def get_feed_cache_segment(request: Request) -> tuple[str | None, bool]:
     """Return (suffix, should_cache) for grant/funding feed page caching.
 
-    suffix is ``:public``, ``:viewer-{user_id}``, or ``None`` when caching is
-    disabled (moderators and hub editors always get a fresh response).
+    suffix is ``:public`` or ``:viewer-{user_id}``.
     """
     user = request.user
-
-    if user.is_authenticated and (
-        getattr(user, "moderator", False) or user.is_hub_editor()
-    ):
-        return None, False
 
     if not user.is_authenticated:
         return ":public", True

--- a/src/feed/cache_segment.py
+++ b/src/feed/cache_segment.py
@@ -13,6 +13,9 @@ def get_feed_cache_segment(request: Request) -> tuple[str | None, bool]:
     if not user.is_authenticated:
         return ":public", True
 
+    if user.is_moderator_or_editor():
+        return ":public", True
+
     has_private_visibility = (
         ResearchhubPost.objects.visible_to(user)
         .filter(

--- a/src/feed/feed_list_dto.py
+++ b/src/feed/feed_list_dto.py
@@ -204,11 +204,19 @@ def _serialize_application_key_insight(application, review_by_ud):
 def serialize_slim_grant_applications(grant, context):
     request = context.get("request")
     viewer = getattr(request, "user", None) if request else None
-    is_grant_reviewer = (
-        viewer is not None
-        and getattr(viewer, "is_authenticated", False)
-        and grant.created_by_id == viewer.id
-    )
+    viewer_authed = viewer is not None and getattr(viewer, "is_authenticated", False)
+    is_grant_reviewer = viewer_authed and grant.created_by_id == viewer.id
+
+    # Match DynamicGrantSerializer.get_applications: moderators and hub editors
+    # may view private applications on any grant, not only ones they created.
+    privileged = context.get("_grant_private_app_viewer")
+    if privileged is None:
+        privileged = viewer_authed and (
+            getattr(viewer, "moderator", False) or viewer.is_hub_editor()
+        )
+        context["_grant_private_app_viewer"] = privileged
+
+    can_view_private = privileged or is_grant_reviewer
     include_key_insights = context.get("include_key_insights", False)
 
     review_by_ud = {}
@@ -225,8 +233,8 @@ def serialize_slim_grant_applications(grant, context):
             continue
 
         proposal_document = application.preregistration_post.unified_document
-        if not proposal_document.is_public and not is_grant_reviewer:
-            if not viewer or not getattr(viewer, "is_authenticated", False):
+        if not proposal_document.is_public and not can_view_private:
+            if not viewer_authed:
                 continue
             if application.applicant_id != viewer.id:
                 continue

--- a/src/feed/tests/test_cache_segment.py
+++ b/src/feed/tests/test_cache_segment.py
@@ -110,7 +110,7 @@ class FeedCacheSegmentTests(AWSMockTestCase):
         self.assertEqual(suffix, f":viewer-{owner.id}")
         self.assertTrue(should_cache)
 
-    def test_moderator_with_private_posts_uses_viewer_segment(self):
+    def test_moderator_with_private_posts_uses_public_segment(self):
         # Arrange
         moderator = create_random_authenticated_user("cache_seg_mod", moderator=True)
         private_doc = ResearchhubUnifiedDocument.objects.create(
@@ -130,5 +130,18 @@ class FeedCacheSegmentTests(AWSMockTestCase):
         suffix, should_cache = get_feed_cache_segment(self._request(moderator))
 
         # Assert
-        self.assertEqual(suffix, f":viewer-{moderator.id}")
+        self.assertEqual(suffix, ":public")
+        self.assertTrue(should_cache)
+
+    def test_hub_editor_uses_public_segment(self):
+        # Arrange
+        from user.tests.helpers import create_hub_editor
+
+        editor, _ = create_hub_editor("cache_seg_editor", "Cache Seg Hub")
+
+        # Act
+        suffix, should_cache = get_feed_cache_segment(self._request(editor))
+
+        # Assert
+        self.assertEqual(suffix, ":public")
         self.assertTrue(should_cache)

--- a/src/feed/tests/test_cache_segment.py
+++ b/src/feed/tests/test_cache_segment.py
@@ -110,7 +110,7 @@ class FeedCacheSegmentTests(AWSMockTestCase):
         self.assertEqual(suffix, f":viewer-{owner.id}")
         self.assertTrue(should_cache)
 
-    def test_moderator_disables_caching_even_with_private_posts(self):
+    def test_moderator_with_private_posts_uses_viewer_segment(self):
         # Arrange
         moderator = create_random_authenticated_user("cache_seg_mod", moderator=True)
         private_doc = ResearchhubUnifiedDocument.objects.create(
@@ -130,5 +130,5 @@ class FeedCacheSegmentTests(AWSMockTestCase):
         suffix, should_cache = get_feed_cache_segment(self._request(moderator))
 
         # Assert
-        self.assertIsNone(suffix)
-        self.assertFalse(should_cache)
+        self.assertEqual(suffix, f":viewer-{moderator.id}")
+        self.assertTrue(should_cache)

--- a/src/feed/tests/test_cache_segment.py
+++ b/src/feed/tests/test_cache_segment.py
@@ -110,7 +110,7 @@ class FeedCacheSegmentTests(AWSMockTestCase):
         self.assertEqual(suffix, f":viewer-{owner.id}")
         self.assertTrue(should_cache)
 
-    def test_moderator_with_private_posts_uses_public_segment(self):
+    def test_moderator_with_private_posts_uses_admin_segment(self):
         # Arrange
         moderator = create_random_authenticated_user("cache_seg_mod", moderator=True)
         private_doc = ResearchhubUnifiedDocument.objects.create(
@@ -130,10 +130,10 @@ class FeedCacheSegmentTests(AWSMockTestCase):
         suffix, should_cache = get_feed_cache_segment(self._request(moderator))
 
         # Assert
-        self.assertEqual(suffix, ":public")
+        self.assertEqual(suffix, ":admin")
         self.assertTrue(should_cache)
 
-    def test_hub_editor_uses_public_segment(self):
+    def test_hub_editor_uses_admin_segment(self):
         # Arrange
         from user.tests.helpers import create_hub_editor
 
@@ -143,5 +143,38 @@ class FeedCacheSegmentTests(AWSMockTestCase):
         suffix, should_cache = get_feed_cache_segment(self._request(editor))
 
         # Assert
-        self.assertEqual(suffix, ":public")
+        self.assertEqual(suffix, ":admin")
+        self.assertTrue(should_cache)
+
+    def test_moderator_grant_owner_uses_admin_segment(self):
+        # Arrange
+        moderator = create_random_authenticated_user(
+            "cache_seg_mod_owner", moderator=True
+        )
+        applicant = create_random_authenticated_user("cache_seg_mod_app")
+        grant_post = create_post(created_by=moderator, document_type=GRANT)
+        Grant.objects.create(
+            created_by=moderator,
+            unified_document=grant_post.unified_document,
+            amount=Decimal("1000.00"),
+            currency=USD,
+            organization="Org",
+            description="desc",
+        )
+        private_post = create_post(
+            created_by=applicant, document_type=PREREGISTRATION, title="Private"
+        )
+        private_post.unified_document.is_public = False
+        private_post.unified_document.save()
+        GrantApplication.objects.create(
+            grant=Grant.objects.get(unified_document=grant_post.unified_document),
+            preregistration_post=private_post,
+            applicant=applicant,
+        )
+
+        # Act
+        suffix, should_cache = get_feed_cache_segment(self._request(moderator))
+
+        # Assert
+        self.assertEqual(suffix, ":admin")
         self.assertTrue(should_cache)

--- a/src/feed/tests/views/test_activity_feed_view.py
+++ b/src/feed/tests/views/test_activity_feed_view.py
@@ -1895,6 +1895,7 @@ class ActivityFeedCacheTests(ActivityFeedBaseTests):
             {"scope": "financial", "page": 1, "page_size": 20},
             {"grant_id": 1, "page": 1, "page_size": 20},
             {"document_type": "PREREGISTRATION", "page": 1, "page_size": 20},
+            {"include_hot_score_breakdown": "true", "page": 1, "page_size": 20},
             {"page": 21, "page_size": 20},
             {"page": 1, "page_size": 10},
         ]

--- a/src/feed/tests/views/test_activity_feed_view.py
+++ b/src/feed/tests/views/test_activity_feed_view.py
@@ -1843,10 +1843,15 @@ class ActivityFeedCacheTests(ActivityFeedBaseTests):
         self.assertFalse(mock_cache.set.called)
 
     @patch("feed.views.activity_feed_view.cache")
-    def test_moderator_bypasses_cache(self, mock_cache):
+    def test_moderator_uses_cache(self, mock_cache):
         # Arrange
         from user.tests.helpers import create_random_authenticated_user
 
+        mock_cache.get.return_value = {
+            "next": None,
+            "previous": None,
+            "results": [{"id": self.prereg_entry.id, "content_object": {"id": 1}}],
+        }
         moderator = create_random_authenticated_user(
             "activity_cache_mod", moderator=True
         )
@@ -1858,14 +1863,19 @@ class ActivityFeedCacheTests(ActivityFeedBaseTests):
 
         # Assert
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        mock_cache.get.assert_not_called()
-        mock_cache.set.assert_not_called()
+        self.assertTrue(mock_cache.get.called)
+        self.assertFalse(mock_cache.set.called)
 
     @patch("feed.views.activity_feed_view.cache")
-    def test_hub_editor_bypasses_cache(self, mock_cache):
+    def test_hub_editor_uses_cache(self, mock_cache):
         # Arrange
         from user.tests.helpers import create_hub_editor
 
+        mock_cache.get.return_value = {
+            "next": None,
+            "previous": None,
+            "results": [{"id": self.prereg_entry.id, "content_object": {"id": 1}}],
+        }
         editor = create_hub_editor("activity_cache_editor", "Activity Cache Hub")[0]
         editor_client = APIClient()
         editor_client.force_authenticate(user=editor)
@@ -1875,8 +1885,8 @@ class ActivityFeedCacheTests(ActivityFeedBaseTests):
 
         # Assert
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        mock_cache.get.assert_not_called()
-        mock_cache.set.assert_not_called()
+        self.assertTrue(mock_cache.get.called)
+        self.assertFalse(mock_cache.set.called)
 
     @patch("feed.views.activity_feed_view.cache")
     def test_scoped_and_filtered_requests_skip_cache(self, mock_cache):

--- a/src/feed/tests/views/test_grant_feed_view.py
+++ b/src/feed/tests/views/test_grant_feed_view.py
@@ -471,6 +471,25 @@ class GrantFeedViewTests(APITestCase):
             response.data["results"][0]["content_object"]["title"], "Open Grant"
         )
 
+    def test_organization_filter_bypasses_cache(self):
+        """organization-filtered responses must not populate discovery cache keys."""
+        # Arrange
+        cache.clear()
+        self.client.force_authenticate(self.user)
+        public_key = (
+            GrantFeedViewSet().get_cache_key(
+                Request(APIRequestFactory().get("/api/grant_feed/")), "grants"
+            )
+            + ":public"
+        )
+
+        # Act
+        response = self.client.get("/api/grant_feed/?organization=NSF")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(cache.get(public_key))
+
     def test_grant_feed_filter_by_organization_partial_match(self):
         """Test grant feed filtering by organization with partial match"""
         self.client.force_authenticate(self.user)

--- a/src/feed/views/activity_feed_view.py
+++ b/src/feed/views/activity_feed_view.py
@@ -70,8 +70,8 @@ class ActivityFeedViewSet(FeedViewMixin, ModelViewSet):
     returns only comments across all grant-related documents.
 
     The unscoped public discovery feed (pages 1–20, page_size=20) may be served
-    from a shared warm cache. Moderators and hub editors always get a live
-    response. Votes are attached after the cache read for authenticated users.
+    from a shared warm cache. Votes are attached after the cache read for
+    authenticated users.
     """
 
     serializer_class = ActivityFeedEntrySerializer

--- a/src/feed/views/funding_cache_mixin.py
+++ b/src/feed/views/funding_cache_mixin.py
@@ -42,7 +42,7 @@ class FundingCacheMixin:
         Delete cached funding-feed list responses
         (pages 1-``FUNDING_FEED_MAX_CACHED_PAGE``).
 
-        Only ``:public`` segment keys that can be written when
+        Only ``:public`` and ``:admin`` segment keys that can be written when
         ``FundingFeedViewSet.list`` uses the cache branch are targeted.
         Per-viewer ``:viewer-{user_id}`` entries are left to TTL.
         Hub-specific ``?hub_slug=`` keys (other than default) are not enumerated;
@@ -79,7 +79,7 @@ class FundingCacheMixin:
                                     if include_ended != "true":
                                         params["include_ended"] = include_ended
                                     req = _funding_invalidation_request(params)
-                                    keys.append(
-                                        view.get_cache_key(req, "funding") + ":public"
-                                    )
+                                    base = view.get_cache_key(req, "funding")
+                                    keys.append(base + ":public")
+                                    keys.append(base + ":admin")
         cache.delete_many(list(dict.fromkeys(keys)))

--- a/src/feed/views/grant_cache_mixin.py
+++ b/src/feed/views/grant_cache_mixin.py
@@ -47,6 +47,7 @@ class GrantCacheMixin:
                                 f"{created_by}:{include_key_insights}"
                             )
                             cache.delete(cache_key + ":public")
+                            cache.delete(cache_key + ":admin")
 
     @staticmethod
     def invalidate_if_grant_linked(unified_document):

--- a/src/feed/views/grant_feed_view.py
+++ b/src/feed/views/grant_feed_view.py
@@ -55,8 +55,11 @@ class GrantFeedViewSet(GrantCacheMixin, FeedViewMixin, ReadOnlyModelViewSet):
     def list(self, request, *args, **kwargs):
         page = request.query_params.get("page", "1")
         page_num = int(page)
+        organization = request.query_params.get("organization")
         suffix, should_cache = get_feed_cache_segment(request)
-        use_cache = should_cache and page_num <= GRANT_FEED_MAX_CACHED_PAGE
+        use_cache = (
+            should_cache and page_num <= GRANT_FEED_MAX_CACHED_PAGE and not organization
+        )
         cache_key = (
             (self.get_cache_key(request, "grants") + suffix) if use_cache else None
         )


### PR DESCRIPTION
## What?
- Remove the cache bypass for moderators and hub editors on the activity, grant, and funding feeds