### PR TITLE
Improve agent retrieval context efficiency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "atproto>=0.0.70",
     "authlib>=1.3.0,<2.0.0",
     "beautifulsoup4==4.12.2",
+    "bm25s>=0.3.11,<0.4",
     "boto3>=1.43.38,<2",
     "cdp-sdk==1.44.0",
     "celery==5.6.3",

--- a/src/purchase/related_models/grant_model.py
+++ b/src/purchase/related_models/grant_model.py
@@ -156,7 +156,7 @@ class Grant(DefaultModel):
         parts.append(self.description or "")
         post = self.unified_document.posts.first()
         if post:
-            body = post.get_full_markdown()
+            body = post.get_full_markdown() or post.renderable_text
             if body:
                 parts.append(body)
         return "\n\n".join(p for p in parts if p).strip()

--- a/src/purchase/tests/test_grant_model.py
+++ b/src/purchase/tests/test_grant_model.py
@@ -299,6 +299,7 @@ class GrantLLMContextTextTests(SimpleTestCase):
         grant.description = "Do good science."
         post = MagicMock()
         post.get_full_markdown.return_value = "# Details\nMore"
+        post.renderable_text = "Rendered duplicate details"
         grant.unified_document.posts.first.return_value = post
 
         # Act
@@ -309,6 +310,24 @@ class GrantLLMContextTextTests(SimpleTestCase):
         self.assertIn("NIH", text)
         self.assertIn("Do good science.", text)
         self.assertIn("# Details", text)
+        self.assertNotIn("Rendered duplicate details", text)
+
+    def test_uses_rendered_post_text_when_markdown_is_unavailable(self):
+        # Arrange
+        grant = MagicMock()
+        grant.short_title = "My RFP"
+        grant.organization = "NIH"
+        grant.description = "Do good science."
+        post = MagicMock()
+        post.get_full_markdown.return_value = None
+        post.renderable_text = "Rendered call requirements"
+        grant.unified_document.posts.first.return_value = post
+
+        # Act
+        text = Grant.get_llm_context_text(grant)
+
+        # Assert
+        self.assertIn("Rendered call requirements", text)
 
     def test_handles_missing_post(self):
         # Arrange

--- a/src/research_ai/prompts/notebook_chat_prompts.py
+++ b/src/research_ai/prompts/notebook_chat_prompts.py
@@ -1,8 +1,8 @@
 """Prompt builder for the notebook chat assistant.
 
 The system prompt pins the agent to one note (id + title) and states the
-tool contract: research via OpenAlex/web tools, note edits via read_note /
-edit_note with full-document replaces. The user prompt is the user's chat
+tool contract: research via OpenAlex/web tools, note edits via bounded read_note /
+edit_note block operations. The user prompt is the user's chat
 message verbatim, so there is no user-prompt builder here.
 """
 

--- a/src/research_ai/prompts/notebook_chat_system.txt
+++ b/src/research_ai/prompts/notebook_chat_system.txt
@@ -23,12 +23,17 @@ edit_note call must use this note id; you have no access to other notes.
   partial, or unresolved; then work from get_user_profile and the literature
   tools instead, and never invent a track record.
 - **Answer and research.** Use search_institutions, search_authors, get_author,
-  get_author_works, and get_work_fulltext to ground answers in real literature
-  from OpenAlex, and web_search for facts outside the literature. Never invent
-  a citation, DOI, author, or finding: if a claim needs a source, find it with
-  a tool first, and say so plainly when you cannot.
+  and cursor-paginated get_author_works to discover real literature from
+  OpenAlex. Work listings are compact: call get_work_abstract for a promising
+  paper's abstract, then search_work_fulltext with a focused query when you need
+  evidence from the paper itself. Follow next_cursor when one page does not give
+  adequate candidate coverage. Use web_search for facts outside the literature.
+  Never invent a citation, DOI, author, or finding: if a claim needs a source,
+  find it with a tool first, and say so plainly when you cannot.
 - **Find funding.** Use search_grants when the user wants grants or RFPs relevant
