### PR TITLE
Serve the model catalog without provider credentials

### DIFF
--- a/src/research_ai/services/agent/model_catalog.py
+++ b/src/research_ai/services/agent/model_catalog.py
@@ -13,16 +13,15 @@ search, adaptive thinking, prompt caching) and every other family through
 OpenRouter. Bedrock refs are equally valid entries; they are just not listed,
 since they would duplicate the Anthropic entries under a second name.
 
-Models whose provider has no credentials configured are hidden -- offering
-them would sell a selection that can only fail at run time. The configured
-generator default is always selectable, even when it falls outside the
-catalog's availability checks, because it is what runs when the user picks
-nothing.
+The catalog is not credential-gated. Provider keys are configured on the
+Celery workers that execute turns, not on the API process that serves this
+listing, so checking them here would hide models that run fine; each provider
+raises on missing credentials where they are actually used. The configured
+generator default is listed too, even when it falls outside the catalog,
+because it is what runs when the user picks nothing.
 """
 
 from dataclasses import dataclass
-
-from django.conf import settings
 
 from research_ai.services.agent.model_capabilities import (
     ModelCapabilities,
@@ -114,14 +113,13 @@ _CATALOG: tuple[ModelOption, ...] = (
 
 
 def available_models() -> list[ModelOption]:
-    """The models a user may select right now, generator default first-class.
+    """The models a user may select, generator default first-class.
 
-    Catalog entries whose provider lacks credentials are dropped; the
-    configured generator default is prepended when the surviving list does not
+    The configured generator default is prepended when the catalog does not
     already carry it, so "what runs by default" is always also a legal
     explicit choice.
     """
