### PR TITLE
Link the drafted proposal to its RFP and let the agent select one

### DIFF
--- a/src/note/serializers/note_serializer.py
+++ b/src/note/serializers/note_serializer.py
@@ -11,6 +11,11 @@ from rest_framework.serializers import (
 
 from hub.serializers import SimpleHubSerializer
 from note.models import Note, NoteContent
+from note.services.grant_selection_service import (
+    GrantSelectionError,
+    selectable_grants,
+    validate_selection,
+)
 from purchase.models import Grant
 from researchhub.serializers import DynamicModelFieldSerializer
 from researchhub_access_group.constants import (
@@ -89,13 +94,7 @@ class NoteSerializer(ModelSerializer):
         fields = super().get_fields()
         request = self.context.get("request")
         if request is not None and hasattr(self, "initial_data"):
-            visible_document_ids = ResearchhubPost.objects.visible_to(
-                request.user
-            ).values("unified_document_id")
-            fields["selected_grant"].queryset = Grant.objects.filter(
-                unified_document_id__in=visible_document_ids,
-                unified_document__is_removed=False,
-            )
+            fields["selected_grant"].queryset = selectable_grants(request.user)
         return fields
 
     def validate(self, attrs: dict) -> dict:
@@ -114,16 +113,10 @@ class NoteSerializer(ModelSerializer):
         selected_grant = attrs.get(
             "selected_grant", getattr(self.instance, "selected_grant", None)
         )
-        if selected_grant is None:
-            return attrs
-        if document_type != PREREGISTRATION:
-            raise ValidationError(
-                {"selected_grant": "Only preregistration notes can select a grant."}
-            )
-        if not selected_grant.is_active():
-            raise ValidationError(
-                {"selected_grant": "Grant is no longer accepting applications."}
-            )
+        try:
+            validate_selection(document_type=document_type, grant=selected_grant)
+        except GrantSelectionError as exc:
+            raise ValidationError({"selected_grant": str(exc)}) from exc
         return attrs
 
     def get_access(self, note):

--- a/src/note/services/grant_selection_service.py
+++ b/src/note/services/grant_selection_service.py
@@ -1,0 +1,59 @@
+"""Rules for the grant (RFP) a preregistration draft applies to.
+
+The note API and the notebook agent both select a grant, so the rules that
+decide whether a selection is allowed live here rather than in either entry
+point, where they would drift apart.
+"""
+
+from note.models import Note
+from purchase.models import Grant
+from researchhub_document.models import ResearchhubPost
+from researchhub_document.related_models.constants.document_type import PREREGISTRATION
+
+NOT_PREREGISTRATION = "Only preregistration notes can select a grant."
+GRANT_INACTIVE = "Grant is no longer accepting applications."
+NOTE_PUBLISHED = "Published notes cannot change grants."
+
+
+class GrantSelectionError(Exception):
+    """A grant selection the note's or the grant's state does not allow."""
+
+
+def selectable_grants(user):
+    """Grants ``user`` may select: live grants on a post they can see."""
+    visible_document_ids = ResearchhubPost.objects.visible_to(user).values(
+        "unified_document_id"
+    )
+    return Grant.objects.filter(
+        unified_document_id__in=visible_document_ids,
+        unified_document__is_removed=False,
+    )
+
+
+def validate_selection(*, document_type, grant) -> None:
+    """Raise when ``grant`` cannot be selected by a note of ``document_type``.
+
+    Clearing a selection (``grant`` of ``None``) is always allowed, so a note
+    can leave the preregistration type without stranding a grant on it.
+    """
+    if grant is None:
+        return
+    if document_type != PREREGISTRATION:
+        raise GrantSelectionError(NOT_PREREGISTRATION)
+    if not grant.is_active():
+        raise GrantSelectionError(GRANT_INACTIVE)
+
+
+def select_grant(*, note: Note, grant: Grant | None) -> Note:
+    """Persist ``grant`` as ``note``'s selected RFP.
+
+    The whole operation for non-HTTP callers: the API's serializer applies
+    ``validate_selection`` itself and the view owns its own 409 for a published
+    note, so this mirrors both rather than being called from there.
+    """
+    if hasattr(note, "post"):
+        raise GrantSelectionError(NOTE_PUBLISHED)
+    validate_selection(document_type=note.document_type, grant=grant)
+    note.selected_grant = grant
+    note.save(update_fields=["selected_grant", "updated_date"])
+    return note

--- a/src/research_ai/prompts/notebook_chat_prompts.py
+++ b/src/research_ai/prompts/notebook_chat_prompts.py
@@ -14,7 +14,13 @@ _SELECTED_RFP_CAPABILITY = """## The selected RFP
 This preregistration may have a funding opportunity selected. When the user's
 request depends on that RFP's fit, requirements, budget, deadline, or wording,
 call read_selected_rfp before answering or editing. Do not use search_grants to
-guess which RFP is selected."""
+guess which RFP is selected.
+
+When the user asks to apply to a grant, switch to a different one, or drop the
+current one, call set_selected_rfp with the grant id from search_grants (or
+null to clear it), and say which RFP the note now applies to. Selecting is the
+user's decision: confirm which one they mean rather than picking a search
+result for them, and never set an RFP as a side effect of research."""
 
 
 def build_notebook_chat_system_prompt(note) -> str:

--- a/src/research_ai/services/notebook_chat/__init__.py
+++ b/src/research_ai/services/notebook_chat/__init__.py
@@ -7,6 +7,7 @@ from research_ai.services.notebook_chat.events import (
 )
 from research_ai.services.notebook_chat.grant_tools import (
     READ_SELECTED_RFP,
+    SET_SELECTED_RFP,
     GrantSearchToolset,
     SelectedRFPToolset,
 )
@@ -25,6 +26,7 @@ __all__ = [
     "ACTIVITY_ALL",
     "ACTIVITY_LIVE",
     "READ_SELECTED_RFP",
+    "SET_SELECTED_RFP",
     "WORKFLOW",
     "ConversationEventPublisher",
     "GrantSearchToolset",

--- a/src/research_ai/services/notebook_chat/activity.py
+++ b/src/research_ai/services/notebook_chat/activity.py
@@ -33,6 +33,7 @@ from research_ai.services.note_tools import EDIT_NOTE, READ_NOTE
 from research_ai.services.notebook_chat.grant_tools import (
     READ_SELECTED_RFP,
     SEARCH_GRANTS,
+    SET_SELECTED_RFP,
 )
 from research_ai.services.researcher_profile.openalex_tools import GET_WORK_FULLTEXT
 
@@ -48,6 +49,7 @@ _LABELS = {
     WEB_SEARCH: "Searched the web",
     SEARCH_GRANTS: "Searched grants",
     READ_SELECTED_RFP: "Read the selected RFP",
+    SET_SELECTED_RFP: "Selected an RFP",
     SEARCH_INSTITUTIONS: "Searched institutions",
     SEARCH_AUTHORS: "Searched scholarly authors",
     GET_AUTHOR: "Looked up an author",
@@ -62,6 +64,7 @@ _ACTIVE_LABELS = {
     WEB_SEARCH: "Searching the web",
     SEARCH_GRANTS: "Searching grants",
     READ_SELECTED_RFP: "Reading the selected RFP",
+    SET_SELECTED_RFP: "Selecting an RFP",
     SEARCH_INSTITUTIONS: "Searching institutions",
     SEARCH_AUTHORS: "Searching scholarly authors",
     GET_AUTHOR: "Looking up an author",
@@ -284,6 +287,9 @@ def _sources(event: ToolCallEvent) -> list[dict]:
         url_field = "url"
     elif event.tool == READ_SELECTED_RFP:
         items = [result]
+        url_field = "url"
+    elif event.tool == SET_SELECTED_RFP:
+        items = [result.get("selected_rfp")]
         url_field = "url"
     elif event.tool == GET_AUTHOR_WORKS:
         items = result.get("works")

--- a/src/research_ai/services/notebook_chat/grant_tools.py
+++ b/src/research_ai/services/notebook_chat/grant_tools.py
@@ -153,10 +153,17 @@ def _parse_grant_id(args: dict) -> tuple[int | None, dict | None]:
     raw_id = args["grant_id"]
     if raw_id is None:
         return None, None
-    try:
-        return int(raw_id), None
-    except (TypeError, ValueError):
-        return None, {"error": "grant_id must be a grant id or null"}
+    # Coercing with int() would truncate 1.9 to 1 and turn True into 1, quietly
+    # resolving a grant nobody asked for; dispatch does not enforce the
+    # declared integer type, so take a real integer or a digit string, nothing
+    # else.
+    if isinstance(raw_id, int) and not isinstance(raw_id, bool):
+        return raw_id, None
+    if isinstance(raw_id, str):
+        text = raw_id.strip()
+        if text.isascii() and text.isdigit():
+            return int(text), None
+    return None, {"error": "grant_id must be a grant id or null"}
 
 
 class SelectedRFPToolset:

--- a/src/research_ai/services/notebook_chat/grant_tools.py
+++ b/src/research_ai/services/notebook_chat/grant_tools.py
@@ -3,6 +3,11 @@
 import logging
 
 from note.models import Note
+from note.services.grant_selection_service import (
+    GrantSelectionError,
+    select_grant,
+    selectable_grants,
+)
 from purchase.services.grant_search_service import GrantSearchService
 from research_ai.constants import BASE_FRONTEND_URL
 from research_ai.services.agent import Tool, Toolset
@@ -12,11 +17,13 @@ logger = logging.getLogger(__name__)
 
 SEARCH_GRANTS = "search_grants"
 READ_SELECTED_RFP = "read_selected_rfp"
+SET_SELECTED_RFP = "set_selected_rfp"
 _MAX_QUERY_CHARS = 500
 _MAX_DESCRIPTION_CHARS = 3000
 _MAX_POST_CONTENT_CHARS = 3000
 _EMPTY_INPUT_SCHEMA = {"type": "object", "properties": {}}
 _SELECTED_RFP_NOT_ACCESSIBLE = "selected RFP not found or not accessible"
+_NOTE_NOT_ACCESSIBLE = "this preregistration is not accessible"
 
 
 def _grant_url(grant, post=None) -> str | None:
@@ -113,8 +120,26 @@ class GrantSearchToolset:
         }
 
 
+def _grant_terms(grant) -> dict:
+    """The structured grant terms both selected-RFP tools report."""
+    post = grant.unified_document.posts.first()
+    title = (grant.short_title or "").strip()
+    if not title and post is not None:
+        title = (post.title or "").strip()
+    return {
+        "id": grant.id,
+        "title": title,
+        "organization": (grant.organization or "").strip(),
+        "amount": str(grant.amount),
+        "currency": grant.currency,
+        "deadline": grant.end_date.isoformat() if grant.end_date else None,
+        "application_visibility": grant.application_visibility,
+        "url": _grant_url(grant, post),
+    }
+
+
 class SelectedRFPToolset:
-    """Read the RFP explicitly selected for one preregistration note."""
+    """Read and set the RFP one preregistration note applies to."""
 
     def __init__(self, *, note: Note, user):
         self._note_id = note.id
@@ -133,16 +158,139 @@ class SelectedRFPToolset:
                 ),
                 input_schema=_EMPTY_INPUT_SCHEMA,
                 handler=self._read_selected_rfp,
-            )
+            ),
+            Tool(
+                name=SET_SELECTED_RFP,
+                description=(
+                    "Select the RFP this preregistration applies to, replacing "
+                    "any current selection, or pass null to clear it. Only use "
+                    "it when the user asks to apply to, switch to, or drop a "
+                    "funding opportunity -- never to record one you merely "
+                    "found. Take grant_id from search_grants; the grant must "
+                    "still be accepting applications, and a published note "
+                    "cannot change its RFP."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "grant_id": {
+                            "type": ["integer", "null"],
+                            "description": (
+                                "Id of the grant to select, from search_grants, "
+                                "or null to clear the current selection."
+                            ),
+                        }
+                    },
+                    "required": ["grant_id"],
+                },
+                handler=self._set_selected_rfp,
+            ),
         ]
 
     def as_toolset(self) -> Toolset:
         return Toolset(self.build_tools())
 
+    # -- handlers ---------------------------------------------------------
+
     def _read_selected_rfp(self, _args: dict) -> dict:
         if self._user is None or not getattr(self._user, "is_authenticated", False):
             return {"error": _SELECTED_RFP_NOT_ACCESSIBLE}
 
+        try:
+            note = self._readable_note()
+            if note is None:
+                return {"error": _SELECTED_RFP_NOT_ACCESSIBLE}
+
+            grant = note.selected_grant
+            if grant is None:
+                return {"error": "this preregistration has no selected RFP"}
+            if grant.unified_document.is_removed or not (
+                grant.unified_document.is_visible_to_user(self._user)
+            ):
+                return {"error": _SELECTED_RFP_NOT_ACCESSIBLE}
+
+            return {**_grant_terms(grant), "rfp_text": grant.get_llm_context_text()}
+        except Exception:  # noqa: BLE001 - tool failures are model-readable
+            logger.exception("selected RFP read failed for note %s", self._note_id)
+            return {"error": "selected RFP is temporarily unavailable"}
+
+    def _set_selected_rfp(self, args: dict) -> dict:
+        if self._user is None or not getattr(self._user, "is_authenticated", False):
+            return {"error": _NOTE_NOT_ACCESSIBLE}
+
+        raw_id = (args or {}).get("grant_id")
+        # Only an explicit null clears the selection; anything else must name a
+        # grant, so a malformed id is never read as "unset the RFP".
+        if raw_id is not None:
+            try:
+                grant_id = int(raw_id)
+            except (TypeError, ValueError):
+                return {"error": "grant_id must be a grant id or null"}
+        else:
+            grant_id = None
+
+        try:
+            note = self._readable_note()
+            if note is None:
+                return {"error": _NOTE_NOT_ACCESSIBLE}
+            permissions = note.permissions
+            if not (
+                permissions.has_admin_user(self._user)
+                or permissions.has_editor_user(self._user)
+            ):
+                return {"error": "no permission to change this note's selected RFP"}
+
+            grant = None
+            if grant_id is not None:
+                # Same visibility rule the note API selects grants through: the
+                # user must be able to see the grant's post.
+                grant = (
+                    selectable_grants(self._user)
+                    .select_related("unified_document")
+                    .prefetch_related("unified_document__posts")
+                    .filter(id=grant_id)
+                    .first()
+                )
+                if grant is None:
+                    return {"error": f"grant {grant_id} not found or not accessible"}
+
+            try:
+                select_grant(note=note, grant=grant)
+            except GrantSelectionError as exc:
+                return {"error": str(exc)}
+            self._notify_note_updated(note)
+
+            if grant is None:
+                return {"note_id": note.id, "selected_rfp": None, "saved": True}
+            return {
+                "note_id": note.id,
+                "selected_rfp": _grant_terms(grant),
+                "saved": True,
+            }
+        except Exception:  # noqa: BLE001 - tool failures are model-readable
+            logger.exception("selected RFP write failed for note %s", self._note_id)
+            return {"error": "selecting an RFP is temporarily unavailable"}
+
+    @staticmethod
+    def _notify_note_updated(note) -> None:
+        """Nudge the notebook so an open client sees the new selection.
+
+        The note API pushes this after every PATCH, and a selection writes no
+        NoteContent, so without it nothing tells an open notebook the RFP
+        changed. An ownerless note has no org room to push to, and a failing
+        channel layer must not undo a write that already committed.
+        """
+        if note.organization_id is None:
+            return
+        try:
+            note.notify_note_updated_title()
+        except Exception:  # noqa: BLE001 - the selection is already saved
+            logger.warning(
+                "could not publish note update after an RFP selection", exc_info=True
+            )
+
+    def _readable_note(self) -> Note | None:
+        """This toolset's note, or ``None`` when the user cannot reach it."""
         try:
             note = (
                 Note.objects.select_related(
@@ -155,34 +303,6 @@ class SelectedRFPToolset:
                     unified_document__is_removed=False,
                 )
             )
-            if not note.permissions.has_user(self._user):
-                return {"error": _SELECTED_RFP_NOT_ACCESSIBLE}
-
-            grant = note.selected_grant
-            if grant is None:
-                return {"error": "this preregistration has no selected RFP"}
-            if grant.unified_document.is_removed or not (
-                grant.unified_document.is_visible_to_user(self._user)
-            ):
-                return {"error": _SELECTED_RFP_NOT_ACCESSIBLE}
-
-            post = grant.unified_document.posts.first()
-            title = (grant.short_title or "").strip()
-            if not title and post is not None:
-                title = (post.title or "").strip()
-            return {
-                "id": grant.id,
-                "title": title,
-                "organization": (grant.organization or "").strip(),
-                "rfp_text": grant.get_llm_context_text(),
-                "amount": str(grant.amount),
-                "currency": grant.currency,
-                "deadline": grant.end_date.isoformat() if grant.end_date else None,
-                "application_visibility": grant.application_visibility,
-                "url": _grant_url(grant, post),
-            }
         except Note.DoesNotExist:
-            return {"error": _SELECTED_RFP_NOT_ACCESSIBLE}
-        except Exception:  # noqa: BLE001 - tool failures are model-readable
-            logger.exception("selected RFP read failed for note %s", self._note_id)
-            return {"error": "selected RFP is temporarily unavailable"}
+            return None
+        return note if note.permissions.has_user(self._user) else None

--- a/src/research_ai/services/notebook_chat/grant_tools.py
+++ b/src/research_ai/services/notebook_chat/grant_tools.py
@@ -8,6 +8,7 @@ from note.services.grant_selection_service import (
     select_grant,
     selectable_grants,
 )
+from purchase.models import Grant
 from purchase.services.grant_search_service import GrantSearchService
 from research_ai.constants import BASE_FRONTEND_URL
 from research_ai.services.agent import Tool, Toolset
@@ -138,6 +139,26 @@ def _grant_terms(grant) -> dict:
     }
 
 
+def _parse_grant_id(args: dict) -> tuple[int | None, dict | None]:
+    """The requested grant id, or ``(None, error)``.
+
+    ``(None, None)`` means clear the selection. Only an explicit null does
+    that: ``dispatch`` does not enforce the declared schema, so an argument
+    object that omits grant_id arrives intact and must not read as "unset the
+    RFP" -- nor must a malformed one.
+    """
+    args = args or {}
+    if "grant_id" not in args:
+        return None, {"error": "grant_id is required; pass null to clear the selection"}
+    raw_id = args["grant_id"]
+    if raw_id is None:
+        return None, None
+    try:
+        return int(raw_id), None
+    except (TypeError, ValueError):
+        return None, {"error": "grant_id must be a grant id or null"}
+
+
 class SelectedRFPToolset:
     """Read and set the RFP one preregistration note applies to."""
 
@@ -215,66 +236,66 @@ class SelectedRFPToolset:
             return {"error": "selected RFP is temporarily unavailable"}
 
     def _set_selected_rfp(self, args: dict) -> dict:
-        if self._user is None or not getattr(self._user, "is_authenticated", False):
-            return {"error": _NOTE_NOT_ACCESSIBLE}
-
-        # Only an explicit null clears the selection. ``dispatch`` does not
-        # enforce the declared schema, so an argument object that omits
-        # grant_id arrives here intact and must not read as "unset the RFP" --
-        # nor must a malformed one.
-        args = args or {}
-        if "grant_id" not in args:
-            return {"error": "grant_id is required; pass null to clear the selection"}
-        raw_id = args["grant_id"]
-        if raw_id is None:
-            grant_id = None
-        else:
-            try:
-                grant_id = int(raw_id)
-            except (TypeError, ValueError):
-                return {"error": "grant_id must be a grant id or null"}
-
         try:
-            note = self._readable_note()
-            if note is None:
-                return {"error": _NOTE_NOT_ACCESSIBLE}
-            permissions = note.permissions
-            if not (
-                permissions.has_admin_user(self._user)
-                or permissions.has_editor_user(self._user)
-            ):
-                return {"error": "no permission to change this note's selected RFP"}
-
-            grant = None
-            if grant_id is not None:
-                # Same visibility rule the note API selects grants through: the
-                # user must be able to see the grant's post.
-                grant = (
-                    selectable_grants(self._user)
-                    .select_related("unified_document")
-                    .prefetch_related("unified_document__posts")
-                    .filter(id=grant_id)
-                    .first()
-                )
-                if grant is None:
-                    return {"error": f"grant {grant_id} not found or not accessible"}
+            # Access before arguments: an unreachable note is answered the same
+            # way whatever the model asked for.
+            note, error = self._editable_note()
+            if error is not None:
+                return error
+            grant_id, error = _parse_grant_id(args)
+            if error is not None:
+                return error
+            grant, error = self._resolve_grant(grant_id)
+            if error is not None:
+                return error
 
             try:
                 select_grant(note=note, grant=grant)
             except GrantSelectionError as exc:
                 return {"error": str(exc)}
             self._notify_note_updated(note)
-
-            if grant is None:
-                return {"note_id": note.id, "selected_rfp": None, "saved": True}
             return {
                 "note_id": note.id,
-                "selected_rfp": _grant_terms(grant),
+                "selected_rfp": _grant_terms(grant) if grant is not None else None,
                 "saved": True,
             }
         except Exception:  # noqa: BLE001 - tool failures are model-readable
             logger.exception("selected RFP write failed for note %s", self._note_id)
             return {"error": "selecting an RFP is temporarily unavailable"}
+
+    def _editable_note(self) -> tuple[Note | None, dict | None]:
+        """This toolset's note when the user may change its RFP."""
+        if self._user is None or not getattr(self._user, "is_authenticated", False):
+            return None, {"error": _NOTE_NOT_ACCESSIBLE}
+        note = self._readable_note()
+        if note is None:
+            return None, {"error": _NOTE_NOT_ACCESSIBLE}
+        permissions = note.permissions
+        if not (
+            permissions.has_admin_user(self._user)
+            or permissions.has_editor_user(self._user)
+        ):
+            return None, {"error": "no permission to change this note's selected RFP"}
+        return note, None
+
+    def _resolve_grant(self, grant_id: int | None) -> tuple[Grant | None, dict | None]:
+        """The grant to select; ``(None, None)`` clears the selection.
+
+        Same visibility rule the note API selects grants through: the user must
+        be able to see the grant's post.
+        """
+        if grant_id is None:
+            return None, None
+        grant = (
+            selectable_grants(self._user)
+            .select_related("unified_document")
+            .prefetch_related("unified_document__posts")
+            .filter(id=grant_id)
+            .first()
+        )
+        if grant is None:
+            return None, {"error": f"grant {grant_id} not found or not accessible"}
+        return grant, None
 
     @staticmethod
     def _notify_note_updated(note) -> None:

--- a/src/research_ai/services/notebook_chat/grant_tools.py
+++ b/src/research_ai/services/notebook_chat/grant_tools.py
@@ -218,16 +218,21 @@ class SelectedRFPToolset:
         if self._user is None or not getattr(self._user, "is_authenticated", False):
             return {"error": _NOTE_NOT_ACCESSIBLE}
 
-        raw_id = (args or {}).get("grant_id")
-        # Only an explicit null clears the selection; anything else must name a
-        # grant, so a malformed id is never read as "unset the RFP".
-        if raw_id is not None:
+        # Only an explicit null clears the selection. ``dispatch`` does not
+        # enforce the declared schema, so an argument object that omits
+        # grant_id arrives here intact and must not read as "unset the RFP" --
+        # nor must a malformed one.
+        args = args or {}
+        if "grant_id" not in args:
+            return {"error": "grant_id is required; pass null to clear the selection"}
+        raw_id = args["grant_id"]
+        if raw_id is None:
+            grant_id = None
+        else:
             try:
                 grant_id = int(raw_id)
             except (TypeError, ValueError):
                 return {"error": "grant_id must be a grant id or null"}
-        else:
-            grant_id = None
 
         try:
             note = self._readable_note()

--- a/src/research_ai/services/proposal_draft/note_writer.py
+++ b/src/research_ai/services/proposal_draft/note_writer.py
@@ -9,11 +9,16 @@ from note.models import Note, NoteContent
 from researchhub_access_group.constants import ADMIN, NO_ACCESS
 from researchhub_access_group.models import Permission
 from researchhub_document.models import ResearchhubUnifiedDocument
-from researchhub_document.related_models.constants.document_type import NOTE
+from researchhub_document.related_models.constants.document_type import (
+    NOTE,
+    PREREGISTRATION,
+)
 
 
 @transaction.atomic
-def write_proposal_note(submitted: dict, *, created_by=None) -> Note:
+def write_proposal_note(
+    submitted: dict, *, created_by=None, selected_grant=None
+) -> Note:
     """Create the Note directly (headless: no notifications).
 
     The view paths require an auth user + org and fire org-scoped websocket
@@ -22,13 +27,20 @@ def write_proposal_note(submitted: dict, *, created_by=None) -> Note:
     their notebook: owned by them, in their personal org, with user-admin /
     org-no-access permissions. For system/automatic runs it stays ownerless.
     The ``NoteContent`` post_save signal sets ``note.latest_version``.
+
+    The note is a PREREGISTRATION carrying ``selected_grant`` -- the RFP the
+    whole draft was written against. Both are what the notebook reads to treat
+    it as a funding proposal for that grant, and a draft that arrived with its
+    RFP already unset would have the user re-pick the one it answers.
     """
     sections = submitted.get("sections") or {}
     title = str(sections.get("title") or "").strip() or "Untitled proposal"
     unified_document = ResearchhubUnifiedDocument.objects.create(document_type=NOTE)
     note = Note.objects.create(
         created_by=created_by,
+        document_type=PREREGISTRATION,
         organization=created_by.organization if created_by else None,
+        selected_grant=selected_grant,
         title=title,
         unified_document=unified_document,
     )

--- a/src/research_ai/services/proposal_draft/runner.py
+++ b/src/research_ai/services/proposal_draft/runner.py
@@ -574,7 +574,9 @@ class _ProposalDraftRunner:
         # separate, a run called off at this instant would still publish.
         with transaction.atomic():
             note = write_proposal_note(
-                submission, created_by=self.recorder.draft.created_by
+                submission,
+                created_by=self.recorder.draft.created_by,
+                selected_grant=self.context_toolset.get_grant(),
             )
             result = self.recorder.complete(note)
         self._attach_conversation_to_note(note)

--- a/src/research_ai/services/proposal_draft/tools/context_tools.py
+++ b/src/research_ai/services/proposal_draft/tools/context_tools.py
@@ -76,12 +76,23 @@ class ProposalContextToolset:
     def _get_rfp_context(self, _args: dict) -> dict:
         return self.get_rfp_context()
 
+    def get_grant(self):
+        """The ``Grant`` (RFP) this proposal is drafted against, or ``None``.
+
+        The run grounds itself in the grant's terms, so the accepted Note is
+        also linked back to it as the note's selected RFP.
+        """
+        unified_document = self.search_expert.expert_search.unified_document
+        if unified_document is None:
+            return None
+        return unified_document.grants.first()
+
     def get_rfp_context(self) -> dict:
         """The funder's RFP terms; ``{"error": ...}`` when none is attached."""
         unified_document = self.search_expert.expert_search.unified_document
         if unified_document is None:
             return {"error": "expert search has no unified document"}
-        grant = unified_document.grants.first()
+        grant = self.get_grant()
         if grant is None:
             return {"error": "no grant on the expert search's unified document"}
         return {

--- a/src/research_ai/tests/notebook_chat/test_grant_tools.py
+++ b/src/research_ai/tests/notebook_chat/test_grant_tools.py
@@ -1,20 +1,23 @@
 from datetime import timedelta
 from decimal import Decimal
+from unittest.mock import patch
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.test import TestCase
 from django.utils import timezone
 
+from note.models import Note
 from note.tests.helpers import create_note
 from purchase.models import Grant
 from research_ai.services.notebook_chat.grant_tools import (
     READ_SELECTED_RFP,
     SEARCH_GRANTS,
+    SET_SELECTED_RFP,
     GrantSearchToolset,
     SelectedRFPToolset,
 )
-from researchhub_access_group.constants import ADMIN
+from researchhub_access_group.constants import ADMIN, VIEWER
 from researchhub_access_group.models import Permission
 from researchhub_document.helpers import create_post
 from researchhub_document.models import ResearchhubUnifiedDocument
@@ -255,3 +258,172 @@ class SelectedRFPToolsetTests(TestCase):
 
         # Assert
         self.assertEqual(result, {"error": "selected RFP not found or not accessible"})
+
+
+class SetSelectedRFPToolTests(TestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("set_rfp_user")
+        self.owner = create_random_authenticated_user("set_rfp_owner")
+        self.note, _ = create_note(self.user, organization=None)
+        self.note.document_type = PREREGISTRATION
+        self.note.save(update_fields=["document_type"])
+        self.permission = Permission.objects.create(
+            access_type=ADMIN,
+            content_type=ContentType.objects.get_for_model(ResearchhubUnifiedDocument),
+            object_id=self.note.unified_document_id,
+            user=self.user,
+        )
+
+    def _grant(self, *, title="Reproducibility RFP", status=Grant.OPEN, is_public=True):
+        post = create_post(
+            created_by=self.owner,
+            document_type=GRANT,
+            title=title,
+        )
+        post.slug = title.lower().replace(" ", "-")
+        post.save(update_fields=["slug"])
+        post.unified_document.is_public = is_public
+        post.unified_document.save(update_fields=["is_public"])
+        return Grant.objects.create(
+            created_by=self.owner,
+            unified_document=post.unified_document,
+            short_title=title,
+            organization="Research Foundation",
+            description="Funding for reproducible research.",
+            amount=Decimal("75000.00"),
+            currency="USD",
+            status=status,
+            end_date=timezone.now() + timedelta(days=30),
+        )
+
+    def _set(self, grant_id, user=None):
+        toolset = SelectedRFPToolset(
+            note=self.note, user=self.user if user is None else user
+        ).as_toolset()
+        result, stop = toolset.dispatch(SET_SELECTED_RFP, {"grant_id": grant_id})
+        self.assertFalse(stop)
+        return result
+
+    def test_selects_replaces_and_clears_the_rfp(self):
+        # Arrange
+        first = self._grant(title="First RFP")
+        second = self._grant(title="Second RFP")
+
+        # Act
+        selected = self._set(first.id)
+        replaced = self._set(second.id)
+        self.note.refresh_from_db()
+        replaced_grant_id = self.note.selected_grant_id
+        cleared = self._set(None)
+        self.note.refresh_from_db()
+
+        # Assert
+        self.assertEqual(selected["selected_rfp"]["id"], first.id)
+        self.assertEqual(selected["selected_rfp"]["title"], "First RFP")
+        self.assertIn("/grant/", selected["selected_rfp"]["url"])
+        self.assertTrue(selected["saved"])
+        self.assertEqual(replaced["selected_rfp"]["id"], second.id)
+        self.assertEqual(replaced_grant_id, second.id)
+        self.assertIsNone(cleared["selected_rfp"])
+        self.assertIsNone(self.note.selected_grant_id)
+
+    def test_refuses_a_grant_that_stopped_accepting_applications(self):
+        # Arrange
+        closed = self._grant(status=Grant.CLOSED)
+
+        # Act
+        result = self._set(closed.id)
+        self.note.refresh_from_db()
+
+        # Assert
+        self.assertEqual(
+            result, {"error": "Grant is no longer accepting applications."}
+        )
+        self.assertIsNone(self.note.selected_grant_id)
+
+    def test_refuses_a_grant_the_user_cannot_view(self):
+        # Arrange
+        private = self._grant(is_public=False)
+
+        # Act
+        result = self._set(private.id)
+        self.note.refresh_from_db()
+
+        # Assert
+        self.assertEqual(
+            result, {"error": f"grant {private.id} not found or not accessible"}
+        )
+        self.assertIsNone(self.note.selected_grant_id)
+
+    def test_refuses_a_user_without_edit_permission(self):
+        # Arrange: a viewer can read the note but must not change its RFP.
+        grant = self._grant()
+        self.permission.access_type = VIEWER
+        self.permission.save(update_fields=["access_type"])
+
+        # Act
+        result = self._set(grant.id)
+        self.note.refresh_from_db()
+
+        # Assert
+        self.assertEqual(
+            result, {"error": "no permission to change this note's selected RFP"}
+        )
+        self.assertIsNone(self.note.selected_grant_id)
+
+    def test_refuses_a_published_note(self):
+        # Arrange
+        grant = self._grant()
+        post = create_post(created_by=self.user, document_type=PREREGISTRATION)
+        post.note = self.note
+        post.save(update_fields=["note"])
+
+        # Act
+        result = self._set(grant.id)
+        self.note.refresh_from_db()
+
+        # Assert
+        self.assertEqual(result, {"error": "Published notes cannot change grants."})
+        self.assertIsNone(self.note.selected_grant_id)
+
+    def test_refuses_a_non_preregistration_note(self):
+        # Arrange
+        grant = self._grant()
+        self.note.document_type = "NOTE"
+        self.note.save(update_fields=["document_type"])
+
+        # Act
+        result = self._set(grant.id)
+        self.note.refresh_from_db()
+
+        # Assert
+        self.assertEqual(result, {"error": "this preregistration is not accessible"})
+        self.assertIsNone(self.note.selected_grant_id)
+
+    def test_rejects_a_malformed_grant_id_rather_than_clearing(self):
+        # Arrange
+        grant = self._grant()
+        self._set(grant.id)
+
+        # Act
+        result = self._set("not-an-id")
+        self.note.refresh_from_db()
+
+        # Assert
+        self.assertEqual(result, {"error": "grant_id must be a grant id or null"})
+        self.assertEqual(self.note.selected_grant_id, grant.id)
+
+    def test_notifies_the_notebook_that_the_note_changed(self):
+        # Arrange: a selection writes no NoteContent, so the org room push is
+        # all that tells an open notebook the RFP changed.
+        self.note.organization = self.user.organization
+        self.note.save(update_fields=["organization"])
+        grant = self._grant()
+
+        # Act
+        with patch.object(Note, "notify_note_updated_title") as notify:
+            result = self._set(grant.id)
+
+        # Assert
+        self.assertTrue(result["saved"])
+        notify.assert_called_once_with()

--- a/src/research_ai/tests/notebook_chat/test_grant_tools.py
+++ b/src/research_ai/tests/notebook_chat/test_grant_tools.py
@@ -413,6 +413,25 @@ class SetSelectedRFPToolTests(TestCase):
         self.assertEqual(result, {"error": "grant_id must be a grant id or null"})
         self.assertEqual(self.note.selected_grant_id, grant.id)
 
+    def test_rejects_an_omitted_grant_id_rather_than_clearing(self):
+        # Arrange: dispatch does not enforce the input schema, so an argument
+        # object with no grant_id reaches the handler; only an explicit null
+        # may clear a selection.
+        grant = self._grant()
+        self._set(grant.id)
+        toolset = SelectedRFPToolset(note=self.note, user=self.user).as_toolset()
+
+        # Act
+        result, _stop = toolset.dispatch(SET_SELECTED_RFP, {})
+        self.note.refresh_from_db()
+
+        # Assert
+        self.assertEqual(
+            result,
+            {"error": "grant_id is required; pass null to clear the selection"},
+        )
+        self.assertEqual(self.note.selected_grant_id, grant.id)
+
     def test_notifies_the_notebook_that_the_note_changed(self):
         # Arrange: a selection writes no NoteContent, so the org room push is
         # all that tells an open notebook the RFP changed.

--- a/src/research_ai/tests/notebook_chat/test_grant_tools.py
+++ b/src/research_ai/tests/notebook_chat/test_grant_tools.py
@@ -472,3 +472,28 @@ class SetSelectedRFPToolTests(TestCase):
 
         # Assert
         self.assertEqual(result["selected_rfp"]["title"], "Untitled Program RFP")
+
+    def test_rejects_grant_ids_that_are_not_whole_numbers(self):
+        # Arrange: int() would truncate 1.9 and coerce True to 1, selecting
+        # grant 1 -- an unrelated RFP the user never asked for.
+        grant = self._grant()
+        self._set(grant.id)
+
+        # Act
+        results = [self._set(value) for value in (1.9, True, "1.9", "  ")]
+        self.note.refresh_from_db()
+
+        # Assert
+        for result in results:
+            self.assertEqual(result, {"error": "grant_id must be a grant id or null"})
+        self.assertEqual(self.note.selected_grant_id, grant.id)
+
+    def test_accepts_a_grant_id_sent_as_a_digit_string(self):
+        # Arrange
+        grant = self._grant()
+
+        # Act
+        result = self._set(str(grant.id))
+
+        # Assert
+        self.assertEqual(result["selected_rfp"]["id"], grant.id)

--- a/src/research_ai/tests/notebook_chat/test_grant_tools.py
+++ b/src/research_ai/tests/notebook_chat/test_grant_tools.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import patch
 
+from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.test import TestCase
@@ -446,3 +447,28 @@ class SetSelectedRFPToolTests(TestCase):
         # Assert
         self.assertTrue(result["saved"])
         notify.assert_called_once_with()
+
+    def test_refuses_an_unauthenticated_caller(self):
+        # Arrange
+        grant = self._grant()
+
+        # Act
+        result = self._set(grant.id, user=AnonymousUser())
+        self.note.refresh_from_db()
+
+        # Assert
+        self.assertEqual(result, {"error": "this preregistration is not accessible"})
+        self.assertIsNone(self.note.selected_grant_id)
+
+    def test_falls_back_to_the_post_title_when_the_grant_has_no_short_title(self):
+        # Arrange: the title reported back is what the model and the activity
+        # feed show for the selected RFP.
+        grant = self._grant(title="Untitled Program RFP")
+        grant.short_title = ""
+        grant.save(update_fields=["short_title"])
+
+        # Act
+        result = self._set(grant.id)
+
+        # Assert
+        self.assertEqual(result["selected_rfp"]["title"], "Untitled Program RFP")

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
@@ -875,6 +875,91 @@ class NotebookChatActivityProjectionTests(TestCase):
         self.execution.save(update_fields=["status"])
         self.assertEqual(self._single_event()["status"], "interrupted")
 
+    def test_selected_rfp_write_reports_the_rfp_it_selected_as_a_source(self):
+        # Arrange
+        self._add_trace_row(
+            1,
+            [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "set_selected_rfp",
+                    "input": {"grant_id": 7},
+                }
+            ],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+        self._add_trace_row(
+            2,
+            [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "t1",
+                    "content": {
+                        "note_id": 3,
+                        "saved": True,
+                        "selected_rfp": {
+                            "title": "Reproducibility RFP",
+                            "url": "https://example.org/rfp",
+                        },
+                    },
+                }
+            ],
+            AgentExecutionMessage.Provenance.TOOL,
+            role="user",
+        )
+        self._finish()
+
+        # Act
+        event = self._single_event()
+
+        # Assert
+        self.assertEqual(event["label"], "Selected an RFP")
+        self.assertEqual(
+            event["sources"],
+            [
+                {
+                    "title": "Reproducibility RFP",
+                    "url": "https://example.org/rfp",
+                }
+            ],
+        )
+
+    def test_selected_rfp_write_reports_no_source_when_it_cleared_the_rfp(self):
+        # Arrange: clearing returns selected_rfp null -- there is no RFP to cite.
+        self._add_trace_row(
+            1,
+            [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "set_selected_rfp",
+                    "input": {"grant_id": None},
+                }
+            ],
+            AgentExecutionMessage.Provenance.MODEL,
+        )
+        self._add_trace_row(
+            2,
+            [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "t1",
+                    "content": {"note_id": 3, "saved": True, "selected_rfp": None},
+                }
+            ],
+            AgentExecutionMessage.Provenance.TOOL,
+            role="user",
+        )
+        self._finish()
+
+        # Act
+        event = self._single_event()
+
+        # Assert
+        self.assertEqual(event["label"], "Selected an RFP")
+        self.assertNotIn("sources", event)
+
     def test_selected_rfp_read_has_a_safe_label_and_source(self):
         # Arrange
         self._add_trace_row(

--- a/src/research_ai/tests/proposal_draft/test_proposal_draft_service.py
+++ b/src/research_ai/tests/proposal_draft/test_proposal_draft_service.py
@@ -51,7 +51,10 @@ from research_ai.services.proposal_draft.runner import (
 from research_ai.services.proposal_draft.tools.assembly import assemble_proposal
 from researchhub_access_group.constants import ADMIN, NO_ACCESS
 from researchhub_document.helpers import create_post
-from researchhub_document.related_models.constants.document_type import GRANT
+from researchhub_document.related_models.constants.document_type import (
+    GRANT,
+    PREREGISTRATION,
+)
 from user.tests.helpers import create_random_default_user
 
 _CRITERIA = ("c1", "c2", "c3", "c4", "c5", "c6", "c7")
@@ -278,6 +281,24 @@ class ProposalDraftServiceTests(TestCase):
         )
 
     # -- clean submit writes the Note -------------------------------------
+
+    def test_shipped_note_is_a_preregistration_for_the_rfp_it_answers(self):
+        # Arrange
+        provider = _ScriptedProvider([_submit_turn(_clean_payload())])
+
+        # Act
+        result = run_proposal_draft(
+            self.search_expert.id,
+            provider=provider,
+            panel=_FakePanel(overall=5),
+            oa_client=_FakeOpenAlex(),
+        )
+
+        # Assert: the note the user opens already applies to the grant the
+        # draft was written against, rather than making them re-pick it.
+        note = Note.objects.get(id=result["note_id"])
+        self.assertEqual(note.document_type, PREREGISTRATION)
+        self.assertEqual(note.selected_grant_id, self.grant.id)
 
     def test_clean_submit_writes_note(self):
         # Arrange: one clean submit; panel clears the threshold; no citations.


### PR DESCRIPTION
The proposal draft runner writes a Note for a proposal it drafted against one specific grant, but never set selected_grant or document_type on it, so the note landed in the notebook untyped with no funding opportunity attached -- and an untyped note could not have carried the grant anyway, since a selection is only valid on a preregistration. Write it as a PREREGISTRATION carrying the grant the whole run was grounded in.

The notebook agent could read the selected RFP but not set one, so finding a grant ended in handing the user off to attach it themselves. Add set_selected_rfp, applying the rules the note API already enforced -- now shared through note.services.grant_selection_service so the two entry points cannot drift -- plus the editor/admin check the read tool did not need, and the org-room push that tells an open notebook the selection changed.