### PR TITLE
[Notebook Chat] Auto-retry transient provider failures with backoff

### DIFF
--- a/src/research_ai/services/agent/errors.py
+++ b/src/research_ai/services/agent/errors.py
@@ -40,7 +40,22 @@ class ProviderError(AgentRunError):
 
     Providers raise this without a transcript; the loop attaches ``messages``
     and ``iterations`` as the error propagates through it.
+
+    ``retryable`` marks transient conditions (overload, rate limit, 5xx, a
+    dropped stream) where repeating the identical request may succeed, as
+    opposed to failures of the request itself (auth, config, invalid input).
     """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        messages: list[Message] | None = None,
+        iterations: int | None = None,
+        retryable: bool = False,
+    ):
+        super().__init__(message, messages=messages, iterations=iterations)
+        self.retryable = retryable
 
 
 class IncompleteTurnError(AgentRunError):

--- a/src/research_ai/services/agent/providers/claude_platform.py
+++ b/src/research_ai/services/agent/providers/claude_platform.py
@@ -26,6 +26,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import Any
 
+import anthropic
+import httpx
 from anthropic import AnthropicAWS
 from django.conf import settings
 
@@ -160,6 +162,28 @@ _SERVER_TOOL_BLOCK_TYPES = (
 _CACHEABLE_BLOCK_TYPES = ("text", "tool_result")
 
 _PROVIDER_STATE_KEY = "anthropic"
+
+# HTTP statuses worth repeating unchanged, matching the Anthropic SDK's own
+# retry set: timeouts, races, rate limits, and every server-side failure
+# (529 is the Messages API's overloaded_error).
+_RETRYABLE_STATUS_CODES = frozenset({408, 409, 429})
+
+
+def _is_retryable_error(error: Exception) -> bool:
+    """Whether this SDK failure is transient rather than a fault of the request.
+
+    Connection failures (including timeouts) and mid-stream transport drops
+    can only be answered by trying again; auth, config, and invalid-request
+    statuses fail identically on every attempt.
+    """
+    if isinstance(error, anthropic.APIConnectionError):
+        return True
+    if isinstance(error, anthropic.APIStatusError):
+        status = error.status_code
+        return status in _RETRYABLE_STATUS_CODES or status >= 500
+    # A stream the API accepted but dropped mid-emission surfaces as a raw
+    # transport error from the iteration, not as an SDK request error.
+    return isinstance(error, httpx.TransportError)
 
 
 def _accepts_sampling_params(model_id: str) -> bool:
@@ -478,7 +502,10 @@ class ClaudePlatformProvider(LLMProvider):
                 response = self._stream_turn(kwargs, on_event=on_event)
             except Exception as e:
                 logger.exception("Claude Platform complete failed")
-                raise ProviderError(f"Claude Platform complete failed: {e}") from e
+                raise ProviderError(
+                    f"Claude Platform complete failed: {e}",
+                    retryable=_is_retryable_error(e),
+                ) from e
             responses.append(response)
             self._log_usage(response)
             self._log_continuation_state(response)

--- a/src/research_ai/services/agent/providers/openrouter.py
+++ b/src/research_ai/services/agent/providers/openrouter.py
@@ -13,6 +13,7 @@ import time
 from collections.abc import Callable
 from typing import Any
 
+import openai
 from django.conf import settings
 from openai import OpenAI
 
@@ -62,6 +63,22 @@ _NO_SAMPLING_PARAMS = (
 def _accepts_sampling_params(model_id: str) -> bool:
     mid = model_id.lower()
     return not any(tag in mid for tag in _NO_SAMPLING_PARAMS)
+
+
+# Statuses worth repeating unchanged: timeouts, races, rate limits, and every
+# server-side failure. Auth/config/invalid-request statuses fail identically
+# on every attempt.
+_RETRYABLE_STATUS_CODES = frozenset({408, 409, 429})
+
+
+def _is_retryable_error(error: Exception) -> bool:
+    """Whether this SDK failure is transient rather than a fault of the request."""
+    if isinstance(error, openai.APIConnectionError):
+        return True
+    if isinstance(error, openai.APIStatusError):
+        status = error.status_code
+        return status in _RETRYABLE_STATUS_CODES or status >= 500
+    return False
 
 
 # Chat Completions ``finish_reason`` -> neutral ``StopReason``.
@@ -162,7 +179,10 @@ class OpenRouterProvider(LLMProvider):
             response = self._client.chat.completions.create(**kwargs)
         except Exception as e:
             logger.exception("OpenRouter complete failed")
-            raise ProviderError(f"OpenRouter complete failed: {e}") from e
+            raise ProviderError(
+                f"OpenRouter complete failed: {e}",
+                retryable=_is_retryable_error(e),
+            ) from e
         latency_ms = int((time.perf_counter() - started) * 1000)
 
         self._log_usage(response)

--- a/src/research_ai/services/agent_persistence/chat_service.py
+++ b/src/research_ai/services/agent_persistence/chat_service.py
@@ -191,7 +191,34 @@ class AgentChatService:
         system_prompt: str | None = None,
         regenerate: bool = False,
         initial_prompt_provenance: str | None = None,
+        pending: bool = False,
     ) -> PreparedAgentExecution:
+        """Create a fresh attempt of ``execution``'s turn.
+
+        With ``pending=True`` the retry is created ``PENDING`` for a worker to
+        claim -- the same contract as ``prepare_turn`` -- and the returned
+        ``recorder`` and ``context`` are ``None``/empty, since the claiming
+        worker rebuilds both.
+        """
+        if pending:
+            if regenerate:
+                raise ValueError("a pending retry cannot replace published output")
+            retry = self.executions.create_pending(
+                execution.conversation,
+                provider=execution.provider,
+                model=execution.model,
+                configuration=(
+                    execution.configuration if configuration is None else configuration
+                ),
+                system_prompt=(
+                    execution.system_prompt if system_prompt is None else system_prompt
+                ),
+                trigger_message=execution.trigger_message,
+                context_parent=execution.context_parent,
+                retry_of=execution,
+                publish_assistant_message=True,
+            )
+            return PreparedAgentExecution(retry, None, execution.trigger_message, [])
         context = (
             self.contexts.reconstruct(execution.context_parent)
             if execution.context_parent

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -363,6 +363,10 @@ class DatabaseAgentRecorder:
             "iterations": getattr(error, "iterations", None),
             "cause_type": type(cause).__name__ if cause else None,
             "cause_message": _safe_exception_message(cause) if cause else None,
+            # The provider's transient-vs-permanent verdict, recorded because
+            # the exception dies with this worker and the public error taxonomy
+            # and retry policy both need the answer later.
+            "retryable": bool(getattr(error, "retryable", False)),
         }
         safe_details, _truncated, _size = bounded_payload(details)
         status = (

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -23,6 +23,11 @@ stale writes, never corrupt the note. A turn is split across two processes:
   ``Agent.continue_conversation``. The recorder persists the trace, marks the
   terminal status, and publishes the assistant's reply to the chat.
 
+A failed turn is not the end of it: a transient provider failure requeues
+itself with backoff (``_maybe_schedule_auto_retry``) through
+``AgentChatService.prepare_retry``, so the user's message is never retyped or
+renumbered.
+
 The agent acts strictly as the conversation's user and only on the
 conversation's note: ``NoteToolset`` enforces note view/edit permissions per
 call, so a viewer can chat and research but the edit tool refuses to write for
@@ -57,8 +62,10 @@ from research_ai.services.agent import (
 from research_ai.services.agent_persistence import (
     AgentChatService,
     AgentContextService,
+    AgentConversationBusyError,
     AgentConversationService,
     AgentExecutionCancelService,
+    AgentStaleRetryError,
     NoteAgentConversationService,
 )
 from research_ai.services.agent_persistence.activity import (
@@ -117,6 +124,15 @@ ACTIVITY_LIVE = "live"
 # full projection anyway. It also keeps a just-cancelled turn in scope while
 # its worker unwinds, when trace rows can genuinely still land.
 ACTIVITY_SETTLED_GRACE = timedelta(seconds=60)
+
+# Automatic retries for transient provider failures. A failed attempt whose
+# error the provider marked retryable is requeued with backoff, at most this
+# many times per trigger message -- counted by walking ``retry_of``. Each
+# retry is created ``PENDING`` immediately, which keeps the conversation's
+# busy check held across the backoff window: a user message cannot interleave
+# with an automatic retry.
+AUTO_RETRY_MAX_ATTEMPTS = 2
+AUTO_RETRY_DELAY_SECONDS = (5, 30)
 
 # Derived chat titles are list labels, not documents: one collapsed line,
 # well under the model field's 255-char bound.
@@ -569,7 +585,9 @@ class NotebookChatService:
             )
         self.events.publish(execution.conversation_id, execution.id, TURN_FAILED)
 
-    def _schedule_turn(self, execution_id: int) -> None:
+    def _schedule_turn(
+        self, execution_id: int, *, countdown: int | None = None
+    ) -> None:
         """Queue the worker turn, failing the execution if the broker refuses.
 
         A ``PENDING`` row with no task behind it would hold the
