### PR TITLE
[Notebook Chat] Let the agent read the user's expert researcher profile

### DIFF
--- a/src/research_ai/prompts/notebook_chat_system.txt
+++ b/src/research_ai/prompts/notebook_chat_system.txt
@@ -15,6 +15,13 @@ edit_note call must use this note id; you have no access to other notes.
   from knowing the user's background, expertise, affiliation, publications, or
   public pages. Profile URLs are leads, not proof of what those external pages
   currently say; use the literature or web tools to verify claims when needed.
+- **Ground in their researcher profile.** Call get_researcher_profile when
+  drafting or personalizing proposal content: when ResearchHub holds an expert
+  profile for this user, it carries their resolved OpenAlex identity, key
+  works, and demonstrated lab capabilities backed by their papers -- the real
+  bounds of what a draft in their name can credibly claim. It may be absent,
+  partial, or unresolved; then work from get_user_profile and the literature
+  tools instead, and never invent a track record.
 - **Answer and research.** Use search_institutions, search_authors, get_author,
   get_author_works, and get_work_fulltext to ground answers in real literature
   from OpenAlex, and web_search for facts outside the literature. Never invent

--- a/src/research_ai/services/notebook_chat/__init__.py
+++ b/src/research_ai/services/notebook_chat/__init__.py
@@ -10,6 +10,10 @@ from research_ai.services.notebook_chat.grant_tools import (
     GrantSearchToolset,
     SelectedRFPToolset,
 )
