### PR TITLE
[Notebook Chat] Public error taxonomy for failed turns

### DIFF
--- a/src/research_ai/services/agent/errors.py
+++ b/src/research_ai/services/agent/errors.py
@@ -40,7 +40,24 @@ class ProviderError(AgentRunError):
 
     Providers raise this without a transcript; the loop attaches ``messages``
     and ``iterations`` as the error propagates through it.
+
+    ``retryable`` is ``True`` for transient conditions (overload, rate limit,
+    5xx, a dropped stream) where repeating the identical request may succeed,
+    ``False`` for failures of the request itself (auth, config, invalid
+    input), and ``None`` -- the default -- when the raise site classified
+    nothing, which downstream must not read as an explicit verdict.
     """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        messages: list[Message] | None = None,
+        iterations: int | None = None,
+        retryable: bool | None = None,
+    ):
+        super().__init__(message, messages=messages, iterations=iterations)
+        self.retryable = retryable
 
 
 class IncompleteTurnError(AgentRunError):

--- a/src/research_ai/services/agent/providers/claude_platform.py
+++ b/src/research_ai/services/agent/providers/claude_platform.py
@@ -26,6 +26,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import Any
 
+import anthropic
+import httpx
 from anthropic import AnthropicAWS
 from django.conf import settings
 
@@ -150,6 +152,28 @@ _SERVER_TOOL_BLOCK_TYPES = (
 _CACHEABLE_BLOCK_TYPES = ("text", "tool_result")
 
 _PROVIDER_STATE_KEY = "anthropic"
+
+# HTTP statuses worth repeating unchanged, matching the Anthropic SDK's own
+# retry set: timeouts, races, rate limits, and every server-side failure
+# (529 is the Messages API's overloaded_error).
+_RETRYABLE_STATUS_CODES = frozenset({408, 409, 429})
+
+
+def _is_retryable_error(error: Exception) -> bool:
+    """Whether this SDK failure is transient rather than a fault of the request.
+
+    Connection failures (including timeouts) and mid-stream transport drops
+    can only be answered by trying again; auth, config, and invalid-request
+    statuses fail identically on every attempt.
+    """
+    if isinstance(error, anthropic.APIConnectionError):
+        return True
+    if isinstance(error, anthropic.APIStatusError):
+        status = error.status_code
+        return status in _RETRYABLE_STATUS_CODES or status >= 500
+    # A stream the API accepted but dropped mid-emission surfaces as a raw
+    # transport error from the iteration, not as an SDK request error.
+    return isinstance(error, httpx.TransportError)
 
 
 def _build_client() -> AnthropicAWS | None:
@@ -452,7 +476,8 @@ class ClaudePlatformProvider(LLMProvider):
                 f"{diagnostics.open_code_execution_spans} unresolved code "
                 "execution span(s)), but no container id was ever recorded "
                 "for the conversation. Only a fresh conversation/context can "
-                "recover."
+                "recover.",
+                retryable=False,
             )
 
         started = time.perf_counter()
@@ -465,7 +490,10 @@ class ClaudePlatformProvider(LLMProvider):
                 response = self._stream_turn(kwargs, on_event=on_event)
             except Exception as e:
                 logger.exception("Claude Platform complete failed")
-                raise ProviderError(f"Claude Platform complete failed: {e}") from e
+                raise ProviderError(
+                    f"Claude Platform complete failed: {e}",
+                    retryable=_is_retryable_error(e),
+                ) from e
             responses.append(response)
             self._log_usage(response)
             self._log_continuation_state(response)

--- a/src/research_ai/services/agent/providers/openrouter.py
+++ b/src/research_ai/services/agent/providers/openrouter.py
@@ -13,6 +13,7 @@ import time
 from collections.abc import Callable
 from typing import Any
 
+import openai
 from django.conf import settings
 from openai import OpenAI
 
@@ -70,6 +71,22 @@ _NO_SAMPLING_PARAMS = (
 def _accepts_sampling_params(model_id: str) -> bool:
     mid = model_id.lower()
     return not any(tag in mid for tag in _NO_SAMPLING_PARAMS)
+
+
+# Statuses worth repeating unchanged: timeouts, races, rate limits, and every
+# server-side failure. Auth/config/invalid-request statuses fail identically
+# on every attempt.
+_RETRYABLE_STATUS_CODES = frozenset({408, 409, 429})
+
+
+def _is_retryable_error(error: Exception) -> bool:
+    """Whether this SDK failure is transient rather than a fault of the request."""
+    if isinstance(error, openai.APIConnectionError):
+        return True
+    if isinstance(error, openai.APIStatusError):
+        status = error.status_code
+        return status in _RETRYABLE_STATUS_CODES or status >= 500
+    return False
 
 
 # Chat Completions ``finish_reason`` -> neutral ``StopReason``.
@@ -192,7 +209,10 @@ class OpenRouterProvider(LLMProvider):
             response = self._client.chat.completions.create(**kwargs)
         except Exception as e:
             logger.exception("OpenRouter complete failed")
-            raise ProviderError(f"OpenRouter complete failed: {e}") from e
+            raise ProviderError(
+                f"OpenRouter complete failed: {e}",
+                retryable=_is_retryable_error(e),
+            ) from e
         latency_ms = int((time.perf_counter() - started) * 1000)
 
         self._log_usage(response)

--- a/src/research_ai/services/agent_persistence/chat_service.py
+++ b/src/research_ai/services/agent_persistence/chat_service.py
@@ -223,16 +223,63 @@ class AgentChatService:
         )
 
     @staticmethod
-    def _public_error(execution: AgentExecution) -> dict[str, str] | None:
+    def _public_error(execution: AgentExecution) -> dict | None:
+        """A user-safe rendering of why this attempt failed.
+
+        A coarse code, a ``retryable`` hint for a client's Retry affordance,
+        and a message written for the user -- never raw provider or exception
+        text, which can carry request internals. Classification reads only
+        what the failure recorded on the row (status, stop reason, and the
+        provider's stored transient-vs-permanent verdict), so it works long
+        after the worker that failed is gone.
+        """
         if not execution.error_type:
             return None
         if execution.status == AgentExecution.Status.INTERRUPTED:
+            # The worker observed the user's own stop mid-run -- named for
+            # the client, but not offered for retry.
             return {
                 "code": "agent_interrupted",
+                "retryable": False,
                 "message": "The agent request was interrupted.",
             }
+        if execution.stop_reason == "iteration_limit":
+            return {
+                "code": "turn_too_long",
+                "retryable": True,
+                "message": (
+                    "The agent ran out of steps before finishing. Try again, "
+                    "or ask for something smaller."
+                ),
+            }
+        if execution.stop_reason == "max_tokens":
+            return {
+                "code": "turn_too_long",
+                "retryable": True,
+                "message": (
+                    "The answer ran out of room before finishing. Try again, "
+                    "or ask for something smaller."
+                ),
+            }
+        if execution.stop_reason == "content_filtered":
+            return {
+                "code": "content_refused",
+                "retryable": False,
+                "message": "The agent declined to complete this request.",
+            }
+        details = execution.error_details
+        verdict = details.get("retryable") if isinstance(details, dict) else None
+        if verdict:
+            return {
+                "code": "provider_busy",
+                "retryable": True,
+                "message": "The model was overloaded — try again.",
+            }
         return {
+            # An explicit permanent verdict means an identical retry would
+            # fail the same way; an unclassified failure is worth one.
             "code": "agent_failed",
+            "retryable": verdict is None,
             "message": "The agent could not complete this request.",
         }
 

--- a/src/research_ai/services/agent_persistence/recorder.py
+++ b/src/research_ai/services/agent_persistence/recorder.py
@@ -358,11 +358,16 @@ class DatabaseAgentRecorder:
             else:
                 stop_reason = "error"
         cause = getattr(error, "__cause__", None)
+        retryable = getattr(error, "retryable", None)
         details = {
             "stop_reason": stop_reason,
             "iterations": getattr(error, "iterations", None),
             "cause_type": type(cause).__name__ if cause else None,
             "cause_message": _safe_exception_message(cause) if cause else None,
+            # The provider's transient-vs-permanent verdict -- None when the
+            # error carries no classification -- recorded because the exception
+            # dies with this worker and the taxonomy needs the answer later.
+            "retryable": None if retryable is None else bool(retryable),
         }
         safe_details, _truncated, _size = bounded_payload(details)
         status = (

--- a/src/research_ai/tests/agent/test_claude_platform_provider.py
+++ b/src/research_ai/tests/agent/test_claude_platform_provider.py
@@ -4,6 +4,8 @@ from copy import deepcopy
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
+import anthropic
+import httpx
 from anthropic.types import (
     CodeExecutionToolResultBlock,
     Container,
@@ -1625,3 +1627,94 @@ class ServerSideToolTests(SimpleTestCase):
         self.assertEqual(
             rendered[-1]["content"][-1]["cache_control"], {"type": "ephemeral"}
         )
+
+
+class RetryableErrorClassificationTests(SimpleTestCase):
+    """Which SDK failures the adapter marks worth repeating unchanged."""
+
+    @staticmethod
+    def _status_error(status_code):
+        request = httpx.Request("POST", "https://api.test/v1/messages")
+        response = httpx.Response(status_code, request=request)
+        return anthropic.APIStatusError("boom", response=response, body=None)
+
+    def test_transient_failures_are_retryable(self):
+        # Arrange
+        request = httpx.Request("POST", "https://api.test/v1/messages")
+        transient = [
+            anthropic.APIConnectionError(request=request),
+            anthropic.APITimeoutError(request=request),
+            httpx.RemoteProtocolError("peer closed connection mid-stream"),
+            self._status_error(429),
+            self._status_error(500),
+            self._status_error(503),
+            # The Messages API's overloaded_error status.
+            self._status_error(529),
+        ]
+
+        # Act / Assert
+        for error in transient:
+            self.assertTrue(
+                claude_platform._is_retryable_error(error),
+                f"{error!r} should be retryable",
+            )
+
+    def test_request_faults_are_permanent(self):
+        # Arrange
+        permanent = [
+            self._status_error(400),
+            self._status_error(401),
+            self._status_error(403),
+            self._status_error(404),
+            self._status_error(422),
+            ValueError("adapter bug"),
+        ]
+
+        # Act / Assert
+        for error in permanent:
+            self.assertFalse(
+                claude_platform._is_retryable_error(error),
+                f"{error!r} should not be retryable",
+            )
+
+    def test_overloaded_client_failure_raises_a_retryable_provider_error(self):
+        # Arrange: the SDK reports the platform overloaded.
+        overloaded = self._status_error(529)
+
+        class ExplodingMessages:
+            def stream(self, **kwargs):
+                raise overloaded
+
+        class ExplodingClient:
+            messages = ExplodingMessages()
+
+        provider = ClaudePlatformProvider(
+            client=ExplodingClient(), model_id="claude-opus-5"
+        )
+
+        # Act
+        with self.assertRaises(ProviderError) as ctx:
+            _complete(provider)
+
+        # Assert
+        self.assertTrue(ctx.exception.retryable)
+
+    def test_foreign_client_failure_raises_a_permanent_provider_error(self):
+        # Arrange
+        class ExplodingMessages:
+            def stream(self, **kwargs):
+                raise ValueError("malformed request payload")
+
+        class ExplodingClient:
+            messages = ExplodingMessages()
+
+        provider = ClaudePlatformProvider(
+            client=ExplodingClient(), model_id="claude-opus-5"
+        )
+
+        # Act
+        with self.assertRaises(ProviderError) as ctx:
+            _complete(provider)
+
+        # Assert
+        self.assertFalse(ctx.exception.retryable)

--- a/src/research_ai/tests/agent/test_openrouter_provider.py
+++ b/src/research_ai/tests/agent/test_openrouter_provider.py
@@ -4,6 +4,8 @@ import json
 from copy import deepcopy
 from types import SimpleNamespace
 
+import httpx
+import openai
 from django.test import SimpleTestCase, override_settings
 
 from research_ai.services.agent.errors import ProviderError
@@ -484,6 +486,64 @@ class ErrorTests(SimpleTestCase):
         # Act / Assert
         with self.assertRaises(ProviderError):
             _complete(provider)
+
+    def test_transient_sdk_failures_classify_as_retryable(self):
+        # Arrange
+        request = httpx.Request("POST", "https://openrouter.test/v1/chat")
+        transient = [
+            openai.APIConnectionError(request=request),
+            openai.APIStatusError(
+                "rate limited",
+                response=httpx.Response(429, request=request),
+                body=None,
+            ),
+            openai.APIStatusError(
+                "upstream down",
+                response=httpx.Response(502, request=request),
+                body=None,
+            ),
+        ]
+        permanent = [
+            openai.APIStatusError(
+                "bad request",
+                response=httpx.Response(400, request=request),
+                body=None,
+            ),
+            RuntimeError("adapter bug"),
+        ]
+
+        # Act / Assert
+        for error in transient:
+            self.assertTrue(openrouter._is_retryable_error(error), repr(error))
+        for error in permanent:
+            self.assertFalse(openrouter._is_retryable_error(error), repr(error))
+
+    def test_rate_limited_client_raises_a_retryable_provider_error(self):
+        # Arrange
+        request = httpx.Request("POST", "https://openrouter.test/v1/chat")
+        rate_limited = openai.APIStatusError(
+            "rate limited",
+            response=httpx.Response(429, request=request),
+            body=None,
+        )
+
+        class ExplodingClient:
+            def __init__(self):
+                self.chat = SimpleNamespace(
+                    completions=SimpleNamespace(create=self._create)
+                )
+
+            def _create(self, **kwargs):
+                raise rate_limited
+
+        provider = OpenRouterProvider(client=ExplodingClient(), model_id="test-model")
+
+        # Act
+        with self.assertRaises(ProviderError) as ctx:
+            _complete(provider)
+
+        # Assert
+        self.assertTrue(ctx.exception.retryable)
 
 
 class DefaultsTests(SimpleTestCase):

--- a/src/research_ai/tests/agent/test_persistence_chat.py
+++ b/src/research_ai/tests/agent/test_persistence_chat.py
@@ -13,6 +13,11 @@ from research_ai.models import (
     AgentExecution,
     AgentExecutionMessage,
 )
+from research_ai.services.agent.errors import (
+    IncompleteTurnError,
+    IterationLimitError,
+    ProviderError,
+)
 from research_ai.services.agent.tools import Tool
 from research_ai.services.agent.types import (
     AssistantTurn,
@@ -26,6 +31,7 @@ from research_ai.services.agent_persistence import (
     AgentChatService,
     AgentConversationBusyError,
     AgentConversationService,
+    AgentExecutionCancelService,
     AgentExecutionService,
     AgentStaleRetryError,
     DatabaseAgentRecorder,
@@ -242,6 +248,7 @@ class AgentChatPersistenceTests(AgentPersistenceTestCase):
             representation["executions"][0]["error"],
             {
                 "code": "agent_failed",
+                "retryable": True,
                 "message": "The agent could not complete this request.",
             },
         )
@@ -807,3 +814,112 @@ class AgentChatPersistenceTests(AgentPersistenceTestCase):
             [message["content"] for message in representation["messages"]], ["Question"]
         )
         self.assertTrue(representation["executions"][0]["assistant_message_pending"])
+
+
+class PublicErrorTaxonomyTests(AgentPersistenceTestCase):
+    """The sanitized failure payload each failure class renders as."""
+
+    def _fail_with(self, error) -> dict:
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+        prepared.recorder.on_run_failed(error)
+        (entry,) = chat.representation(self.conversation)["executions"]
+        return entry["error"]
+
+    def test_transient_provider_failure_renders_provider_busy(self):
+        # Arrange / Act
+        error = self._fail_with(
+            ProviderError("upstream overloaded_error at 03:14", retryable=True)
+        )
+
+        # Assert: coarse code and retry hint, never the raw provider text.
+        self.assertEqual(error["code"], "provider_busy")
+        self.assertTrue(error["retryable"])
+        self.assertNotIn("overloaded_error", error["message"])
+
+    def test_permanent_provider_failure_renders_agent_failed(self):
+        # Arrange / Act
+        error = self._fail_with(
+            ProviderError("credentials rejected for workspace ws-1", retryable=False)
+        )
+
+        # Assert: the provider's explicit permanent verdict is honored -- an
+        # identical retry would fail the same way.
+        self.assertEqual(error["code"], "agent_failed")
+        self.assertFalse(error["retryable"])
+        self.assertNotIn("ws-1", error["message"])
+
+    def test_unclassified_failure_renders_agent_failed_and_retryable(self):
+        # Arrange / Act: an internal crash carries no provider verdict.
+        error = self._fail_with(RuntimeError("toolset bug"))
+
+        # Assert: no verdict means a retry is worth one.
+        self.assertEqual(error["code"], "agent_failed")
+        self.assertTrue(error["retryable"])
+
+    def test_unclassified_provider_failure_stays_retryable(self):
+        # Arrange / Act: a raise site that passed no verdict (e.g. Bedrock's
+        # catch-all) must not read as an explicit permanent verdict.
+        error = self._fail_with(ProviderError("Bedrock complete failed: boom"))
+
+        # Assert
+        self.assertEqual(error["code"], "agent_failed")
+        self.assertTrue(error["retryable"])
+
+    def test_iteration_limit_renders_turn_too_long(self):
+        # Arrange / Act
+        error = self._fail_with(
+            IterationLimitError("Agent exceeded 30 iterations", iterations=30)
+        )
+
+        # Assert
+        self.assertEqual(error["code"], "turn_too_long")
+        self.assertTrue(error["retryable"])
+
+    def test_truncated_answer_renders_turn_too_long(self):
+        # Arrange / Act: a no-tool turn that hit the output-token ceiling.
+        error = self._fail_with(
+            IncompleteTurnError(
+                "Provider stopped without completing the agent run: max_tokens",
+                stop_reason="max_tokens",
+            )
+        )
+
+        # Assert
+        self.assertEqual(error["code"], "turn_too_long")
+        self.assertTrue(error["retryable"])
+        self.assertIn("ran out of room", error["message"])
+
+    def test_refused_turn_renders_content_refused_and_not_retryable(self):
+        # Arrange / Act
+        error = self._fail_with(
+            IncompleteTurnError(
+                "Provider stopped without completing the agent run",
+                stop_reason="content_filtered",
+            )
+        )
+
+        # Assert: retrying the same prompt would be refused again.
+        self.assertEqual(error["code"], "content_refused")
+        self.assertFalse(error["retryable"])
+
+    def test_interrupted_execution_renders_agent_interrupted(self):
+        # Arrange / Act: the worker observed the user's own stop mid-run.
+        error = self._fail_with(InterruptedError("execution is no longer running"))
+
+        # Assert: named for the client, but not offered for retry.
+        self.assertEqual(error["code"], "agent_interrupted")
+        self.assertFalse(error["retryable"])
+        self.assertNotIn("execution", error["message"])
+
+    def test_cancelled_execution_renders_no_error(self):
+        # Arrange: a cancellation is the user's own stop, not a failure.
+        chat = AgentChatService()
+        prepared = chat.prepare_turn(self.conversation, "Question")
+        AgentExecutionCancelService().cancel(prepared.execution)
+
+        # Act
+        (entry,) = chat.representation(self.conversation)["executions"]
+
+        # Assert
+        self.assertIsNone(entry["error"])


### PR DESCRIPTION
## What

Failed notebook chat turns now render a sanitized, user-readable error on `executions[]` instead of a bare `agent_failed` for everything.

- **Public error taxonomy** in `AgentChatService._public_error`: a coarse `code` (`agent_interrupted`, `provider_busy`, `turn_too_long`, `content_refused`, `agent_failed`), a `retryable` hint for the client's future Retry affordance, and a message written for the user. Raw provider/exception text never reaches the payload.
- **Provider failure classification** (`ProviderError(retryable=...)`) for Claude Platform and OpenRouter: connection drops, timeouts, 408/409/429, and 5xx (incl. 529 overloads) are transient; auth/config/invalid-request statuses are not. The verdict is recorded in `error_details` at failure time, because the exception dies with the failing worker and the taxonomy needs the answer later.

Scope note: this PR is error messaging only. Retries (the manual retry endpoint and automatic backoff) are deferred to a follow-up PR, and the reaper/time-limits work was dropped earlier (#4053, #4054).

## How

- `_public_error` classifies from what the failure recorded on the row (status, stop reason, and the stored transient-vs-permanent verdict), so it works long after the worker that failed is gone.
- The stored verdict is tri-state — `ProviderError.retryable` defaults to `None` (unclassified), so only a raise site that actually classified the failure produces a verdict. An explicit permanent verdict renders `agent_failed` with `retryable: false`; an unclassified failure (internal crash, Bedrock's unclassified wrapper, invalid-response raises) stays `retryable: true`.
- `INTERRUPTED` is the worker-side recording of the user's own cancel (the loop raises `InterruptedError` when it notices the row is no longer running), so `agent_interrupted` renders `retryable: false` — same treatment as `CANCELLED`, which renders no error at all.
- The unrecoverable missing-container dead-end in Claude Platform is explicitly marked `retryable=False` — its own comment notes retrying fails identically. Config pre-flight raises (missing workspace/key) stay unclassified deliberately: an environment misconfiguration is transient with respect to time.

## Testing

- Full `research_ai` suite green locally (1134 tests, rebased onto current main incl. #4049), ruff clean.
- New coverage: taxonomy rendering per failure class — transient verdicts render `provider_busy`, permanent verdicts render non-retryable, unclassified failures stay retryable, truncated answers (`max_tokens`) render `turn_too_long`, interrupted turns render as not retryable, cancels render no error, and internal detail never leaks — plus retryable classification for both providers.