### PR TITLE
Clamp max_tokens to each model's reviewed output ceiling

### DIFF
--- a/src/research_ai/services/agent/model_capabilities.py
+++ b/src/research_ai/services/agent/model_capabilities.py
@@ -1,6 +1,6 @@
 """Reviewed generation controls supported by each model family."""
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 
 EFFORT_LEVELS = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 THINKING_MODES = ("adaptive", "disabled")
@@ -74,7 +74,12 @@ _OPENROUTER_OPEN_WEIGHT = ModelCapabilities(
 
 def _model(controls: ModelCapabilities, max_output_tokens: int) -> ModelCapabilities:
     """One model: a shared control set plus that model's own output ceiling."""
-    return replace(controls, max_output_tokens=max_output_tokens)
+    return ModelCapabilities(
+        effort=controls.effort,
+        thinking=controls.thinking,
+        temperature=controls.temperature,
+        max_output_tokens=max_output_tokens,
+    )
 
 
 # One row per model -- id tags, controls, and the output ceiling its own docs

--- a/src/research_ai/services/agent/model_capabilities.py
+++ b/src/research_ai/services/agent/model_capabilities.py
@@ -1,6 +1,6 @@
 """Reviewed generation controls supported by each model family."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 EFFORT_LEVELS = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 THINKING_MODES = ("adaptive", "disabled")
@@ -18,8 +18,12 @@ class ModelCapabilities:
     effort: tuple[str, ...] = ()
     thinking: tuple[str, ...] = ()
     temperature: bool = False
+    # The model's output ceiling: a ``max_tokens`` above it is rejected
+    # outright. ``None`` means unreviewed, not unlimited.
+    max_output_tokens: int | None = None
 
     def as_dict(self) -> dict:
+        # The model-picker payload: the controls a caller may choose.
         return {
             "effort": list(self.effort),
             "thinking": list(self.thinking),
@@ -27,6 +31,8 @@ class ModelCapabilities:
         }
 
 
+# Control sets, shared by every model that accepts the same knobs. An output
+# ceiling is never shared: each model states its own below.
 _TEMPERATURE = ModelCapabilities(temperature=True)
 _CLAUDE_EFFORT_TEMPERATURE = ModelCapabilities(
     effort=CLAUDE_EFFORT_LEVELS,
@@ -45,67 +51,66 @@ _CLAUDE_MANDATORY_THINKING = ModelCapabilities(
     effort=CLAUDE_EFFORT_LEVELS,
     thinking=("adaptive",),
 )
+_OPENROUTER_REASONING = ModelCapabilities(
+    effort=OPENROUTER_EFFORT_LEVELS,
+    thinking=THINKING_MODES,
+)
+_OPENROUTER_GEMINI = ModelCapabilities(
+    effort=("low", "medium", "high"),
+    thinking=("adaptive",),
+    temperature=True,
+)
+_OPENROUTER_GROK = ModelCapabilities(
+    effort=("low", "medium", "high", "xhigh"),
+    thinking=("adaptive",),
+    temperature=True,
+)
+_OPENROUTER_OPEN_WEIGHT = ModelCapabilities(
+    effort=("none", "low", "high", "max"),
+    thinking=THINKING_MODES,
+    temperature=True,
+)
 
+
+def _model(controls: ModelCapabilities, max_output_tokens: int) -> ModelCapabilities:
+    """One model: a shared control set plus that model's own output ceiling."""
+    return replace(controls, max_output_tokens=max_output_tokens)
+
+
+# One row per model -- id tags, controls, and the output ceiling its own docs
+# state. A model absent here is unreviewed and the adapters refuse to serve it.
 _CLAUDE_RULES = (
-    (("haiku-4-5", "haiku-4.5", "sonnet-4-5", "sonnet-4.5"), _TEMPERATURE),
-    (("opus-4-5", "opus-4.5"), _CLAUDE_EFFORT_TEMPERATURE),
-    (
-        ("opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6"),
-        _CLAUDE_ADAPTIVE_TEMPERATURE,
-    ),
-    (("fable", "mythos"), _CLAUDE_MANDATORY_THINKING),
-    (
-        (
-            "opus-4-7",
-            "opus-4.7",
-            "opus-4-8",
-            "opus-4.8",
-            "opus-5",
-            "sonnet-5",
-        ),
-        _CLAUDE_ADAPTIVE,
-    ),
+    (("haiku-4-5", "haiku-4.5"), _model(_TEMPERATURE, 64_000)),
+    (("sonnet-4-5", "sonnet-4.5"), _model(_TEMPERATURE, 64_000)),
+    (("opus-4-5", "opus-4.5"), _model(_CLAUDE_EFFORT_TEMPERATURE, 64_000)),
+    (("opus-4-6", "opus-4.6"), _model(_CLAUDE_ADAPTIVE_TEMPERATURE, 128_000)),
+    (("sonnet-4-6", "sonnet-4.6"), _model(_CLAUDE_ADAPTIVE_TEMPERATURE, 128_000)),
+    (("fable",), _model(_CLAUDE_MANDATORY_THINKING, 128_000)),
+    (("mythos",), _model(_CLAUDE_MANDATORY_THINKING, 128_000)),
+    (("opus-4-7", "opus-4.7"), _model(_CLAUDE_ADAPTIVE, 128_000)),
+    (("opus-4-8", "opus-4.8"), _model(_CLAUDE_ADAPTIVE, 128_000)),
+    (("opus-5",), _model(_CLAUDE_ADAPTIVE, 128_000)),
+    (("sonnet-5",), _model(_CLAUDE_ADAPTIVE, 128_000)),
 )
 
 _OPENROUTER_RULES = (
-    (
-        ("anthropic/claude-opus-5", "anthropic/claude-sonnet-5"),
-        ModelCapabilities(
-            effort=("none", "low", "medium", "high", "xhigh", "max"),
-            thinking=THINKING_MODES,
-        ),
-    ),
-    (
-        ("openai/gpt-5.6-sol", "openai/gpt-5.6-terra", "openai/gpt-5.6-luna"),
-        ModelCapabilities(
-            effort=OPENROUTER_EFFORT_LEVELS,
-            thinking=THINKING_MODES,
-        ),
-    ),
-    (
-        ("google/gemini-3.1-pro-preview", "google/gemini-3.7-flash"),
-        ModelCapabilities(
-            effort=("low", "medium", "high"),
-            thinking=("adaptive",),
-            temperature=True,
-        ),
-    ),
-    (
-        ("x-ai/grok-4.6",),
-        ModelCapabilities(
-            effort=("low", "medium", "high", "xhigh"),
-            thinking=("adaptive",),
-            temperature=True,
-        ),
-    ),
-    (
-        ("deepseek/deepseek-v4-pro-0813", "moonshotai/kimi-k3"),
-        ModelCapabilities(
-            effort=("none", "low", "high", "max"),
-            thinking=THINKING_MODES,
-            temperature=True,
-        ),
-    ),
+    (("anthropic/claude-opus-5",), _model(_OPENROUTER_REASONING, 128_000)),
+    (("anthropic/claude-sonnet-5",), _model(_OPENROUTER_REASONING, 128_000)),
+    (("openai/gpt-5.6-sol",), _model(_OPENROUTER_REASONING, 128_000)),
+    (("openai/gpt-5.6-terra",), _model(_OPENROUTER_REASONING, 128_000)),
+    (("openai/gpt-5.6-luna",), _model(_OPENROUTER_REASONING, 128_000)),
+    (("google/gemini-3.1-pro-preview",), _model(_OPENROUTER_GEMINI, 65_536)),
+    (("google/gemini-3.7-flash",), _model(_OPENROUTER_GEMINI, 65_536)),
+    (("x-ai/grok-4.6",), _model(_OPENROUTER_GROK, 450_000)),
+    (("deepseek/deepseek-v4-pro-0813",), _model(_OPENROUTER_OPEN_WEIGHT, 384_000)),
+    (("moonshotai/kimi-k3",), _model(_OPENROUTER_OPEN_WEIGHT, 943_718)),
+)
+
+# The Converse adapter currently exposes sampling only; Claude-specific effort
+# and adaptive-thinking fields are implemented by Claude Platform.
+_BEDROCK_RULES = (
+    (("haiku-4-5", "haiku-4.5"), _model(_TEMPERATURE, 64_000)),
+    (("sonnet-4-5", "sonnet-4.5"), _model(_TEMPERATURE, 64_000)),
 )
 
 
@@ -117,14 +122,7 @@ def model_capabilities(provider: str, model_id: str) -> ModelCapabilities:
     elif provider == "claude_platform":
         rules = _CLAUDE_RULES
     elif provider == "bedrock":
-        # The Converse adapter currently exposes sampling only; Claude-specific
-        # effort and adaptive-thinking fields are implemented by Claude Platform.
-        rules = (
-            (
-                ("haiku-4-5", "haiku-4.5", "sonnet-4-5", "sonnet-4.5"),
-                _TEMPERATURE,
-            ),
-        )
+        rules = _BEDROCK_RULES
     else:
         return ModelCapabilities()
     for tags, capabilities in rules:

--- a/src/research_ai/services/agent/model_capabilities.py
+++ b/src/research_ai/services/agent/model_capabilities.py
@@ -1,5 +1,6 @@
 """Reviewed generation controls supported by each model family."""
 
+import re
 from dataclasses import dataclass
 
 EFFORT_LEVELS = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
@@ -82,58 +83,74 @@ def _model(controls: ModelCapabilities, max_output_tokens: int) -> ModelCapabili
     )
 
 
