### PR TITLE
Stream tool-call drafts in notebook chat

### DIFF
--- a/src/research_ai/services/agent/providers/claude_platform.py
+++ b/src/research_ai/services/agent/providers/claude_platform.py
@@ -44,8 +44,10 @@ from research_ai.services.agent.types import (
     TextStreamDelta,
     ThinkingBlock,
     ThinkingStreamDelta,
+    ToolInputStreamDelta,
     ToolResultBlock,
     ToolUseBlock,
+    ToolUseStreamStart,
     TurnUsage,
 )
 
@@ -586,14 +588,31 @@ class ClaudePlatformProvider(LLMProvider):
             kwargs["temperature"] = temperature
         return kwargs
 
-    @staticmethod
-    def _report_stream_event(event: Any, on_event) -> None:
-        """Translate SDK deltas into the provider-neutral streaming surface."""
-        if on_event is None or getattr(event, "type", None) != "content_block_delta":
+    # Content block types whose opening marks the model composing a tool call:
+    # our own tools and the ones Anthropic runs server-side (web search, code
+    # execution). Their arguments then arrive as ``input_json_delta`` chunks.
+    _TOOL_USE_BLOCK_TYPES = frozenset({"tool_use", "server_tool_use"})
+
+    @classmethod
+    def _report_stream_event(cls, event: Any, on_event) -> None:
+        """Translate SDK events into the provider-neutral streaming surface."""
+        if on_event is None:
             return
         index = getattr(event, "index", None)
+        if not isinstance(index, int):
+            return
+        event_type = getattr(event, "type", None)
+        if event_type == "content_block_start":
+            block = getattr(event, "content_block", None)
+            if getattr(block, "type", None) in cls._TOOL_USE_BLOCK_TYPES:
+                name = getattr(block, "name", None)
+                if isinstance(name, str) and name:
+                    on_event(ToolUseStreamStart(block_index=index, name=name))
+            return
+        if event_type != "content_block_delta":
+            return
         delta = getattr(event, "delta", None)
-        if not isinstance(index, int) or delta is None:
+        if delta is None:
             return
         delta_type = getattr(delta, "type", None)
         if delta_type == "text_delta":
@@ -604,6 +623,12 @@ class ClaudePlatformProvider(LLMProvider):
             thinking = getattr(delta, "thinking", None)
             if isinstance(thinking, str) and thinking:
                 on_event(ThinkingStreamDelta(block_index=index, text=thinking))