@@ -581,7 +599,12 @@ class NotebookChatService:
         from research_ai.tasks import run_notebook_chat_turn_task
 
         try:
-            run_notebook_chat_turn_task.delay(execution_id)
+            if countdown is None:
+                run_notebook_chat_turn_task.delay(execution_id)
+            else:
+                run_notebook_chat_turn_task.apply_async(
+                    args=[execution_id], countdown=countdown
+                )
         except Exception as exc:  # noqa: BLE001 - any enqueue failure
             logger.exception("could not queue notebook chat turn %s", execution_id)
             execution = AgentExecution.objects.filter(id=execution_id).first()
@@ -637,7 +660,11 @@ class NotebookChatService:
                         "could not finalize crashed notebook chat turn",
                         exc_info=True,
                     )
-            return {"execution_id": execution.id, "error": str(exc)}
+            result = {"execution_id": execution.id, "error": str(exc)}
+            retry_id = self._maybe_schedule_auto_retry(execution, exc)
+            if retry_id is not None:
+                result["retry_execution_id"] = retry_id
+            return result
 
     def _run_turn(self, execution: AgentExecution, recorder) -> dict:
         conversation = execution.conversation
@@ -692,13 +719,77 @@ class NotebookChatService:
             # The loop already recorded the failure (status, error fields,
             # partial trace) through the recorder; report, don't re-raise.
             logger.warning("notebook chat turn %s failed: %s", execution.id, exc)