-    options = [option for option in _CATALOG if _provider_configured(option.provider)]
+    options = list(_CATALOG)
     default_ref = default_model_ref()
     if not any(option.ref == default_ref for option in options):
         options.insert(
@@ -151,23 +149,9 @@ def validate_model_ref(value: str | None) -> str | None:
     for option in available_models():
         if _canonical(option.ref) == requested:
             return option.ref
-    raise ValueError(f"unknown or unavailable model: {value.strip()!r}")
+    raise ValueError(f"unknown model: {value.strip()!r}")
 
 
 def _canonical(ref: str) -> str:
     provider, model_id = split_model_ref(ref)
     return f"{provider}:{model_id or ''}"
-
-
-def _provider_configured(name: str) -> bool:
-    """Whether ``name`` has the credentials its client needs, settings-only.
-
-    Deliberately no client construction (same contract as the registry).
-    Bedrock rides the ambient AWS credential chain, which cannot be checked
-    from settings, so it always counts as configured.
-    """
-    if name == CLAUDE_PLATFORM:
-        return bool(settings.ANTHROPIC_AWS_WORKSPACE_ID and settings.AWS_REGION_NAME)
-    if name == OPENROUTER:
-        return bool(getattr(settings, "OPENROUTER_API_KEY", ""))
-    return True

--- a/src/research_ai/tests/agent/test_model_catalog.py
+++ b/src/research_ai/tests/agent/test_model_catalog.py
@@ -13,7 +13,7 @@ from research_ai.services.agent.model_catalog import (
 )
 
 # Provider keys live on the workers that run turns, not on the API process
-# that serves the catalog, so listing must not depend on them.
+# that serves the catalog, so every assertion below holds with none set.
 NO_PROVIDER_CREDENTIALS = {
     "ANTHROPIC_AWS_WORKSPACE_ID": "",
     "AWS_REGION_NAME": "",
@@ -21,6 +21,7 @@ NO_PROVIDER_CREDENTIALS = {
 }
 
 
+@override_settings(**NO_PROVIDER_CREDENTIALS)
 class AvailableModelsTests(SimpleTestCase):
     def test_catalog_refs_have_valid_structure(self):
         # Act
@@ -89,15 +90,6 @@ class AvailableModelsTests(SimpleTestCase):
         self.assertEqual(capabilities.thinking, ("adaptive", "disabled"))
         self.assertFalse(capabilities.temperature)
 
-    @override_settings(**NO_PROVIDER_CREDENTIALS)
-    def test_models_are_listed_without_provider_credentials(self):
-        # Act
-        providers = {option.provider for option in available_models()}
-
-        # Assert
-        self.assertIn("openrouter", providers)
-        self.assertIn("claude_platform", providers)
-
     @override_settings(RESEARCH_AI_GENERATOR_PROVIDER="bedrock")
     def test_generator_default_outside_the_catalog_is_still_selectable(self):
         # Arrange: no Bedrock ref is catalogued, so the default is not one.
@@ -154,6 +146,7 @@ class CapabilityLookupTests(SimpleTestCase):
                 )
 
 
+@override_settings(**NO_PROVIDER_CREDENTIALS)
 class ValidateModelRefTests(SimpleTestCase):
     def test_no_selection_returns_none(self):
         # Act / Assert
@@ -178,14 +171,6 @@ class ValidateModelRefTests(SimpleTestCase):
         # Act / Assert
         with self.assertRaises(ValueError):
             validate_model_ref("openrouter:acme/totally-made-up")
-
-    @override_settings(**NO_PROVIDER_CREDENTIALS)
-    def test_catalog_ref_is_accepted_without_provider_credentials(self):
-        # Act / Assert
-        self.assertEqual(
-            validate_model_ref("openrouter:openai/gpt-5.6-sol"),
-            "openrouter:openai/gpt-5.6-sol",
-        )
 
 
 class ValidateGenerationOptionsTests(SimpleTestCase):

--- a/src/research_ai/tests/agent/test_model_catalog.py
+++ b/src/research_ai/tests/agent/test_model_catalog.py
@@ -12,15 +12,15 @@ from research_ai.services.agent.model_catalog import (
     validate_model_ref,
 )
 
-# Every provider credential present, so the whole catalog is listed.
-ALL_PROVIDERS_CONFIGURED = {
-    "ANTHROPIC_AWS_WORKSPACE_ID": "ws-test",
-    "AWS_REGION_NAME": "us-east-1",
-    "OPENROUTER_API_KEY": "or-test",
+# Provider keys live on the workers that run turns, not on the API process
+# that serves the catalog, so listing must not depend on them.
+NO_PROVIDER_CREDENTIALS = {
+    "ANTHROPIC_AWS_WORKSPACE_ID": "",
+    "AWS_REGION_NAME": "",
+    "OPENROUTER_API_KEY": "",
 }
 
 
-@override_settings(**ALL_PROVIDERS_CONFIGURED)
 class AvailableModelsTests(SimpleTestCase):
     def test_catalog_refs_have_valid_structure(self):
         # Act
@@ -89,29 +89,26 @@ class AvailableModelsTests(SimpleTestCase):
         self.assertEqual(capabilities.thinking, ("adaptive", "disabled"))
         self.assertFalse(capabilities.temperature)
 
-    @override_settings(OPENROUTER_API_KEY="")
-    def test_unconfigured_provider_models_are_hidden(self):
+    @override_settings(**NO_PROVIDER_CREDENTIALS)
+    def test_models_are_listed_without_provider_credentials(self):
         # Act
-        options = available_models()
+        providers = {option.provider for option in available_models()}
 
         # Assert
-        self.assertTrue(options)
-        self.assertFalse(any(o.provider == "openrouter" for o in options))
+        self.assertIn("openrouter", providers)
+        self.assertIn("claude_platform", providers)
 
-    @override_settings(ANTHROPIC_AWS_WORKSPACE_ID="")
-    def test_generator_default_is_always_selectable(self):
-        # Arrange: the default generator's provider has no credentials, so its
-        # catalog entries are hidden -- but the default itself must survive.
+    @override_settings(RESEARCH_AI_GENERATOR_PROVIDER="bedrock")
+    def test_generator_default_outside_the_catalog_is_still_selectable(self):
+        # Arrange: no Bedrock ref is catalogued, so the default is not one.
         default = default_model_ref()
 
         # Act
         options = available_models()
 
         # Assert
+        self.assertEqual(default, "bedrock:us.anthropic.claude-opus-5")
         self.assertEqual(options[0].ref, default)
-        self.assertNotIn(
-            "claude_platform:claude-sonnet-5", [option.ref for option in options]
-        )
 
 
 class CapabilityLookupTests(SimpleTestCase):
@@ -157,7 +154,6 @@ class CapabilityLookupTests(SimpleTestCase):
                 )
 
 
-@override_settings(**ALL_PROVIDERS_CONFIGURED)
 class ValidateModelRefTests(SimpleTestCase):
     def test_no_selection_returns_none(self):
         # Act / Assert
@@ -183,11 +179,13 @@ class ValidateModelRefTests(SimpleTestCase):
         with self.assertRaises(ValueError):
             validate_model_ref("openrouter:acme/totally-made-up")
 
-    @override_settings(OPENROUTER_API_KEY="")
-    def test_model_on_unconfigured_provider_is_rejected(self):
+    @override_settings(**NO_PROVIDER_CREDENTIALS)
+    def test_catalog_ref_is_accepted_without_provider_credentials(self):
         # Act / Assert
-        with self.assertRaises(ValueError):
-            validate_model_ref("openrouter:openai/gpt-5.6-sol")
+        self.assertEqual(
+            validate_model_ref("openrouter:openai/gpt-5.6-sol"),
+            "openrouter:openai/gpt-5.6-sol",
+        )
 
 
 class ValidateGenerationOptionsTests(SimpleTestCase):

--- a/src/research_ai/tests/test_model_views.py
+++ b/src/research_ai/tests/test_model_views.py
@@ -1,6 +1,5 @@
 """API tests for the selectable-model listing."""
 
-from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -59,19 +58,3 @@ class AvailableModelsViewTests(APITestCase):
         self.assertIn("low", opus["capabilities"]["effort"])
         self.assertEqual(opus["capabilities"]["thinking"], ["adaptive", "disabled"])
         self.assertFalse(opus["capabilities"]["temperature"])
-
-    @override_settings(
-        ANTHROPIC_AWS_WORKSPACE_ID="", AWS_REGION_NAME="", OPENROUTER_API_KEY=""
-    )
-    def test_lists_models_without_provider_credentials(self):
-        # Arrange: keys are configured on the workers that run turns, not on
-        # the API process serving this listing.
-        self.client.force_authenticate(self.moderator)
-
-        # Act
-        response = self.client.get(URL)
-
-        # Assert
-        providers = {model["provider"] for model in response.json()["models"]}
-        self.assertIn("openrouter", providers)
-        self.assertIn("claude_platform", providers)

--- a/src/research_ai/tests/test_model_views.py
+++ b/src/research_ai/tests/test_model_views.py
@@ -9,11 +9,6 @@ from user.tests.helpers import create_random_authenticated_user
 URL = "/api/research_ai/models/"
 
 
-@override_settings(
-    ANTHROPIC_AWS_WORKSPACE_ID="ws-test",
-    AWS_REGION_NAME="us-east-1",
-    OPENROUTER_API_KEY="or-test",
-)
 class AvailableModelsViewTests(APITestCase):
     def setUp(self):
         self.moderator = create_random_authenticated_user("mod", moderator=True)
@@ -65,9 +60,12 @@ class AvailableModelsViewTests(APITestCase):
         self.assertEqual(opus["capabilities"]["thinking"], ["adaptive", "disabled"])
         self.assertFalse(opus["capabilities"]["temperature"])
 
-    @override_settings(OPENROUTER_API_KEY="")
-    def test_hides_models_without_provider_credentials(self):
-        # Arrange
+    @override_settings(
+        ANTHROPIC_AWS_WORKSPACE_ID="", AWS_REGION_NAME="", OPENROUTER_API_KEY=""
+    )
+    def test_lists_models_without_provider_credentials(self):
+        # Arrange: keys are configured on the workers that run turns, not on
+        # the API process serving this listing.
         self.client.force_authenticate(self.moderator)
 
         # Act
@@ -75,4 +73,5 @@ class AvailableModelsViewTests(APITestCase):
 
         # Assert
         providers = {model["provider"] for model in response.json()["models"]}
-        self.assertNotIn("openrouter", providers)
+        self.assertIn("openrouter", providers)
+        self.assertIn("claude_platform", providers)


### PR DESCRIPTION
## Problem

Provider keys (`ANTHROPIC_AWS_WORKSPACE_ID`, `OPENROUTER_API_KEY`) are configured on the Celery workers that execute agent turns, not on the API process. That is the right split — the API never calls a provider — but `available_models()` credential-gated the catalog, so the API process hid models it had no keys for even though those models run fine on the worker.

In prod this showed up as a notebook picker with a single bare-label `claude-opus-5` entry (the generator-default fallback), and because `validate_model_ref()` validates against the same list, every non-default selection 400'd.

## Change

- Remove `_provider_configured()` and the credential filter from `available_models()`. `_CATALOG` is the allowlist on its own.
- `validate_model_ref()` follows automatically, so the API accepts any catalogued ref without keys.
- Keep the "prepend the generator default when it falls outside the catalog" behavior — that is independent of credentials (e.g. a Bedrock generator).
- Trim the rejection message to `unknown model: ...`, since unavailability is no longer a reason to reject.

The credential checks that matter are untouched: `OpenRouterProvider.complete()` and `ClaudePlatformProvider.complete()` each raise `ProviderError` with an explicit "not configured" message, on the worker, where the keys actually live.

## Tradeoff

A model whose worker key is genuinely missing now appears in the picker and fails at turn time instead of being hidden up front. Keys are set on the worker environments today, so this only bites on a future provider added without credentials — and it surfaces as a classified provider error, not a crash.

## Tests

The provider keys are already empty in the test environment, so the catalog tests were the credential-free case all along — they just did not say so. The class-level override that supplied fake keys is replaced by one supplying none, which pins the property deterministically (including for a developer whose `config_local` carries real keys) without a test that exists only to restate it.

The "default is always selectable" test now uses `RESEARCH_AI_GENERATOR_PROVIDER="bedrock"` to put the default outside the catalog, since a blank workspace id no longer hides anything.

Verified the guard bites: temporarily reinstating the gate fails four of the surviving tests across both files.

Full `research_ai` suite passes (1138 tests); ruff clean.
