### PR TITLE
[Notebook Chat] Reap stale agent executions and bound turn tasks

### DIFF
--- a/src/research_ai/services/agent_persistence/__init__.py
+++ b/src/research_ai/services/agent_persistence/__init__.py
@@ -12,6 +12,7 @@ from .execution_service import (
     AgentExecutionService,
     AgentStaleRetryError,
 )
+from .reaper_service import AgentExecutionReaperService
 from .recorder import DatabaseAgentRecorder
 from .retention_service import AgentRetentionService
 from .run_details_service import (
@@ -25,6 +26,7 @@ __all__ = [
     "AgentConversationBusyError",
     "AgentConversationService",
     "AgentExecutionCancelService",
+    "AgentExecutionReaperService",
     "AgentExecutionService",
     "AgentRetentionService",
     "AgentRunDetails",

--- a/src/research_ai/services/agent_persistence/cancel_service.py
+++ b/src/research_ai/services/agent_persistence/cancel_service.py
@@ -1,11 +1,14 @@
-"""Cooperative cancellation for agent executions.
+"""Cooperative cancellation and interruption for agent executions.
 
 A conversation permits one active execution, so one that never reaches a
 terminal status refuses every later turn as busy -- what happens when a worker
 dies before recording an outcome, or the broker never delivers a queued attempt.
-Cancelling unsticks it, and is deliberately the only way: no timeout is guessed
-at here, because one provider call can retry inside the vendor SDK for over an
-hour, so silence says nothing about whether a run is alive.
+Cancelling unsticks it on request; the liveness sweep (``reaper_service``)
+interrupts it unasked once its durable heartbeat goes stale, and both sealing
+paths share the reconciliation below. No timeout is guessed at from wall-clock
+silence alone: the sweep reads the heartbeat the recorder stamps on every
+durable write, with the task's own time limits bounding how long a healthy run
+may go quiet.
 
 It does not reach into the worker. The run stops before its next tool call,
 where the loop checks it still owns the execution, or at its next durable write,
@@ -38,7 +41,7 @@ CANCELLED_STOP_REASON = "cancelled"
 
 
 class AgentExecutionCancelService:
-    """Cancels executions on request."""
+    """Seals active executions from outside the worker that runs them."""
 
     def cancel(self, execution: AgentExecution) -> bool:
         """Mark an active execution ``CANCELLED``; report whether it landed.
@@ -48,6 +51,47 @@ class AgentExecutionCancelService:
         execution already reached a terminal state, which is the ordinary race
         of cancelling a turn that was finishing anyway.
         """
+        return self._seal(
+            execution,
+            status=AgentExecution.Status.CANCELLED,
+            stop_reason=CANCELLED_STOP_REASON,
+        )
+
+    def interrupt(
+        self,
+        execution: AgentExecution,
+        *,
+        stop_reason: str,
+        error_type: str,
+        error_message: str,
+        error_details: dict | None = None,
+    ) -> bool:
+        """Mark an active execution ``INTERRUPTED``; report whether it landed.
+
+        The same reconciliation as :meth:`cancel` -- the run stopped without
+        recording its own outcome either way -- but with error fields, because
+        this transition reports a failure the user did not ask for, not a
+        decision they made.
+        """
+        return self._seal(
+            execution,
+            status=AgentExecution.Status.INTERRUPTED,
+            stop_reason=stop_reason,
+            error_type=error_type,
+            error_message=error_message,
+            error_details=error_details,
+        )
+
+    def _seal(
+        self,
+        execution: AgentExecution,
+        *,
+        status: str,
+        stop_reason: str,
+        error_type: str = "",
+        error_message: str = "",
+        error_details: dict | None = None,
+    ) -> bool:
         with transaction.atomic():
             locked = (
                 AgentExecution.objects.select_for_update()
@@ -63,24 +107,28 @@ class AgentExecutionCancelService:
             if locked is None:
                 return False
             now = timezone.now()
-            locked.status = AgentExecution.Status.CANCELLED
-            locked.stop_reason = CANCELLED_STOP_REASON
+            locked.status = status
+            locked.stop_reason = stop_reason
             locked.finished_at = now
             locked.last_activity_at = now
             if locked.started_at is not None:
                 locked.duration_ms = max(
                     0, round((now - locked.started_at).total_seconds() * 1000)
                 )
-            locked.save(
-                update_fields=[
-                    "status",
-                    "stop_reason",
-                    "finished_at",
-                    "last_activity_at",
-                    "duration_ms",
-                    "updated_date",
-                ]
-            )
+            update_fields = [
+                "status",
+                "stop_reason",
+                "finished_at",
+                "last_activity_at",
+                "duration_ms",
+                "updated_date",
+            ]
+            if error_type:
+                locked.error_type = error_type
+                locked.error_message = error_message
+                locked.error_details = error_details or {}
+                update_fields.extend(["error_type", "error_message", "error_details"])
+            locked.save(update_fields=update_fields)
             self._preserve_trigger_prompt(locked)
             self._drop_unpublished_answer(locked)
         execution.refresh_from_db()
@@ -120,7 +168,7 @@ class AgentExecutionCancelService:
             return
         last.delete()
         logger.info(
-            "dropped an unpublished answer from a cancelled turn",
+            "dropped an unpublished answer from a stopped turn",
             extra={"execution_id": execution.id},
         )
 

--- a/src/research_ai/services/agent_persistence/reaper_service.py
+++ b/src/research_ai/services/agent_persistence/reaper_service.py
@@ -1,0 +1,141 @@
+"""Liveness sweep for agent executions whose worker silently died.
+
+A conversation permits one active execution, so a ``RUNNING`` row whose worker
+was OOM-killed, redeployed, or SIGKILLed -- and a ``PENDING`` row whose task
+was never delivered or claimed -- blocks every later turn on the conversation
+forever. The sweep finds those rows by their durable heartbeat
+(``last_activity_at``, stamped on every recorder write) and seals them
+``INTERRUPTED`` through the cancel service, which reconciles the recorded
+context with what the chat shows.
+
+Staleness thresholds must not undercut the turn task's own time limits: a live
+worker can go heartbeat-quiet for a whole model turn, and the task's soft time
+limit is what bounds that. Reaping earlier than the limit would interrupt
+healthy long turns; see ``run_notebook_chat_turn_task`` in
+``research_ai.tasks``.
+
+The sweep covers every workflow sharing the execution models (notebook chat,
+proposal drafting); callers that push user-facing events layer that on per
+reaped execution.
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
+
+from research_ai.models import AgentExecution
+from research_ai.services.agent_persistence.cancel_service import (
+    AgentExecutionCancelService,
+)
+
+logger = logging.getLogger(__name__)
+
+# Kept at (not under) the turn task's soft time limit plus scheduling slack, so
+# only a run whose worker is really gone can look stale.
+RUNNING_STALE_AFTER = timedelta(minutes=15)
+
+# A queued turn is normally claimed within seconds; this covers the stranded
+# window where the broker accepted the task but no worker ever ran it.
+PENDING_STALE_AFTER = timedelta(minutes=15)
+
+STALLED_STOP_REASON = "stalled"
+STALLED_ERROR_TYPE = "AgentExecutionStalled"
+
+
+class AgentExecutionReaperService:
+    """Seals executions abandoned by a dead worker or a lost task."""
+
+    def __init__(
+        self,
+        *,
+        cancel_service: AgentExecutionCancelService | None = None,
+        running_stale_after: timedelta = RUNNING_STALE_AFTER,
+        pending_stale_after: timedelta = PENDING_STALE_AFTER,
+    ):
+        self.cancels = (
+            AgentExecutionCancelService() if cancel_service is None else cancel_service
+        )
+        self.running_stale_after = running_stale_after
+        self.pending_stale_after = pending_stale_after
+
+    def reap(self, *, now: datetime | None = None) -> list[AgentExecution]:
+        """Interrupt every stale active execution; return the rows sealed here."""
+        now = timezone.now() if now is None else now
+        reaped = []
+        for execution_id in self._stale_execution_ids(now):
+            execution = self._reap_one(execution_id, now)
+            if execution is not None:
+                reaped.append(execution)
+        return reaped
+
+    def _stale_q(self, now: datetime) -> Q:
+        running_cutoff = now - self.running_stale_after
+        pending_cutoff = now - self.pending_stale_after
+        # Every RUNNING row gets a heartbeat at claim time; the fallback on
+        # ``updated_date`` only keeps a row with a manually blanked heartbeat
+        # from becoming unreapable.
+        running_stale = Q(status=AgentExecution.Status.RUNNING) & (
+            Q(last_activity_at__lt=running_cutoff)
+            | (Q(last_activity_at__isnull=True) & Q(updated_date__lt=running_cutoff))
+        )
+        pending_stale = Q(
+            status=AgentExecution.Status.PENDING, created_date__lt=pending_cutoff
+        )
+        return running_stale | pending_stale
+
+    def _stale_execution_ids(self, now: datetime) -> list[int]:
+        return list(
+            AgentExecution.objects.filter(self._stale_q(now))
+            .order_by("id")
+            .values_list("id", flat=True)
+        )
+
+    def _reap_one(self, execution_id: int, now: datetime) -> AgentExecution | None:
+        """Seal one candidate, re-checking staleness under the row lock.
+
+        The heartbeat can advance between the sweep's scan and this write; the
+        locked re-read is what makes interrupting a live run impossible rather
+        than merely unlikely. ``skip_locked`` treats a row a worker is writing
+        this instant as alive, and keeps concurrent sweeps off each other.
+        """
+        with transaction.atomic():
+            execution = (
+                AgentExecution.objects.select_for_update(skip_locked=True)
+                .filter(self._stale_q(now), id=execution_id)
+                .first()
+            )
+            if execution is None:
+                return None
+            was_pending = execution.status == AgentExecution.Status.PENDING
+            if was_pending:
+                minutes = round(self.pending_stale_after.total_seconds() / 60)
+                error_message = (
+                    f"The queued turn was not claimed by any worker within "
+                    f"{minutes} minutes."
+                )
+            else:
+                minutes = round(self.running_stale_after.total_seconds() / 60)
+                error_message = (
+                    f"The turn recorded no activity for over {minutes} minutes; "
+                    f"its worker likely died."
+                )
+            if not self.cancels.interrupt(
+                execution,
+                stop_reason=STALLED_STOP_REASON,
+                error_type=STALLED_ERROR_TYPE,
+                error_message=error_message,
+                error_details={"stop_reason": STALLED_STOP_REASON},
+            ):
+                return None
+        logger.warning(
+            "reaped a stale agent execution",
+            extra={
+                "execution_id": execution.id,
+                "conversation_id": execution.conversation_id,
+                "was_pending": was_pending,
+            },
+        )
+        return execution

--- a/src/research_ai/services/agent_persistence/retention_service.py
+++ b/src/research_ai/services/agent_persistence/retention_service.py
@@ -1,6 +1,18 @@
 """Explicit retention services for disposable execution traces."""
 
-from research_ai.models import AgentConversation, AgentExecution
+from datetime import datetime, timedelta
+
+from django.utils import timezone
+
+from research_ai.models import AgentConversation, AgentExecution, AgentExecutionMessage
+
+# How long observational trace rows stay before the scheduled sweep removes
+# them. Chat messages and context lineage are unaffected -- see the service.
+TRACE_RETENTION = timedelta(days=30)
+
+# Rows deleted per query during the sweep, so the first run over a large
+# backlog holds no long transaction.
+_DELETE_BATCH_SIZE = 5_000
 
 
 class AgentRetentionService:
@@ -15,3 +27,28 @@ class AgentRetentionService:
         # pending/failure markers, and continuation. Only observational trace
         # rows are disposable.
         conversation.trace_messages.all().delete()
+
+    def delete_stale_traces(
+        self,
+        *,
+        older_than: timedelta = TRACE_RETENTION,
+        now: datetime | None = None,
+    ) -> int:
+        """Delete trace rows past the retention window; return how many.
+
+        Same scope rule as above: only ``AgentExecutionMessage`` rows go.
+        Context lineage must survive indefinitely -- an old chat's next turn
+        still reconstructs from it -- and chat messages are the product.
+        """
+        cutoff = (timezone.now() if now is None else now) - older_than
+        total = 0
+        while True:
+            batch = list(
+                AgentExecutionMessage.objects.filter(
+                    created_date__lt=cutoff
+                ).values_list("id", flat=True)[:_DELETE_BATCH_SIZE]
+            )
+            if not batch:
+                return total
+            deleted, _ = AgentExecutionMessage.objects.filter(id__in=batch).delete()
+            total += deleted

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -76,6 +76,7 @@ from research_ai.services.notebook_chat.activity import (
 from research_ai.services.notebook_chat.config import NotebookChatConfig
 from research_ai.services.notebook_chat.events import (
     TURN_CANCELLED,
+    TURN_FAILED,
     TURN_QUEUED,
     ConversationEventPublisher,
     PublishingRecorder,
@@ -549,6 +550,24 @@ class NotebookChatService:
         # terminal transition precedence for the execution.
         self.events.publish(conversation.id, execution.id, TURN_CANCELLED)
         return execution
+
+    def notify_turn_reaped(self, execution: AgentExecution) -> None:
+        """Push the terminal event for a turn the liveness sweep interrupted.
+
+        The sweep seals the row itself; this is only the client-facing tail
+        the worker would have produced -- clear any transient stream preview,
+        then nudge subscribers to refetch. Harmless for conversations no one
+        subscribes to (headless workflows share the execution models).
+        """
+        try:
+            self.streams.clear(execution.id)
+        except Exception:  # noqa: BLE001 - preview cleanup is optional
+            logger.warning(
+                "notebook chat stream clear failed for reaped execution %s",
+                execution.id,
+                exc_info=True,
+            )
+        self.events.publish(execution.conversation_id, execution.id, TURN_FAILED)
 
     def _schedule_turn(self, execution_id: int) -> None:
         """Queue the worker turn, failing the execution if the broker refuses.

--- a/src/research_ai/tasks.py
+++ b/src/research_ai/tasks.py
@@ -6,6 +6,10 @@ from django.utils import timezone
 
 from research_ai.constants import VALID_EMAIL_TEMPLATE_KEYS
 from research_ai.models import ExpertSearch, GeneratedEmail, ProposalDraft
+from research_ai.services.agent_persistence import (
+    AgentExecutionReaperService,
+    AgentRetentionService,
+)
 from research_ai.services.expert_finder import finder as expert_finder_mod
 from research_ai.services.expert_finder.display import ExpertDisplay
 from research_ai.services.expert_finder.persist import ExpertPersist
@@ -237,7 +241,23 @@ def run_expert_finder_search(
         raise
 
 
-@app.task(queue=QUEUE_AGENTS)
+# One notebook chat turn's wall-clock budget. The soft limit raises inside the
+# task so ``run_turn``'s safety net seals the execution FAILED; the hard limit
+# is the backstop when even that hangs, and the reaper's staleness threshold
+# must stay at or above these so it only ever collects truly dead runs.
+NOTEBOOK_CHAT_TURN_SOFT_TIME_LIMIT = 15 * 60
+NOTEBOOK_CHAT_TURN_TIME_LIMIT = NOTEBOOK_CHAT_TURN_SOFT_TIME_LIMIT + 60
+
+
+@app.task(
+    queue=QUEUE_AGENTS,
+    # Acknowledged after completion, so a worker that dies holding a prefetched,
+    # not-yet-claimed turn hands it to another worker instead of losing it.
+    # ``run_turn``'s atomic claim makes any duplicate delivery a no-op.
+    acks_late=True,
+    soft_time_limit=NOTEBOOK_CHAT_TURN_SOFT_TIME_LIMIT,
+    time_limit=NOTEBOOK_CHAT_TURN_TIME_LIMIT,
+)
 def run_notebook_chat_turn_task(execution_id: int):
     """
     Background task to run one prepared notebook chat turn.
@@ -250,6 +270,34 @@ def run_notebook_chat_turn_task(execution_id: int):
             extra={"execution_id": execution_id, "error": result["error"]},
         )
     return result
+
+
+@app.task(queue=QUEUE_AGENTS)
+def reap_stale_agent_executions():
+    """
+    Beat-scheduled liveness sweep: seal executions abandoned by dead workers.
+    """
+    service = NotebookChatService()
+    reaped = AgentExecutionReaperService().reap()
+    for execution in reaped:
+        service.notify_turn_reaped(execution)
+    if reaped:
+        logger.warning(
+            "Reaped stale agent executions",
+            extra={"execution_ids": [execution.id for execution in reaped]},
+        )
+    return {"reaped": [execution.id for execution in reaped]}
+
+
+@app.task(queue=QUEUE_AGENTS)
+def prune_agent_execution_traces():
+    """
+    Beat-scheduled retention sweep: drop observational trace rows past the
+    retention window. Chat messages and context lineage are kept.
+    """
+    deleted = AgentRetentionService().delete_stale_traces()
+    logger.info("Pruned agent execution traces", extra={"deleted": deleted})
+    return {"deleted": deleted}
 
 
 @app.task(queue=QUEUE_AGENTS)

--- a/src/research_ai/tests/agent/test_persistence_reaper.py
+++ b/src/research_ai/tests/agent/test_persistence_reaper.py
@@ -1,0 +1,213 @@
+"""Liveness-sweep coverage: stale executions are sealed, live ones are not."""
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+from research_ai.models import AgentConversation, AgentExecution
+from research_ai.services.agent.types import Message, TextBlock
+from research_ai.services.agent_persistence import (
+    AgentChatService,
+    AgentExecutionReaperService,
+    AgentExecutionService,
+)
+from research_ai.services.agent_persistence.reaper_service import (
+    STALLED_ERROR_TYPE,
+    STALLED_STOP_REASON,
+)
+from research_ai.tests.agent.persistence_test_helpers import AgentPersistenceTestCase
+
+
+class AgentExecutionReaperTests(AgentPersistenceTestCase):
+    def setUp(self):
+        super().setUp()
+        self.chat = AgentChatService()
+        self.reaper = AgentExecutionReaperService()
+
+    def _pending_turn(self, text="Please summarize."):
+        return self.chat.prepare_turn(self.conversation, text, pending=True).execution
+
+    def _running_turn(self, text="Please summarize."):
+        execution = self._pending_turn(text)
+        recorder = AgentExecutionService().claim_pending(execution)
+        self.assertIsNotNone(recorder)
+        return execution, recorder
+
+    @staticmethod
+    def _age(execution, minutes, **field_overrides):
+        past = timezone.now() - timedelta(minutes=minutes)
+        fields = {"last_activity_at": past, "created_date": past}
+        fields.update(field_overrides)
+        AgentExecution.objects.filter(id=execution.id).update(**fields)
+        execution.refresh_from_db()
+
+    def test_stale_running_execution_is_interrupted_with_error_fields(self):
+        # Arrange
+        execution, _recorder = self._running_turn()
+        self._age(execution, minutes=20)
+
+        # Act
+        reaped = self.reaper.reap()
+
+        # Assert
+        execution.refresh_from_db()
+        self.assertEqual([reaped_row.id for reaped_row in reaped], [execution.id])
+        self.assertEqual(execution.status, AgentExecution.Status.INTERRUPTED)
+        self.assertEqual(execution.stop_reason, STALLED_STOP_REASON)
+        self.assertEqual(execution.error_type, STALLED_ERROR_TYPE)
+        self.assertIn("worker likely died", execution.error_message)
+        self.assertIsNotNone(execution.finished_at)
+
+    def test_fresh_running_execution_is_left_alone(self):
+        # Arrange: heartbeat stamped at claim time, moments ago.
+        execution, _recorder = self._running_turn()
+
+        # Act
+        reaped = self.reaper.reap()
+
+        # Assert
+        execution.refresh_from_db()
+        self.assertEqual(reaped, [])
+        self.assertEqual(execution.status, AgentExecution.Status.RUNNING)
+
+    def test_stale_pending_execution_is_interrupted_and_context_seeded(self):
+        # Arrange: a queued turn whose task was lost before any worker claimed
+        # it. Its prompt exists only as the chat message that triggered it.
+        execution = self._pending_turn("The lost question")
+        self._age(execution, minutes=20)
+
+        # Act
+        reaped = self.reaper.reap()
+
+        # Assert: sealed, and the prompt was seeded into the durable context
+        # so the next turn's model view still contains it.
+        execution.refresh_from_db()
+        self.assertEqual([reaped_row.id for reaped_row in reaped], [execution.id])
+        self.assertEqual(execution.status, AgentExecution.Status.INTERRUPTED)
+        self.assertIn("not claimed", execution.error_message)
+        (context_row,) = execution.context_messages.all()
+        self.assertEqual(context_row.content[0]["text"], "The lost question")
+
+    def test_fresh_pending_execution_is_left_alone(self):
+        # Arrange
+        execution = self._pending_turn()
+
+        # Act
+        reaped = self.reaper.reap()
+
+        # Assert
+        execution.refresh_from_db()
+        self.assertEqual(reaped, [])
+        self.assertEqual(execution.status, AgentExecution.Status.PENDING)
+
+    def test_running_execution_without_heartbeat_falls_back_to_updated_date(self):
+        # Arrange: a defensive path -- claim always stamps the heartbeat, so
+        # only a manually blanked row can look like this.
+        execution, _recorder = self._running_turn()
+        past = timezone.now() - timedelta(minutes=20)
+        AgentExecution.objects.filter(id=execution.id).update(
+            last_activity_at=None, updated_date=past
+        )
+
+        # Act
+        reaped = self.reaper.reap()
+
+        # Assert
+        execution.refresh_from_db()
+        self.assertEqual(len(reaped), 1)
+        self.assertEqual(execution.status, AgentExecution.Status.INTERRUPTED)
+
+    def test_zombie_turns_unpublished_closing_answer_is_dropped(self):
+        # Arrange: the worker died after durably recording its final answer
+        # but before sealing SUCCEEDED -- the answer was never published, so
+        # the next turn must not resume from a reply the user never saw.
+        execution, recorder = self._running_turn("Question")
+        recorder.record_message(Message(role="user", content=[TextBlock(text="Q")]))
+        recorder.record_message(
+            Message(role="assistant", content=[TextBlock(text="Unseen answer")])
+        )
+        self._age(execution, minutes=20)
+
+        # Act
+        self.reaper.reap()
+
+        # Assert
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, AgentExecution.Status.INTERRUPTED)
+        roles = list(
+            execution.context_messages.order_by("sequence").values_list(
+                "role", flat=True
+            )
+        )
+        self.assertEqual(roles, ["user"])
+
+    def test_reaped_conversation_accepts_the_next_turn(self):
+        # Arrange: the exact failure being fixed -- a dead worker's RUNNING
+        # row used to 409-block the conversation forever.
+        execution, _recorder = self._running_turn()
+        self._age(execution, minutes=20)
+
+        # Act
+        self.reaper.reap()
+        next_turn = self.chat.prepare_turn(
+            self.conversation, "Trying again", pending=True
+        )
+
+        # Assert
+        self.assertEqual(next_turn.execution.status, AgentExecution.Status.PENDING)
+
+    def test_terminal_executions_are_never_reaped(self):
+        # Arrange
+        execution, recorder = self._running_turn()
+        recorder.on_run_failed(RuntimeError("already sealed"))
+        self._age(execution, minutes=60)
+
+        # Act
+        reaped = self.reaper.reap()
+
+        # Assert
+        execution.refresh_from_db()
+        self.assertEqual(reaped, [])
+        self.assertEqual(execution.status, AgentExecution.Status.FAILED)
+
+    def test_sweep_covers_every_workflow_sharing_the_models(self):
+        # Arrange: a headless proposal-draft run abandoned by its worker.
+        conversation = AgentConversation.objects.create(workflow="proposal_draft")
+        recorder = AgentExecutionService().start(conversation, provider="fake")
+        execution = recorder.execution
+        self._age(execution, minutes=20)
+
+        # Act
+        reaped = self.reaper.reap()
+
+        # Assert
+        execution.refresh_from_db()
+        self.assertEqual([reaped_row.id for reaped_row in reaped], [execution.id])
+        self.assertEqual(execution.status, AgentExecution.Status.INTERRUPTED)
+
+    def test_candidate_whose_heartbeat_advanced_is_skipped_under_the_lock(self):
+        # Arrange: the row looked stale when the sweep scanned, but its worker
+        # wrote a heartbeat before the sweep reached it.
+        execution, _recorder = self._running_turn()
+
+        # Act: the per-row seal re-checks staleness and must refuse.
+        sealed = self.reaper._reap_one(execution.id, timezone.now())
+
+        # Assert
+        execution.refresh_from_db()
+        self.assertIsNone(sealed)
+        self.assertEqual(execution.status, AgentExecution.Status.RUNNING)
+
+    def test_reaped_turn_renders_an_interrupted_public_error(self):
+        # Arrange
+        execution, _recorder = self._running_turn()
+        self._age(execution, minutes=20)
+
+        # Act
+        self.reaper.reap()
+        (entry,) = self.chat.representation(self.conversation)["executions"]
+
+        # Assert: the public payload names the interruption without leaking
+        # the internal message.
+        self.assertEqual(entry["error"]["code"], "agent_interrupted")
+        self.assertNotIn("worker", entry["error"]["message"])

--- a/src/research_ai/tests/agent/test_persistence_services.py
+++ b/src/research_ai/tests/agent/test_persistence_services.py
@@ -1,8 +1,10 @@
 """Conversation, context, run-detail, and retention service coverage."""
 
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.db import IntegrityError, transaction
+from django.utils import timezone
 
 from note.models import Note
 from research_ai.models import (
@@ -124,6 +126,47 @@ class AgentPersistenceServiceTests(AgentPersistenceTestCase):
         )
         self.assertEqual(AgentExecutionMessage.objects.count(), 0)
         self.assertEqual(AgentContextMessage.objects.count(), 2)
+
+    def test_stale_trace_sweep_deletes_only_old_trace_rows(self):
+        # Arrange: a finished turn whose trace has aged past retention, and a
+        # newer one that must survive.
+        human_message = AgentConversationService().add_human_message(
+            self.conversation, "Old question"
+        )
+        recorder = AgentExecutionService().start(
+            self.conversation,
+            trigger_message=human_message,
+            initial_prompt_provenance=AgentExecutionMessage.Provenance.HUMAN,
+            publish_assistant_message=True,
+        )
+        agent(FakeProvider([text_turn("Old answer")]), recorder).run("Old question")
+        old_execution = recorder.execution
+        AgentExecutionMessage.objects.filter(execution=old_execution).update(
+            created_date=timezone.now() - timedelta(days=45)
+        )
+        fresh_message = AgentConversationService().add_human_message(
+            self.conversation, "Fresh question"
+        )
+        fresh_recorder = AgentExecutionService().start(
+            self.conversation,
+            trigger_message=fresh_message,
+            initial_prompt_provenance=AgentExecutionMessage.Provenance.HUMAN,
+            publish_assistant_message=True,
+        )
+        agent(FakeProvider([text_turn("Fresh answer")]), fresh_recorder).run(
+            "Fresh question"
+        )
+
+        # Act
+        deleted = AgentRetentionService().delete_stale_traces()
+
+        # Assert: old trace rows gone; fresh trace, all context lineage, and
+        # the chat itself untouched.
+        self.assertEqual(deleted, 2)
+        self.assertEqual(old_execution.messages.count(), 0)
+        self.assertEqual(fresh_recorder.execution.messages.count(), 2)
+        self.assertEqual(old_execution.context_messages.count(), 2)
+        self.assertEqual(self.conversation.chat_messages.count(), 4)
 
     def test_context_reconstruction_orders_messages_across_executions(self):
         # Arrange

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -14,6 +14,7 @@ from research_ai.models import (
 from research_ai.services.agent.types import StopReason
 from research_ai.services.agent_persistence import (
     AgentConversationBusyError,
+    AgentExecutionCancelService,
     DatabaseAgentRecorder,
 )
 from research_ai.services.notebook_chat import (
@@ -1181,4 +1182,73 @@ class NotebookChatEventSendOrderTests(TransactionTestCase):
                 }
                 for kind in (TURN_QUEUED, TURN_FAILED)
             ],
+        )
+
+
+class NotifyTurnReapedTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="owner@researchhub_test.com",
+            password="password",
+            email="owner@researchhub_test.com",
+        )
+        self.note = create_note(self.user, organization=None)[0]
+        Permission.objects.create(
+            access_type=ADMIN,
+            content_type=ContentType.objects.get_for_model(ResearchhubUnifiedDocument),
+            object_id=self.note.unified_document.id,
+            user=self.user,
+        )
+        self.publisher = Mock()
+        self.service = _make_service(event_publisher=self.publisher)
+        self.conversation = self.service.create_conversation(self.note, self.user)
+
+    def _reaped_execution(self):
+        with (
+            patch("research_ai.tasks.run_notebook_chat_turn_task.delay"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            execution = self.service.submit_message(
+                self.note, self.conversation, "Hello"
+            )
+        AgentExecutionCancelService().interrupt(
+            execution,
+            stop_reason="stalled",
+            error_type="AgentExecutionStalled",
+            error_message="worker died",
+        )
+        return execution
+
+    def test_notify_clears_the_stream_and_publishes_turn_failed(self):
+        # Arrange
+        execution = self._reaped_execution()
+        self.publisher.reset_mock()
+        self.service.streams = Mock()
+
+        # Act
+        self.service.notify_turn_reaped(execution)
+
+        # Assert
+        self.service.streams.clear.assert_called_once_with(execution.id)
+        self.publisher.publish.assert_called_once_with(
+            self.conversation.id, execution.id, TURN_FAILED
+        )
+
+    def test_notify_survives_stream_cleanup_failure(self):
+        # Arrange
+        execution = self._reaped_execution()
+        self.publisher.reset_mock()
+        self.service.streams = Mock()
+        self.service.streams.clear.side_effect = RuntimeError("redis down")
+
+        # Act
+        with self.assertLogs(
+            "research_ai.services.notebook_chat.service", level="WARNING"
+        ):
+            self.service.notify_turn_reaped(execution)
+
+        # Assert: the refetch nudge still goes out.
+        self.publisher.publish.assert_called_once_with(
+            self.conversation.id, execution.id, TURN_FAILED
         )

--- a/src/research_ai/tests/test_tasks.py
+++ b/src/research_ai/tests/test_tasks.py
@@ -1,10 +1,16 @@
-"""Tests for research_ai.tasks: expert search, bulk email, send queued emails."""
+"""Tests for research_ai.tasks: expert search, bulk email, send queued emails,
+notebook chat turns, and the agent maintenance sweeps."""
 
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.test import TestCase, override_settings
+from django.utils import timezone
 
 from research_ai.models import (
+    AgentConversation,
+    AgentExecution,
+    AgentExecutionMessage,
     Expert,
     ExpertSearch,
     GeneratedEmail,
@@ -12,8 +18,13 @@ from research_ai.models import (
     SearchExpert,
 )
 from research_ai.tasks import (
+    NOTEBOOK_CHAT_TURN_SOFT_TIME_LIMIT,
+    NOTEBOOK_CHAT_TURN_TIME_LIMIT,
     _update_search_progress,
     process_bulk_generate_emails_task,
+    prune_agent_execution_traces,
+    reap_stale_agent_executions,
+    run_notebook_chat_turn_task,
     run_proposal_draft_task,
     send_queued_emails_task,
 )
@@ -408,3 +419,149 @@ class RunProposalDraftTaskTests(TestCase):
         mock_run.assert_not_called()
         self.assertEqual(result["status"], ProposalDraft.Status.PROCESSING)
         self.assertEqual(result["skipped"], "already_claimed")
+
+
+# --- run_notebook_chat_turn_task ---
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+class RunNotebookChatTurnTaskTests(TestCase):
+    @patch("research_ai.tasks.NotebookChatService")
+    def test_runs_the_service_and_returns_its_result(self, service_class):
+        # Arrange
+        service_class.return_value.run_turn.return_value = {
+            "execution_id": 7,
+            "final_text": "Done.",
+        }
+
+        # Act
+        result = run_notebook_chat_turn_task.apply(args=[7]).get()
+
+        # Assert
+        service_class.return_value.run_turn.assert_called_once_with(7)
+        self.assertEqual(result["final_text"], "Done.")
+
+    @patch("research_ai.tasks.logger")
+    @patch("research_ai.tasks.NotebookChatService")
+    def test_error_outcome_is_logged(self, service_class, mock_logger):
+        # Arrange
+        service_class.return_value.run_turn.return_value = {
+            "execution_id": 7,
+            "error": "provider exploded",
+        }
+
+        # Act
+        result = run_notebook_chat_turn_task.apply(args=[7]).get()
+
+        # Assert: the task reports rather than raises -- the service already
+        # sealed the execution -- but the failure is visible in logs.
+        self.assertEqual(result["error"], "provider exploded")
+        mock_logger.warning.assert_called_once()
+
+    def test_turn_task_is_bounded_and_survives_worker_loss(self):
+        # Assert: acks_late hands a prefetched turn to another worker when
+        # this one dies before claiming it, and the time limits guarantee a
+        # live worker cannot hold an execution forever.
+        self.assertTrue(run_notebook_chat_turn_task.acks_late)
+        self.assertEqual(
+            run_notebook_chat_turn_task.soft_time_limit,
+            NOTEBOOK_CHAT_TURN_SOFT_TIME_LIMIT,
+        )
+        self.assertEqual(
+            run_notebook_chat_turn_task.time_limit, NOTEBOOK_CHAT_TURN_TIME_LIMIT
+        )
+        self.assertGreater(
+            NOTEBOOK_CHAT_TURN_TIME_LIMIT, NOTEBOOK_CHAT_TURN_SOFT_TIME_LIMIT
+        )
+
+
+# --- agent maintenance sweeps ---
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+class ReapStaleAgentExecutionsTaskTests(TestCase):
+    def test_reaps_and_notifies_stale_executions(self):
+        # Arrange: a RUNNING row whose worker died long ago, and a live one.
+        conversation = AgentConversation.objects.create(workflow="notebook_chat")
+        past = timezone.now() - timedelta(minutes=30)
+        stale = AgentExecution.objects.create(
+            conversation=conversation,
+            attempt=1,
+            status=AgentExecution.Status.RUNNING,
+            started_at=past,
+            last_activity_at=past,
+        )
+        live_conversation = AgentConversation.objects.create(workflow="notebook_chat")
+        live = AgentExecution.objects.create(
+            conversation=live_conversation,
+            attempt=1,
+            status=AgentExecution.Status.RUNNING,
+            started_at=timezone.now(),
+            last_activity_at=timezone.now(),
+        )
+
+        # Act
+        with patch("research_ai.tasks.NotebookChatService") as service_class:
+            result = reap_stale_agent_executions.apply().get()
+
+        # Assert
+        stale.refresh_from_db()
+        live.refresh_from_db()
+        self.assertEqual(result["reaped"], [stale.id])
+        self.assertEqual(stale.status, AgentExecution.Status.INTERRUPTED)
+        self.assertEqual(live.status, AgentExecution.Status.RUNNING)
+        notified = service_class.return_value.notify_turn_reaped
+        notified.assert_called_once()
+        self.assertEqual(notified.call_args.args[0].id, stale.id)
+
+    def test_quiet_sweep_reaps_nothing(self):
+        # Act
+        with patch("research_ai.tasks.NotebookChatService") as service_class:
+            result = reap_stale_agent_executions.apply().get()
+
+        # Assert
+        self.assertEqual(result["reaped"], [])
+        service_class.return_value.notify_turn_reaped.assert_not_called()
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+class PruneAgentExecutionTracesTaskTests(TestCase):
+    def test_prunes_only_traces_past_retention(self):
+        # Arrange
+        conversation = AgentConversation.objects.create(workflow="notebook_chat")
+        execution = AgentExecution.objects.create(
+            conversation=conversation,
+            attempt=1,
+            status=AgentExecution.Status.SUCCEEDED,
+        )
+        old_trace = AgentExecutionMessage.objects.create(
+            conversation=conversation,
+            execution=execution,
+            sequence=1,
+            execution_sequence=1,
+            role="user",
+            provenance=AgentExecutionMessage.Provenance.HUMAN,
+            content=[{"type": "text", "text": "old"}],
+        )
+        AgentExecutionMessage.objects.filter(id=old_trace.id).update(
+            created_date=timezone.now() - timedelta(days=45)
+        )
+        fresh_trace = AgentExecutionMessage.objects.create(
+            conversation=conversation,
+            execution=execution,
+            sequence=2,
+            execution_sequence=2,
+            role="assistant",
+            provenance=AgentExecutionMessage.Provenance.MODEL,
+            content=[{"type": "text", "text": "fresh"}],
+        )
+
+        # Act
+        result = prune_agent_execution_traces.apply().get()
+
+        # Assert
+        self.assertEqual(result["deleted"], 1)
+        self.assertFalse(AgentExecutionMessage.objects.filter(id=old_trace.id).exists())
+        self.assertTrue(
+            AgentExecutionMessage.objects.filter(id=fresh_trace.id).exists()
+        )

--- a/src/researchhub/celery.py
+++ b/src/researchhub/celery.py
@@ -202,6 +202,25 @@ app.conf.beat_schedule = {
             "queue": QUEUE_PAPER_MISC,
         },
     },
+    # Research AI agents
+    "research-ai_reap-stale-agent-executions": {
+        "task": "research_ai.tasks.reap_stale_agent_executions",
+        # Every 5 minutes: with a 15-minute staleness threshold, a dead
+        # worker's conversation is unblocked within ~20 minutes.
+        "schedule": crontab(minute="*/5"),
+        "options": {
+            "priority": 2,
+            "queue": QUEUE_AGENTS,
+        },
+    },
+    "research-ai_prune-agent-execution-traces": {
+        "task": "research_ai.tasks.prune_agent_execution_traces",
+        "schedule": crontab(hour=3, minute=40),
+        "options": {
+            "priority": 5,
+            "queue": QUEUE_AGENTS,
+        },
+    },
     # Paper ingestion tasks
     "paper-fetch-all": {
         "task": "paper.ingestion.pipeline.fetch_all_papers",


### PR DESCRIPTION
## What

First of a 3-PR stack making notebook agent failure a non-event (this → auto-retry → error taxonomy + retry endpoint).

A worker death (OOM, deploy, SIGKILL) leaves its `AgentExecution` RUNNING forever, and the `ra_agent_exec_one_active` constraint then 409-blocks every future message on that conversation permanently. A lost enqueue can strand a PENDING row the same way. There was no liveness sweep (the docstring in `chat_service.py` referenced one that didn't exist), no time limits on the turn task, and no `research_ai` beat entries — two zombie rows have been RUNNING in dev since Jul 31.

## How

- **`AgentExecutionReaperService`** (new, `agent_persistence/reaper_service.py`): finds RUNNING executions whose `last_activity_at` heartbeat is stale (15 min, `updated_date` fallback for null heartbeats) and PENDING rows older than 15 min, and seals them INTERRUPTED with error fields. Staleness is re-checked under `select_for_update(skip_locked=True)`, so a heartbeat that advances between scan and seal — or a row a worker is writing that instant — can never be reaped. Sweeps **all** workflows sharing the models (notebook chat and proposal drafting).
- **Cancel-service reuse**: `AgentExecutionCancelService` grows a shared `_seal()` behind `cancel()` (unchanged) and a new `interrupt()`, so both sealing paths run the same reconciliation — a reaped PENDING turn's prompt is seeded into context, a zombie's unpublished closing answer is dropped.
- **Turn task bounds**: `run_notebook_chat_turn_task` gets `soft_time_limit=900`, `time_limit=960`, and `acks_late=True`. The soft limit lets `run_turn`'s safety net seal the execution FAILED itself; `acks_late` hands a prefetched-but-unclaimed turn to another worker on worker loss (`claim_pending` already makes duplicate delivery a no-op). The reaper threshold is deliberately ≥ the limits, so only truly dead runs can look stale.
- **Beat entries**: reaper every 5 min (worst-case unbrick ~20 min) and `AgentRetentionService.delete_stale_traces` daily — observational trace rows older than 30 days go, in batches; chat messages and context lineage are untouchable.
- `NotebookChatService.notify_turn_reaped` pushes `turn_failed` and clears the transient stream snapshot for reaped turns (harmless no-op group for headless workflows).

No migrations. One accepted trade-off: reaping a proposal-draft execution doesn't touch the `ProposalDraft` row's own status lifecycle (pre-existing gap, unchanged).

## Testing

- New `tests/agent/test_persistence_reaper.py` (11 tests: stale vs fresh RUNNING/PENDING, context reconciliation, cross-workflow sweep, locked staleness re-check, conversation unblocked afterwards, public error rendering).
- New retention sweep test, `run_notebook_chat_turn_task` wrapper tests (previously untested), and reap/prune task tests with AAA markers.
- Full `research_ai` suite passes on this branch alone (1119 tests); `ruff check` and `ruff format` clean.