-            return {"execution_id": execution.id, "error": str(exc)}
+            outcome = {"execution_id": execution.id, "error": str(exc)}
+            retry_id = self._maybe_schedule_auto_retry(execution, exc)
+            if retry_id is not None:
+                outcome["retry_execution_id"] = retry_id
+            return outcome
         return {
             "execution_id": execution.id,
             "stop_reason": result.stop_reason,
             "iterations": result.iterations,
             "final_text": result.final_text,
         }
+
+    def _maybe_schedule_auto_retry(
+        self, execution: AgentExecution, error: Exception
+    ) -> int | None:
+        """Requeue a transient failure with backoff; return the retry's id.
+
+        Only failures the provider marked retryable qualify, only while the
+        turn actually sealed ``FAILED`` -- a cancellation or an external seal
+        is someone else's decision -- and only within the per-trigger budget.
+        The retry is created ``PENDING`` before this returns, so the
+        conversation stays busy for the whole backoff window and a user
+        message cannot slip between the failure and its retry. Losing the
+        creation race to a concurrent turn simply means the user already
+        moved on.
+        """
+        if not getattr(error, "retryable", False):
+            return None
+        execution.refresh_from_db()
+        if execution.status != AgentExecution.Status.FAILED:
+            return None
+        prior_attempts = self._retry_chain_length(execution)
+        if prior_attempts >= AUTO_RETRY_MAX_ATTEMPTS:
+            logger.info(
+                "notebook chat turn %s exhausted its automatic retries",
+                execution.id,
+            )
+            return None
+        try:
+            prepared = self.chat.prepare_retry(execution, pending=True)
+        except (AgentConversationBusyError, AgentStaleRetryError):
+            return None
+        retry = prepared.execution
+        countdown = AUTO_RETRY_DELAY_SECONDS[
+            min(prior_attempts, len(AUTO_RETRY_DELAY_SECONDS) - 1)
+        ]
+        self.events.publish(retry.conversation_id, retry.id, TURN_QUEUED)
+        self._schedule_turn(retry.id, countdown=countdown)
+        logger.info(
+            "notebook chat turn %s scheduled automatic retry %s in %ss",
+            execution.id,
+            retry.id,
+            countdown,
+        )
+        return retry.id
+
+    @staticmethod
+    def _retry_chain_length(execution: AgentExecution) -> int:
+        """How many attempts precede this one on its ``retry_of`` chain."""
+        length = 0
+        seen = {execution.id}
+        current_id = execution.retry_of_id
+        while current_id is not None and current_id not in seen:
+            seen.add(current_id)
+            length += 1
+            current_id = (
+                AgentExecution.objects.filter(id=current_id)
+                .values_list("retry_of_id", flat=True)
+                .first()
+            )
+        return length
 
     def _publishing_recorder(
         self, recorder, execution: AgentExecution

--- a/src/research_ai/tests/agent/test_claude_platform_provider.py
+++ b/src/research_ai/tests/agent/test_claude_platform_provider.py
@@ -4,6 +4,8 @@ from copy import deepcopy
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
+import anthropic
+import httpx
 from anthropic.types import (
     CodeExecutionToolResultBlock,
     Container,
@@ -1553,3 +1555,94 @@ class ServerSideToolTests(SimpleTestCase):
         self.assertEqual(
             rendered[-1]["content"][-1]["cache_control"], {"type": "ephemeral"}
         )
+
+
+class RetryableErrorClassificationTests(SimpleTestCase):
+    """Which SDK failures the adapter marks worth repeating unchanged."""
+
+    @staticmethod
+    def _status_error(status_code):
+        request = httpx.Request("POST", "https://api.test/v1/messages")
+        response = httpx.Response(status_code, request=request)
+        return anthropic.APIStatusError("boom", response=response, body=None)
+
+    def test_transient_failures_are_retryable(self):
+        # Arrange
+        request = httpx.Request("POST", "https://api.test/v1/messages")
+        transient = [
+            anthropic.APIConnectionError(request=request),
+            anthropic.APITimeoutError(request=request),
+            httpx.RemoteProtocolError("peer closed connection mid-stream"),
+            self._status_error(429),
+            self._status_error(500),
+            self._status_error(503),
+            # The Messages API's overloaded_error status.
+            self._status_error(529),
+        ]
+
+        # Act / Assert
+        for error in transient:
+            self.assertTrue(
+                claude_platform._is_retryable_error(error),
+                f"{error!r} should be retryable",
+            )
+
+    def test_request_faults_are_permanent(self):
+        # Arrange
+        permanent = [
+            self._status_error(400),
+            self._status_error(401),
+            self._status_error(403),
+            self._status_error(404),
+            self._status_error(422),
+            ValueError("adapter bug"),
+        ]
+
+        # Act / Assert
+        for error in permanent:
+            self.assertFalse(
+                claude_platform._is_retryable_error(error),
+                f"{error!r} should not be retryable",
+            )
+
+    def test_overloaded_client_failure_raises_a_retryable_provider_error(self):
+        # Arrange: the SDK reports the platform overloaded.
+        overloaded = self._status_error(529)
+
+        class ExplodingMessages:
+            def stream(self, **kwargs):
+                raise overloaded
+
+        class ExplodingClient:
+            messages = ExplodingMessages()
+
+        provider = ClaudePlatformProvider(
+            client=ExplodingClient(), model_id="claude-opus-5"
+        )
+
+        # Act
+        with self.assertRaises(ProviderError) as ctx:
+            _complete(provider)
+
+        # Assert
+        self.assertTrue(ctx.exception.retryable)
+
+    def test_foreign_client_failure_raises_a_permanent_provider_error(self):
+        # Arrange
+        class ExplodingMessages:
+            def stream(self, **kwargs):
+                raise ValueError("malformed request payload")
+
+        class ExplodingClient:
+            messages = ExplodingMessages()
+
+        provider = ClaudePlatformProvider(
+            client=ExplodingClient(), model_id="claude-opus-5"
+        )
+
+        # Act
+        with self.assertRaises(ProviderError) as ctx:
+            _complete(provider)
+
+        # Assert
+        self.assertFalse(ctx.exception.retryable)

--- a/src/research_ai/tests/agent/test_openrouter_provider.py
+++ b/src/research_ai/tests/agent/test_openrouter_provider.py
@@ -4,6 +4,8 @@ import json
 from copy import deepcopy
 from types import SimpleNamespace
 
+import httpx
+import openai
 from django.test import SimpleTestCase, override_settings
 
 from research_ai.services.agent.errors import ProviderError
@@ -419,6 +421,64 @@ class ErrorTests(SimpleTestCase):
         # Act / Assert
         with self.assertRaises(ProviderError):
             _complete(provider)
+
+    def test_transient_sdk_failures_classify_as_retryable(self):
+        # Arrange
+        request = httpx.Request("POST", "https://openrouter.test/v1/chat")
+        transient = [
+            openai.APIConnectionError(request=request),
+            openai.APIStatusError(
+                "rate limited",
+                response=httpx.Response(429, request=request),
+                body=None,
+            ),
+            openai.APIStatusError(
+                "upstream down",
+                response=httpx.Response(502, request=request),
+                body=None,
+            ),
+        ]
+        permanent = [
+            openai.APIStatusError(
+                "bad request",
+                response=httpx.Response(400, request=request),
+                body=None,
+            ),
+            RuntimeError("adapter bug"),
+        ]
+
+        # Act / Assert
+        for error in transient:
+            self.assertTrue(openrouter._is_retryable_error(error), repr(error))
+        for error in permanent:
+            self.assertFalse(openrouter._is_retryable_error(error), repr(error))
+
+    def test_rate_limited_client_raises_a_retryable_provider_error(self):
+        # Arrange
+        request = httpx.Request("POST", "https://openrouter.test/v1/chat")
+        rate_limited = openai.APIStatusError(
+            "rate limited",
+            response=httpx.Response(429, request=request),
+            body=None,
+        )
+
+        class ExplodingClient:
+            def __init__(self):
+                self.chat = SimpleNamespace(
+                    completions=SimpleNamespace(create=self._create)
+                )
+
+            def _create(self, **kwargs):
+                raise rate_limited
+
+        provider = OpenRouterProvider(client=ExplodingClient(), model_id="test-model")
+
+        # Act
+        with self.assertRaises(ProviderError) as ctx:
+            _complete(provider)
+
+        # Assert
+        self.assertTrue(ctx.exception.retryable)
 
 
 class DefaultsTests(SimpleTestCase):

--- a/src/research_ai/tests/agent/test_persistence_chat.py
+++ b/src/research_ai/tests/agent/test_persistence_chat.py
@@ -807,3 +807,63 @@ class AgentChatPersistenceTests(AgentPersistenceTestCase):
             [message["content"] for message in representation["messages"]], ["Question"]
         )
         self.assertTrue(representation["executions"][0]["assistant_message_pending"])
+
+
+class PendingRetryPreparationTests(AgentPersistenceTestCase):
+    def _failed_pending_turn(self, text="Question"):
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, text, pending=True)
+        recorder = AgentExecutionService().claim_pending(prepared.execution)
+        recorder.on_run_failed(RuntimeError("worker-side failure"))
+        prepared.execution.refresh_from_db()
+        return chat, prepared
+
+    def test_pending_retry_is_claimable_and_reuses_the_turn(self):
+        # Arrange
+        chat, prepared = self._failed_pending_turn()
+
+        # Act
+        retry = chat.prepare_retry(prepared.execution, pending=True)
+
+        # Assert: a queued attempt for a worker, carrying the original turn's
+        # message and lineage; the recorder is the claiming worker's to build.
+        execution = retry.execution
+        self.assertEqual(execution.status, AgentExecution.Status.PENDING)
+        self.assertIsNone(retry.recorder)
+        self.assertEqual(retry.context, [])
+        self.assertEqual(execution.retry_of_id, prepared.execution.id)
+        self.assertEqual(
+            execution.trigger_message_id, prepared.execution.trigger_message_id
+        )
+        self.assertEqual(
+            execution.context_parent_id, prepared.execution.context_parent_id
+        )
+        self.assertTrue(execution.publish_output_to_chat)
+        self.assertIsNotNone(AgentExecutionService().claim_pending(execution))
+
+    def test_pending_retry_holds_the_conversations_busy_check(self):
+        # Arrange
+        chat, prepared = self._failed_pending_turn()
+        chat.prepare_retry(prepared.execution, pending=True)
+
+        # Act / Assert: no new turn can interleave while the retry is queued.
+        with self.assertRaises(AgentConversationBusyError):
+            chat.prepare_turn(self.conversation, "Impatient follow-up", pending=True)
+
+    def test_pending_retry_refuses_while_a_turn_is_active(self):
+        # Arrange
+        chat, prepared = self._failed_pending_turn()
+        chat.prepare_turn(self.conversation, "Newer question", pending=True)
+
+        # Act / Assert
+        with self.assertRaises(AgentConversationBusyError):
+            chat.prepare_retry(prepared.execution, pending=True)
+
+    def test_pending_retry_cannot_regenerate(self):
+        # Arrange
+        chat, prepared = self._failed_pending_turn()
+
+        # Act / Assert: regeneration replaces published output, which only a
+        # recorder-owning attempt may do.
+        with self.assertRaises(ValueError):
+            chat.prepare_retry(prepared.execution, pending=True, regenerate=True)

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -11,6 +11,7 @@ from research_ai.models import (
     AgentExecution,
     NoteAgentConversation,
 )