-# One row per model -- id tags, controls, and the output ceiling its own docs
-# state. A model absent here is unreviewed and the adapters refuse to serve it.
-_CLAUDE_RULES = (
-    (("haiku-4-5", "haiku-4.5"), _model(_TEMPERATURE, 64_000)),
-    (("sonnet-4-5", "sonnet-4.5"), _model(_TEMPERATURE, 64_000)),
-    (("opus-4-5", "opus-4.5"), _model(_CLAUDE_EFFORT_TEMPERATURE, 64_000)),
-    (("opus-4-6", "opus-4.6"), _model(_CLAUDE_ADAPTIVE_TEMPERATURE, 128_000)),
-    (("sonnet-4-6", "sonnet-4.6"), _model(_CLAUDE_ADAPTIVE_TEMPERATURE, 128_000)),
-    (("fable",), _model(_CLAUDE_MANDATORY_THINKING, 128_000)),
-    (("mythos",), _model(_CLAUDE_MANDATORY_THINKING, 128_000)),
-    (("opus-4-7", "opus-4.7"), _model(_CLAUDE_ADAPTIVE, 128_000)),
-    (("opus-4-8", "opus-4.8"), _model(_CLAUDE_ADAPTIVE, 128_000)),
-    (("opus-5",), _model(_CLAUDE_ADAPTIVE, 128_000)),
-    (("sonnet-5",), _model(_CLAUDE_ADAPTIVE, 128_000)),
-)
+# Ids arrive decorated: Bedrock inference-profile prefixes and ``-v1:0``
+# suffixes, dated snapshots, Vertex ``@date``, OpenRouter ``:variant`` tags.
+# Strip those, then a model resolves on its own id alone -- never on a longer
+# id that merely contains it (``claude-opus-50`` is not Claude Opus 5).
+_ID_PREFIXES = ("global.", "us.", "eu.", "apac.", "anthropic.")
+_ID_DECORATIONS = re.compile(r"(-v\d+:\d+|[-@]\d{8}|:[a-z][a-z-]*)$")
 