+from research_ai.services.notebook_chat.researcher_profile_tools import (
+    GET_RESEARCHER_PROFILE,
+    ResearcherProfileToolset,
+)
 from research_ai.services.notebook_chat.service import (
     ACTIVITY_ALL,
     ACTIVITY_LIVE,
@@ -24,6 +28,7 @@ from research_ai.services.notebook_chat.toolset import (
 __all__ = [
     "ACTIVITY_ALL",
     "ACTIVITY_LIVE",
+    "GET_RESEARCHER_PROFILE",
     "READ_SELECTED_RFP",
     "WORKFLOW",
     "ConversationEventPublisher",
@@ -31,6 +36,7 @@ __all__ = [
     "NotebookChatConfig",
     "NotebookChatService",
     "NotebookWebSearchToolset",
+    "ResearcherProfileToolset",
     "SelectedRFPToolset",
     "compose_notebook_toolset",
     "conversation_group",

--- a/src/research_ai/services/notebook_chat/activity.py
+++ b/src/research_ai/services/notebook_chat/activity.py
@@ -34,6 +34,9 @@ from research_ai.services.notebook_chat.grant_tools import (
     READ_SELECTED_RFP,
     SEARCH_GRANTS,
 )
+from research_ai.services.notebook_chat.researcher_profile_tools import (
+    GET_RESEARCHER_PROFILE,
+)
 from research_ai.services.researcher_profile.openalex_tools import GET_WORK_FULLTEXT
 
 WEB_SEARCH = "web_search"
@@ -53,6 +56,7 @@ _LABELS = {
     GET_AUTHOR: "Looked up an author",
     GET_AUTHOR_WORKS: "Fetched an author's publications",
     GET_WORK_FULLTEXT: "Read a paper",
+    GET_RESEARCHER_PROFILE: "Read your researcher profile",
 }
 # What each tool is doing while the call is still open, for the live phase.
 # Distinct from _LABELS, which reads as a completed step.
@@ -67,6 +71,7 @@ _ACTIVE_LABELS = {
     GET_AUTHOR: "Looking up an author",
     GET_AUTHOR_WORKS: "Fetching an author's publications",
     GET_WORK_FULLTEXT: "Reading a paper",
+    GET_RESEARCHER_PROFILE: "Reading your researcher profile",
 }
 # What the model is doing while it is still writing a tool call's arguments.
 # Only tools whose arguments are substantial work in themselves need copy

--- a/src/research_ai/services/notebook_chat/researcher_profile_tools.py
+++ b/src/research_ai/services/notebook_chat/researcher_profile_tools.py
@@ -1,0 +1,69 @@
+"""Researcher-profile read tool for the notebook chat agent.
+
+Exposes the acting user's ``Expert.profile`` -- the grounded researcher
+profile the expert pipeline builds -- to the chat agent. Read-only and
+scoped to the conversation's user: no selector is accepted from the model,
+mirroring ``UserProfileToolset``'s identity boundary.
+"""
+
+import logging
+
+from research_ai.services.agent import Tool, Toolset
+from research_ai.services.researcher_profile.user_expert import expert_for_user
+from user.models import User
+
+logger = logging.getLogger(__name__)
+
+GET_RESEARCHER_PROFILE = "get_researcher_profile"
+
+_EMPTY_INPUT_SCHEMA = {"type": "object", "properties": {}}
+_PROFILE_KEYS = ("schema_version", "built_at", "resolution", "works", "capabilities")
+
+
+class ResearcherProfileToolset:
+    """Read the acting user's expert researcher profile."""
+
+    def __init__(self, *, user: User):
+        self._user = user
+
+    def build_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name=GET_RESEARCHER_PROFILE,
+                description=(
+                    "Read the expert researcher profile ResearchHub holds for "
+                    "the current user, when one exists: their resolved "
+                    "OpenAlex identity, key works, and demonstrated lab "
+                    "capabilities backed by their papers. Use it to ground "
+                    "drafting in what the user's record actually supports. "
+                    "It may be absent, partial, or unresolved; work from "
+                    "get_user_profile and the OpenAlex tools then."
+                ),
+                input_schema=_EMPTY_INPUT_SCHEMA,
+                handler=self._get_researcher_profile,
+            )
+        ]
+
+    def as_toolset(self) -> Toolset:
+        return Toolset(self.build_tools())
+
+    def _get_researcher_profile(self, _args: dict) -> dict:
+        try:
+            expert = expert_for_user(self._user)
+        except Exception:  # noqa: BLE001 - tool failures are model-readable
+            logger.exception("researcher profile read failed")
+            return {"error": "researcher profile is temporarily unavailable"}
+        profile = expert.profile if expert is not None else None
+        if not isinstance(profile, dict) or not profile:
+            return {
+                "status": "no_profile",
+                "guidance": (
+                    "ResearchHub has no expert profile for this user. Work "
+                    "from get_user_profile and the OpenAlex tools instead, "
+                    "and never invent a track record."
+                ),
+            }
+        return {
+            "status": "ready",
+            "profile": {key: profile.get(key) for key in _PROFILE_KEYS},
+        }

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -84,6 +84,9 @@ from research_ai.services.notebook_chat.grant_tools import (
     GrantSearchToolset,
     SelectedRFPToolset,
 )
+from research_ai.services.notebook_chat.researcher_profile_tools import (
+    ResearcherProfileToolset,
+)
 from research_ai.services.notebook_chat.streaming import ExecutionStreamStore
 from research_ai.services.notebook_chat.toolset import (
     NotebookWebSearchToolset,
@@ -172,6 +175,7 @@ class NotebookChatService:
         oa_client: OpenAlex | None = None,
         web_search_client=None,
         grant_toolset_factory=None,
+        researcher_profile_toolset_factory=None,
         chat_service: AgentChatService | None = None,
         conversation_service: AgentConversationService | None = None,
         note_conversation_service: NoteAgentConversationService | None = None,
@@ -188,6 +192,11 @@ class NotebookChatService:
             GrantSearchToolset
             if grant_toolset_factory is None
             else grant_toolset_factory
+        )
+        self._researcher_profile_toolset_factory = (
+            ResearcherProfileToolset
+            if researcher_profile_toolset_factory is None
+            else researcher_profile_toolset_factory
         )
         self.chat = AgentChatService() if chat_service is None else chat_service
         self.conversations = (
@@ -629,6 +638,9 @@ class NotebookChatService:
         toolset = compose_notebook_toolset(
             note_toolset=NoteToolset(user=conversation.user, note_ids={note.id}),
             user_profile_toolset=UserProfileToolset(user=conversation.user),
+            researcher_profile_toolset=self._researcher_profile_toolset_factory(
+                user=conversation.user
+            ),
             grant_toolset=self._grant_toolset_factory(user=conversation.user),
             selected_rfp_toolset=(
                 SelectedRFPToolset(note=note, user=conversation.user)

--- a/src/research_ai/services/notebook_chat/toolset.py
+++ b/src/research_ai/services/notebook_chat/toolset.py
@@ -94,13 +94,14 @@ def compose_notebook_toolset(
     *,
     note_toolset,
     user_profile_toolset,
+    researcher_profile_toolset,
     grant_toolset,
     selected_rfp_toolset=None,
     openalex_toolset,
     web_search_toolset,
     native_tool_names: frozenset[str] = frozenset(),
 ) -> Toolset:
-    """Note read/edit + user profile + grants + literature + web search.
+    """Note read/edit + user/researcher profile + grants + literature + web search.
 
     ``native_tool_names`` are the names the provider runs server-side (on
     Claude Platform, ``web_search``). A local tool by that name is left out:
@@ -112,6 +113,7 @@ def compose_notebook_toolset(
     ]
     candidates.extend(web_search_toolset.build_tools())
     candidates.extend(user_profile_toolset.build_tools())
+    candidates.extend(researcher_profile_toolset.build_tools())
     candidates.extend(grant_toolset.build_tools())
     if selected_rfp_toolset is not None:
         candidates.extend(selected_rfp_toolset.build_tools())

--- a/src/research_ai/services/researcher_profile/user_expert.py
+++ b/src/research_ai/services/researcher_profile/user_expert.py
@@ -32,12 +32,17 @@ def expert_for_user(user: User) -> Expert | None:
 
 
 def _invited_expert(user: User) -> Expert | None:
-    """The expert identity behind an invitation this user holds, newest first."""
+    """The expert identity behind an invitation this user holds, newest first.
+
+    Resolved from the invitation's own ``recipient_email`` -- stamped at
+    creation and never editable -- not from ``GeneratedEmail.expert_email``,
+    which editors can retarget after the invitation was claimed.
+    """
     emails = (
         GeneratedEmail.objects.filter(note_invitation__recipient=user)
-        .exclude(expert_email="")
+        .exclude(note_invitation__recipient_email="")
         .order_by("-created_date")
-        .values_list("expert_email", flat=True)
+        .values_list("note_invitation__recipient_email", flat=True)
     )
     seen: set[str] = set()
     for email in emails:

--- a/src/research_ai/services/researcher_profile/user_expert.py
+++ b/src/research_ai/services/researcher_profile/user_expert.py
@@ -1,0 +1,51 @@
+"""Resolve which ``Expert`` row is a ResearchHub user.
+
+The notebook chat grounds drafting in the researcher profile the expert
+pipeline keeps on ``Expert.profile``. Resolution is read-only, strongest
+evidence first:
+
+1. ``registered_user`` -- the explicit link the signup matcher records.
+2. The invitation chain -- outreach emails hang a ``NoteInvitation`` off
+   ``GeneratedEmail.note_invitation``, and accepting one claims it for
+   whichever authenticated user clicked the tokenized link. That associates
+   the user with the invited expert identity even when they signed up under
+   a different email than the one the outreach targeted.
+3. The user's account email.
+"""
+
+from research_ai.models import Expert, GeneratedEmail
+from user.models import User
+
+
+def expert_for_user(user: User) -> Expert | None:
+    """The user's Expert row, or ``None`` when no row matches."""
+    expert = Expert.objects.filter(registered_user=user).order_by("id").first()
+    if expert is not None:
+        return expert
+    expert = _invited_expert(user)
+    if expert is not None:
+        return expert
+    email = (user.email or "").strip().lower()
+    if not email:
+        return None
+    return Expert.objects.filter(email__iexact=email).order_by("id").first()
+
+
+def _invited_expert(user: User) -> Expert | None:
+    """The expert identity behind an invitation this user holds, newest first."""
+    emails = (
+        GeneratedEmail.objects.filter(note_invitation__recipient=user)
+        .exclude(expert_email="")
+        .order_by("-created_date")
+        .values_list("expert_email", flat=True)
+    )
+    seen: set[str] = set()
+    for email in emails:
+        email = email.strip().lower()
+        if not email or email in seen:
+            continue
+        seen.add(email)
+        expert = Expert.objects.filter(email__iexact=email).order_by("id").first()
+        if expert is not None:
+            return expert
+    return None

--- a/src/research_ai/tests/notebook_chat/test_researcher_profile_tools.py
+++ b/src/research_ai/tests/notebook_chat/test_researcher_profile_tools.py
@@ -1,0 +1,98 @@
+"""Tests for the notebook chat researcher-profile read tool."""
+
+from unittest.mock import Mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from research_ai.models import Expert
+from research_ai.services.notebook_chat.researcher_profile_tools import (
+    GET_RESEARCHER_PROFILE,
+    ResearcherProfileToolset,
+)
+from research_ai.services.notebook_chat.toolset import compose_notebook_toolset
+
+
+def _make_user(email="jane@researchhub_test.com"):
+    return get_user_model().objects.create_user(
+        username=email, password="password", email=email
+    )
+
+
+def _handler(toolset: ResearcherProfileToolset):
+    (tool,) = toolset.build_tools()
+    return tool.handler
+
+
+class GetResearcherProfileToolTests(TestCase):
+    def test_reports_no_profile_without_an_expert_row(self):
+        # Arrange
+        toolset = ResearcherProfileToolset(user=_make_user())
+        # Act
+        result = _handler(toolset)({})
+        # Assert
+        self.assertEqual(result["status"], "no_profile")
+        self.assertIn("never invent a track record", result["guidance"])
+
+    def test_reports_no_profile_for_an_empty_profile(self):
+        # Arrange
+        user = _make_user()
+        Expert.objects.create(email=user.email, registered_user=user, profile={})
+        toolset = ResearcherProfileToolset(user=user)
+        # Act & Assert
+        self.assertEqual(_handler(toolset)({})["status"], "no_profile")
+
+    def test_returns_profile_without_internal_errors_key(self):
+        # Arrange
+        user = _make_user()
+        Expert.objects.create(
+            email=user.email,
+            registered_user=user,
+            profile={
+                "schema_version": 2,
+                "built_at": "2026-08-26T00:00:00Z",
+                "resolution": {"openalex_author_id": "A1"},
+                "works": [{"title": "Paper"}],
+                "capabilities": [{"name": "scRNA-seq"}],
+                "errors": ["internal"],
+            },
+        )
+        toolset = ResearcherProfileToolset(user=user)
+        # Act
+        result = _handler(toolset)({})
+        # Assert
+        self.assertEqual(result["status"], "ready")
+        self.assertEqual(result["profile"]["works"], [{"title": "Paper"}])
+        self.assertEqual(result["profile"]["capabilities"], [{"name": "scRNA-seq"}])
+        self.assertNotIn("errors", result["profile"])
+
+    def test_email_matched_row_is_readable_without_registration_link(self):
+        # Arrange
+        user = _make_user()
+        Expert.objects.create(
+            email=user.email,
+            profile={"resolution": {"openalex_author_id": "A1"}, "works": []},
+        )
+        toolset = ResearcherProfileToolset(user=user)
+        # Act
+        result = _handler(toolset)({})
+        # Assert
+        self.assertEqual(result["status"], "ready")
+        self.assertEqual(result["profile"]["works"], [])
+
+
+class ComposeToolsetTests(TestCase):
+    def test_researcher_profile_tool_is_registered(self):
+        # Arrange
+        empty = Mock(build_tools=Mock(return_value=[]))
+        # Act
+        toolset = compose_notebook_toolset(
+            note_toolset=empty,
+            user_profile_toolset=empty,
+            researcher_profile_toolset=ResearcherProfileToolset(user=_make_user()),
+            grant_toolset=empty,
+            openalex_toolset=Mock(build_tools=Mock(return_value=[])),
+            web_search_toolset=empty,
+        )
+        # Assert
+        self.assertIn(GET_RESEARCHER_PROFILE, toolset.names)

--- a/src/research_ai/tests/researcher_profile/test_user_expert.py
+++ b/src/research_ai/tests/researcher_profile/test_user_expert.py
@@ -51,6 +51,18 @@ class ExpertForUserTests(TestCase):
         # Act & Assert
         self.assertEqual(expert_for_user(user), invited)
 
+    def test_resolves_the_invited_identity_despite_a_retargeted_email(self):
+        # Arrange: the outreach row's editable expert_email is changed after
+        # the invite was claimed; the invitation's addressee must still win.
+        user = _make_user(email="jane.personal@researchhub_test.com")
+        invited = Expert.objects.create(email="jane@stanford.edu", first_name="Invited")
+        Expert.objects.create(email="bob@mit.edu", first_name="Retargeted")
+        generated = _invite(user, "jane@stanford.edu")
+        generated.expert_email = "bob@mit.edu"
+        generated.save(update_fields=["expert_email"])
+        # Act & Assert
+        self.assertEqual(expert_for_user(user), invited)
+
     def test_invitation_chain_outranks_account_email(self):
         # Arrange
         user = _make_user()

--- a/src/research_ai/tests/researcher_profile/test_user_expert.py
+++ b/src/research_ai/tests/researcher_profile/test_user_expert.py
@@ -1,0 +1,77 @@
+"""Tests for resolving a ResearchHub user to their Expert row."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from invite.models import NoteInvitation
+from note.tests.helpers import create_note
+from research_ai.models import Expert, GeneratedEmail
+from research_ai.services.researcher_profile.user_expert import expert_for_user
+from researchhub_access_group.constants import EDITOR
+
+
+def _make_user(email="jane@researchhub_test.com"):
+    return get_user_model().objects.create_user(
+        username=email, password="password", email=email
+    )
+
+
+def _invite(recipient, expert_email, inviter=None):
+    """An outreach email whose note invitation ``recipient`` holds."""
+    inviter = inviter or _make_user(email=f"inviter+{expert_email}")
+    note, _ = create_note(inviter, organization=None)
+    invitation = NoteInvitation.create(
+        recipient=recipient,
+        recipient_email=expert_email,
+        inviter=inviter,
+        note=note,
+        invite_type=EDITOR,
+    )
+    return GeneratedEmail.objects.create(
+        created_by=inviter, expert_email=expert_email, note_invitation=invitation
+    )
+
+
+class ExpertForUserTests(TestCase):
+    def test_prefers_registered_user_link_over_email(self):
+        # Arrange
+        user = _make_user()
+        Expert.objects.create(email=user.email, first_name="ByEmail")
+        linked = Expert.objects.create(
+            email="other@example.com", first_name="Linked", registered_user=user
+        )
+        # Act & Assert
+        self.assertEqual(expert_for_user(user), linked)
+
+    def test_resolves_through_a_held_invitation_despite_different_email(self):
+        # Arrange: invited at the institutional address, signed up with another.
+        user = _make_user(email="jane.personal@researchhub_test.com")
+        invited = Expert.objects.create(email="jane@stanford.edu", first_name="Invited")
+        _invite(user, "jane@stanford.edu")
+        # Act & Assert
+        self.assertEqual(expert_for_user(user), invited)
+
+    def test_invitation_chain_outranks_account_email(self):
+        # Arrange
+        user = _make_user()
+        Expert.objects.create(email=user.email, first_name="ByEmail")
+        invited = Expert.objects.create(email="jane@stanford.edu", first_name="Invited")
+        _invite(user, "jane@stanford.edu")
+        # Act & Assert
+        self.assertEqual(expert_for_user(user), invited)
+
+    def test_falls_back_to_account_email_case_insensitively(self):
+        # Arrange
+        user = _make_user()
+        by_email = Expert.objects.create(email=user.email.upper(), first_name="ByEmail")
+        # Act & Assert
+        self.assertEqual(expert_for_user(user), by_email)
+
+    def test_none_for_missing_email_or_row(self):
+        # Arrange
+        user = _make_user()
+        no_email = _make_user(email="second@researchhub_test.com")
+        no_email.email = ""
+        # Act & Assert
+        self.assertIsNone(expert_for_user(no_email))
+        self.assertIsNone(expert_for_user(user))


### PR DESCRIPTION
## What

Step 1 of grounding the notebook chat assistant in who the user is as a researcher: a read-only `get_researcher_profile` tool that exposes the `Expert.profile` ResearchHub already holds for the acting user (resolved OpenAlex identity, key works, and paper-backed lab capabilities built by the expert pipeline).

## How

- **`expert_for_user` resolver** (`services/researcher_profile/user_expert.py`) — read-only, strongest evidence first:
  1. `Expert.registered_user` — the explicit link the signup matcher records.
  2. The invitation chain — outreach emails hang a `NoteInvitation` off `GeneratedEmail.note_invitation`, and accepting one claims it for whichever authenticated user clicked the tokenized link, so an expert invited at their institutional address still resolves when they signed up under a different email. Newest outreach wins.
  3. The user's account email.
- **`ResearcherProfileToolset`** (`services/notebook_chat/researcher_profile_tools.py`) — one tool, scoped to the conversation's user (no selector accepted from the model). Returns the profile (internal `errors` list filtered out) or a `no_profile` status with guidance to fall back to `get_user_profile`/OpenAlex tools and never invent a track record.
- Wiring: toolset composition, injectable factory on `NotebookChatService`, activity labels, and one system-prompt bullet telling the agent to ground drafting in the profile when it exists.

No migrations, no writes, no new tasks. Users without a matching expert profile get the honest fallback; invited experts who signed up get grounding immediately.

## Testing

- New: `tests/researcher_profile/test_user_expert.py` (resolution precedence incl. the invitation chain), `tests/notebook_chat/test_researcher_profile_tools.py` (tool outcomes, toolset registration).
- Full `research_ai` suite passes (1082 tests); `ruff check` and `ruff format` clean.