+        elif delta_type == "input_json_delta":
+            partial_json = getattr(delta, "partial_json", None)
+            if isinstance(partial_json, str) and partial_json:
+                on_event(
+                    ToolInputStreamDelta(block_index=index, partial_json=partial_json)
+                )
 
     def _render_messages(
         self, messages: list[Message], *, cache_last: bool = False

--- a/src/research_ai/services/agent/providers/claude_platform.py
+++ b/src/research_ai/services/agent/providers/claude_platform.py
@@ -598,37 +598,56 @@ class ClaudePlatformProvider(LLMProvider):
         """Translate SDK events into the provider-neutral streaming surface."""
         if on_event is None:
             return
+        stream_event = cls._stream_event(event)
+        if stream_event is not None:
+            on_event(stream_event)
+
+    @classmethod
+    def _stream_event(cls, event: Any) -> ProviderStreamEvent | None:
+        """Return the provider-neutral event represented by one SDK event."""
         index = getattr(event, "index", None)
         if not isinstance(index, int):
-            return
+            return None
         event_type = getattr(event, "type", None)
         if event_type == "content_block_start":
-            block = getattr(event, "content_block", None)
-            if getattr(block, "type", None) in cls._TOOL_USE_BLOCK_TYPES:
-                name = getattr(block, "name", None)
-                if isinstance(name, str) and name:
-                    on_event(ToolUseStreamStart(block_index=index, name=name))
-            return
-        if event_type != "content_block_delta":
-            return
+            return cls._tool_use_stream_start(event, index)
+        if event_type == "content_block_delta":
+            return cls._stream_delta(event, index)
+        return None
+
+    @classmethod
+    def _tool_use_stream_start(
+        cls, event: Any, index: int
+    ) -> ToolUseStreamStart | None:
+        block = getattr(event, "content_block", None)
+        if getattr(block, "type", None) not in cls._TOOL_USE_BLOCK_TYPES:
+            return None
+        name = getattr(block, "name", None)
+        if not isinstance(name, str) or not name:
+            return None
+        return ToolUseStreamStart(block_index=index, name=name)
+
+    @staticmethod
+    def _stream_delta(event: Any, index: int) -> ProviderStreamEvent | None:
         delta = getattr(event, "delta", None)
         if delta is None:
-            return
+            return None
         delta_type = getattr(delta, "type", None)
         if delta_type == "text_delta":
             text = getattr(delta, "text", None)
             if isinstance(text, str) and text:
-                on_event(TextStreamDelta(block_index=index, text=text))
-        elif delta_type == "thinking_delta":
+                return TextStreamDelta(block_index=index, text=text)
+        if delta_type == "thinking_delta":
             thinking = getattr(delta, "thinking", None)
             if isinstance(thinking, str) and thinking:
-                on_event(ThinkingStreamDelta(block_index=index, text=thinking))
-        elif delta_type == "input_json_delta":
+                return ThinkingStreamDelta(block_index=index, text=thinking)
+        if delta_type == "input_json_delta":
             partial_json = getattr(delta, "partial_json", None)
             if isinstance(partial_json, str) and partial_json:
-                on_event(
-                    ToolInputStreamDelta(block_index=index, partial_json=partial_json)
+                return ToolInputStreamDelta(
+                    block_index=index, partial_json=partial_json
                 )
+        return None
 
     def _render_messages(
         self, messages: list[Message], *, cache_last: bool = False

--- a/src/research_ai/services/agent/types.py
+++ b/src/research_ai/services/agent/types.py
@@ -169,13 +169,46 @@ class ThinkingStreamDelta:
 
 
 @dataclass(frozen=True)
+class ToolUseStreamStart:
+    """A tool-use block opened in an in-flight provider turn.
+
+    Emitted when the model begins composing a tool call -- client-side or
+    server-side -- so an observer can show what the model is about to do
+    while the (often long) arguments stream in.
+    """
+
+    block_index: int
+    name: str
+    type: str = "tool_use_start"
+
+
+@dataclass(frozen=True)
+class ToolInputStreamDelta:
+    """One fragment of a tool call's JSON arguments from an in-flight turn.
+
+    ``partial_json`` is a raw slice of the arguments document; fragments
+    concatenate into valid JSON only once the block completes.
+    """
+
+    block_index: int
+    partial_json: str
+    type: str = "input_json_delta"
+
+
+@dataclass(frozen=True)
 class StreamReset:
     """Discard the current preview before a provider replaces an attempt."""
 
     type: str = "stream_reset"
 
 
-ProviderStreamEvent = TextStreamDelta | ThinkingStreamDelta | StreamReset
+ProviderStreamEvent = (
+    TextStreamDelta
+    | ThinkingStreamDelta
+    | ToolUseStreamStart
+    | ToolInputStreamDelta
+    | StreamReset
+)
 
 
 @dataclass(frozen=True)

--- a/src/research_ai/services/notebook_chat/activity.py
+++ b/src/research_ai/services/notebook_chat/activity.py
@@ -68,6 +68,13 @@ _ACTIVE_LABELS = {
     GET_AUTHOR_WORKS: "Fetching an author's publications",
     GET_WORK_FULLTEXT: "Reading a paper",
 }
+# What the model is doing while it is still writing a tool call's arguments.
+# Only tools whose arguments are substantial work in themselves need copy
+# distinct from the active label: an edit is drafted for seconds before the
+# call runs, whereas a search query is written in an instant.
+_DRAFTING_LABELS = {
+    EDIT_NOTE: "Drafting an edit",
+}
 # The input field per tool whose value is the user's own kind of text -- safe
 # and meaningful to echo as the event detail.
 _DETAIL_INPUT_FIELDS = {
@@ -227,6 +234,15 @@ def _active_label(tool: str) -> str:
     if tool in _ACTIVE_LABELS:
         return _ACTIVE_LABELS[tool]
     return f"Running {tool}" if tool else "Running a tool"
+
+
+def drafting_label(tool: str) -> str:
+    """Live copy for a tool call the model is composing but has not sent."""
+    if tool in _DRAFTING_LABELS:
+        return _DRAFTING_LABELS[tool]
+    if tool in _ACTIVE_LABELS:
+        return _ACTIVE_LABELS[tool]
+    return f"Preparing {tool}" if tool else "Preparing a tool call"
 
 
 def _status(event: ToolCallEvent, execution_active: bool) -> str:

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -65,6 +65,10 @@ from research_ai.services.agent_persistence.activity import (
 )
 from research_ai.services.note_tools import NoteToolset
 from research_ai.services.notebook_chat.activity import (
+    PHASE_RESPONDING,
+    PHASE_THINKING,
+    PHASE_USING_TOOL,
+    drafting_label,
     execution_phase,
     public_activity,
 )
@@ -330,13 +334,20 @@ class NotebookChatService:
                 last_item = stream["items"][-1]
                 if last_item.get("type") == "narration":
                     execution["phase"] = {
-                        "state": "responding",
+                        "state": PHASE_RESPONDING,
                         "label": "Writing a response",
                     }
                 elif last_item.get("type") == "thinking":
                     execution["phase"] = {
-                        "state": "thinking",
+                        "state": PHASE_THINKING,
                         "label": "Thinking",
+                    }
+                elif last_item.get("type") == "tool_draft":
+                    tool = last_item.get("tool") or ""
+                    execution["phase"] = {
+                        "state": PHASE_USING_TOOL,
+                        "label": last_item.get("label") or drafting_label(tool),
+                        "tool": tool or None,
                     }
         return data
 

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -126,6 +126,33 @@ def _derive_title(text: str) -> str:
     return " ".join(text.split())[:TITLE_MAX_CHARS].rstrip()
 
 
+def _stream_phase(stream: dict | None) -> dict | None:
+    """Return the live phase implied by the newest transient stream item."""
+    if not stream or not stream.get("items"):
+        return None
+
+    last_item = stream["items"][-1]
+    item_type = last_item.get("type")
+    if item_type == "narration":
+        return {
+            "state": PHASE_RESPONDING,
+            "label": "Writing a response",
+        }
+    if item_type == "thinking":
+        return {
+            "state": PHASE_THINKING,
+            "label": "Thinking",
+        }
+    if item_type == "tool_draft":
+        tool = last_item.get("tool") or ""
+        return {
+            "state": PHASE_USING_TOOL,
+            "label": last_item.get("label") or drafting_label(tool),
+            "tool": tool or None,
+        }
+    return None
+
+
 class NotebookChatService:
     """Prepare and run notebook chat turns.
 
@@ -330,25 +357,9 @@ class NotebookChatService:
             # A live provider delta is newer than the last durable trace row.
             # It can therefore refine the coarse phase without becoming
             # durable state itself.
-            if stream and stream.get("items"):
-                last_item = stream["items"][-1]
-                if last_item.get("type") == "narration":
-                    execution["phase"] = {
-                        "state": PHASE_RESPONDING,
-                        "label": "Writing a response",
-                    }
-                elif last_item.get("type") == "thinking":
-                    execution["phase"] = {
-                        "state": PHASE_THINKING,
-                        "label": "Thinking",
-                    }
-                elif last_item.get("type") == "tool_draft":
-                    tool = last_item.get("tool") or ""
-                    execution["phase"] = {
-                        "state": PHASE_USING_TOOL,
-                        "label": last_item.get("label") or drafting_label(tool),
-                        "tool": tool or None,
-                    }
+            stream_phase = _stream_phase(stream)
+            if stream_phase is not None:
+                execution["phase"] = stream_phase
         return data
 
     @staticmethod

--- a/src/research_ai/services/notebook_chat/streaming.py
+++ b/src/research_ai/services/notebook_chat/streaming.py
@@ -5,6 +5,13 @@ authoritative message. This module holds only a bounded user-visible preview:
 small coalesced WebSocket deltas for the fast path and one cache snapshot for
 reconnect and polling recovery.
 
+Three item kinds share the preview: ``narration`` (answer text), ``thinking``
+(readable reasoning) and ``tool_draft`` -- a tool call the model is composing.
+Draft items carry the tool name and a label from the moment the block opens,
+so the client can say what the model is doing during the long stretches where
+every output token is a tool argument; for tools whose arguments are note
+prose (``edit_note``) the text being written streams into the item as well.
+
 The preview is deliberately best-effort. Execution status is durable and
 authoritative, so clients must discard preview events after an execution has
 settled. That rule keeps cancellation independent from Redis availability and
@@ -21,6 +28,13 @@ from research_ai.services.agent.types import (
     StreamReset,
     TextStreamDelta,
     ThinkingStreamDelta,
+    ToolInputStreamDelta,
+    ToolUseStreamStart,
+)
+from research_ai.services.notebook_chat.activity import drafting_label
+from research_ai.services.notebook_chat.tool_draft import (
+    TOOL_DRAFT_PROSE_TOOLS,
+    ToolDraftTextExtractor,
 )
 
 STREAM_DELTA = "stream_delta"
@@ -31,6 +45,14 @@ STREAM_ACTIVE_CHECK_INTERVAL_SECONDS = 1.0
 STREAM_PUBLISH_TIMEOUT_SECONDS = 5.0
 MAX_STREAM_TEXT_CHARS = 100_000
 MAX_STREAM_THINKING_CHARS = 4_000
+# A drafted edit is the prose of the blocks being rewritten -- a few
+# paragraphs in practice; the bound only stops a runaway call from growing
+# the per-flush snapshot without limit.
+MAX_STREAM_TOOL_DRAFT_CHARS = 20_000
+
+ITEM_NARRATION = "narration"
+ITEM_THINKING = "thinking"
+ITEM_TOOL_DRAFT = "tool_draft"
 
 
 def _cache_key(execution_id: int) -> str:
@@ -82,6 +104,8 @@ class NotebookStreamBuffer:
         self.items: OrderedDict[str, dict] = OrderedDict()
         self.pending: OrderedDict[str, dict] = OrderedDict()
         self.pending_chars = 0
+        # Per draft item, the scanner turning argument JSON into prose.
+        self.drafts: dict[str, ToolDraftTextExtractor] = {}
         self.last_flush_at: float | None = None
         self.last_active_check_at: float | None = None
         self.stream_revision = 0
@@ -102,18 +126,17 @@ class NotebookStreamBuffer:
 
         item_id = f"iteration-{iteration}:block-{event.block_index}:{item_type}"
         item = self.items.get(item_id)
+        opened = item is None
         if item is None:
-            item = {
-                "id": item_id,
-                "type": item_type,
-                "text": "",
-                "at": timezone.now().isoformat(),
-            }
+            item = self._new_item(item_id, item_type, event)
             self.items[item_id] = item
 
         room = maximum - len(item["text"])
-        fragment = event.text[: max(0, room)]
-        if not fragment:
+        fragment = self._fragment(item, event)[: max(0, room)]
+        # A tool-use start carries no text but must still announce its item;
+        # anything else with nothing to show is a no-op.
+        announces = opened and isinstance(event, ToolUseStreamStart)
+        if not fragment and not announces:
             return
         item["text"] += fragment
 
@@ -125,17 +148,49 @@ class NotebookStreamBuffer:
                 "delta": "",
                 "at": item["at"],
             }
+            if item_type == ITEM_TOOL_DRAFT:
+                pending["tool"] = item["tool"]
+                pending["label"] = item["label"]
             self.pending[item_id] = pending
         pending["delta"] += fragment
         self.pending_chars += len(fragment)
 
         now = self.clock()
         if (
-            self.last_flush_at is None
+            # A draft announcement must not wait out the coalescing window:
+            # a server-side tool can follow it with seconds of silence.
+            announces
+            or self.last_flush_at is None
             or now - self.last_flush_at >= STREAM_FLUSH_INTERVAL_SECONDS
             or self.pending_chars >= STREAM_FLUSH_CHARS
         ):
             self.flush(now=now)
+
+    def _new_item(self, item_id: str, item_type: str, event) -> dict:
+        item = {
+            "id": item_id,
+            "type": item_type,
+            "text": "",
+            "at": timezone.now().isoformat(),
+        }
+        if item_type == ITEM_TOOL_DRAFT:
+            # An argument delta without its start event (not expected from
+            # the provider) still gets an item, just an unnamed one.
+            tool = event.name if isinstance(event, ToolUseStreamStart) else ""
+            item["tool"] = tool
+            item["label"] = drafting_label(tool)
+            if tool in TOOL_DRAFT_PROSE_TOOLS:
+                self.drafts[item_id] = ToolDraftTextExtractor()
+        return item
+
+    def _fragment(self, item: dict, event) -> str:
+        """The user-visible text ``event`` adds to ``item``."""
+        if isinstance(event, ToolUseStreamStart):
+            return ""
+        if isinstance(event, ToolInputStreamDelta):
+            extractor = self.drafts.get(item["id"])
+            return extractor.feed(event.partial_json) if extractor else ""
+        return event.text
 
     def flush(self, *, now: float | None = None) -> None:
         if not self.pending or self.iteration is None:
@@ -218,6 +273,7 @@ class NotebookStreamBuffer:
         self.items.clear()
         self.pending.clear()
         self.pending_chars = 0
+        self.drafts.clear()
         self.iteration = iteration
         self.sequence = 0
         self.last_flush_at = None
@@ -245,7 +301,9 @@ class NotebookStreamBuffer:
     @staticmethod
     def _event_shape(event) -> tuple[str | None, int]:
         if isinstance(event, TextStreamDelta):
-            return "narration", MAX_STREAM_TEXT_CHARS
+            return ITEM_NARRATION, MAX_STREAM_TEXT_CHARS
         if isinstance(event, ThinkingStreamDelta):
-            return "thinking", MAX_STREAM_THINKING_CHARS
+            return ITEM_THINKING, MAX_STREAM_THINKING_CHARS
+        if isinstance(event, ToolUseStreamStart | ToolInputStreamDelta):
+            return ITEM_TOOL_DRAFT, MAX_STREAM_TOOL_DRAFT_CHARS
         return None, 0

--- a/src/research_ai/services/notebook_chat/tool_draft.py
+++ b/src/research_ai/services/notebook_chat/tool_draft.py
@@ -1,0 +1,169 @@
+"""Readable preview of a tool call's arguments while the model writes them.
+
+A notebook turn spends most of its output tokens inside ``edit_note``
+arguments -- the rewritten paragraphs travel as JSON -- and none of that is
+text the provider streams as prose. Showing the raw JSON would be noise, so
+:class:`ToolDraftTextExtractor` scans the argument fragments incrementally and
+surfaces only the strings that are note content:
+
+- bare string elements of any array (compact blocks and inline text runs), and
+- values of a ``"text"`` key (marked text nodes).
+
+Everything else -- ``op``/``type`` enums, attribute values, ids -- is skipped.
+Consecutive strings are separated by a blank line so the preview reads as
+paragraphs. The scanner tolerates fragments split anywhere, including inside
+escape sequences, and never raises on malformed input: the preview is
+best-effort and a broken stream simply stops yielding text.
+"""
+
+from research_ai.services.note_tools import EDIT_NOTE
+
+# Tools whose arguments carry note prose worth previewing. Other tools' inputs
+# (queries, ids, code) still announce themselves via the draft item but surface
+# no text.
+TOOL_DRAFT_PROSE_TOOLS = frozenset({EDIT_NOTE})
+
+_PROSE_KEY = "text"
+_PARAGRAPH_BREAK = "\n\n"
+_SIMPLE_ESCAPES = {
+    '"': '"',
+    "\\": "\\",
+    "/": "/",
+    "b": "\b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+}
+
+_ROLE_KEY = "key"
+_ROLE_PROSE = "prose"
+_ROLE_SKIP = "skip"
+
+
+class ToolDraftTextExtractor:
+    """Feed JSON fragments; get back the prose written since the last feed."""
+
+    def __init__(self):
+        # One entry per open container: ("object", expecting_key) or ("array",).
+        self._stack: list[list] = []
+        self._current_key: str | None = None
+        self._in_string = False
+        self._role = _ROLE_SKIP
+        self._key_chars: list[str] = []
+        self._escaped = False
+        self._unicode_digits: list[str] | None = None
+        self._high_surrogate: str | None = None
+        self._emitted_any = False
+        self._break_pending = False
+
+    def feed(self, fragment: str) -> str:
+        out: list[str] = []
+        for char in fragment:
+            if self._in_string:
+                self._string_char(char, out)
+            else:
+                self._structural_char(char)
+        return "".join(out)
+
+    # -- inside a string ---------------------------------------------------
+
+    def _string_char(self, char: str, out: list[str]) -> None:
+        if self._unicode_digits is not None:
+            self._unicode_digits.append(char)
+            if len(self._unicode_digits) == 4:
+                self._finish_unicode_escape(out)
+            return
+        if self._escaped:
+            self._escaped = False
+            if char == "u":
+                self._unicode_digits = []
+                return
+            self._emit(_SIMPLE_ESCAPES.get(char, char), out)
+            return
+        if char == "\\":
+            self._escaped = True
+            return
+        if char == '"':
+            self._end_string()
+            return
+        self._emit(char, out)
+
+    def _finish_unicode_escape(self, out: list[str]) -> None:
+        digits = "".join(self._unicode_digits or [])
+        self._unicode_digits = None
+        try:
+            code = int(digits, 16)
+        except ValueError:
+            return
+        if 0xD800 <= code <= 0xDBFF:
+            # High surrogate: hold until its low half arrives.
+            self._high_surrogate = chr(code)
+            return
+        if 0xDC00 <= code <= 0xDFFF and self._high_surrogate is not None:
+            pair = self._high_surrogate + chr(code)
+            self._high_surrogate = None
+            self._emit(pair.encode("utf-16", "surrogatepass").decode("utf-16"), out)
+            return
+        self._high_surrogate = None
+        self._emit(chr(code), out)
+
+    def _emit(self, text: str, out: list[str]) -> None:
+        if self._role == _ROLE_KEY:
+            self._key_chars.append(text)
+            return
+        if self._role != _ROLE_PROSE:
+            return
+        if self._break_pending:
+            out.append(_PARAGRAPH_BREAK)
+            self._break_pending = False
+        out.append(text)
+        self._emitted_any = True
+
+    def _end_string(self) -> None:
+        self._in_string = False
+        self._high_surrogate = None
+        if self._role == _ROLE_KEY:
+            self._current_key = "".join(self._key_chars)
+            self._key_chars = []
+        elif self._role == _ROLE_PROSE and self._emitted_any:
+            # Separate this string from the next prose string, but never
+            # emit a leading break: an empty string is not a paragraph.
+            self._break_pending = True
+        self._role = _ROLE_SKIP
+
+    # -- between strings -----------------------------------------------------
+
+    def _structural_char(self, char: str) -> None:
+        top = self._stack[-1] if self._stack else None
+        if char == '"':
+            self._in_string = True
+            self._escaped = False
+            self._role = self._string_role(top)
+            if self._role == _ROLE_KEY:
+                self._key_chars = []
+        elif char == "{":
+            self._stack.append(["object", True])
+        elif char == "[":
+            self._stack.append(["array"])
+        elif char in "}]":
+            if self._stack:
+                self._stack.pop()
+            self._current_key = None
+        elif char == ":":
+            if top is not None and top[0] == "object":
+                top[1] = False
+        elif char == ",":
+            if top is not None and top[0] == "object":
+                top[1] = True
+                self._current_key = None
+
+    def _string_role(self, top: list | None) -> str:
+        """What the string opening now is: a key, prose, or ignorable."""
+        if top is None:
+            return _ROLE_SKIP
+        if top[0] == "object":
+            if top[1]:
+                return _ROLE_KEY
+            return _ROLE_PROSE if self._current_key == _PROSE_KEY else _ROLE_SKIP
+        return _ROLE_PROSE

--- a/src/research_ai/services/notebook_chat/tool_draft.py
+++ b/src/research_ai/services/notebook_chat/tool_draft.py
@@ -153,10 +153,9 @@ class ToolDraftTextExtractor:
         elif char == ":":
             if top is not None and top[0] == "object":
                 top[1] = False
-        elif char == ",":
-            if top is not None and top[0] == "object":
-                top[1] = True
-                self._current_key = None
+        elif char == "," and top is not None and top[0] == "object":
+            top[1] = True
+            self._current_key = None
 
     def _string_role(self, top: list | None) -> str:
         """What the string opening now is: a key, prose, or ignorable."""

--- a/src/research_ai/tests/agent/test_claude_platform_provider.py
+++ b/src/research_ai/tests/agent/test_claude_platform_provider.py
@@ -41,8 +41,10 @@ from research_ai.services.agent.types import (
     TextStreamDelta,
     ThinkingBlock,
     ThinkingStreamDelta,
+    ToolInputStreamDelta,
     ToolResultBlock,
     ToolUseBlock,
+    ToolUseStreamStart,
     TurnUsage,
 )
 
@@ -348,6 +350,65 @@ class CompleteAndParseTests(SimpleTestCase):
             [
                 ThinkingStreamDelta(block_index=0, text="plan "),
                 TextStreamDelta(block_index=1, text="answer"),
+            ],
+        )
+
+    def test_reports_tool_use_starts_and_argument_deltas(self):
+        # Arrange
+        response = _build_response([AnthropicTextBlock(type="text", text="done")])
+        sdk_events = [
+            SimpleNamespace(
+                type="content_block_start",
+                index=0,
+                content_block=SimpleNamespace(type="tool_use", name="edit_note"),
+            ),
+            SimpleNamespace(
+                type="content_block_delta",
+                index=0,
+                delta=SimpleNamespace(type="input_json_delta", partial_json='{"no'),
+            ),
+            # Server-side tools announce themselves the same way.
+            SimpleNamespace(
+                type="content_block_start",
+                index=1,
+                content_block=SimpleNamespace(
+                    type="server_tool_use", name="web_search"
+                ),
+            ),
+            # Text blocks opening is not a tool event.
+            SimpleNamespace(
+                type="content_block_start",
+                index=2,
+                content_block=SimpleNamespace(type="text"),
+            ),
+        ]
+
+        class Messages:
+            def stream(self, **_kwargs):
+                return _FakeStream(response, sdk_events)
+
+        provider = ClaudePlatformProvider(
+            client=SimpleNamespace(messages=Messages()), model_id="claude-opus-5"
+        )
+        observed = []
+
+        # Act
+        provider.complete_with_events(
+            system_prompt="sys",
+            messages=[Message(role="user", content=[TextBlock(text="hi")])],
+            rendered_tools=[],
+            max_tokens=100,
+            temperature=0.0,
+            on_event=observed.append,
+        )
+
+        # Assert
+        self.assertEqual(
+            observed,
+            [
+                ToolUseStreamStart(block_index=0, name="edit_note"),
+                ToolInputStreamDelta(block_index=0, partial_json='{"no'),
+                ToolUseStreamStart(block_index=1, name="web_search"),
             ],
         )
 

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
@@ -598,6 +598,41 @@ class NotebookChatActivityProjectionTests(TestCase):
             {"state": "responding", "label": "Writing a response"},
         )
 
+    def test_live_tool_draft_refines_the_phase_to_the_drafting_label(self):
+        # Arrange
+        snapshot = {
+            "id": f"{self.execution.id}:1",
+            "sequence": 2,
+            "iteration": 1,
+            "items": [
+                {
+                    "id": "iteration-1:block-2:tool_draft",
+                    "type": "tool_draft",
+                    "tool": "edit_note",
+                    "label": "Drafting an edit",
+                    "text": "New opening paragraph.",
+                    "at": timezone.now().isoformat(),
+                }
+            ],
+        }
+        stream_store = Mock()
+        stream_store.get.return_value = snapshot
+        service = _make_service(stream_store=stream_store)
+
+        # Act
+        data = service.representation(self.conversation)
+        (execution,) = data["executions"]
+
+        # Assert
+        self.assertEqual(
+            execution["phase"],
+            {
+                "state": "using_tool",
+                "label": "Drafting an edit",
+                "tool": "edit_note",
+            },
+        )
+
     def test_stream_cache_failure_is_treated_as_a_missing_snapshot(self):
         # Arrange
         stream_store = Mock()

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_streaming.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_streaming.py
@@ -6,9 +6,12 @@ from research_ai.services.agent.types import (
     StreamReset,
     TextStreamDelta,
     ThinkingStreamDelta,
+    ToolInputStreamDelta,
+    ToolUseStreamStart,
 )
 from research_ai.services.notebook_chat.streaming import (
     MAX_STREAM_THINKING_CHARS,
+    MAX_STREAM_TOOL_DRAFT_CHARS,
     ExecutionStreamStore,
     NotebookStreamBuffer,
 )
@@ -116,6 +119,92 @@ class NotebookStreamBufferTests(SimpleTestCase):
         self.assertEqual(item["type"], "thinking")
         self.assertEqual(len(item["text"]), MAX_STREAM_THINKING_CHARS)
         self.assertEqual(len(self.publisher.calls), 1)
+
+    def test_tool_use_start_publishes_a_labeled_draft_immediately(self):
+        # Arrange: a flush just happened, so the coalescing window is open.
+        self.buffer.append(1, TextStreamDelta(block_index=0, text="I'll edit."))
+        self.now += 0.01
+
+        # Act
+        self.buffer.append(1, ToolUseStreamStart(block_index=1, name="edit_note"))
+
+        # Assert: the announcement does not wait out the flush interval.
+        self.assertEqual(len(self.publisher.calls), 2)
+        draft_delta = self.publisher.calls[-1][1]["deltas"][-1]
+        self.assertEqual(
+            draft_delta,
+            {
+                "id": "iteration-1:block-1:tool_draft",
+                "type": "tool_draft",
+                "delta": "",
+                "at": draft_delta["at"],
+                "tool": "edit_note",
+                "label": "Drafting an edit",
+            },
+        )
+        draft_item = self.store.get(9)["items"][-1]
+        self.assertEqual(draft_item["type"], "tool_draft")
+        self.assertEqual(draft_item["tool"], "edit_note")
+        self.assertEqual(draft_item["label"], "Drafting an edit")
+        self.assertEqual(draft_item["text"], "")
+
+    def test_edit_note_argument_json_streams_as_prose(self):
+        # Arrange
+        self.buffer.append(1, ToolUseStreamStart(block_index=0, name="edit_note"))
+        payload = '{"edits": [{"op": "replace", "blocks": ["One.", "Two."]}]}'
+
+        # Act: fragments split mid-string; time passes so each delta flushes.
+        for offset in range(0, len(payload), 7):
+            self.now += 0.1
+            self.buffer.append(
+                1,
+                ToolInputStreamDelta(
+                    block_index=0, partial_json=payload[offset : offset + 7]
+                ),
+            )
+        self.buffer.flush()
+
+        # Assert: the snapshot carries the drafted prose, never raw JSON.
+        item = self.store.get(9)["items"][0]
+        self.assertEqual(item["text"], "One.\n\nTwo.")
+        deltas = [
+            delta["delta"]
+            for call in self.publisher.calls
+            for delta in call[1]["deltas"]
+        ]
+        self.assertEqual("".join(deltas), "One.\n\nTwo.")
+
+    def test_other_tools_announce_but_surface_no_argument_text(self):
+        # Arrange
+        self.buffer.append(1, ToolUseStreamStart(block_index=0, name="web_search"))
+
+        # Act
+        self.now += 1
+        self.buffer.append(
+            1,
+            ToolInputStreamDelta(block_index=0, partial_json='{"query": ["secret"]}'),
+        )
+
+        # Assert: one announcement, and the argument text never leaves it.
+        item = self.store.get(9)["items"][0]
+        self.assertEqual(item["label"], "Searching the web")
+        self.assertEqual(item["text"], "")
+        self.assertEqual(len(self.publisher.calls), 1)
+
+    def test_tool_draft_text_is_bounded(self):
+        # Arrange
+        self.buffer.append(1, ToolUseStreamStart(block_index=0, name="edit_note"))
+        oversized = "x" * (MAX_STREAM_TOOL_DRAFT_CHARS + 10)
+
+        # Act
+        self.buffer.append(
+            1,
+            ToolInputStreamDelta(block_index=0, partial_json=f'["{oversized}"]'),
+        )
+
+        # Assert
+        item = self.store.get(9)["items"][0]
+        self.assertEqual(len(item["text"]), MAX_STREAM_TOOL_DRAFT_CHARS)
 
     def test_clear_removes_the_reconnect_snapshot(self):
         # Arrange

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_tool_draft.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_tool_draft.py
@@ -1,0 +1,89 @@
+import unittest
+
+from research_ai.services.notebook_chat.tool_draft import ToolDraftTextExtractor
+
+
+def _feed_all(extractor: ToolDraftTextExtractor, chunks) -> str:
+    return "".join(extractor.feed(chunk) for chunk in chunks)
+
+
+class ToolDraftTextExtractorTests(unittest.TestCase):
+    def test_extracts_bare_block_strings_and_skips_scalars_and_enums(self):
+        # Arrange
+        payload = (
+            '{"note_id": 1524, "expected_version_id": 7381, "edits": ['
+            '{"op": "replace", "from": 3, "to": 4, '
+            '"blocks": ["First paragraph.", "Second paragraph."]}]}'
+        )
+
+        # Act
+        text = ToolDraftTextExtractor().feed(payload)
+
+        # Assert: prose only, one paragraph break between strings.
+        self.assertEqual(text, "First paragraph.\n\nSecond paragraph.")
+
+    def test_extracts_text_key_values_but_not_other_object_values(self):
+        # Arrange
+        payload = (
+            '{"edits": [{"op": "insert", "at": 0, "blocks": ['
+            '{"type": "heading", "attrs": {"level": 2}, "content": ['
+            '{"type": "text", "text": "Discussion", '
+            '"marks": [{"type": "bold"}]}]}]}]}'
+        )
+
+        # Act
+        text = ToolDraftTextExtractor().feed(payload)
+
+        # Assert: node/mark type names and attrs never surface.
+        self.assertEqual(text, "Discussion")
+
+    def test_fragments_split_anywhere_reassemble_including_escapes(self):
+        # Arrange
+        payload = '{"blocks": ["a \\"quoted\\" word", "tab\\there \\u00e9"]}'
+        chunks = [payload[i : i + 3] for i in range(0, len(payload), 3)]
+
+        # Act
+        text = _feed_all(ToolDraftTextExtractor(), chunks)
+
+        # Assert
+        self.assertEqual(text, 'a "quoted" word\n\ntab\there é')
+
+    def test_surrogate_pair_escapes_decode_to_one_character(self):
+        # Arrange
+        payload = '{"blocks": ["\\ud83d\\ude00"]}'
+
+        # Act
+        text = ToolDraftTextExtractor().feed(payload)
+
+        # Assert
+        self.assertEqual(text, "\U0001f600")
+
+    def test_empty_strings_produce_no_stray_paragraph_breaks(self):
+        # Arrange
+        payload = '{"blocks": ["", "one", "", "two"]}'
+
+        # Act
+        text = ToolDraftTextExtractor().feed(payload)
+
+        # Assert
+        self.assertEqual(text, "one\n\ntwo")
+
+    def test_keys_with_escapes_do_not_leak_into_prose(self):
+        # Arrange: a key containing the word "text" is still just a key.
+        payload = '{"con\\u0074ent": ["prose"], "context": "skipped"}'
+
+        # Act
+        text = ToolDraftTextExtractor().feed(payload)
+
+        # Assert
+        self.assertEqual(text, "prose")
+
+    def test_malformed_input_never_raises(self):
+        # Arrange
+        extractor = ToolDraftTextExtractor()
+
+        # Act
+        text = extractor.feed(']}{"": \\u12 "x" [[')
+
+        # Assert: best-effort silence, not an exception.
+        self.assertIsInstance(text, str)


### PR DESCRIPTION
Most of a notebook turn's output tokens are edit_note arguments, which never streamed: the user saw only 'Thinking' for the 8-18s the model spent drafting an edit. Publish a tool_draft stream item when a tool-use block opens (client and server tools alike), and for edit_note extract the prose out of the argument JSON incrementally so the drafted paragraphs stream into the preview. The live phase reports 'Drafting an edit' while the draft is the newest item.