-_OPENROUTER_RULES = (
-    (("anthropic/claude-opus-5",), _model(_OPENROUTER_REASONING, 128_000)),
-    (("anthropic/claude-sonnet-5",), _model(_OPENROUTER_REASONING, 128_000)),
-    (("openai/gpt-5.6-sol",), _model(_OPENROUTER_REASONING, 128_000)),
-    (("openai/gpt-5.6-terra",), _model(_OPENROUTER_REASONING, 128_000)),
-    (("openai/gpt-5.6-luna",), _model(_OPENROUTER_REASONING, 128_000)),
-    (("google/gemini-3.1-pro-preview",), _model(_OPENROUTER_GEMINI, 65_536)),
-    (("google/gemini-3.7-flash",), _model(_OPENROUTER_GEMINI, 65_536)),
-    (("x-ai/grok-4.6",), _model(_OPENROUTER_GROK, 450_000)),
-    (("deepseek/deepseek-v4-pro-0813",), _model(_OPENROUTER_OPEN_WEIGHT, 384_000)),
-    (("moonshotai/kimi-k3",), _model(_OPENROUTER_OPEN_WEIGHT, 943_718)),
-)
+
+def _normalized(model_id: str) -> str:
+    """Reduce a platform-decorated id to the bare model id rules are keyed by."""
+    mid = model_id.lower().strip()
+    while True:
+        stripped = _ID_DECORATIONS.sub("", mid)
+        for prefix in _ID_PREFIXES:
+            stripped = stripped.removeprefix(prefix)
+        if stripped == mid:
+            return mid
+        mid = stripped
+
+
+# One entry per model: its bare id, its controls, and the output ceiling its
+# own docs state. A model absent here is unreviewed; adapters refuse to serve
+# it rather than borrow another model's numbers.
+_CLAUDE_MODELS = {
+    "claude-haiku-4-5": _model(_TEMPERATURE, 64_000),
+    "claude-sonnet-4-5": _model(_TEMPERATURE, 64_000),
+    "claude-opus-4-5": _model(_CLAUDE_EFFORT_TEMPERATURE, 64_000),
+    "claude-opus-4-6": _model(_CLAUDE_ADAPTIVE_TEMPERATURE, 128_000),
+    "claude-sonnet-4-6": _model(_CLAUDE_ADAPTIVE_TEMPERATURE, 128_000),
+    "claude-fable-5": _model(_CLAUDE_MANDATORY_THINKING, 128_000),
+    "claude-mythos-5": _model(_CLAUDE_MANDATORY_THINKING, 128_000),
+    "claude-opus-4-7": _model(_CLAUDE_ADAPTIVE, 128_000),
+    "claude-opus-4-8": _model(_CLAUDE_ADAPTIVE, 128_000),
+    "claude-opus-5": _model(_CLAUDE_ADAPTIVE, 128_000),
+    "claude-sonnet-5": _model(_CLAUDE_ADAPTIVE, 128_000),
+}
+
+_OPENROUTER_MODELS = {
+    "anthropic/claude-opus-5": _model(_OPENROUTER_REASONING, 128_000),
+    "anthropic/claude-sonnet-5": _model(_OPENROUTER_REASONING, 128_000),
+    "openai/gpt-5.6-sol": _model(_OPENROUTER_REASONING, 128_000),
+    "openai/gpt-5.6-terra": _model(_OPENROUTER_REASONING, 128_000),
+    "openai/gpt-5.6-luna": _model(_OPENROUTER_REASONING, 128_000),
+    "google/gemini-3.1-pro-preview": _model(_OPENROUTER_GEMINI, 65_536),
+    "google/gemini-3.7-flash": _model(_OPENROUTER_GEMINI, 65_536),
+    "x-ai/grok-4.6": _model(_OPENROUTER_GROK, 450_000),
+    "deepseek/deepseek-v4-pro-0813": _model(_OPENROUTER_OPEN_WEIGHT, 384_000),
+    "moonshotai/kimi-k3": _model(_OPENROUTER_OPEN_WEIGHT, 943_718),
+}
 
 # The Converse adapter currently exposes sampling only; Claude-specific effort
 # and adaptive-thinking fields are implemented by Claude Platform.