-  to a preregistration. Read the note, derive focused search terms from it, and
+  to a preregistration. Its results are compact cards; call get_grant_details
+  before judging the exact fit or requirements of a promising result. Read the
+  note, derive focused search terms from it, and
   distinguish promising matches from confirmed eligibility; the user must verify
   the full RFP terms before applying.
 - **Edit the note.** When the user asks for changes to the note (rewrite a
@@ -37,7 +42,10 @@ edit_note call must use this note id; you have no access to other notes.
 
 ## Editing rules
 
-1. Edit from your latest read_note or edit_note result; a stale rejection
+1. Long notes may require several bounded read_note calls. Continue from
+   next_start_block until you have read every block relevant to the request.
+   Global block indices remain stable across those windows. Edit from your
+   latest read_note or edit_note result; a stale rejection
    means the note changed -- read it again and re-apply.
 2. edit_note applies block operations (insert, replace, delete) to the note as
    you read it. Send only the blocks you are changing; every block you do not

--- a/src/research_ai/prompts/notebook_chat_system.txt
+++ b/src/research_ai/prompts/notebook_chat_system.txt
@@ -43,9 +43,11 @@ edit_note call must use this note id; you have no access to other notes.
 ## Editing rules
 
 1. Long notes may require several bounded read_note calls. Continue from
-   next_start_block until you have read every block relevant to the request.
-   Global block indices remain stable across those windows. Edit from your
-   latest read_note or edit_note result; a stale rejection
+   next_start_block until you have read every block relevant to the request,
+   passing the first response's version_id on every continuation read. Global
+   block indices remain stable across those windows because each page comes
+   from that immutable version. Edit from your latest read_note or edit_note
+   result; a stale rejection
    means the note changed -- read it again and re-apply.
 2. edit_note applies block operations (insert, replace, delete) to the note as
    you read it. Send only the blocks you are changing; every block you do not

--- a/src/research_ai/services/note_tools.py
+++ b/src/research_ai/services/note_tools.py
@@ -1,10 +1,11 @@
 """Notebook note tools for the agent core.
 
 ``NoteToolset`` lets an agent read and edit Tiptap notes on behalf of a
-specific user. Reads hand the model the note's top-level blocks in the
-compact dialect of ``utils.prosemirror``, indexed by position, plus a version
-id. Edits are block-level operations (insert/replace/delete) against those
-indices, guarded by that version id (optimistic concurrency), with the new
+specific user. Reads hand the model a bounded window of the note's top-level
+blocks in the compact dialect of ``utils.prosemirror``, indexed by global
+position, plus a version id. Edits are block-level operations
+(insert/replace/delete) against those indices, guarded by that version id
+(optimistic concurrency), with the new
 blocks validated against the vendored editor schema before anything is
 stored. Tool traffic thus stays proportional to the change, not to the note:
 the model never receives or regenerates the parts of the document it is not
@@ -43,6 +44,7 @@ logger = logging.getLogger(__name__)
 
 READ_NOTE = "read_note"
 EDIT_NOTE = "edit_note"
+_MAX_BLOCKS_PER_READ = 50
 
 _BLOCK_FORMAT = (
     "Blocks use a compact Tiptap form: a bare string at block level is a "
@@ -82,8 +84,11 @@ class NoteToolset:
                 description=(
                     "Read a ResearchHub notebook note. Returns the note "
                     "title, the version_id that edit_note requires, "
-                    "block_count, and the note body as `blocks`: a map from "
-                    'top-level block index ("0", "1", ...) to that block. '
+                    "total block_count, and a bounded window of the note body "
+                    "as `blocks`: a map from global top-level block index "
+                    '("0", "1", ...) to that block. Use start_block and '
+                    "max_blocks to continue through a long note; next_start_block "
+                    "is null at the end. "
                     f"{_BLOCK_FORMAT} A note with no content yet reads as "
                     "`blocks` null; populate it with an insert."
                 ),
@@ -93,6 +98,19 @@ class NoteToolset:
                         "note_id": {
                             "type": "integer",
                             "description": "Id of the note to read.",
+                        },
+                        "start_block": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "First global block index (default 0).",
+                        },
+                        "max_blocks": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": _MAX_BLOCKS_PER_READ,
+                            "description": (
+                                "Maximum blocks to return (default and limit 50)."
+                            ),
                         },
                     },
                     "required": ["note_id"],
@@ -207,18 +225,52 @@ class NoteToolset:
                 # cleaned up), so surface the mismatch instead of hiding it.
                 logger.warning("note %s content fails the editor schema", note.id)
                 return {"error": f"note {note.id} content could not be read: {exc}"}
+        try:
+            start = self._read_bound(input.get("start_block"), default=0, minimum=0)
+            limit = self._read_bound(
+                input.get("max_blocks"),
+                default=_MAX_BLOCKS_PER_READ,
+                minimum=1,
+                maximum=_MAX_BLOCKS_PER_READ,
+            )
+        except ValueError as exc:
+            return {"error": str(exc)}
+        block_count = 0 if blocks is None else len(blocks)
+        if start > block_count:
+            return {
+                "error": (
+                    f"start_block {start} is out of range; note {note.id} has "
+                    f"{block_count} blocks"
+                )
+            }
+        end = min(start + limit, block_count)
         result = {
             "note_id": note.id,
             "title": note.title,
             "version_id": latest.id if latest else None,
-            "block_count": 0 if blocks is None else len(blocks),
+            "block_count": block_count,
+            "start_block": start,
+            "returned_block_count": end - start,
+            "next_start_block": end if end < block_count else None,
             "blocks": (
                 None
                 if blocks is None
-                else {str(index): block for index, block in enumerate(blocks)}
+                else {str(index): blocks[index] for index in range(start, end)}
             ),
         }
         return result
+
+    @staticmethod
+    def _read_bound(value, *, default: int, minimum: int, maximum: int | None = None):
+        if value is None:
+            return default
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError("read_note bounds must be integers")
+        if value < minimum or (maximum is not None and value > maximum):
+            if maximum is None:
+                raise ValueError(f"read_note bound must be at least {minimum}")
+            raise ValueError(f"read_note bound must be between {minimum} and {maximum}")
+        return value
 
     def _edit_note(self, input: dict) -> dict:
         note = self._get_readable_note(input.get("note_id"))

--- a/src/research_ai/services/note_tools.py
+++ b/src/research_ai/services/note_tools.py
@@ -88,7 +88,9 @@ class NoteToolset:
                     "as `blocks`: a map from global top-level block index "
                     '("0", "1", ...) to that block. Use start_block and '
                     "max_blocks to continue through a long note; next_start_block "
-                    "is null at the end. "
+                    "is null at the end. Pass the first response's version_id "
+                    "on every continuation read so all pages come from the same "
+                    "immutable note version. "
                     f"{_BLOCK_FORMAT} A note with no content yet reads as "
                     "`blocks` null; populate it with an insert."
                 ),
@@ -110,6 +112,13 @@ class NoteToolset:
                             "maximum": _MAX_BLOCKS_PER_READ,
                             "description": (
                                 "Maximum blocks to return (default and limit 50)."
+                            ),
+                        },
+                        "version_id": {
+                            "type": "integer",
+                            "description": (
+                                "Version returned by the first read. Required "
+                                "when start_block is greater than 0."
                             ),
                         },
                     },
@@ -211,10 +220,21 @@ class NoteToolset:
         note = self._get_readable_note(input.get("note_id"))
         if note is None:
             return {"error": f"note {input.get('note_id')} not found or not accessible"}
-        latest = note.latest_version
+        try:
+            start = self._read_bound(input.get("start_block"), default=0, minimum=0)
+            limit = self._read_bound(
+                input.get("max_blocks"),
+                default=_MAX_BLOCKS_PER_READ,
+                minimum=1,
+                maximum=_MAX_BLOCKS_PER_READ,
+            )
+            version = self._read_version(note, input.get("version_id"), start=start)
+        except ValueError as exc:
+            return {"error": str(exc)}
+
         # Stored JSON may be a JSON-encoded string rather than a dict;
         # normalize before block extraction.
-        doc = parse_note_json(latest.json) if latest else None
+        doc = parse_note_json(version.json) if version else None
         if doc is None:
             blocks = None
         else:
@@ -225,16 +245,6 @@ class NoteToolset:
                 # cleaned up), so surface the mismatch instead of hiding it.
                 logger.warning("note %s content fails the editor schema", note.id)
                 return {"error": f"note {note.id} content could not be read: {exc}"}
-        try:
-            start = self._read_bound(input.get("start_block"), default=0, minimum=0)
-            limit = self._read_bound(
-                input.get("max_blocks"),
-                default=_MAX_BLOCKS_PER_READ,
-                minimum=1,
-                maximum=_MAX_BLOCKS_PER_READ,
-            )
-        except ValueError as exc:
-            return {"error": str(exc)}
         block_count = 0 if blocks is None else len(blocks)
         if start > block_count:
             return {
@@ -247,7 +257,7 @@ class NoteToolset:
         result = {
             "note_id": note.id,
             "title": note.title,
-            "version_id": latest.id if latest else None,
+            "version_id": version.id if version else None,
             "block_count": block_count,
             "start_block": start,
             "returned_block_count": end - start,
@@ -259,6 +269,23 @@ class NoteToolset:
             ),
         }
         return result
+
+    @staticmethod
+    def _read_version(note: Note, version_id, *, start: int) -> NoteContent | None:
+        """Resolve one immutable version and require it for continuation reads."""
+        if version_id is None:
+            if start > 0:
+                raise ValueError(
+                    "version_id is required when start_block is greater than 0; "
+                    "pass the version_id from the first read_note response"
+                )
+            return note.latest_version
+        if isinstance(version_id, bool) or not isinstance(version_id, int):
+            raise ValueError("read_note version_id must be an integer")
+        version = NoteContent.objects.filter(note_id=note.id, id=version_id).first()
+        if version is None:
+            raise ValueError(f"version {version_id} not found for note {note.id}")
+        return version
 
     @staticmethod
     def _read_bound(value, *, default: int, minimum: int, maximum: int | None = None):

--- a/src/research_ai/services/notebook_chat/activity.py
+++ b/src/research_ai/services/notebook_chat/activity.py
@@ -31,6 +31,7 @@ from research_ai.services.agent_persistence.activity import (
 )
 from research_ai.services.note_tools import EDIT_NOTE, READ_NOTE
 from research_ai.services.notebook_chat.grant_tools import (
+    GET_GRANT_DETAILS,
     READ_SELECTED_RFP,
     SEARCH_GRANTS,
     SET_SELECTED_RFP,
@@ -38,7 +39,11 @@ from research_ai.services.notebook_chat.grant_tools import (
 from research_ai.services.notebook_chat.researcher_profile_tools import (
     GET_RESEARCHER_PROFILE,
 )
-from research_ai.services.researcher_profile.openalex_tools import GET_WORK_FULLTEXT
+from research_ai.services.researcher_profile.openalex_tools import (
+    GET_WORK_ABSTRACT,
+    GET_WORK_FULLTEXT,
+    SEARCH_WORK_FULLTEXT,
+)
 
 WEB_SEARCH = "web_search"
 SEARCH_INSTITUTIONS = "search_institutions"
@@ -51,6 +56,7 @@ _LABELS = {
     EDIT_NOTE: "Edited the note",
     WEB_SEARCH: "Searched the web",
     SEARCH_GRANTS: "Searched grants",
+    GET_GRANT_DETAILS: "Read grant details",
     READ_SELECTED_RFP: "Read the selected RFP",
     SET_SELECTED_RFP: "Selected an RFP",
     SEARCH_INSTITUTIONS: "Searched institutions",
@@ -58,6 +64,8 @@ _LABELS = {
     GET_AUTHOR: "Looked up an author",
     GET_AUTHOR_WORKS: "Fetched an author's publications",
     GET_WORK_FULLTEXT: "Read a paper",
+    GET_WORK_ABSTRACT: "Read a paper abstract",
+    SEARCH_WORK_FULLTEXT: "Searched a paper",
     GET_RESEARCHER_PROFILE: "Read your researcher profile",
 }
 # What each tool is doing while the call is still open, for the live phase.
@@ -67,6 +75,7 @@ _ACTIVE_LABELS = {
     EDIT_NOTE: "Editing the note",
     WEB_SEARCH: "Searching the web",
     SEARCH_GRANTS: "Searching grants",
+    GET_GRANT_DETAILS: "Reading grant details",
     READ_SELECTED_RFP: "Reading the selected RFP",
     SET_SELECTED_RFP: "Selecting an RFP",
     SEARCH_INSTITUTIONS: "Searching institutions",
@@ -74,6 +83,8 @@ _ACTIVE_LABELS = {
     GET_AUTHOR: "Looking up an author",
     GET_AUTHOR_WORKS: "Fetching an author's publications",
     GET_WORK_FULLTEXT: "Reading a paper",
+    GET_WORK_ABSTRACT: "Reading a paper abstract",
+    SEARCH_WORK_FULLTEXT: "Searching a paper",
     GET_RESEARCHER_PROFILE: "Reading your researcher profile",
 }
 # What the model is doing while it is still writing a tool call's arguments.
@@ -90,6 +101,7 @@ _DETAIL_INPUT_FIELDS = {
     SEARCH_GRANTS: "query",
     SEARCH_INSTITUTIONS: "query",
     SEARCH_AUTHORS: "name",
+    SEARCH_WORK_FULLTEXT: "query",
 }
 _MAX_DETAIL_CHARS = 200
 _MAX_SOURCES = 5
@@ -290,7 +302,7 @@ def _sources(event: ToolCallEvent) -> list[dict]:
     elif event.tool == SEARCH_GRANTS:
         items = result.get("grants")
         url_field = "url"
-    elif event.tool == READ_SELECTED_RFP:
+    elif event.tool in (GET_GRANT_DETAILS, READ_SELECTED_RFP):
         items = [result]
         url_field = "url"
     elif event.tool == SET_SELECTED_RFP:
@@ -299,7 +311,7 @@ def _sources(event: ToolCallEvent) -> list[dict]:
     elif event.tool == GET_AUTHOR_WORKS:
         items = result.get("works")
         url_field = "source_url"
-    elif event.tool == GET_WORK_FULLTEXT:
+    elif event.tool in (GET_WORK_ABSTRACT, GET_WORK_FULLTEXT, SEARCH_WORK_FULLTEXT):
         items = [result]
         url_field = "source_url"
     else:

--- a/src/research_ai/services/notebook_chat/grant_tools.py
+++ b/src/research_ai/services/notebook_chat/grant_tools.py
@@ -17,11 +17,11 @@ from researchhub_document.related_models.constants.document_type import PREREGIS
 logger = logging.getLogger(__name__)
 
 SEARCH_GRANTS = "search_grants"
+GET_GRANT_DETAILS = "get_grant_details"
 READ_SELECTED_RFP = "read_selected_rfp"
 SET_SELECTED_RFP = "set_selected_rfp"
 _MAX_QUERY_CHARS = 500
-_MAX_DESCRIPTION_CHARS = 3000
-_MAX_POST_CONTENT_CHARS = 3000
+_MAX_SUMMARY_CHARS = 280
 _EMPTY_INPUT_SCHEMA = {"type": "object", "properties": {}}
 _SELECTED_RFP_NOT_ACCESSIBLE = "selected RFP not found or not accessible"
 _NOTE_NOT_ACCESSIBLE = "this preregistration is not accessible"
@@ -56,7 +56,8 @@ class GrantSearchToolset:
                     "preregistration. Use a focused topic, method, disease, or "
                     "research-area query derived from the note. Returns only "
                     "grants currently accepting applications that the user can "
-                    "view, with their terms, deadlines, and ResearchHub URLs."
+                    "view, as compact result cards. Call get_grant_details with "
+                    "a result id before evaluating exact requirements or fit."
                 ),
                 input_schema={
                     "type": "object",
@@ -72,7 +73,26 @@ class GrantSearchToolset:
                     "required": ["query"],
                 },
                 handler=self._search_grants,
-            )
+            ),
+            Tool(
+                name=GET_GRANT_DETAILS,
+                description=(
+                    "Inspect one grant/RFP in full. Pass an id from "
+                    "search_grants. Visibility is checked again for the acting "
+                    "user before any call text is returned."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "grant_id": {
+                            "type": "integer",
+                            "description": "Grant id from search_grants.",
+                        }
+                    },
+                    "required": ["grant_id"],
+                },
+                handler=self._get_grant_details,
+            ),
         ]
 
     def as_toolset(self) -> Toolset:
@@ -93,32 +113,54 @@ class GrantSearchToolset:
 
         return {
             "query": query,
-            "grants": [self._serialize(grant) for grant in grants],
+            "grants": [self._serialize_card(grant) for grant in grants],
         }
 
     @staticmethod
-    def _serialize(grant) -> dict:
+    def _serialize_card(grant) -> dict:
         posts = list(grant.unified_document.posts.all())
         post = posts[0] if posts else None
         title = (grant.short_title or "").strip()
         if not title and post is not None:
             title = (post.title or "").strip()
+        summary = (post.renderable_text or "").strip() if post is not None else ""
+        if not summary:
+            summary = (grant.description or "").strip()
+        if len(summary) > _MAX_SUMMARY_CHARS:
+            summary = summary[: _MAX_SUMMARY_CHARS - 1].rstrip() + "…"
         return {
             "id": grant.id,
             "title": title,
             "organization": (grant.organization or "").strip(),
-            "description": (grant.description or "")[:_MAX_DESCRIPTION_CHARS],
-            "post_content": (
-                (post.renderable_text or "").strip()[:_MAX_POST_CONTENT_CHARS]
-                if post is not None
-                else ""
-            ),
+            "summary": summary,
             "amount": str(grant.amount),
             "currency": grant.currency,
             "deadline": grant.end_date.isoformat() if grant.end_date else None,
-            "application_visibility": grant.application_visibility,
             "url": _grant_url(grant, post),
         }
+
+    def _get_grant_details(self, args: dict) -> dict:
+        grant_id, error = _parse_required_grant_id(args)
+        if error is not None:
+            return error
+        try:
+            grant = (
+                selectable_grants(self._user)
+                .select_related("unified_document")
+                .prefetch_related("unified_document__posts")
+                .filter(id=grant_id)
+                .first()
+            )
+            if grant is None:
+                return {"error": f"grant {grant_id} not found or not accessible"}
+            return {
+                **_grant_terms(grant),
+                "description": (grant.description or "").strip(),
+                "rfp_text": _grant_full_text(grant),
+            }
+        except Exception:  # noqa: BLE001 - tool failures are model-readable
+            logger.exception("grant detail read failed for grant %s", grant_id)
+            return {"error": "grant details are temporarily unavailable"}
 
 
 def _grant_terms(grant) -> dict:
@@ -137,6 +179,16 @@ def _grant_terms(grant) -> dict:
         "application_visibility": grant.application_visibility,
         "url": _grant_url(grant, post),
     }
+
+
+def _grant_full_text(grant) -> str:
+    """All available RFP text, including a rendered post without a source file."""
+    text = str(grant.get_llm_context_text() or "").strip()
+    post = grant.unified_document.posts.first()
+    rendered = str(getattr(post, "renderable_text", "") or "").strip()
+    if rendered and rendered not in text:
+        text = f"{text}\n\n{rendered}" if text else rendered
+    return text
 
 
 def _parse_grant_id(args: dict) -> tuple[int | None, dict | None]:
@@ -164,6 +216,16 @@ def _parse_grant_id(args: dict) -> tuple[int | None, dict | None]:
         if text.isascii() and text.isdigit():
             return int(text), None
     return None, {"error": "grant_id must be a grant id or null"}
+
+
+def _parse_required_grant_id(args: dict) -> tuple[int | None, dict | None]:
+    """A non-null grant id for read-only detail lookup."""
+    grant_id, error = _parse_grant_id(args)
+    if error is not None:
+        return None, error
+    if grant_id is None:
+        return None, {"error": "grant_id must be a grant id"}
+    return grant_id, None
 
 
 class SelectedRFPToolset:
@@ -237,7 +299,7 @@ class SelectedRFPToolset:
             ):
                 return {"error": _SELECTED_RFP_NOT_ACCESSIBLE}
 
-            return {**_grant_terms(grant), "rfp_text": grant.get_llm_context_text()}
+            return {**_grant_terms(grant), "rfp_text": _grant_full_text(grant)}
         except Exception:  # noqa: BLE001 - tool failures are model-readable
             logger.exception("selected RFP read failed for note %s", self._note_id)
             return {"error": "selected RFP is temporarily unavailable"}

--- a/src/research_ai/services/notebook_chat/grant_tools.py
+++ b/src/research_ai/services/notebook_chat/grant_tools.py
@@ -22,6 +22,9 @@ READ_SELECTED_RFP = "read_selected_rfp"
 SET_SELECTED_RFP = "set_selected_rfp"
 _MAX_QUERY_CHARS = 500
 _MAX_SUMMARY_CHARS = 280
+# At most 8,000 Python characters also stays below the agent's 128 KiB JSON
+# result limit for worst-case non-BMP Unicode escaping, with room for metadata.
+_MAX_RFP_PAGE_CHARS = 8000
 _EMPTY_INPUT_SCHEMA = {"type": "object", "properties": {}}
 _SELECTED_RFP_NOT_ACCESSIBLE = "selected RFP not found or not accessible"
 _NOTE_NOT_ACCESSIBLE = "this preregistration is not accessible"
@@ -77,9 +80,10 @@ class GrantSearchToolset:
             Tool(
                 name=GET_GRANT_DETAILS,
                 description=(
-                    "Inspect one grant/RFP in full. Pass an id from "
-                    "search_grants. Visibility is checked again for the acting "
-                    "user before any call text is returned."
+                    "Inspect one grant/RFP. Pass an id from search_grants. "
+                    "Visibility and active status are checked again for the "
+                    "acting user. Long call text is paginated; pass the returned "
+                    "next_start_char to continue reading."
                 ),
                 input_schema={
                     "type": "object",
@@ -87,7 +91,23 @@ class GrantSearchToolset:
                         "grant_id": {
                             "type": "integer",
                             "description": "Grant id from search_grants.",
-                        }
+                        },
+                        "start_char": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": (
+                                "Character offset for the RFP text page; default 0."
+                            ),
+                        },
+                        "max_chars": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": _MAX_RFP_PAGE_CHARS,
+                            "description": (
+                                "Maximum RFP text characters to return; default "
+                                f"and maximum {_MAX_RFP_PAGE_CHARS}."
+                            ),
+                        },
                     },
                     "required": ["grant_id"],
                 },
@@ -146,6 +166,10 @@ class GrantSearchToolset:
         grant_id, error = _parse_required_grant_id(args)
         if error is not None:
             return error
+        page_bounds, error = _parse_rfp_page_bounds(args)
+        if error is not None:
+            return error
+        start_char, max_chars = page_bounds
         try:
             grant = (
                 selectable_grants(self._user)
@@ -156,10 +180,28 @@ class GrantSearchToolset:
             )
             if grant is None:
                 return {"error": f"grant {grant_id} not found or not accessible"}
+            if not grant.is_active():
+                return {
+                    "error": f"grant {grant_id} is no longer accepting applications"
+                }
+            rfp_text = _grant_full_text(grant)
+            if start_char > len(rfp_text):
+                return {
+                    "error": (
+                        f"start_char must be at most the RFP text length "
+                        f"({len(rfp_text)})"
+                    )
+                }
+            end_char = min(start_char + max_chars, len(rfp_text))
+            next_start_char = end_char if end_char < len(rfp_text) else None
             return {
                 **_grant_terms(grant),
-                "description": (grant.description or "").strip(),
-                "rfp_text": _grant_full_text(grant),
+                "rfp_text": rfp_text[start_char:end_char],
+                "rfp_text_start_char": start_char,
+                "rfp_text_end_char": end_char,
+                "rfp_text_total_chars": len(rfp_text),
+                "rfp_text_is_partial": start_char > 0 or next_start_char is not None,
+                "next_start_char": next_start_char,
             }
         except Exception:  # noqa: BLE001 - tool failures are model-readable
             logger.exception("grant detail read failed for grant %s", grant_id)
@@ -275,6 +317,28 @@ def _parse_required_grant_id(args: dict) -> tuple[int | None, dict | None]:
     if grant_id is None:
         return None, {"error": "grant_id must be a grant id"}
     return grant_id, None
+
+
+def _parse_rfp_page_bounds(args: dict) -> tuple[tuple[int, int] | None, dict | None]:
+    """Validate character pagination for grant detail text."""
+    args = args or {}
+    start_char = args.get("start_char", 0)
+    max_chars = args.get("max_chars", _MAX_RFP_PAGE_CHARS)
+    if (
+        isinstance(start_char, bool)
+        or not isinstance(start_char, int)
+        or start_char < 0
+    ):
+        return None, {"error": "start_char must be a non-negative integer"}
+    if (
+        isinstance(max_chars, bool)
+        or not isinstance(max_chars, int)
+        or not 1 <= max_chars <= _MAX_RFP_PAGE_CHARS
+    ):
+        return None, {
+            "error": f"max_chars must be an integer from 1 to {_MAX_RFP_PAGE_CHARS}"
+        }
+    return (start_char, max_chars), None
 
 
 class SelectedRFPToolset:

--- a/src/research_ai/services/notebook_chat/grant_tools.py
+++ b/src/research_ai/services/notebook_chat/grant_tools.py
@@ -236,13 +236,8 @@ def _grant_terms(grant) -> dict:
 
 
 def _grant_full_text(grant) -> str:
-    """All available RFP text, including a rendered post without a source file."""
-    text = str(grant.get_llm_context_text() or "").strip()
-    post = grant.unified_document.posts.first()
-    rendered = str(getattr(post, "renderable_text", "") or "").strip()
-    if rendered and rendered not in text:
-        text = f"{text}\n\n{rendered}" if text else rendered
-    return text
+    """The canonical RFP text, with Markdown preferred over rendered fallback."""
+    return str(grant.get_llm_context_text() or "").strip()
 
 
 def _parse_grant_id(args: dict) -> tuple[int | None, dict | None]:

--- a/src/research_ai/services/notebook_chat/grant_tools.py
+++ b/src/research_ai/services/notebook_chat/grant_tools.py
@@ -188,16 +188,9 @@ class GrantSearchToolset:
                         f"({len(rfp_text)})"
                     )
                 }
-            end_char = min(start_char + max_chars, len(rfp_text))
-            next_start_char = end_char if end_char < len(rfp_text) else None
             return {
                 **_grant_terms(grant),
-                "rfp_text": rfp_text[start_char:end_char],
-                "rfp_text_start_char": start_char,
-                "rfp_text_end_char": end_char,
-                "rfp_text_total_chars": len(rfp_text),
-                "rfp_text_is_partial": start_char > 0 or next_start_char is not None,
-                "next_start_char": next_start_char,
+                **_rfp_text_page(rfp_text, start_char=start_char, max_chars=max_chars),
             }
         except Exception:  # noqa: BLE001 - tool failures are model-readable
             logger.exception("grant detail read failed for grant %s", grant_id)
@@ -278,6 +271,22 @@ def _grant_full_text(grant) -> str:
     return str(grant.get_llm_context_text() or "").strip()
 
 
+def _rfp_text_page(
+    rfp_text: str, *, start_char: int = 0, max_chars: int = _MAX_RFP_PAGE_CHARS
+) -> dict:
+    """A bounded RFP text page plus continuation metadata."""
+    end_char = min(start_char + max_chars, len(rfp_text))
+    next_start_char = end_char if end_char < len(rfp_text) else None
+    return {
+        "rfp_text": rfp_text[start_char:end_char],
+        "rfp_text_start_char": start_char,
+        "rfp_text_end_char": end_char,
+        "rfp_text_total_chars": len(rfp_text),
+        "rfp_text_is_partial": start_char > 0 or next_start_char is not None,
+        "next_start_char": next_start_char,
+    }
+
+
 def _parse_grant_id(args: dict) -> tuple[int | None, dict | None]:
     """The requested grant id, or ``(None, error)``.
 
@@ -349,11 +358,12 @@ class SelectedRFPToolset:
             Tool(
                 name=READ_SELECTED_RFP,
                 description=(
-                    "Read the full RFP selected for this preregistration note. "
+                    "Read the selected RFP for this preregistration note. "
                     "Use it before evaluating fit, requirements, budget, "
                     "deadline, or revising the note for the selected funding "
-                    "opportunity. Returns structured grant terms and the full "
-                    "call text."
+                    "opportunity. Returns structured grant terms and a bounded "
+                    "call-text page. If next_start_char is returned, continue "
+                    "with get_grant_details using the returned id and offset."
                 ),
                 input_schema=_EMPTY_INPUT_SCHEMA,
                 handler=self._read_selected_rfp,
@@ -408,7 +418,10 @@ class SelectedRFPToolset:
             ):
                 return {"error": _SELECTED_RFP_NOT_ACCESSIBLE}
 
-            return {**_grant_terms(grant), "rfp_text": _grant_full_text(grant)}
+            return {
+                **_grant_terms(grant),
+                **_rfp_text_page(_grant_full_text(grant)),
+            }
         except Exception:  # noqa: BLE001 - tool failures are model-readable
             logger.exception("selected RFP read failed for note %s", self._note_id)
             return {"error": "selected RFP is temporarily unavailable"}

--- a/src/research_ai/services/notebook_chat/grant_tools.py
+++ b/src/research_ai/services/notebook_chat/grant_tools.py
@@ -113,21 +113,24 @@ class GrantSearchToolset:
 
         return {
             "query": query,
-            "grants": [self._serialize_card(grant) for grant in grants],
+            "grants": [self._serialize_card(grant, query) for grant in grants],
         }
 
     @staticmethod
-    def _serialize_card(grant) -> dict:
+    def _serialize_card(grant, query: str) -> dict:
         posts = list(grant.unified_document.posts.all())
         post = posts[0] if posts else None
-        title = (grant.short_title or "").strip()
-        if not title and post is not None:
-            title = (post.title or "").strip()
-        summary = (post.renderable_text or "").strip() if post is not None else ""
-        if not summary:
-            summary = (grant.description or "").strip()
-        if len(summary) > _MAX_SUMMARY_CHARS:
-            summary = summary[: _MAX_SUMMARY_CHARS - 1].rstrip() + "…"
+        short_title = (grant.short_title or "").strip()
+        post_title = (post.title or "").strip() if post is not None else ""
+        title = max(
+            (short_title, post_title),
+            key=lambda text: (
+                _match_rank(text, query),
+                bool(text),
+                text == short_title,
+            ),
+        )
+        summary = _grant_search_summary(grant, post, query)
         return {
             "id": grant.id,
             "title": title,
@@ -161,6 +164,57 @@ class GrantSearchToolset:
         except Exception:  # noqa: BLE001 - tool failures are model-readable
             logger.exception("grant detail read failed for grant %s", grant_id)
             return {"error": "grant details are temporarily unavailable"}
+
+
+def _grant_search_summary(grant, post, query: str) -> str:
+    """Return a compact snippet from the body field with the strongest match."""
+    description = " ".join(str(grant.description or "").split())
+    post_text = (
+        " ".join(str(post.renderable_text or "").split()) if post is not None else ""
+    )
+    candidates = [description, post_text]
+    matching = [text for text in candidates if _match_position(text, query) is not None]
+    source = max(matching, key=lambda text: _match_rank(text, query), default="")
+    if not source:
+        source = post_text or description
+    return _compact_match_snippet(source, query)
+
+
+def _match_rank(text: str, query: str) -> tuple[bool, int]:
+    lower = text.lower()
+    query_lower = query.lower()
+    terms = dict.fromkeys(query_lower.split()[:12])
+    return query_lower in lower, sum(term in lower for term in terms)
+
+
+def _match_position(text: str, query: str) -> int | None:
+    lower = text.lower()
+    query_lower = query.lower()
+    phrase_position = lower.find(query_lower)
+    if phrase_position >= 0:
+        return phrase_position
+    positions = [lower.find(term) for term in query_lower.split()[:12]]
+    positions = [position for position in positions if position >= 0]
+    return min(positions, default=None)
+
+
+def _compact_match_snippet(text: str, query: str) -> str:
+    if len(text) <= _MAX_SUMMARY_CHARS:
+        return text
+    position = _match_position(text, query) or 0
+    start = max(0, position - _MAX_SUMMARY_CHARS // 4)
+    if start:
+        next_space = text.find(" ", start)
+        start = next_space + 1 if next_space >= 0 else start
+    prefix = "…" if start else ""
+    available = _MAX_SUMMARY_CHARS - len(prefix) - 1
+    body = text[start : start + available]
+    if start + len(body) < len(text):
+        body = body.rsplit(" ", 1)[0] or body
+        suffix = "…"
+    else:
+        suffix = ""
+    return f"{prefix}{body.rstrip()}{suffix}"
 
 
 def _grant_terms(grant) -> dict:

--- a/src/research_ai/services/notebook_chat/grant_tools.py
+++ b/src/research_ai/services/notebook_chat/grant_tools.py
@@ -81,9 +81,9 @@ class GrantSearchToolset:
                 name=GET_GRANT_DETAILS,
                 description=(
                     "Inspect one grant/RFP. Pass an id from search_grants. "
-                    "Visibility and active status are checked again for the "
-                    "acting user. Long call text is paginated; pass the returned "
-                    "next_start_char to continue reading."
+                    "Visibility is checked again for the acting user. Long call "
+                    "text is paginated; pass the returned next_start_char to "
+                    "continue reading."
                 ),
                 input_schema={
                     "type": "object",
@@ -180,10 +180,6 @@ class GrantSearchToolset:
             )
             if grant is None:
                 return {"error": f"grant {grant_id} not found or not accessible"}
-            if not grant.is_active():
-                return {
-                    "error": f"grant {grant_id} is no longer accepting applications"
-                }
             rfp_text = _grant_full_text(grant)
             if start_char > len(rfp_text):
                 return {

--- a/src/research_ai/services/researcher_profile/agent.py
+++ b/src/research_ai/services/researcher_profile/agent.py
@@ -48,14 +48,18 @@ How to work:
   Compare candidates' institutions, topics, and citation counts before choosing.
 - Prefer missing over wrong: if no candidate is a confident match, submit with
   openalex_author_id = null and a low confidence.
-- Once resolved, call get_author_works and select five papers. Strongly prefer
+- Once resolved, call get_author_works and select five papers. Its listings are
+  compact and cursor-paginated: follow next_cursor when the first page does not
+  provide adequate candidates, and call get_work_abstract only for papers you
+  are seriously considering. Strongly prefer
   ones where this author is first or last author; fall back to a middle-author
   paper only to reach five when there are not enough first/last ones. Among
   eligible papers, favor recent and relevant work. Only keep papers with a
-  pdf_url (readable full text); aim for five, but return fewer rather than
+  has_fulltext = true; aim for five, but return fewer rather than
   padding with papers that lack one.
-- Then map the lab's capabilities. Call get_work_fulltext on the most relevant
-  works (prefer first/last-author ones) and read their Methods for the concrete
+- Then map the lab's capabilities. Call search_work_fulltext with focused
+  Methods queries on the most relevant works (prefer first/last-author ones)
+  for the concrete
   techniques, instruments/platforms, model systems, and datasets the lab
   actually works with -- the real bounds of what a proposal for this researcher
   could credibly do. Submit these as `capabilities`. A capability that appears

--- a/src/research_ai/services/researcher_profile/openalex_tools.py
+++ b/src/research_ai/services/researcher_profile/openalex_tools.py
@@ -16,6 +16,7 @@ final profile from these records so a hallucinated citation cannot survive.
 """
 
 import logging
+import re
 from collections.abc import Callable
 
 from research_ai.services.agent import Tool, Toolset
@@ -23,17 +24,18 @@ from research_ai.services.pdf_text import (
     extract_text_from_pdf_bytes,
     get_pdf_bytes_from_url,
 )
-from utils.openalex import OpenAlex
+from utils.openalex import OpenAlex, Work
 
 logger = logging.getLogger(__name__)
 
 # Terminal tool the model calls once to hand back the finished profile.
 SUBMIT_PROFILE = "submit_profile"
 
-# The profile builder's full-text reader. The proposal agent ships a tool of
-# the same name scoped to the researcher profile's works, so composers that
-# reuse this toolset skip this one by name instead of shadowing it silently.
+# The proposal agent's profile-scoped full-text tool name. Kept here as the
+# shared composition constant; OpenAlex discovery exposes focused passage search.
 GET_WORK_FULLTEXT = "get_work_fulltext"
+GET_WORK_ABSTRACT = "get_work_abstract"
+SEARCH_WORK_FULLTEXT = "search_work_fulltext"
 
 _MAX_AUTHOR_CANDIDATES = 10  # author search results surfaced to the model
 _MAX_ALTERNATIVES = 5
@@ -41,7 +43,31 @@ _MAX_INSTITUTIONS = 5
 _MAX_TOPICS = 8
 _MAX_WORKS_PER_CALL = 50  # ceiling on a single get_author_works fetch
 _MAX_FULLTEXT_FETCHES = 6  # per-run ceiling on full-text reads
-_MAX_FULLTEXT_CHARS = 24000  # per-read character ceiling (~6k tokens)
+_MAX_FULLTEXT_SOURCE_CHARS = 120000
+_MAX_PASSAGES = 5
+_MAX_PASSAGE_CHARS = 1400
+_MAX_FULLTEXT_QUERY_CHARS = 500
+_WORD_RE = re.compile(r"[a-z0-9][a-z0-9_-]*")
+_QUERY_STOPWORDS = frozenset(
+    {
+        "about",
+        "after",
+        "also",
+        "from",
+        "into",
+        "paper",
+        "that",
+        "their",
+        "this",
+        "using",
+        "were",
+        "what",
+        "when",
+        "where",
+        "which",
+        "with",
+    }
+)
 
 
 def _institution_names(record: dict) -> list[str]:
@@ -97,6 +123,7 @@ class OpenAlexToolset:
         self._pdf_text_fetcher = pdf_text_fetcher or self._fetch_pdf_text
         self._max_fulltext_fetches = max_fulltext_fetches
         self._fulltext_fetches_used = 0
+        self._fulltext_cache: dict[str, str] = {}
         # Full ground-truth work record for every work handed to the model,
         # keyed by source_url. The profile is materialized from these rather
         # than from the model's (often mangled) copy of each work.
@@ -179,9 +206,12 @@ class OpenAlexToolset:
             Tool(
                 name="get_author_works",
                 description=(
-                    "List a resolved author's papers, most recent first. Only "
-                    "works whose source_url/pdf_url appear here may be cited in "
-                    "the profile."
+                    "List a resolved author's papers as compact cards, most "
+                    "recent first. Results are cursor-paginated; follow "
+                    "next_cursor when the first page does not give adequate "
+                    "candidate coverage. Fetch an abstract or search full text "
+                    "separately for promising works. Only works whose source_url "
+                    "appears here may be cited in the profile."
                 ),
                 input_schema={
                     "type": "object",
@@ -198,7 +228,16 @@ class OpenAlexToolset:
                         },
                         "max_results": {
                             "type": "integer",
-                            "description": "Max works to return (default 25).",
+                            "minimum": 1,
+                            "maximum": _MAX_WORKS_PER_CALL,
+                            "description": "Works per page (default 25, maximum 50).",
+                        },
+                        "cursor": {
+                            "type": "string",
+                            "description": (
+                                "Opaque next_cursor from the prior page. Omit for "
+                                "the first page."
+                            ),
                         },
                     },
                     "required": ["openalex_author_id"],
@@ -206,15 +245,11 @@ class OpenAlexToolset:
                 handler=self._get_author_works,
             ),
             Tool(
-                name=GET_WORK_FULLTEXT,
+                name=GET_WORK_ABSTRACT,
                 description=(
-                    "Read the full text of a work returned by get_author_works "
-                    "(pass its source_url exactly). Use it to inspect Methods "
-                    "sections for the lab's actual techniques, instruments, "
-                    "model systems, and datasets. Falls back to the abstract "
-                    "when no readable PDF exists. Limited to "
-                    f"{self._max_fulltext_fetches} reads per run -- spend them "
-                    "on the works that best evidence what the lab can do."
+                    "Fetch the abstract of one work returned by get_author_works. "
+                    "Pass its source_url exactly. Use this inexpensive detail "
+                    "read to screen candidate papers before searching full text."
                 ),
                 input_schema={
                     "type": "object",
@@ -229,7 +264,46 @@ class OpenAlexToolset:
                     },
                     "required": ["source_url"],
                 },
-                handler=self._get_work_fulltext,
+                handler=self._get_work_abstract,
+            ),
+            Tool(
+                name=SEARCH_WORK_FULLTEXT,
+                description=(
+                    "Search the readable full text of a work returned by "
+                    "get_author_works for a focused question, method, instrument, "
+                    "model system, or finding. Returns only the most relevant "
+                    "passages, never the whole paper. Does not substitute the "
+                    "abstract when no PDF is readable; call get_work_abstract "
+                    "separately. Limited to "
+                    f"{self._max_fulltext_fetches} document fetches per run."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "source_url": {
+                            "type": "string",
+                            "description": (
+                                "The work's source_url, exactly as returned by "
+                                "get_author_works."
+                            ),
+                        },
+                        "query": {
+                            "type": "string",
+                            "maxLength": _MAX_FULLTEXT_QUERY_CHARS,
+                            "description": (
+                                "Focused terms or question to locate in the paper."
+                            ),
+                        },
+                        "max_passages": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": _MAX_PASSAGES,
+                            "description": "Maximum passages to return (default 3).",
+                        },
+                    },
+                    "required": ["source_url", "query"],
+                },
+                handler=self._search_work_fulltext,
             ),
             Tool(
                 name=SUBMIT_PROFILE,
@@ -303,24 +377,39 @@ class OpenAlexToolset:
         author_id = str(args.get("openalex_author_id") or "").strip()
         if not author_id:
             return {"error": "openalex_author_id is required"}
-        max_results = int(args.get("max_results") or 25)
-        batch_size = max(1, min(max_results, _MAX_WORKS_PER_CALL))
+        try:
+            max_results = self._bounded_integer(
+                args.get("max_results"), default=25, minimum=1, maximum=50
+            )
+        except ValueError as exc:
+            return {"error": str(exc)}
+        cursor = str(args.get("cursor") or "").strip() or "*"
         open_access_only = args.get("open_access_only", True)
-        works = self._oa.get_works_typed(
+        raw_works, next_cursor = self._oa.get_works(
             openalex_author_id=author_id,
-            batch_size=batch_size,
+            next_cursor=cursor,
+            batch_size=max_results,
             sort="publication_date:desc",
             open_access_only=bool(open_access_only),
         )
         payload = []
-        for work in works[:max_results]:
+        for entity in raw_works or []:
+            work = Work.from_openalex(entity, author_id=author_id)
+            if work is None:
+                continue
             data = work.as_dict()
             if data["source_url"]:
                 self.returned_works[data["source_url"]] = data
-            payload.append(data)
-        return {"works": payload}
+            payload.append(self._work_card(data))
+            if len(payload) >= max_results:
+                break
+        return {
+            "works": payload,
+            "next_cursor": next_cursor,
+            "has_more": bool(next_cursor),
+        }
 
-    def _get_work_fulltext(self, args: dict) -> dict:
+    def _get_work_abstract(self, args: dict) -> dict:
         source_url = str((args or {}).get("source_url") or "").strip()
         if not source_url:
             return {"error": "source_url is required"}
@@ -332,35 +421,167 @@ class OpenAlexToolset:
                     "get_author_works."
                 )
             }
-        if self._fulltext_fetches_used >= self._max_fulltext_fetches:
-            return {
-                "error": (
-                    "Full-text read budget exhausted "
-                    f"({self._max_fulltext_fetches} reads). Work from the "
-                    "abstracts already returned."
-                )
-            }
-        self._fulltext_fetches_used += 1
-
-        text = self._pdf_text_fetcher(str(work.get("pdf_url") or "").strip())
-        content_type = "pdf"
-        if not text:
-            text = str(work.get("abstract") or "").strip()
-            content_type = "abstract"
-        if not text:
+        abstract = str(work.get("abstract") or "").strip()
+        if not abstract:
             return {
                 "source_url": source_url,
-                "content_type": "none",
-                "error": "No readable full text or abstract available for this work.",
+                "title": str(work.get("title") or "").strip(),
+                "error": "No abstract is available for this work.",
             }
-        truncated = len(text) > _MAX_FULLTEXT_CHARS
         return {
             "source_url": source_url,
             "title": str(work.get("title") or "").strip(),
-            "content_type": content_type,
-            "truncated": truncated,
-            "text": text[:_MAX_FULLTEXT_CHARS] if truncated else text,
+            "abstract": abstract,
         }
+
+    def _search_work_fulltext(self, args: dict) -> dict:
+        source_url = str((args or {}).get("source_url") or "").strip()
+        query = " ".join(str((args or {}).get("query") or "").split())
+        if not source_url:
+            return {"error": "source_url is required"}
+        if not query:
+            return {"error": "query is required"}
+        if len(query) > _MAX_FULLTEXT_QUERY_CHARS:
+            return {"error": f"query exceeds {_MAX_FULLTEXT_QUERY_CHARS} characters"}
+        try:
+            max_passages = self._bounded_integer(
+                (args or {}).get("max_passages"),
+                default=3,
+                minimum=1,
+                maximum=_MAX_PASSAGES,
+            )
+        except ValueError as exc:
+            return {"error": str(exc)}
+
+        work = self.returned_works.get(source_url)
+        if work is None:
+            return {
+                "error": (
+                    "Unknown source_url -- it must match a work returned by "
+                    "get_author_works."
+                )
+            }
+        text, error = self._fulltext(source_url, work)
+        if error is not None:
+            return error
+        if not text:
+            return {
+                "source_url": source_url,
+                "title": str(work.get("title") or "").strip(),
+                "error": (
+                    "No readable full text is available for this work. "
+                    "Call get_work_abstract to inspect its abstract."
+                ),
+            }
+        passages = self._relevant_passages(text, query, limit=max_passages)
+        return {
+            "source_url": source_url,
+            "title": str(work.get("title") or "").strip(),
+            "query": query,
+            "searched_characters": len(text),
+            "passages": passages,
+            "match_count": len(passages),
+        }
+
+    def _fulltext(self, source_url: str, work: dict) -> tuple[str, dict | None]:
+        if source_url in self._fulltext_cache:
+            return self._fulltext_cache[source_url], None
+        if self._fulltext_fetches_used >= self._max_fulltext_fetches:
+            return "", {
+                "error": (
+                    "Full-text fetch budget exhausted "
+                    f"({self._max_fulltext_fetches} documents). Work from text "
+                    "already searched or from separately fetched abstracts."
+                )
+            }
+        pdf_url = str(work.get("pdf_url") or "").strip()
+        if not pdf_url:
+            self._fulltext_cache[source_url] = ""
+            return "", None
+        self._fulltext_fetches_used += 1
+        text = self._pdf_text_fetcher(pdf_url)
+        text = str(text or "").strip()
+        self._fulltext_cache[source_url] = text
+        return text, None
+
+    @staticmethod
+    def _work_card(work: dict) -> dict:
+        return {
+            "title": work.get("title"),
+            "publication_date": work.get("publication_date"),
+            "publication_year": work.get("publication_year"),
+            "source_url": work.get("source_url"),
+            "author_position": work.get("author_position"),
+            "is_oa": bool(work.get("is_oa")),
+            "has_abstract": bool(work.get("abstract")),
+            "has_fulltext": bool(work.get("pdf_url")),
+        }
+
+    @staticmethod
+    def _bounded_integer(value, *, default: int, minimum: int, maximum: int) -> int:
+        if value is None:
+            return default
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError("numeric bounds must be integers")
+        if value < minimum or value > maximum:
+            raise ValueError(f"numeric bound must be between {minimum} and {maximum}")
+        return value
+
+    @classmethod
+    def _relevant_passages(cls, text: str, query: str, *, limit: int) -> list[dict]:
+        """Rank overlapping text windows by focused lexical query coverage."""
+        query_lower = query.lower()
+        terms = [
+            term
+            for term in dict.fromkeys(_WORD_RE.findall(query_lower))
+            if len(term) >= 3 and term not in _QUERY_STOPWORDS
+        ]
+        if not terms:
+            terms = list(dict.fromkeys(_WORD_RE.findall(query_lower)))
+
+        window_size = _MAX_PASSAGE_CHARS
+        overlap = 240
+        candidates = []
+        start = 0
+        while start < len(text):
+            end = min(start + window_size, len(text))
+            if end < len(text):
+                boundary = text.rfind(" ", start + window_size // 2, end)
+                if boundary > start:
+                    end = boundary
+            passage = " ".join(text[start:end].split())
+            lower = passage.lower()
+            matched = [term for term in terms if term in lower]
+            score = sum(lower.count(term) for term in terms) + 3 * len(matched)
+            if query_lower in lower:
+                score += 10
+            if score:
+                candidates.append((score, len(matched), start, end, passage))
+            if end >= len(text):
+                break
+            start = max(start + 1, end - overlap)
+
+        candidates.sort(key=lambda item: (-item[0], -item[1], item[2]))
+        selected = []
+        selected_ranges: list[tuple[int, int]] = []
+        for score, _coverage, start, end, passage in candidates:
+            if any(
+                start < kept_end and end > kept_start
+                for kept_start, kept_end in selected_ranges
+            ):
+                continue
+            selected_ranges.append((start, end))
+            selected.append(
+                {
+                    "start_char": start,
+                    "end_char": end,
+                    "score": score,
+                    "text": passage,
+                }
+            )
+            if len(selected) >= limit:
+                break
+        return selected
 
     @staticmethod
     def _fetch_pdf_text(pdf_url: str) -> str:
@@ -369,10 +590,12 @@ class OpenAlexToolset:
             pdf_bytes = get_pdf_bytes_from_url(pdf_url)
             if not pdf_bytes:
                 return ""
-            return extract_text_from_pdf_bytes(pdf_bytes, max_chars=_MAX_FULLTEXT_CHARS)
+            return extract_text_from_pdf_bytes(
+                pdf_bytes, max_chars=_MAX_FULLTEXT_SOURCE_CHARS
+            )
         except Exception as exc:  # noqa: BLE001 - a bad PDF must not break the loop
             logger.warning(
-                "get_work_fulltext: PDF read failed for %s: %s", pdf_url, exc
+                "search_work_fulltext: PDF read failed for %s: %s", pdf_url, exc
             )
             return ""
 

--- a/src/research_ai/services/researcher_profile/openalex_tools.py
+++ b/src/research_ai/services/researcher_profile/openalex_tools.py
@@ -104,7 +104,7 @@ class OpenAlexToolset:
         self._pdf_text_fetcher = pdf_text_fetcher or self._fetch_pdf_text
         self._max_fulltext_fetches = max_fulltext_fetches
         self._fulltext_fetches_used = 0
-        self._fulltext_cache: dict[str, str] = {}
+        self._fulltext_cache: dict[str, tuple[str, bool]] = {}
         # Full ground-truth work record for every work handed to the model,
         # keyed by source_url. The profile is materialized from these rather
         # than from the model's (often mangled) copy of each work.
@@ -442,7 +442,7 @@ class OpenAlexToolset:
                     "get_author_works."
                 )
             }
-        text, error = self._fulltext(source_url, work)
+        text, source_truncated, error = self._fulltext(source_url, work)
         if error is not None:
             return error
         if not text:
@@ -455,35 +455,48 @@ class OpenAlexToolset:
                 ),
             }
         passages = self._relevant_passages(text, query, limit=max_passages)
-        return {
+        result = {
             "source_url": source_url,
             "title": str(work.get("title") or "").strip(),
             "query": query,
             "searched_characters": len(text),
+            "source_truncated": source_truncated,
             "passages": passages,
             "match_count": len(passages),
         }
+        if source_truncated:
+            result["warning"] = (
+                f"Search covered only the first {_MAX_FULLTEXT_SOURCE_CHARS} "
+                "characters of the extracted PDF text."
+            )
+        return result
 
-    def _fulltext(self, source_url: str, work: dict) -> tuple[str, dict | None]:
+    def _fulltext(self, source_url: str, work: dict) -> tuple[str, bool, dict | None]:
         if source_url in self._fulltext_cache:
-            return self._fulltext_cache[source_url], None
+            text, source_truncated = self._fulltext_cache[source_url]
+            return text, source_truncated, None
         if self._fulltext_fetches_used >= self._max_fulltext_fetches:
-            return "", {
-                "error": (
-                    "Full-text fetch budget exhausted "
-                    f"({self._max_fulltext_fetches} documents). Work from text "
-                    "already searched or from separately fetched abstracts."
-                )
-            }
+            return (
+                "",
+                False,
+                {
+                    "error": (
+                        "Full-text fetch budget exhausted "
+                        f"({self._max_fulltext_fetches} documents). Work from text "
+                        "already searched or from separately fetched abstracts."
+                    )
+                },
+            )
         pdf_url = str(work.get("pdf_url") or "").strip()
         if not pdf_url:
-            self._fulltext_cache[source_url] = ""
-            return "", None
+            self._fulltext_cache[source_url] = ("", False)
+            return "", False, None
         self._fulltext_fetches_used += 1
-        text = self._pdf_text_fetcher(pdf_url)
-        text = str(text or "").strip()
-        self._fulltext_cache[source_url] = text
-        return text, None
+        source_text = str(self._pdf_text_fetcher(pdf_url) or "")
+        source_truncated = len(source_text) > _MAX_FULLTEXT_SOURCE_CHARS
+        text = source_text[:_MAX_FULLTEXT_SOURCE_CHARS].strip()
+        self._fulltext_cache[source_url] = (text, source_truncated)
+        return text, source_truncated, None
 
     @staticmethod
     def _work_card(work: dict) -> dict:
@@ -608,7 +621,7 @@ class OpenAlexToolset:
             if not pdf_bytes:
                 return ""
             return extract_text_from_pdf_bytes(
-                pdf_bytes, max_chars=_MAX_FULLTEXT_SOURCE_CHARS
+                pdf_bytes, max_chars=_MAX_FULLTEXT_SOURCE_CHARS + 1
             )
         except Exception as exc:  # noqa: BLE001 - a bad PDF must not break the loop
             logger.warning(

--- a/src/research_ai/services/researcher_profile/openalex_tools.py
+++ b/src/research_ai/services/researcher_profile/openalex_tools.py
@@ -17,7 +17,9 @@ final profile from these records so a hallucinated citation cannot survive.
 
 import logging
 import re
+from collections import Counter
 from collections.abc import Callable
+from math import log
 
 from research_ai.services.agent import Tool, Toolset
 from research_ai.services.pdf_text import (
@@ -48,26 +50,6 @@ _MAX_PASSAGES = 5
 _MAX_PASSAGE_CHARS = 1400
 _MAX_FULLTEXT_QUERY_CHARS = 500
 _WORD_RE = re.compile(r"[a-z0-9][a-z0-9_-]*")
-_QUERY_STOPWORDS = frozenset(
-    {
-        "about",
-        "after",
-        "also",
-        "from",
-        "into",
-        "paper",
-        "that",
-        "their",
-        "this",
-        "using",
-        "were",
-        "what",
-        "when",
-        "where",
-        "which",
-        "with",
-    }
-)
 
 
 def _institution_names(record: dict) -> list[str]:
@@ -538,21 +520,43 @@ class OpenAlexToolset:
 
     @staticmethod
     def _query_terms(query_lower: str) -> list[str]:
-        all_terms = list(dict.fromkeys(_WORD_RE.findall(query_lower)))
-        focused_terms = [
-            term
-            for term in all_terms
-            if len(term) >= 3 and term not in _QUERY_STOPWORDS
+        return list(dict.fromkeys(_WORD_RE.findall(query_lower)))
+
+    @classmethod
+    def _passage_candidates(
+        cls, text: str, query_lower: str, terms: list[str]
+    ) -> list[tuple[float, int, int, int, str]]:
+        windows = cls._passage_windows(text)
+        token_counts = [
+            Counter(_WORD_RE.findall(passage.lower())) for *_, passage in windows
         ]
-        return focused_terms or all_terms
+        document_frequency = Counter(
+            term for counts in token_counts for term in terms if counts[term]
+        )
+        window_count = len(windows)
+        candidates = []
+        for (start, end, passage), counts in zip(windows, token_counts, strict=True):
+            matched = [term for term in terms if counts[term]]
+            score = sum(
+                log(
+                    1
+                    + (window_count - document_frequency[term] + 0.5)
+                    / (document_frequency[term] + 0.5)
+                )
+                * (counts[term] * 2.2 / (counts[term] + 1.2))
+                for term in matched
+            )
+            if query_lower in passage.lower():
+                score += 2
+            if score:
+                candidates.append((score, len(matched), start, end, passage))
+        return candidates
 
     @staticmethod
-    def _passage_candidates(
-        text: str, query_lower: str, terms: list[str]
-    ) -> list[tuple[int, int, int, int, str]]:
+    def _passage_windows(text: str) -> list[tuple[int, int, str]]:
         window_size = _MAX_PASSAGE_CHARS
         overlap = 240
-        candidates = []
+        windows = []
         start = 0
         while start < len(text):
             end = min(start + window_size, len(text))
@@ -561,21 +565,15 @@ class OpenAlexToolset:
                 if boundary > start:
                     end = boundary
             passage = " ".join(text[start:end].split())
-            lower = passage.lower()
-            matched = [term for term in terms if term in lower]
-            score = sum(lower.count(term) for term in terms) + 3 * len(matched)
-            if query_lower in lower:
-                score += 10
-            if score:
-                candidates.append((score, len(matched), start, end, passage))
+            windows.append((start, end, passage))
             if end >= len(text):
                 break
             start = max(start + 1, end - overlap)
-        return candidates
+        return windows
 
     @staticmethod
     def _select_nonoverlapping_passages(
-        candidates: list[tuple[int, int, int, int, str]], *, limit: int
+        candidates: list[tuple[float, int, int, int, str]], *, limit: int
     ) -> list[dict]:
         selected = []
         selected_ranges: list[tuple[int, int]] = []
@@ -590,7 +588,7 @@ class OpenAlexToolset:
                 {
                     "start_char": start,
                     "end_char": end,
-                    "score": score,
+                    "score": round(score, 4),
                     "text": passage,
                 }
             )

--- a/src/research_ai/services/researcher_profile/openalex_tools.py
+++ b/src/research_ai/services/researcher_profile/openalex_tools.py
@@ -531,14 +531,25 @@ class OpenAlexToolset:
     def _relevant_passages(cls, text: str, query: str, *, limit: int) -> list[dict]:
         """Rank overlapping text windows by focused lexical query coverage."""
         query_lower = query.lower()
-        terms = [
+        terms = cls._query_terms(query_lower)
+        candidates = cls._passage_candidates(text, query_lower, terms)
+        candidates.sort(key=lambda item: (-item[0], -item[1], item[2]))
+        return cls._select_nonoverlapping_passages(candidates, limit=limit)
+
+    @staticmethod
+    def _query_terms(query_lower: str) -> list[str]:
+        all_terms = list(dict.fromkeys(_WORD_RE.findall(query_lower)))
+        focused_terms = [
             term
-            for term in dict.fromkeys(_WORD_RE.findall(query_lower))
+            for term in all_terms
             if len(term) >= 3 and term not in _QUERY_STOPWORDS
         ]
-        if not terms:
-            terms = list(dict.fromkeys(_WORD_RE.findall(query_lower)))
+        return focused_terms or all_terms
 
+    @staticmethod
+    def _passage_candidates(
+        text: str, query_lower: str, terms: list[str]
+    ) -> list[tuple[int, int, int, int, str]]:
         window_size = _MAX_PASSAGE_CHARS
         overlap = 240
         candidates = []
@@ -560,8 +571,12 @@ class OpenAlexToolset:
             if end >= len(text):
                 break
             start = max(start + 1, end - overlap)
+        return candidates
 
-        candidates.sort(key=lambda item: (-item[0], -item[1], item[2]))
+    @staticmethod
+    def _select_nonoverlapping_passages(
+        candidates: list[tuple[int, int, int, int, str]], *, limit: int
+    ) -> list[dict]:
         selected = []
         selected_ranges: list[tuple[int, int]] = []
         for score, _coverage, start, end, passage in candidates:

--- a/src/research_ai/services/researcher_profile/openalex_tools.py
+++ b/src/research_ai/services/researcher_profile/openalex_tools.py
@@ -16,10 +16,9 @@ final profile from these records so a hallucinated citation cannot survive.
 """
 
 import logging
-import re
-from collections import Counter
 from collections.abc import Callable
-from math import log
+
+import bm25s
 
 from research_ai.services.agent import Tool, Toolset
 from research_ai.services.pdf_text import (
@@ -49,7 +48,7 @@ _MAX_FULLTEXT_SOURCE_CHARS = 120000
 _MAX_PASSAGES = 5
 _MAX_PASSAGE_CHARS = 1400
 _MAX_FULLTEXT_QUERY_CHARS = 500
-_WORD_RE = re.compile(r"[a-z0-9][a-z0-9_-]*")
+_BM25_TOKEN_PATTERN = r"(?u)\b\w[\w-]*\b"
 
 
 def _institution_names(record: dict) -> list[str]:
@@ -511,46 +510,51 @@ class OpenAlexToolset:
 
     @classmethod
     def _relevant_passages(cls, text: str, query: str, *, limit: int) -> list[dict]:
-        """Rank overlapping text windows by focused lexical query coverage."""
-        query_lower = query.lower()
-        terms = cls._query_terms(query_lower)
-        candidates = cls._passage_candidates(text, query_lower, terms)
-        candidates.sort(key=lambda item: (-item[0], -item[1], item[2]))
+        """Rank overlapping text windows with Lucene-compatible BM25."""
+        candidates = cls._passage_candidates(text, query)
         return cls._select_nonoverlapping_passages(candidates, limit=limit)
-
-    @staticmethod
-    def _query_terms(query_lower: str) -> list[str]:
-        return list(dict.fromkeys(_WORD_RE.findall(query_lower)))
 
     @classmethod
     def _passage_candidates(
-        cls, text: str, query_lower: str, terms: list[str]
-    ) -> list[tuple[float, int, int, int, str]]:
+        cls, text: str, query: str
+    ) -> list[tuple[float, int, int, str]]:
         windows = cls._passage_windows(text)
-        token_counts = [
-            Counter(_WORD_RE.findall(passage.lower())) for *_, passage in windows
-        ]
-        document_frequency = Counter(
-            term for counts in token_counts for term in terms if counts[term]
+        if not windows:
+            return []
+        corpus_tokens = cls._bm25_tokens([passage for *_, passage in windows])
+        query_tokens = cls._bm25_tokens([query])
+        if not query_tokens[0]:
+            return []
+
+        # Match OpenSearch/Lucene's BM25 variant for local, transient passages.
+        retriever = bm25s.BM25(method="lucene")
+        retriever.index(corpus_tokens, show_progress=False)
+        ranked = retriever.retrieve(
+            query_tokens,
+            corpus=list(range(len(windows))),
+            k=len(windows),
+            show_progress=False,
         )
-        window_count = len(windows)
         candidates = []
-        for (start, end, passage), counts in zip(windows, token_counts, strict=True):
-            matched = [term for term in terms if counts[term]]
-            score = sum(
-                log(
-                    1
-                    + (window_count - document_frequency[term] + 0.5)
-                    / (document_frequency[term] + 0.5)
-                )
-                * (counts[term] * 2.2 / (counts[term] + 1.2))
-                for term in matched
-            )
-            if query_lower in passage.lower():
-                score += 2
-            if score:
-                candidates.append((score, len(matched), start, end, passage))
+        for window_index, score in zip(
+            ranked.documents[0], ranked.scores[0], strict=True
+        ):
+            if score <= 0:
+                continue
+            start, end, passage = windows[int(window_index)]
+            candidates.append((float(score), start, end, passage))
         return candidates
+
+    @staticmethod
+    def _bm25_tokens(texts: list[str]) -> list[list[str]]:
+        return bm25s.tokenize(
+            texts,
+            token_pattern=_BM25_TOKEN_PATTERN,
+            # BM25 downweights document-common terms without a global stop list.
+            stopwords=None,
+            return_ids=False,
+            show_progress=False,
+        )
 
     @staticmethod
     def _passage_windows(text: str) -> list[tuple[int, int, str]]:
@@ -573,11 +577,11 @@ class OpenAlexToolset:
 
     @staticmethod
     def _select_nonoverlapping_passages(
-        candidates: list[tuple[float, int, int, int, str]], *, limit: int
+        candidates: list[tuple[float, int, int, str]], *, limit: int
     ) -> list[dict]:
         selected = []
         selected_ranges: list[tuple[int, int]] = []
-        for score, _coverage, start, end, passage in candidates:
+        for score, start, end, passage in candidates:
             if any(
                 start < kept_end and end > kept_start
                 for kept_start, kept_end in selected_ranges

--- a/src/research_ai/tests/notebook_chat/test_grant_tools.py
+++ b/src/research_ai/tests/notebook_chat/test_grant_tools.py
@@ -12,6 +12,7 @@ from note.models import Note
 from note.tests.helpers import create_note
 from purchase.models import Grant
 from research_ai.services.notebook_chat.grant_tools import (
+    GET_GRANT_DETAILS,
     READ_SELECTED_RFP,
     SEARCH_GRANTS,
     SET_SELECTED_RFP,
@@ -73,6 +74,12 @@ class GrantSearchToolsetTests(TestCase):
         self.assertFalse(stop)
         return result
 
+    def _details(self, user, grant_id):
+        toolset = GrantSearchToolset(user=user).as_toolset()
+        result, stop = toolset.dispatch(GET_GRANT_DETAILS, {"grant_id": grant_id})
+        self.assertFalse(stop)
+        return result
+
     def test_search_returns_only_matching_active_visible_grants(self):
         # Arrange
         matching = self._grant(
@@ -111,6 +118,8 @@ class GrantSearchToolsetTests(TestCase):
         self.assertEqual(item["currency"], "USD")
         post_id = matching.unified_document.posts.first().id
         self.assertIn(f"/grant/{post_id}/", item["url"])
+        self.assertNotIn("description", item)
+        self.assertNotIn("post_content", item)
 
     def test_search_respects_private_grant_owner_visibility(self):
         # Arrange
@@ -128,7 +137,7 @@ class GrantSearchToolsetTests(TestCase):
         self.assertEqual([item["id"] for item in owner_result["grants"]], [private.id])
         self.assertEqual(other_result["grants"], [])
 
-    def test_search_returns_content_when_only_the_backing_post_matches(self):
+    def test_search_returns_compact_summary_when_only_the_backing_post_matches(self):
         # Arrange
         post_content = "Supports single-cell proteomics in rare diseases. " + (
             "x" * 4000
@@ -147,7 +156,44 @@ class GrantSearchToolsetTests(TestCase):
         self.assertEqual([item["id"] for item in result["grants"]], [matching.id])
         item = result["grants"][0]
         self.assertEqual(item["title"], "Emerging Methods Award")
-        self.assertEqual(item["post_content"], post_content[:3000])
+        self.assertTrue(item["summary"].startswith("Supports single-cell proteomics"))
+        self.assertLessEqual(len(item["summary"]), 280)
+        self.assertNotIn("post_content", item)
+
+    def test_grant_details_returns_full_text_on_demand(self):
+        # Arrange
+        grant = self._grant(
+            title="Rare Disease Methods",
+            description="Structured program summary.",
+            post_content="Full RFP requirements for single-cell proteomics.",
+        )
+
+        # Act
+        result = self._details(self.user, grant.id)
+
+        # Assert
+        self.assertEqual(result["id"], grant.id)
+        self.assertEqual(result["description"], "Structured program summary.")
+        self.assertIn("Full RFP requirements", result["rfp_text"])
+
+    def test_grant_details_rechecks_visibility(self):
+        # Arrange
+        private = self._grant(
+            title="Private Methods Call",
+            description="Not public.",
+            is_public=False,
+        )
+
+        # Act
+        owner_result = self._details(self.owner, private.id)
+        other_result = self._details(self.user, private.id)
+
+        # Assert
+        self.assertEqual(owner_result["id"], private.id)
+        self.assertEqual(
+            other_result,
+            {"error": f"grant {private.id} not found or not accessible"},
+        )
 
     def test_search_requires_a_bounded_query(self):
         # Arrange

--- a/src/research_ai/tests/notebook_chat/test_grant_tools.py
+++ b/src/research_ai/tests/notebook_chat/test_grant_tools.py
@@ -231,23 +231,6 @@ class GrantSearchToolsetTests(TestCase):
         self.assertFalse(result["rfp_text_is_partial"])
         self.assertIsNone(result["next_start_char"])
 
-    def test_grant_details_rechecks_that_the_grant_is_active(self):
-        # Arrange: this grant could have closed after a prior search returned it.
-        grant = self._grant(
-            title="Closed Methods Call",
-            description="No longer accepting applications.",
-            status=Grant.CLOSED,
-        )
-
-        # Act
-        result = self._details(self.user, grant.id)
-
-        # Assert
-        self.assertEqual(
-            result,
-            {"error": f"grant {grant.id} is no longer accepting applications"},
-        )
-
     def test_grant_details_paginates_long_rfp_text(self):
         # Arrange
         grant = self._grant(

--- a/src/research_ai/tests/notebook_chat/test_grant_tools.py
+++ b/src/research_ai/tests/notebook_chat/test_grant_tools.py
@@ -160,6 +160,59 @@ class GrantSearchToolsetTests(TestCase):
         self.assertLessEqual(len(item["summary"]), 280)
         self.assertNotIn("post_content", item)
 
+    def test_search_summary_preserves_a_description_only_match(self):
+        # Arrange: the backing post exists but contains generic boilerplate
+        # unrelated to the query that matched the structured description.
+        matching = self._grant(
+            title="Emerging Methods Award",
+            description="Supports spatial metabolomics for rare diseases.",
+            post_content="Applications are invited from eligible investigators.",
+        )
+
+        # Act
+        result = self._search(self.user, "spatial metabolomics")
+
+        # Assert
+        self.assertEqual([item["id"] for item in result["grants"]], [matching.id])
+        self.assertIn("spatial metabolomics", result["grants"][0]["summary"].lower())
+
+    def test_search_summary_keeps_a_deep_backing_post_match(self):
+        # Arrange: the relevant phrase falls outside a naive prefix truncation.
+        matching = self._grant(
+            title="Emerging Methods Award",
+            description="Funding for reproducible experimental research.",
+            post_content=(
+                "General application guidance and eligibility boilerplate. " * 12
+                + "Supports spatial metabolomics in rare diseases."
+            ),
+        )
+
+        # Act
+        result = self._search(self.user, "spatial metabolomics")
+
+        # Assert
+        self.assertEqual([item["id"] for item in result["grants"]], [matching.id])
+        summary = result["grants"][0]["summary"]
+        self.assertIn("spatial metabolomics", summary.lower())
+        self.assertLessEqual(len(summary), 280)
+
+    def test_search_card_preserves_a_backing_post_title_match(self):
+        # Arrange: the structured short title differs from the post title that
+        # made the grant match.
+        matching = self._grant(
+            title="Spatial Metabolomics Award",
+            short_title="Emerging Methods Award",
+            description="Funding for reproducible experimental research.",
+            post_content="Applications are invited from eligible investigators.",
+        )
+
+        # Act
+        result = self._search(self.user, "spatial metabolomics")
+
+        # Assert
+        self.assertEqual([item["id"] for item in result["grants"]], [matching.id])
+        self.assertEqual(result["grants"][0]["title"], "Spatial Metabolomics Award")
+
     def test_grant_details_returns_full_text_on_demand(self):
         # Arrange
         grant = self._grant(

--- a/src/research_ai/tests/notebook_chat/test_grant_tools.py
+++ b/src/research_ai/tests/notebook_chat/test_grant_tools.py
@@ -226,8 +226,75 @@ class GrantSearchToolsetTests(TestCase):
 
         # Assert
         self.assertEqual(result["id"], grant.id)
-        self.assertEqual(result["description"], "Structured program summary.")
+        self.assertIn("Structured program summary.", result["rfp_text"])
         self.assertIn("Full RFP requirements", result["rfp_text"])
+        self.assertFalse(result["rfp_text_is_partial"])
+        self.assertIsNone(result["next_start_char"])
+
+    def test_grant_details_rechecks_that_the_grant_is_active(self):
+        # Arrange: this grant could have closed after a prior search returned it.
+        grant = self._grant(
+            title="Closed Methods Call",
+            description="No longer accepting applications.",
+            status=Grant.CLOSED,
+        )
+
+        # Act
+        result = self._details(self.user, grant.id)
+
+        # Assert
+        self.assertEqual(
+            result,
+            {"error": f"grant {grant.id} is no longer accepting applications"},
+        )
+
+    def test_grant_details_paginates_long_rfp_text(self):
+        # Arrange
+        grant = self._grant(
+            title="Long Methods Call",
+            description="Detailed eligibility and application instructions. " * 300,
+        )
+        toolset = GrantSearchToolset(user=self.user).as_toolset()
+
+        # Act
+        first, _ = toolset.dispatch(
+            GET_GRANT_DETAILS,
+            {"grant_id": grant.id, "max_chars": 100},
+        )
+        second, _ = toolset.dispatch(
+            GET_GRANT_DETAILS,
+            {
+                "grant_id": grant.id,
+                "start_char": first["next_start_char"],
+                "max_chars": 100,
+            },
+        )
+
+        # Assert
+        self.assertEqual(len(first["rfp_text"]), 100)
+        self.assertEqual(first["rfp_text_start_char"], 0)
+        self.assertEqual(first["rfp_text_end_char"], 100)
+        self.assertEqual(first["next_start_char"], 100)
+        self.assertTrue(first["rfp_text_is_partial"])
+        self.assertEqual(second["rfp_text_start_char"], 100)
+        self.assertNotEqual(first["rfp_text"], second["rfp_text"])
+
+    def test_grant_details_page_stays_below_dispatch_limit_for_unicode(self):
+        # Arrange: json.dumps expands each non-BMP character to two surrogates.
+        grant = self._grant(
+            title="Unicode Methods Call",
+            description="🔬" * 20000,
+        )
+        toolset = GrantSearchToolset(user=self.user).as_toolset()
+
+        # Act
+        result, _ = toolset.dispatch(GET_GRANT_DETAILS, {"grant_id": grant.id})
+
+        # Assert
+        self.assertNotIn("error", result)
+        self.assertEqual(len(result["rfp_text"]), 8000)
+        self.assertTrue(result["rfp_text_is_partial"])
+        self.assertEqual(result["next_start_char"], 8000)
 
     def test_grant_details_rechecks_visibility(self):
         # Arrange

--- a/src/research_ai/tests/notebook_chat/test_grant_tools.py
+++ b/src/research_ai/tests/notebook_chat/test_grant_tools.py
@@ -325,6 +325,7 @@ class SelectedRFPToolsetTests(TestCase):
         self.assertEqual(result["amount"], "75000.00")
         self.assertIn("Funding for reproducible research.", result["rfp_text"])
         self.assertIn("Applicants must publish their methods.", result["rfp_text"])
+        self.assertNotIn("some text", result["rfp_text"])
         self.assertIn("/grant/", result["url"])
 
     def test_reports_when_preregistration_has_no_selected_rfp(self):

--- a/src/research_ai/tests/notebook_chat/test_grant_tools.py
+++ b/src/research_ai/tests/notebook_chat/test_grant_tools.py
@@ -328,17 +328,25 @@ class SelectedRFPToolsetTests(TestCase):
             user=self.user,
         )
 
-    def _grant(self, *, is_public=True):
+    def _grant(
+        self,
+        *,
+        is_public=True,
+        markdown="# Full call\nApplicants must publish their methods.",
+        renderable_text="",
+    ):
         post = create_post(
             created_by=self.owner,
             document_type=GRANT,
             title="Reproducibility RFP",
+            renderable_text=renderable_text,
         )
         post.slug = "reproducibility-rfp"
-        post.discussion_src.save(
-            "rfp.md",
-            ContentFile(b"# Full call\nApplicants must publish their methods."),
-        )
+        if markdown is not None:
+            post.discussion_src.save(
+                "rfp.md",
+                ContentFile(markdown.encode()),
+            )
         post.save(update_fields=["slug"])
         post.unified_document.is_public = is_public
         post.unified_document.save(update_fields=["is_public"])
@@ -377,6 +385,32 @@ class SelectedRFPToolsetTests(TestCase):
         self.assertIn("Applicants must publish their methods.", result["rfp_text"])
         self.assertNotIn("some text", result["rfp_text"])
         self.assertIn("/grant/", result["url"])
+        self.assertFalse(result["rfp_text_is_partial"])
+        self.assertIsNone(result["next_start_char"])
+
+    def test_bounds_selected_rfp_text_from_markdown_or_rendered_fallback(self):
+        for source, options in (
+            ("markdown", {"markdown": "🔬" * 20000}),
+            (
+                "rendered fallback",
+                {"markdown": None, "renderable_text": "🔬" * 20000},
+            ),
+        ):
+            with self.subTest(source=source):
+                # Arrange
+                grant = self._grant(**options)
+                self.note.selected_grant = grant
+                self.note.save(update_fields=["selected_grant"])
+
+                # Act
+                result = self._read()
+
+                # Assert
+                self.assertNotIn("error", result)
+                self.assertEqual(len(result["rfp_text"]), 8000)
+                self.assertTrue(result["rfp_text_is_partial"])
+                self.assertEqual(result["next_start_char"], 8000)
+                self.assertGreater(result["rfp_text_total_chars"], 8000)
 
     def test_reports_when_preregistration_has_no_selected_rfp(self):
         # Act

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_activity.py
@@ -289,20 +289,30 @@ class NotebookChatActivityTests(TestCase):
 
     def test_scholarly_tools_report_names_and_citation_sources(self):
         # Arrange: a resolved author whose works ground the turn's citations.
-        # The work has no readable PDF, so the full-text read falls back to
-        # the abstract without touching the network.
         author = {"id": "https://openalex.org/A1", "display_name": "Jennifer Doudna"}
-        work = Mock()
-        work.as_dict.return_value = {
-            "title": "CRISPR paper",
-            "source_url": "https://doi.org/10.1000/crispr",
-            "pdf_url": "",
-            "abstract": "An abstract the user never needs to see raw.",
+        work = {
+            "id": "https://openalex.org/W1",
+            "doi": "https://doi.org/10.1000/crispr",
+            "display_name": "CRISPR paper",
+            "primary_location": {},
+            "locations": [],
+            "open_access": {"is_oa": True},
+            "abstract_inverted_index": {
+                "An": [0],
+                "abstract": [1],
+                "the": [2],
+                "user": [3],
+                "never": [4],
+                "needs": [5],
+                "to": [6],
+                "see": [7],
+                "raw.": [8],
+            },
         }
         oa_client = Mock()
         oa_client.search_authors_via_name.return_value = {"results": [author]}
         oa_client.get_author.return_value = author
-        oa_client.get_works_typed.return_value = [work]
+        oa_client.get_works.return_value = ([work], None)
         execution = self._run_turn(
             [
                 tool_turn("t1", "search_authors", {"name": "Jennifer Doudna"}),
@@ -312,7 +322,7 @@ class NotebookChatActivityTests(TestCase):
                 ),
                 tool_turn(
                     "t4",
-                    "get_work_fulltext",
+                    "get_work_abstract",
                     {"source_url": "https://doi.org/10.1000/crispr"},
                 ),
                 text_turn("Done."),
@@ -337,7 +347,7 @@ class NotebookChatActivityTests(TestCase):
         self.assertEqual(works["label"], "Fetched an author's publications")
         self.assertEqual(works["status"], "succeeded")
         self.assertEqual(works["sources"], [expected_source])
-        self.assertEqual(read_paper["label"], "Read a paper")
+        self.assertEqual(read_paper["label"], "Read a paper abstract")
         self.assertEqual(read_paper["status"], "succeeded")
         self.assertEqual(read_paper["sources"], [expected_source])
         for event in _tool_calls(activity):

--- a/src/research_ai/tests/researcher_profile/test_agent.py
+++ b/src/research_ai/tests/researcher_profile/test_agent.py
@@ -67,7 +67,26 @@ def _scripted_provider(calls, *, final_text=None):
 
 def _oa_client_returning(*works):
     client = MagicMock()
-    client.get_works_typed.return_value = list(works)
+    client.get_works.return_value = (
+        [
+            {
+                "id": work.source_url,
+                "doi": work.source_url,
+                "display_name": work.title,
+                "publication_date": work.publication_date,
+                "publication_year": work.publication_year,
+                "primary_location": {
+                    "pdf_url": work.pdf_url,
+                    "version": "publishedVersion",
+                },
+                "locations": [],
+                "open_access": {"is_oa": work.is_oa},
+                "abstract_inverted_index": {"Abstract": [0], "text": [1]},
+            }
+            for work in works
+        ],
+        None,
+    )
     return client
 
 

--- a/src/research_ai/tests/researcher_profile/test_openalex_tools.py
+++ b/src/research_ai/tests/researcher_profile/test_openalex_tools.py
@@ -200,13 +200,25 @@ class WorkDetailTests(SimpleTestCase):
         # Assert
         self.assertIn("CRISPR", result["passages"][0]["text"])
 
-    def test_fulltext_query_terms_do_not_use_a_manual_stopword_list(self):
-        # Act / Assert: generic terms are retained and receive low weight only
-        # when they are empirically common in this particular document.
-        self.assertEqual(
-            OpenAlexToolset._query_terms("paper using cells after treatment"),
-            ["paper", "using", "cells", "after", "treatment"],
+    def test_fulltext_search_retains_common_research_query_terms(self):
+        # Arrange: these terms were previously handled by a manual stop list.
+        text = (
+            "Unrelated introduction and background. " * 60
+            + "This paper reports what happened after using the intervention. "
+            + "Unrelated conclusions and references. " * 60
         )
+        _, toolset, url = self._toolset_with_work(
+            pdf_text_fetcher=lambda _pdf_url: text
+        )
+
+        # Act
+        result, _ = toolset.dispatch(
+            "search_work_fulltext",
+            {"source_url": url, "query": "paper what after using"},
+        )
+
+        # Assert
+        self.assertIn("paper reports", result["passages"][0]["text"])
 
     def test_fulltext_search_does_not_fall_back_to_abstract(self):
         # Arrange

--- a/src/research_ai/tests/researcher_profile/test_openalex_tools.py
+++ b/src/research_ai/tests/researcher_profile/test_openalex_tools.py
@@ -231,6 +231,25 @@ class WorkDetailTests(SimpleTestCase):
         self.assertIn("No readable full text", result["error"])
         self.assertNotIn("Abstract text", str(result))
 
+    def test_fulltext_search_reports_when_source_text_was_truncated(self):
+        # Arrange: the only query match falls beyond the bounded search prefix.
+        text = "background " * 12000 + "unique-tail-evidence"
+        _, toolset, url = self._toolset_with_work(
+            pdf_text_fetcher=lambda _pdf_url: text
+        )
+
+        # Act
+        result, _ = toolset.dispatch(
+            "search_work_fulltext",
+            {"source_url": url, "query": "unique-tail-evidence"},
+        )
+
+        # Assert
+        self.assertTrue(result["source_truncated"])
+        self.assertEqual(result["searched_characters"], 120000)
+        self.assertEqual(result["match_count"], 0)
+        self.assertIn("first 120000 characters", result["warning"])
+
     def test_unknown_source_url_errors(self):
         # Arrange
         _, toolset, _ = self._toolset_with_work(pdf_text_fetcher=lambda u: "")

--- a/src/research_ai/tests/researcher_profile/test_openalex_tools.py
+++ b/src/research_ai/tests/researcher_profile/test_openalex_tools.py
@@ -8,7 +8,6 @@ from research_ai.services.researcher_profile.openalex_tools import (
     SUBMIT_PROFILE,
     OpenAlexToolset,
 )
-from utils.openalex import Work
 from utils.tests.openalex_helpers import create_oa_author_record, create_oa_work
 
 
@@ -25,7 +24,8 @@ class ToolBuildTests(SimpleTestCase):
                 "search_authors",
                 "get_author",
                 "get_author_works",
-                "get_work_fulltext",
+                "get_work_abstract",
+                "search_work_fulltext",
                 SUBMIT_PROFILE,
             },
         )
@@ -61,11 +61,10 @@ class DispatchTests(SimpleTestCase):
     def test_get_author_works_records_work_provenance(self):
         # Arrange
         client = MagicMock()
-        client.get_works_typed.return_value = [
-            Work.from_openalex(
-                create_oa_work("Lead Paper", 2024, "first"), author_id=None
-            )
-        ]
+        client.get_works.return_value = (
+            [create_oa_work("Lead Paper", 2024, "first")],
+            "next-page",
+        )
         provider = OpenAlexToolset(client=client)
         toolset = provider.as_toolset()
         # Act
@@ -76,6 +75,37 @@ class DispatchTests(SimpleTestCase):
         url = result["works"][0]["source_url"]
         self.assertIn(url, provider.returned_works)
         self.assertEqual(provider.returned_works[url]["title"], "Lead Paper")
+        self.assertNotIn("abstract", result["works"][0])
+        self.assertNotIn("pdf_url", result["works"][0])
+        self.assertTrue(result["works"][0]["has_abstract"])
+        self.assertEqual(result["next_cursor"], "next-page")
+        self.assertTrue(result["has_more"])
+
+    def test_get_author_works_passes_cursor_and_keeps_broad_page_size(self):
+        # Arrange
+        client = MagicMock()
+        client.get_works.return_value = ([], "later")
+        toolset = OpenAlexToolset(client=client).as_toolset()
+
+        # Act
+        result, _ = toolset.dispatch(
+            "get_author_works",
+            {
+                "openalex_author_id": "https://openalex.org/A123",
+                "cursor": "prior-cursor",
+                "max_results": 40,
+            },
+        )
+
+        # Assert
+        client.get_works.assert_called_once_with(
+            openalex_author_id="https://openalex.org/A123",
+            next_cursor="prior-cursor",
+            batch_size=40,
+            sort="publication_date:desc",
+            open_access_only=True,
+        )
+        self.assertEqual(result["next_cursor"], "later")
 
     def test_submit_profile_captures_input_and_stops(self):
         # Arrange
@@ -101,15 +131,14 @@ class DispatchTests(SimpleTestCase):
         self.assertIn("oa down", result["error"])
 
 
-class GetWorkFulltextTests(SimpleTestCase):
+class WorkDetailTests(SimpleTestCase):
     def _toolset_with_work(self, **kwargs):
         """A toolset that has already returned one work (so it can be read)."""
         client = MagicMock()
-        client.get_works_typed.return_value = [
-            Work.from_openalex(
-                create_oa_work("Lead Paper", 2024, "first"), author_id=None
-            )
-        ]
+        client.get_works.return_value = (
+            [create_oa_work("Lead Paper", 2024, "first")],
+            None,
+        )
         provider = OpenAlexToolset(client=client, **kwargs)
         toolset = provider.as_toolset()
         result, _ = toolset.dispatch(
@@ -117,45 +146,111 @@ class GetWorkFulltextTests(SimpleTestCase):
         )
         return provider, toolset, result["works"][0]["source_url"]
 
-    def test_reads_pdf_text_for_returned_work(self):
-        # Arrange: a stub fetcher stands in for the PDF download/extract.
-        _, toolset, url = self._toolset_with_work(
-            pdf_text_fetcher=lambda pdf_url: "METHODS: single-cell RNA-seq on ..."
-        )
+    def test_fetches_abstract_separately_from_work_listing(self):
+        # Arrange
+        _, toolset, url = self._toolset_with_work(pdf_text_fetcher=lambda _url: "")
+
         # Act
-        result, stop = toolset.dispatch("get_work_fulltext", {"source_url": url})
+        result, stop = toolset.dispatch("get_work_abstract", {"source_url": url})
+
         # Assert
         self.assertFalse(stop)
-        self.assertEqual(result["content_type"], "pdf")
-        self.assertIn("single-cell", result["text"])
+        self.assertEqual(result["abstract"], "Abstract text")
 
-    def test_falls_back_to_abstract_when_no_pdf_text(self):
-        # Arrange: the fetcher yields nothing, so the abstract is used.
+    def test_fulltext_search_returns_relevant_passages_not_the_paper(self):
+        # Arrange: a stub fetcher stands in for the PDF download/extract.
+        text = (
+            "Background material about unrelated observations. " * 40
+            + "METHODS: single-cell RNA-seq was performed on tumor samples. "
+            + "Additional unrelated discussion. " * 80
+        )
+        _, toolset, url = self._toolset_with_work(
+            pdf_text_fetcher=lambda _pdf_url: text
+        )
+        # Act
+        result, stop = toolset.dispatch(
+            "search_work_fulltext",
+            {"source_url": url, "query": "single-cell RNA-seq tumor samples"},
+        )
+        # Assert
+        self.assertFalse(stop)
+        self.assertNotIn("text", result)
+        self.assertGreater(result["match_count"], 0)
+        self.assertIn("single-cell", result["passages"][0]["text"])
+        self.assertLess(len(result["passages"][0]["text"]), len(text))
+
+    def test_fulltext_search_does_not_fall_back_to_abstract(self):
+        # Arrange
         _, toolset, url = self._toolset_with_work(pdf_text_fetcher=lambda pdf_url: "")
         # Act
-        result, _ = toolset.dispatch("get_work_fulltext", {"source_url": url})
+        result, _ = toolset.dispatch(
+            "search_work_fulltext", {"source_url": url, "query": "methods"}
+        )
         # Assert
-        self.assertEqual(result["content_type"], "abstract")
-        self.assertEqual(result["text"], "Abstract text")
+        self.assertIn("No readable full text", result["error"])
+        self.assertNotIn("Abstract text", str(result))
 
     def test_unknown_source_url_errors(self):
         # Arrange
         _, toolset, _ = self._toolset_with_work(pdf_text_fetcher=lambda u: "")
         # Act
         result, _ = toolset.dispatch(
-            "get_work_fulltext", {"source_url": "https://doi.org/10.9/nope"}
+            "search_work_fulltext",
+            {"source_url": "https://doi.org/10.9/nope", "query": "methods"},
         )
         # Assert
         self.assertIn("error", result)
 
     def test_read_budget_is_enforced(self):
-        # Arrange: a one-read budget; the second read is refused.
-        _, toolset, url = self._toolset_with_work(
-            pdf_text_fetcher=lambda u: "text", max_fulltext_fetches=1
+        # Arrange: a one-document budget with two returned works.
+        client = MagicMock()
+        client.get_works.return_value = (
+            [
+                create_oa_work("Paper One", 2024, "first"),
+                create_oa_work("Paper Two", 2023, "last"),
+            ],
+            None,
         )
+        provider = OpenAlexToolset(
+            client=client,
+            pdf_text_fetcher=lambda _url: "Methods include microscopy.",
+            max_fulltext_fetches=1,
+        )
+        toolset = provider.as_toolset()
+        listed, _ = toolset.dispatch("get_author_works", {"openalex_author_id": "A123"})
+        first_url, second_url = [work["source_url"] for work in listed["works"]]
         # Act
-        first, _ = toolset.dispatch("get_work_fulltext", {"source_url": url})
-        second, _ = toolset.dispatch("get_work_fulltext", {"source_url": url})
+        first, _ = toolset.dispatch(
+            "search_work_fulltext", {"source_url": first_url, "query": "microscopy"}
+        )
+        second, _ = toolset.dispatch(
+            "search_work_fulltext", {"source_url": second_url, "query": "microscopy"}
+        )
         # Assert
         self.assertNotIn("error", first)
         self.assertIn("budget", second["error"].lower())
+
+    def test_repeated_queries_reuse_one_document_fetch(self):
+        # Arrange
+        calls = []
+
+        def fetch(url):
+            calls.append(url)
+            return "Methods used microscopy. Results reported biomarkers."
+
+        _, toolset, url = self._toolset_with_work(
+            pdf_text_fetcher=fetch, max_fulltext_fetches=1
+        )
+
+        # Act
+        first, _ = toolset.dispatch(
+            "search_work_fulltext", {"source_url": url, "query": "microscopy"}
+        )
+        second, _ = toolset.dispatch(
+            "search_work_fulltext", {"source_url": url, "query": "biomarkers"}
+        )
+
+        # Assert
+        self.assertNotIn("error", first)
+        self.assertNotIn("error", second)
+        self.assertEqual(len(calls), 1)

--- a/src/research_ai/tests/researcher_profile/test_openalex_tools.py
+++ b/src/research_ai/tests/researcher_profile/test_openalex_tools.py
@@ -179,6 +179,35 @@ class WorkDetailTests(SimpleTestCase):
         self.assertIn("single-cell", result["passages"][0]["text"])
         self.assertLess(len(result["passages"][0]["text"]), len(text))
 
+    def test_fulltext_search_downweights_terms_common_across_the_document(self):
+        # Arrange: "using" appears throughout the paper, while the substantive
+        # query term identifies one passage.
+        text = (
+            "Background using standard controls and routine analysis. " * 100
+            + "METHODS: using CRISPR screens to identify resistance genes. "
+            + "Discussion using standard controls and routine analysis. " * 100
+        )
+        _, toolset, url = self._toolset_with_work(
+            pdf_text_fetcher=lambda _pdf_url: text
+        )
+
+        # Act
+        result, _ = toolset.dispatch(
+            "search_work_fulltext",
+            {"source_url": url, "query": "using CRISPR"},
+        )
+
+        # Assert
+        self.assertIn("CRISPR", result["passages"][0]["text"])
+
+    def test_fulltext_query_terms_do_not_use_a_manual_stopword_list(self):
+        # Act / Assert: generic terms are retained and receive low weight only
+        # when they are empirically common in this particular document.
+        self.assertEqual(
+            OpenAlexToolset._query_terms("paper using cells after treatment"),
+            ["paper", "using", "cells", "after", "treatment"],
+        )
+
     def test_fulltext_search_does_not_fall_back_to_abstract(self):
         # Arrange
         _, toolset, url = self._toolset_with_work(pdf_text_fetcher=lambda pdf_url: "")

--- a/src/research_ai/tests/test_note_tools.py
+++ b/src/research_ai/tests/test_note_tools.py
@@ -126,6 +126,52 @@ class NoteToolsetTests(TestCase):
         # Assert
         self.assertIn("could not be read", result["error"])
 
+    def test_read_note_returns_bounded_windows_with_global_indices(self):
+        # Arrange: enough compact paragraph blocks to require two reads.
+        document = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": f"Block {i}"}],
+                }
+                for i in range(75)
+            ],
+        }
+        seeded = self._seed_version(document)
+
+        # Act
+        first, _ = self.toolset.dispatch(READ_NOTE, {"note_id": self.note.id})
+        second, _ = self.toolset.dispatch(
+            READ_NOTE,
+            {"note_id": self.note.id, "start_block": 50, "max_blocks": 25},
+        )
+
+        # Assert
+        self.assertEqual(first["version_id"], seeded.id)
+        self.assertEqual(first["block_count"], 75)
+        self.assertEqual(first["returned_block_count"], 50)
+        self.assertEqual(first["next_start_block"], 50)
+        self.assertEqual(first["blocks"]["49"], "Block 49")
+        self.assertEqual(second["start_block"], 50)
+        self.assertEqual(second["returned_block_count"], 25)
+        self.assertIsNone(second["next_start_block"])
+        self.assertEqual(second["blocks"]["50"], "Block 50")
+        self.assertEqual(second["blocks"]["74"], "Block 74")
+
+    def test_read_note_rejects_invalid_bounds(self):
+        # Act
+        too_wide, _ = self.toolset.dispatch(
+            READ_NOTE, {"note_id": self.note.id, "max_blocks": 51}
+        )
+        negative, _ = self.toolset.dispatch(
+            READ_NOTE, {"note_id": self.note.id, "start_block": -1}
+        )
+
+        # Assert
+        self.assertIn("between 1 and 50", too_wide["error"])
+        self.assertIn("at least 0", negative["error"])
+
     def test_read_note_denied_for_user_without_access(self):
         # Arrange
         toolset = NoteToolset(user=self.outsider).as_toolset()

--- a/src/research_ai/tests/test_note_tools.py
+++ b/src/research_ai/tests/test_note_tools.py
@@ -144,7 +144,12 @@ class NoteToolsetTests(TestCase):
         first, _ = self.toolset.dispatch(READ_NOTE, {"note_id": self.note.id})
         second, _ = self.toolset.dispatch(
             READ_NOTE,
-            {"note_id": self.note.id, "start_block": 50, "max_blocks": 25},
+            {
+                "note_id": self.note.id,
+                "version_id": seeded.id,
+                "start_block": 50,
+                "max_blocks": 25,
+            },
         )
 
         # Assert
@@ -158,6 +163,72 @@ class NoteToolsetTests(TestCase):
         self.assertIsNone(second["next_start_block"])
         self.assertEqual(second["blocks"]["50"], "Block 50")
         self.assertEqual(second["blocks"]["74"], "Block 74")
+
+    def test_read_note_continuation_stays_on_the_requested_version(self):
+        # Arrange: read the first page, then append a newer version whose
+        # insertion would shift every later global block index.
+        original = self._seed_version(
+            {
+                "type": "doc",
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": f"Block {i}"}],
+                    }
+                    for i in range(75)
+                ],
+            }
+        )
+        first, _ = self.toolset.dispatch(READ_NOTE, {"note_id": self.note.id})
+        edit, _ = self.toolset.dispatch(
+            EDIT_NOTE,
+            {
+                "note_id": self.note.id,
+                "expected_version_id": original.id,
+                "edits": _insert(["New first block"]),
+            },
+        )
+
+        # Act
+        continuation, _ = self.toolset.dispatch(
+            READ_NOTE,
+            {
+                "note_id": self.note.id,
+                "version_id": first["version_id"],
+                "start_block": first["next_start_block"],
+            },
+        )
+
+        # Assert: the page uses the original immutable content even though the
+        # note now has a newer latest version.
+        self.assertTrue(edit["saved"])
+        self.assertNotEqual(edit["version_id"], original.id)
+        self.assertEqual(continuation["version_id"], original.id)
+        self.assertEqual(continuation["block_count"], 75)
+        self.assertEqual(continuation["blocks"]["50"], "Block 50")
+
+    def test_read_note_continuation_requires_version_id(self):
+        # Act
+        result, _ = self.toolset.dispatch(
+            READ_NOTE, {"note_id": self.note.id, "start_block": 1}
+        )
+
+        # Assert
+        self.assertIn("version_id is required", result["error"])
+
+    def test_read_note_rejects_version_from_another_note(self):
+        # Arrange
+        other_note, other_version = create_note(self.owner, organization=None)
+
+        # Act
+        result, _ = self.toolset.dispatch(
+            READ_NOTE,
+            {"note_id": self.note.id, "version_id": other_version.id},
+        )
+
+        # Assert: a version can only be read through its own accessible note.
+        self.assertNotEqual(other_note.id, self.note.id)
+        self.assertIn("not found for note", result["error"])
 
     def test_read_note_rejects_invalid_bounds(self):
         # Act

--- a/uv.lock
+++ b/uv.lock
@@ -298,6 +298,18 @@ wheels = [
 ]
 
 [[package]]
+name = "bm25s"
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f6/38a4eb22be0c715aa9bc290e44a48bbdf7a27cffa7f85914fd10242442e4/bm25s-0.3.11.tar.gz", hash = "sha256:8ae0f0707d279969829383c7aaeef00fb09ca343101160222571d6bfc969f889", size = 80978, upload-time = "2026-08-25T03:14:57.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/d9/bb770dabb7e0edeb2c949460a05c38df7f4f564a1693a778352fb0d213b0/bm25s-0.3.11-py3-none-any.whl", hash = "sha256:3d1d28badb299d6fc9324111e5c8276927e990b908607b39ff9bd65b102e9a24", size = 74985, upload-time = "2026-08-25T03:14:56.051Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.43.38"
 source = { registry = "https://pypi.org/simple" }
@@ -1848,6 +1860,25 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/d2/6b24738a0ef4557d189b150046cd07823c50e4273e8aebd651222e24306f/numpy-2.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8e4cb9a754c8a0c62eaa88273a5fba3391f4a610d1dee893c0755da31c083f15", size = 16886595, upload-time = "2026-08-09T13:45:27.323Z" },
+    { url = "https://files.pythonhosted.org/packages/65/60/f2d208d366f263f39c6e69ed309290717aab41078b6d04c9be2a84fa2a07/numpy-2.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:52c808f96484f5571a5cc863775ce50247c17dfb3b0361f8ed6b4b0456f80080", size = 11896845, upload-time = "2026-08-09T13:45:31.638Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/79/81e0bf24f4d020a2b1d5cd297a9f60c3f24eeb116f9bba5870443f7b6a4a/numpy-2.5.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:29d81e97f668489cba8ebfd796b9bdd453525d35dd9e162e2daec94bf3fc7740", size = 5343880, upload-time = "2026-08-09T13:45:34.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cc/e3141cf06d1a8a2c7e107543fe1269c1d1af760d4d683c0794a4ee1127c2/numpy-2.5.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:afb3f0632d6b2e3ba04dbce8d1e48d321b369138b73830b5ca371a0e8d479d56", size = 6682264, upload-time = "2026-08-09T13:45:36.7Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f1/2a64a307d92c5d98f5255a4014eb43bb6103ee477087b61ecae44a3aa9b9/numpy-2.5.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0aadf13b60048d501e05fa699efaf7734e2494f3498a4c2a5521d822640324f3", size = 15609566, upload-time = "2026-08-09T13:45:39.518Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/44/59a1eb68e773c4098d107ef34a0dbdeca501d72ffcfbff9a7707343921ce/numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee", size = 16709995, upload-time = "2026-08-09T13:45:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4c/3e54d4ddbc359a1295f8b633e8106bcd4d7d4a206e82df051bdfb3058755/numpy-2.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6950c4b7dd562453090548ba7f5da7e59f57f85663f15d5dcc60e249192f7e59", size = 16972511, upload-time = "2026-08-09T13:45:47.094Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9f/02e371638ebf19b66d46231e4be52999e87f32d1961b113bc45656608b22/numpy-2.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9727f472d2f3888053b8a75ab0cb94745a9de224bb5846dbadc0092101bc71d", size = 18465609, upload-time = "2026-08-09T13:45:50.808Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/ad6645abc7a3510fe48e8ea1ab4598166f500057ef4ebf38bfad4f1577de/numpy-2.5.2-cp313-cp313-win32.whl", hash = "sha256:4f9744f9fbdcea0bc552e8f19e1f141f811a3f9bc2be2cc6e86d982cab23e3f4", size = 6070204, upload-time = "2026-08-09T13:45:54.111Z" },
+    { url = "https://files.pythonhosted.org/packages/15/20/f3489f86d81ea460b2bcdceaed094142ca6579f6be0ec527b781d39afe68/numpy-2.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:85aaccb24182c25df891ad0ec333585967e115269d5f1b17f2c9ae005bc96657", size = 12460532, upload-time = "2026-08-09T13:45:57.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/21/35b31dde1b283b79de828b80f876afd8c94e28fe1e9c375f89e261cc4c0d/numpy-2.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:bd68ece1553d2023c09a4226d9e41c586ad2d20594d1a456186c33513d2cb3f2", size = 10396725, upload-time = "2026-08-09T13:46:00.478Z" },
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2576,6 +2607,7 @@ dependencies = [
     { name = "atproto" },
     { name = "authlib" },
     { name = "beautifulsoup4" },
+    { name = "bm25s" },
     { name = "boto3" },
     { name = "cdp-sdk" },
     { name = "celery" },
@@ -2644,6 +2676,7 @@ requires-dist = [
     { name = "atproto", specifier = ">=0.0.70" },
     { name = "authlib", specifier = ">=1.3.0,<2.0.0" },
     { name = "beautifulsoup4", specifier = "==4.12.2" },
+    { name = "bm25s", specifier = ">=0.3.11,<0.4" },
     { name = "boto3", specifier = ">=1.43.38,<2" },
     { name = "cdp-sdk", specifier = "==1.44.0" },
     { name = "celery", specifier = "==5.6.3" },


### PR DESCRIPTION
## Summary

- return compact grant search cards and add permission-checked `get_grant_details`
- make OpenAlex work discovery compact and cursor-paginated, with separate abstract reads and focused full-text passage search
- add bounded note reads over compact blocks while preserving global block indices and block-based edits
- update notebook/researcher prompts and user-safe activity labels for the new tool contracts

## Verification

- `CONFIG=1 APP_ENV=test uv run python manage.py test research_ai --keepdb` (1,148 tests)
- `uv run ruff check src/research_ai`
- focused Ruff formatting checks and `git diff --check`