+from research_ai.services.agent import ProviderError
 from research_ai.services.agent.types import StopReason
 from research_ai.services.agent_persistence import (
     AgentConversationBusyError,
@@ -1181,6 +1182,210 @@ class NotebookChatEventSendOrderTests(TransactionTestCase):
                     "kind": kind,
                 }
                 for kind in (TURN_QUEUED, TURN_FAILED)
+            ],
+        )
+
+
+class SealingProvider(FakeProvider):
+    """Seals the execution to a terminal status mid-call, then fails."""
+
+    def __init__(self, turns, execution_id, status):
+        super().__init__(turns)
+        self.execution_id = execution_id
+        self.sealed_status = status
+
+    def complete(self, **kwargs):
+        AgentExecution.objects.filter(id=self.execution_id).update(
+            status=self.sealed_status
+        )
+        return super().complete(**kwargs)
+
+
+class NotebookChatAutoRetryTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="owner@researchhub_test.com",
+            password="password",
+            email="owner@researchhub_test.com",
+        )
+        self.note = create_note(self.user, organization=None)[0]
+        Permission.objects.create(
+            access_type=ADMIN,
+            content_type=ContentType.objects.get_for_model(ResearchhubUnifiedDocument),
+            object_id=self.note.unified_document.id,
+            user=self.user,
+        )
+        self.service = _make_service()
+        self.conversation = self.service.create_conversation(self.note, self.user)
+
+    def _submit(self, text="Please add a summary."):
+        with (
+            patch("research_ai.tasks.run_notebook_chat_turn_task.delay"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            return self.service.submit_message(self.note, self.conversation, text)
+
+    def _run_failing(self, execution_id, error, **service_kwargs):
+        """Run the turn against a provider that raises ``error``."""
+        runner = _make_service(provider=FakeProvider([error]), **service_kwargs)
+        with patch(
+            "research_ai.tasks.run_notebook_chat_turn_task.apply_async"
+        ) as apply_async:
+            result = runner.run_turn(execution_id)
+        return result, apply_async
+
+    def test_transient_provider_failure_schedules_a_backoff_retry(self):
+        # Arrange
+        execution = self._submit()
+
+        # Act
+        result, apply_async = self._run_failing(
+            execution.id, ProviderError("overloaded", retryable=True)
+        )
+
+        # Assert: the failure sealed, its classification was stored, and a
+        # queued retry of the same trigger holds the conversation.
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, AgentExecution.Status.FAILED)
+        self.assertTrue(execution.error_details["retryable"])
+        retry = AgentExecution.objects.get(id=result["retry_execution_id"])
+        self.assertEqual(retry.status, AgentExecution.Status.PENDING)
+        self.assertEqual(retry.retry_of_id, execution.id)
+        self.assertEqual(retry.trigger_message_id, execution.trigger_message_id)
+        apply_async.assert_called_once_with(args=[retry.id], countdown=5)
+
+    def test_retry_of_a_retry_backs_off_longer_then_stops(self):
+        # Arrange
+        execution = self._submit()
+        overloaded = ProviderError("overloaded", retryable=True)
+        first_result, _ = self._run_failing(execution.id, overloaded)
+        first_retry_id = first_result["retry_execution_id"]
+
+        # Act: the first retry fails the same way; then the second one does.
+        second_result, second_schedule = self._run_failing(first_retry_id, overloaded)
+        second_retry_id = second_result["retry_execution_id"]
+        final_result, final_schedule = self._run_failing(second_retry_id, overloaded)
+
+        # Assert: backoff grew, and the third failure went terminal for the
+        # user to retry manually.
+        second_schedule.assert_called_once_with(args=[second_retry_id], countdown=30)
+        final_schedule.assert_not_called()
+        self.assertNotIn("retry_execution_id", final_result)
+        self.assertEqual(
+            AgentExecution.objects.filter(
+                conversation=self.conversation,
+                status=AgentExecution.Status.FAILED,
+            ).count(),
+            3,
+        )
+
+    def test_permanent_provider_failure_is_not_retried(self):
+        # Arrange
+        execution = self._submit()
+
+        # Act
+        result, apply_async = self._run_failing(
+            execution.id, ProviderError("invalid request", retryable=False)
+        )
+
+        # Assert
+        self.assertNotIn("retry_execution_id", result)
+        apply_async.assert_not_called()
+        self.assertEqual(self.conversation.executions.count(), 1)
+
+    def test_unexpected_crash_is_not_retried(self):
+        # Arrange
+        execution = self._submit()
+
+        # Act
+        result, apply_async = self._run_failing(
+            execution.id, RuntimeError("toolset bug")
+        )
+
+        # Assert
+        self.assertNotIn("retry_execution_id", result)
+        apply_async.assert_not_called()
+
+    def test_cancelled_turn_is_never_auto_retried(self):
+        # Arrange: the user cancels while the provider call is in flight, and
+        # the call then dies with a retryable error. The cancellation is the
+        # user's decision; no retry may override it.
+        execution = self._submit()
+        provider = SealingProvider(
+            [ProviderError("overloaded", retryable=True)],
+            execution.id,
+            AgentExecution.Status.CANCELLED,
+        )
+        runner = _make_service(provider=provider)
+
+        # Act
+        with patch(
+            "research_ai.tasks.run_notebook_chat_turn_task.apply_async"
+        ) as apply_async:
+            result = runner.run_turn(execution.id)
+
+        # Assert
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
+        self.assertNotIn("retry_execution_id", result)
+        apply_async.assert_not_called()
+
+    def test_lost_retry_race_is_quietly_abandoned(self):
+        # Arrange: by the time the retry is prepared, the conversation moved
+        # on (its busy check refuses the attempt).
+        execution = self._submit()
+        runner = _make_service(
+            provider=FakeProvider([ProviderError("overloaded", retryable=True)])
+        )
+
+        # Act
+        with (
+            patch.object(
+                runner.chat,
+                "prepare_retry",
+                side_effect=AgentConversationBusyError("busy"),
+            ),
+            patch(
+                "research_ai.tasks.run_notebook_chat_turn_task.apply_async"
+            ) as apply_async,
+        ):
+            result = runner.run_turn(execution.id)
+
+        # Assert
+        self.assertNotIn("retry_execution_id", result)
+        apply_async.assert_not_called()
+
+    def test_pending_auto_retry_keeps_the_conversation_busy(self):
+        # Arrange: an auto retry is waiting out its backoff window.
+        execution = self._submit()
+        self._run_failing(execution.id, ProviderError("overloaded", retryable=True))
+
+        # Act / Assert: a user message cannot interleave with the retry.
+        with self.assertRaises(AgentConversationBusyError):
+            self.service.submit_message(self.note, self.conversation, "hello?")
+
+    def test_auto_retry_announces_itself_as_a_queued_turn(self):
+        # Arrange
+        execution = self._submit()
+        run_publisher = Mock()
+        runner = _make_service(
+            provider=FakeProvider([ProviderError("overloaded", retryable=True)]),
+            event_publisher=run_publisher,
+        )
+
+        # Act
+        with patch("research_ai.tasks.run_notebook_chat_turn_task.apply_async"):
+            result = runner.run_turn(execution.id)
+
+        # Assert: subscribers see the failure, then the retry queued under its
+        # own execution id.
+        events = [call.args for call in run_publisher.publish.call_args_list]
+        self.assertEqual(
+            events[-2:],
+            [
+                (self.conversation.id, execution.id, TURN_FAILED),
+                (self.conversation.id, result["retry_execution_id"], TURN_QUEUED),
             ],
         )
 


### PR DESCRIPTION
## What

Second PR of the failure-recovery stack (**stacked on #4053** — base is set to its branch so only this increment shows; retarget to `main` after #4053 merges).

A single `overloaded_error` costs the user their whole turn — four in six minutes observed on Aug 13 — while `AgentChatService.prepare_retry` sat fully built with zero production callers. This wires it up for transient failures.

## How

- **Provider-layer classification**: `ProviderError` gains a `retryable` flag. The Claude Platform and OpenRouter adapters (the two catalog providers) classify the wrapped SDK failure: connection errors, timeouts, mid-stream transport drops, 408/409/429, and every 5xx (incl. the Messages API's 529 `overloaded_error`) are transient; auth, config, and invalid-request failures are permanent. The recorder stores the verdict in `error_details` at failure time, since the exception dies with the worker.
- **`prepare_retry(pending=True)`**: creates the retry as a claimable PENDING attempt — the same contract `prepare_turn`/`run_turn` already use — with `retry_of`, the same trigger message, and the same context parent.
- **Automatic retry in `run_turn`**: on a retryable terminal FAILED (never a cancellation or external seal — status is re-checked), the turn requeues itself with backoff (5s, then 30s), capped at 2 per trigger by walking `retry_of`. The retry row is created **before** the backoff starts, so the conversation's busy check spans the whole window: a user message can't interleave with an automatic retry, and losing the creation race to a fresh user message just abandons the retry. Each retry announces itself with `turn_queued` so clients render it as a new attempt.

No migrations; `error_details` is an existing JSON field.

## Testing

- Provider classification tests for both adapters (transient vs permanent, and that `ProviderError.retryable` survives the wrap).
- `PendingRetryPreparationTests`: claimability, lineage reuse, busy-check held, regenerate refused.
- `NotebookChatAutoRetryTests`: backoff schedule and cap, permanent failures and crashes not retried, cancelled turns never overridden, lost races abandoned quietly, busy check across the backoff window, event ordering.
- Full `research_ai` suite passes on this branch (1137 tests); ruff clean.