-_BEDROCK_RULES = (
-    (("haiku-4-5", "haiku-4.5"), _model(_TEMPERATURE, 64_000)),
-    (("sonnet-4-5", "sonnet-4.5"), _model(_TEMPERATURE, 64_000)),
-)
+_BEDROCK_MODELS = {
+    "claude-haiku-4-5": _model(_TEMPERATURE, 64_000),
+    "claude-sonnet-4-5": _model(_TEMPERATURE, 64_000),
+}
+
+_PROVIDER_MODELS = {
+    "claude_platform": _CLAUDE_MODELS,
+    "openrouter": _OPENROUTER_MODELS,
+    "bedrock": _BEDROCK_MODELS,
+}
 
 
 def model_capabilities(provider: str, model_id: str) -> ModelCapabilities:
     """Return the reviewed controls for a provider/model pair."""
-    mid = model_id.lower()
-    if provider == "openrouter":
-        rules = _OPENROUTER_RULES
-    elif provider == "claude_platform":
-        rules = _CLAUDE_RULES
-    elif provider == "bedrock":
-        rules = _BEDROCK_RULES
-    else:
-        return ModelCapabilities()
-    for tags, capabilities in rules:
-        if any(tag in mid for tag in tags):
-            return capabilities
-    return ModelCapabilities()
+    models = _PROVIDER_MODELS.get(provider, {})
+    return models.get(_normalized(model_id), ModelCapabilities())
 
 
 def validate_generation_options(
@@ -179,7 +196,7 @@ def validate_generation_options(
     if (
         thinking == "disabled"
         and effort in ("xhigh", "max")
-        and "opus-5" in model_id.lower()
+        and _normalized(model_id).endswith("claude-opus-5")
     ):
         raise ValueError(
             "Claude Opus 5 cannot use disabled thinking with xhigh or max effort"

--- a/src/research_ai/services/agent/providers/claude_platform.py
+++ b/src/research_ai/services/agent/providers/claude_platform.py
@@ -61,11 +61,6 @@ logger = logging.getLogger(__name__)
 # Callers that want a different model pass ``model_id``.
 MODEL_ID = "claude-opus-5"
 
-# claude-opus-5's output ceiling; what ``max_tokens=None`` resolves to. On
-# Opus 5 the budget covers thinking + text together, so an artificially low
-# ceiling truncates tool calls mid-emission. Review alongside MODEL_ID.
-MAX_OUTPUT_TOKENS = 128_000
-
 # How much the model may deliberate and spend per turn: low | medium | high |
 # xhigh | max. ``low`` keeps routine agent workflows economical; higher levels
 # trade more tokens for depth. "" omits the parameter entirely (models older
@@ -574,9 +569,22 @@ class ClaudePlatformProvider(LLMProvider):
             # the system block caches the whole tools+system prefix -- the
             # bytes that repeat unchanged on every turn.
             system["cache_control"] = {"type": "ephemeral"}
+        capabilities = model_capabilities("claude_platform", self.model_id)
+        if capabilities.max_output_tokens is None:
+            # No guessed ceiling: too high is a 400, too low truncates a turn
+            # mid-emission. A model is reviewed before it is served.
+            raise ProviderError(
+                f"model {self.model_id!r} has no reviewed output ceiling; add "
+                "it to model_capabilities before serving it.",
+                retryable=False,
+            )
+        # A ceiling above the model's own cap is a 400, so clamp rather than
+        # forward what Haiku 4.5 (64K) cannot accept.
+        ceiling = capabilities.max_output_tokens
+        max_tokens = ceiling if max_tokens is None else min(max_tokens, ceiling)
         kwargs: dict = {
             "model": self.model_id,
-            "max_tokens": MAX_OUTPUT_TOKENS if max_tokens is None else max_tokens,
+            "max_tokens": max_tokens,
             "system": [system],
             "messages": self._render_messages(messages, cache_last=self.prompt_caching),
         }
@@ -589,7 +597,6 @@ class ClaudePlatformProvider(LLMProvider):
             # state, separate from the content blocks replayed above.
             kwargs["container"] = container_id
             logger.info("claude platform: reusing code execution container")
-        capabilities = model_capabilities("claude_platform", self.model_id)
         thinking_mode = self.thinking if self.thinking in capabilities.thinking else ""
         if thinking_mode:
             thinking: dict = {"type": thinking_mode}

--- a/src/research_ai/services/agent/providers/openrouter.py
+++ b/src/research_ai/services/agent/providers/openrouter.py
@@ -41,9 +41,12 @@ OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 # that want a different route pass ``model_id`` or use a prefixed model ref.
 MODEL_ID = "anthropic/claude-opus-5"
 
-# What ``max_tokens=None`` resolves to. Deliberately below the model's 128K
-# ceiling: the completion is not streamed, so a longer emission would outlive
-# the client read timeout and die whole. Raise only after moving to streaming.
+# What ``max_tokens=None`` resolves to: a spend budget, not a model limit.
+# Deliberately below every routed model's ceiling because the completion is not
+# streamed, so a longer emission would outlive the client read timeout and die
+# whole. Raise only after moving to streaming. The model's own ceiling
+# (``ModelCapabilities.max_output_tokens``) clamps this and anything a caller
+# asks for.
 MAX_OUTPUT_TOKENS = 32_768
 
 # How much the model may deliberate and spend per turn. OpenRouter normalizes
@@ -184,10 +187,20 @@ class OpenRouterProvider(LLMProvider):
             raise ProviderError(
                 "OPENROUTER_API_KEY is not configured; cannot call OpenRouter."
             )
+        capabilities = model_capabilities("openrouter", self.model_id)
+        if capabilities.max_output_tokens is None:
+            # No guessed ceiling: too high is a 400, too low truncates a turn
+            # mid-emission. A model is reviewed before it is served.
+            raise ProviderError(
+                f"model {self.model_id!r} has no reviewed output ceiling; add "
+                "it to model_capabilities before serving it.",
+                retryable=False,
+            )
+        budget = MAX_OUTPUT_TOKENS if max_tokens is None else max_tokens
         kwargs: dict = {
             "model": self.model_id,
             "messages": self._render_messages(system_prompt, messages),
-            "max_tokens": MAX_OUTPUT_TOKENS if max_tokens is None else max_tokens,
+            "max_tokens": min(budget, capabilities.max_output_tokens),
         }
         if _accepts_sampling_params(self.model_id):
             kwargs["temperature"] = temperature

--- a/src/research_ai/tests/agent/test_claude_platform_provider.py
+++ b/src/research_ai/tests/agent/test_claude_platform_provider.py
@@ -175,6 +175,7 @@ def _complete(
     *,
     messages=None,
     rendered_tools=None,
+    max_tokens=100,
     temperature=0.0,
     before_retry=None,
 ):
@@ -182,7 +183,7 @@ def _complete(
         system_prompt="sys",
         messages=messages or [Message(role="user", content=[TextBlock(text="hi")])],
         rendered_tools=rendered_tools if rendered_tools is not None else [],
-        max_tokens=100,
+        max_tokens=max_tokens,
         temperature=temperature,
         before_retry=before_retry,
     )
@@ -540,18 +541,30 @@ class CompleteAndParseTests(SimpleTestCase):
         self.assertNotIn("thinking", call)
         self.assertEqual(call["temperature"], 0.7)
 
-    def test_unknown_model_omits_unreviewed_optional_controls(self):
+    def test_haiku_4_5_clamps_max_tokens_to_the_model_output_cap(self):
+        # Arrange: Haiku 4.5 caps output at 64K and rejects anything above it.
+        provider = _build_provider(
+            [_build_response([]), _build_response([])],
+            model_id="claude-haiku-4-5",
+        )
+
+        # Act: both an unset ceiling and a caller ceiling above the cap.
+        _complete(provider, max_tokens=None, temperature=0.7)
+        _complete(provider, max_tokens=100_000, temperature=0.7)
+
+        # Assert
+        calls = provider._client.messages.calls
+        self.assertEqual(calls[0]["max_tokens"], 64_000)
+        self.assertEqual(calls[1]["max_tokens"], 64_000)
+
+    def test_unreviewed_model_is_refused_before_the_request(self):
         # Arrange
         provider = _build_provider([_build_response([])], model_id="claude-future")
 
-        # Act
-        _complete(provider, temperature=0.7)
-
-        # Assert
-        call = provider._client.messages.calls[0]
-        self.assertNotIn("output_config", call)
-        self.assertNotIn("thinking", call)
-        self.assertNotIn("temperature", call)
+        # Act / Assert
+        with self.assertRaisesRegex(ProviderError, "no reviewed output ceiling"):
+            _complete(provider, temperature=0.7)
+        self.assertEqual(provider._client.messages.calls, [])
 
     def test_prompt_caching_marks_system_and_the_last_message_block(self):
         # Arrange
@@ -719,7 +732,7 @@ class CompleteAndParseTests(SimpleTestCase):
         self.assertIsInstance(ctx.exception.__cause__, ValueError)
 
     def test_none_max_tokens_resolves_to_the_model_output_ceiling(self):
-        # Arrange
+        # Arrange: an unset ceiling resolves to Opus 5's reviewed cap.
         provider = _build_provider([_build_response([])])
 
         # Act
@@ -733,7 +746,7 @@ class CompleteAndParseTests(SimpleTestCase):
 
         # Assert
         call = provider._client.messages.calls[0]
-        self.assertEqual(call["max_tokens"], claude_platform.MAX_OUTPUT_TOKENS)
+        self.assertEqual(call["max_tokens"], 128_000)
 
     def test_explicit_max_tokens_is_forwarded_unchanged(self):
         # Arrange: the _complete helper passes max_tokens=100.

--- a/src/research_ai/tests/agent/test_model_catalog.py
+++ b/src/research_ai/tests/agent/test_model_catalog.py
@@ -114,7 +114,7 @@ class AvailableModelsTests(SimpleTestCase):
         )
 
 
-class BedrockCapabilitiesTests(SimpleTestCase):
+class CapabilityLookupTests(SimpleTestCase):
     def test_bedrock_haiku_carries_sampling_and_its_own_ceiling(self):
         # Act: the Converse adapter takes prefixed ids and exposes sampling only.
         capabilities = model_capabilities(
@@ -126,6 +126,35 @@ class BedrockCapabilitiesTests(SimpleTestCase):
         self.assertEqual(capabilities.effort, ())
         self.assertEqual(capabilities.thinking, ())
         self.assertEqual(capabilities.max_output_tokens, 64_000)
+
+    def test_platform_decorations_resolve_to_the_same_model(self):
+        # Arrange: dated snapshots and OpenRouter variant tags name one model.
+        decorated = (
+            ("claude_platform", "claude-haiku-4-5-20251001", 64_000),
+            ("claude_platform", "claude-opus-4-5-20251101", 64_000),
+            ("openrouter", "deepseek/deepseek-v4-pro-0813:free", 384_000),
+        )
+
+        # Act / Assert
+        for provider, model_id, ceiling in decorated:
+            with self.subTest(model_id=model_id):
+                capabilities = model_capabilities(provider, model_id)
+                self.assertEqual(capabilities.max_output_tokens, ceiling)
+
+    def test_an_id_that_merely_contains_a_reviewed_id_is_unreviewed(self):
+        # Arrange: a longer id is a different model, not the one it contains.
+        near_misses = (
+            ("claude_platform", "claude-opus-50"),
+            ("claude_platform", "claude-haiku-4-50"),
+            ("openrouter", "openai/gpt-5.6-sol-next"),
+        )
+
+        # Act / Assert
+        for provider, model_id in near_misses:
+            with self.subTest(model_id=model_id):
+                self.assertIsNone(
+                    model_capabilities(provider, model_id).max_output_tokens
+                )
 
 
 @override_settings(**ALL_PROVIDERS_CONFIGURED)

--- a/src/research_ai/tests/agent/test_model_catalog.py
+++ b/src/research_ai/tests/agent/test_model_catalog.py
@@ -2,7 +2,10 @@
 
 from django.test import SimpleTestCase, override_settings
 
-from research_ai.services.agent.model_capabilities import validate_generation_options
+from research_ai.services.agent.model_capabilities import (
+    model_capabilities,
+    validate_generation_options,
+)
 from research_ai.services.agent.model_catalog import (
     available_models,
     default_model_ref,
@@ -109,6 +112,20 @@ class AvailableModelsTests(SimpleTestCase):
         self.assertNotIn(
             "claude_platform:claude-sonnet-5", [option.ref for option in options]
         )
+
+
+class BedrockCapabilitiesTests(SimpleTestCase):
+    def test_bedrock_haiku_carries_sampling_and_its_own_ceiling(self):
+        # Act: the Converse adapter takes prefixed ids and exposes sampling only.
+        capabilities = model_capabilities(
+            "bedrock", "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        )
+
+        # Assert
+        self.assertTrue(capabilities.temperature)
+        self.assertEqual(capabilities.effort, ())
+        self.assertEqual(capabilities.thinking, ())
+        self.assertEqual(capabilities.max_output_tokens, 64_000)
 
 
 @override_settings(**ALL_PROVIDERS_CONFIGURED)

--- a/src/research_ai/tests/agent/test_model_catalog.py
+++ b/src/research_ai/tests/agent/test_model_catalog.py
@@ -38,6 +38,22 @@ class AvailableModelsTests(SimpleTestCase):
             self.assertTrue(option.label)
             self.assertIn(option.provider, ("bedrock", "claude_platform", "openrouter"))
 
+    def test_every_catalog_model_declares_an_output_ceiling(self):
+        # Arrange: both adapters refuse a model whose ceiling is unreviewed, so
+        # a catalog entry without one cannot run a turn.
+        options = available_models()
+
+        # Act
+        unreviewed = [
+            option.ref
+            for option in options
+            if option.capabilities.max_output_tokens is None
+        ]
+
+        # Assert
+        self.assertTrue(options)
+        self.assertEqual(unreviewed, [])
+
     def test_haiku_advertises_temperature_but_not_effort_or_thinking(self):
         # Arrange
         option = next(

--- a/src/research_ai/tests/agent/test_openrouter_provider.py
+++ b/src/research_ai/tests/agent/test_openrouter_provider.py
@@ -56,7 +56,7 @@ def _tool_call(call_id="call-1", name="search", arguments='{"q": 1}'):
     )
 
 
-def _build_provider(responses=None, model_id="test-model", **kwargs):
+def _build_provider(responses=None, model_id="google/gemini-3.7-flash", **kwargs):
     """Build an OpenRouterProvider with a fake client so no HTTP client exists."""
     return OpenRouterProvider(
         client=FakeChatCompletionsClient(responses or []),
@@ -203,21 +203,20 @@ class CompleteRequestTests(SimpleTestCase):
 
         # Assert
         kwargs = provider._client.calls[0]
-        self.assertEqual(kwargs["model"], "test-model")
+        self.assertEqual(kwargs["model"], "google/gemini-3.7-flash")
         self.assertEqual(kwargs["max_tokens"], 100)
         self.assertEqual(kwargs["temperature"], 0.5)
         self.assertEqual(kwargs["tools"], rendered_tools)
         self.assertEqual(kwargs["extra_body"], {"reasoning": {"effort": "low"}})
 
-    def test_effort_can_be_omitted_for_incompatible_models(self):
+    def test_unreviewed_model_is_refused_before_the_request(self):
         # Arrange
-        provider = _build_provider([_response(content="ok")])
+        provider = _build_provider([_response(content="ok")], model_id="new/model")
 
-        # Act
-        _complete(provider)
-
-        # Assert
-        self.assertNotIn("extra_body", provider._client.calls[0])
+        # Act / Assert
+        with self.assertRaisesRegex(ProviderError, "no reviewed output ceiling"):
+            _complete(provider)
+        self.assertEqual(provider._client.calls, [])
 
     def test_default_effort_is_sent_for_a_capable_model(self):
         # Arrange
@@ -289,6 +288,22 @@ class CompleteRequestTests(SimpleTestCase):
             provider._client.calls[0]["max_tokens"], openrouter.MAX_OUTPUT_TOKENS
         )
 
+    def test_max_tokens_is_clamped_to_the_model_output_ceiling(self):
+        # Arrange: Gemini 3.7 Flash caps output at 65,536.
+        provider = _build_provider([_response(content="ok")])
+
+        # Act
+        provider.complete(
+            system_prompt="sys",
+            messages=[Message(role="user", content=[TextBlock(text="hi")])],
+            rendered_tools=[],
+            max_tokens=100_000,
+            temperature=0.5,
+        )
+
+        # Assert
+        self.assertEqual(provider._client.calls[0]["max_tokens"], 65_536)
+
     def test_no_tools_key_when_toolset_is_empty(self):
         # Arrange
         provider = _build_provider([_response(content="ok")])
@@ -302,7 +317,7 @@ class CompleteRequestTests(SimpleTestCase):
     def test_sampling_params_omitted_for_models_that_reject_them(self):
         # Arrange
         provider = _build_provider(
-            [_response(content="ok")], model_id="anthropic/claude-opus-4.8"
+            [_response(content="ok")], model_id="anthropic/claude-opus-5"
         )
 
         # Act
@@ -464,7 +479,7 @@ class ErrorTests(SimpleTestCase):
     @override_settings(OPENROUTER_API_KEY="")
     def test_missing_api_key_raises_provider_error_on_complete(self):
         # Arrange
-        provider = OpenRouterProvider(model_id="test-model")
+        provider = OpenRouterProvider(model_id="google/gemini-3.7-flash")
 
         # Act / Assert
         with self.assertRaises(ProviderError):
@@ -481,7 +496,9 @@ class ErrorTests(SimpleTestCase):
             def _create(self, **kwargs):
                 raise RuntimeError("boom")
 
-        provider = OpenRouterProvider(client=ExplodingClient(), model_id="test-model")
+        provider = OpenRouterProvider(
+            client=ExplodingClient(), model_id="google/gemini-3.7-flash"
+        )
 
         # Act / Assert
         with self.assertRaises(ProviderError):
@@ -536,7 +553,9 @@ class ErrorTests(SimpleTestCase):
             def _create(self, **kwargs):
                 raise rate_limited
 
-        provider = OpenRouterProvider(client=ExplodingClient(), model_id="test-model")
+        provider = OpenRouterProvider(
+            client=ExplodingClient(), model_id="google/gemini-3.7-flash"
+        )
 
         # Act
         with self.assertRaises(ProviderError) as ctx:


### PR DESCRIPTION
## Problem

Notebook chat leaves `max_tokens` unset, so the Claude Platform adapter resolved it to a flat `MAX_OUTPUT_TOKENS = 128_000` regardless of model. Haiku 4.5 caps output at 64K and rejects anything larger, so every Haiku turn died:

```
400 invalid_request_error: max_tokens: 128000 > 64000, which is the maximum
allowed number of output tokens for claude-haiku-4-5-20251001
```

## Change

- **Per-model ceilings.** `ModelCapabilities` gains `max_output_tokens`, and the rules tables become one row per model. The shared constants (`_CLAUDE_ADAPTIVE`, `_TEMPERATURE`, …) go back to describing *controls* only; each row pairs one with that model's own ceiling, so Haiku and Sonnet 4.5 agree on 64K because each says so rather than by sharing an object.
- **Resolve and clamp.** Both adapters resolve `max_tokens=None` from the table and clamp what a caller asks for, instead of forwarding a value the model will reject.
- **No guessed ceiling.** A model with no reviewed entry is refused with a non-retryable `ProviderError` before any request goes out; `claude_platform.MAX_OUTPUT_TOKENS` is deleted. OpenRouter's `MAX_OUTPUT_TOKENS = 32_768` stays, but only as the spend budget an unset `max_tokens` resolves to (that path isn't streamed), now clamped by the model's ceiling.

Ceilings are the documented synchronous Messages API limits — 64K for the 4.5 generation, 128K for 4.6 and later — and the values OpenRouter reports per model (128K for the GPT-5.6 and Claude routes, 65,536 for Gemini, 450,000 for Grok 4.6, 384,000 for DeepSeek V4 Pro, 943,718 for Kimi K3).

## Behavior change

An OpenRouter ref outside the table is now refused rather than served — e.g. `anthropic/claude-opus-4.8`. Nothing hits this by default: `JUDGE_MODEL_IDS` is empty so the roster falls back to the generator, and every catalog entry is reviewed. A custom judge roster needs its models added to the table first.

Bedrock is deliberately untouched: its rules table reviews controls for `haiku-4-5`/`sonnet-4-5` only, while `bedrock.MODEL_ID` is `us.anthropic.claude-opus-5`, so the same refusal would reject that adapter's own default. Filling in that table is a separate pass.

## Tests

- Clamp and refusal coverage on both adapters.
- `test_every_catalog_model_declares_an_output_ceiling` fails CI if a model is added to the catalog without a reviewed ceiling.
- OpenRouter tests moved off the fictional `test-model` id onto reviewed ones.

`research_ai`: 1138 tests, OK. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)