### PR TITLE
[1/2] Add AI usage budget foundation

### DIFF
--- a/src/research_ai/migrations/0026_llmusageevent.py
+++ b/src/research_ai/migrations/0026_llmusageevent.py
@@ -1,0 +1,79 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("research_ai", "0025_proposaldraft_model_ref"),
+        ("user", "0150_author_user_soft_delete_fields"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="LLMUsageEvent",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_date", models.DateTimeField(auto_now_add=True)),
+                ("updated_date", models.DateTimeField(auto_now=True)),
+                ("feature", models.CharField(db_index=True, max_length=64)),
+                ("provider", models.CharField(max_length=64)),
+                ("model", models.CharField(max_length=255)),
+                ("input_tokens", models.PositiveBigIntegerField(blank=True, null=True)),
+                (
+                    "output_tokens",
+                    models.PositiveBigIntegerField(blank=True, null=True),
+                ),
+                (
+                    "cache_read_tokens",
+                    models.PositiveBigIntegerField(blank=True, null=True),
+                ),
+                (
+                    "cache_write_tokens",
+                    models.PositiveBigIntegerField(blank=True, null=True),
+                ),
+                (
+                    "web_search_requests",
+                    models.PositiveBigIntegerField(blank=True, null=True),
+                ),
+                (
+                    "cost_microusd",
+                    models.PositiveBigIntegerField(blank=True, null=True),
+                ),
+                (
+                    "execution",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="usage_events",
+                        to="research_ai.agentexecution",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="research_ai_usage_events",
+                        to="user.user",
+                    ),
+                ),
+            ],
+            options={"db_table": "research_ai_llm_usage_event"},
+        ),
+        migrations.AddIndex(
+            model_name="llmusageevent",
+            index=models.Index(
+                fields=["user", "created_date"], name="ra_usage_user_date"
+            ),
+        ),
+    ]

--- a/src/research_ai/models/__init__.py
+++ b/src/research_ai/models/__init__.py
@@ -12,6 +12,7 @@ from .expert_search import ExpertSearch
 from .generated_email import GeneratedEmail
 from .proposal_draft import ProposalDraft
 from .search_expert import SearchExpert
+from .usage_event import LLMUsageEvent
 
 __all__ = [
     "AgentContextMessage",
@@ -23,6 +24,7 @@ __all__ = [
     "Expert",
     "ExpertSearch",
     "GeneratedEmail",
+    "LLMUsageEvent",
     "NoteAgentConversation",
     "ProposalDraft",
     "SearchExpert",

--- a/src/research_ai/models/usage_event.py
+++ b/src/research_ai/models/usage_event.py
@@ -1,0 +1,37 @@
+from django.db import models
+
+from utils.models import DefaultModel
+
+
+class LLMUsageEvent(DefaultModel):
+    """Immutable accounting row for one provider model call."""
+
+    user = models.ForeignKey(
+        "user.User",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="research_ai_usage_events",
+    )
+    feature = models.CharField(max_length=64, db_index=True)
+    provider = models.CharField(max_length=64)
+    model = models.CharField(max_length=255)
+    input_tokens = models.PositiveBigIntegerField(null=True, blank=True)
+    output_tokens = models.PositiveBigIntegerField(null=True, blank=True)
+    cache_read_tokens = models.PositiveBigIntegerField(null=True, blank=True)
+    cache_write_tokens = models.PositiveBigIntegerField(null=True, blank=True)
+    web_search_requests = models.PositiveBigIntegerField(null=True, blank=True)
+    cost_microusd = models.PositiveBigIntegerField(null=True, blank=True)
+    execution = models.ForeignKey(
+        "research_ai.AgentExecution",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="usage_events",
+    )
+
+    class Meta:
+        db_table = "research_ai_llm_usage_event"
+        indexes = [
+            models.Index(fields=["user", "created_date"], name="ra_usage_user_date"),
+        ]

--- a/src/research_ai/permissions.py
+++ b/src/research_ai/permissions.py
@@ -3,11 +3,10 @@ from utils.permissions import AuthorizationBasedPermission
 
 class ResearchAIPermission(AuthorizationBasedPermission):
     """
-    Placeholder permission for Research AI features.
-    For now: allows any authenticated user. Compose with UserIsEditor | IsModerator
-    in views for editor/moderator access, e.g.:
-        permission_classes = [ResearchAIPermission, UserIsEditor | IsModerator]
-    Future: Add business logic here (min funded, subscription tier, credits).
+    Placeholder permission for legacy Research AI features.
+
+    Budgeted features use ``ResearchAIBudgetPermission`` so changing the
+    notebook/proposal rollout does not alter Expert Finder authorization.
     """
 
     message = "Not allowed to use Research AI features."
@@ -21,6 +20,21 @@ class ResearchAIPermission(AuthorizationBasedPermission):
         return self._can_use_research_ai(request.user)
 
     def _can_use_research_ai(self, user):
-        # Placeholder - expand with business logic later
-        # e.g., check minimum funding, subscription, credits
         return True
+
+
+class ResearchAIBudgetPermission(AuthorizationBasedPermission):
+    """Allow users whose resolved Research AI tier is not blocked."""
+
+    message = "Not allowed to use Research AI features."
+
+    def is_authorized(self, request, view, obj):
+        return self._can_use_research_ai(request.user)
+
+    def has_permission(self, request, view):
+        return self._can_use_research_ai(request.user)
+
+    def _can_use_research_ai(self, user):
+        from research_ai.services.usage_budget import resolve_ai_tier
+
+        return resolve_ai_tier(user).name != "blocked"

--- a/src/research_ai/services/agent/__init__.py
+++ b/src/research_ai/services/agent/__init__.py
@@ -26,6 +26,7 @@ Importing this package has no side effects (no network, no Django models).
 from research_ai.services.agent.agent_service import AgentService
 from research_ai.services.agent.errors import (
     AgentRunError,
+    BudgetExceededError,
     IncompleteTurnError,
     IterationLimitError,
     ProviderError,
@@ -70,6 +71,7 @@ __all__ = [
     "AgentService",
     "AssistantTurn",
     "BedrockProvider",
+    "BudgetExceededError",
     "ClaudePlatformProvider",
     "IncompleteTurnError",
     "IterationLimitError",

--- a/src/research_ai/services/agent/errors.py
+++ b/src/research_ai/services/agent/errors.py
@@ -82,3 +82,9 @@ class IncompleteTurnError(AgentRunError):
 
 class IterationLimitError(AgentRunError):
     """The loop hit ``max_iterations`` without the run completing."""
+
+
+class BudgetExceededError(AgentRunError):
+    """The user exhausted their daily budget during a multi-turn run."""
+
+    stop_reason = "budget_exhausted"

--- a/src/research_ai/services/agent/loop.py
+++ b/src/research_ai/services/agent/loop.py
@@ -228,6 +228,13 @@ class Agent:
         if not active:
             raise InterruptedError("agent execution is no longer running")
 
+    def _ensure_can_spend(self) -> None:
+        """Check cancellation and an optional recorder-owned spend guard."""
+        self._ensure_active()
+        before_model_call = getattr(self.recorder, "before_model_call", None)
+        if before_model_call is not None:
+            before_model_call()
+
     def _record_terminal(self, hook: str, *args) -> None:
         """Best-effort terminal observation must not mask the run outcome."""
         if self.recorder is None:
@@ -245,7 +252,7 @@ class Agent:
                 rendered_tools=rendered_tools,
                 max_tokens=self.max_tokens,
                 temperature=self.temperature,
-                before_retry=self._ensure_active,
+                before_retry=self._ensure_can_spend,
                 on_event=lambda event: self._record_stream_event(iteration, event),
             )
         except AgentRunError as exc:
@@ -369,7 +376,7 @@ class Agent:
             # call is the most expensive thing an iteration does and can hold the
             # worker for the vendor SDK's whole retry budget, so a run that was
             # stopped must not start another one.
-            self._ensure_active()
+            self._ensure_can_spend()
             turn = self._complete_turn(messages, rendered_tools, iteration)
             # The turn is replayed exactly as the provider sent it: reasoning
             # blocks are signed and must lead, and a server-side tool's result

--- a/src/research_ai/services/agent/loop.py
+++ b/src/research_ai/services/agent/loop.py
@@ -29,6 +29,7 @@ from research_ai.services.agent.types import (
     StopReason,
     TextBlock,
     ToolResultBlock,
+    TurnUsage,
 )
 
 logger = logging.getLogger(__name__)
@@ -253,6 +254,7 @@ class Agent:
                 max_tokens=self.max_tokens,
                 temperature=self.temperature,
                 before_retry=self._ensure_can_spend,
+                on_usage=self._record_usage,
                 on_event=lambda event: self._record_stream_event(iteration, event),
             )
         except AgentRunError as exc:
@@ -275,6 +277,18 @@ class Agent:
             ) from exc
         finally:
             self._flush_stream_events()
+
+    def _record_usage(self, usage: TurnUsage) -> None:
+        """Deliver one completed provider response's billable usage."""
+        callback = getattr(self.recorder, "record_usage", None)
+        if callback is None:
+            return
+        try:
+            callback(usage)
+        except Exception:  # noqa: BLE001 - observers are best-effort by default
+            if getattr(self.recorder, "requires_durable_usage", False):
+                raise
+            logger.warning("agent recorder record_usage failed", exc_info=True)
 
     def _record_stream_event(self, iteration: int, event) -> None:
         """Best-effort delivery of transient model output to an observer."""

--- a/src/research_ai/services/agent/model_pricing.py
+++ b/src/research_ai/services/agent/model_pricing.py
@@ -1,0 +1,113 @@
+"""Reviewed per-token prices for models exposed by the agent catalog."""
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+
+from research_ai.services.agent.model_capabilities import _normalized
+from research_ai.services.agent.providers.registry import split_model_ref
+from research_ai.services.agent.types import TurnUsage
+
+
+@dataclass(frozen=True)
+class ModelPricing:
+    """USD charged per million tokens for each provider usage bucket."""
+
+    input_usd_per_mtok: Decimal
+    output_usd_per_mtok: Decimal
+    cache_read_usd_per_mtok: Decimal
+    cache_write_usd_per_mtok: Decimal
+    web_search_usd_per_request: Decimal
+
+
+def _price(
+    input_: str,
+    output: str,
+    cache_read: str,
+    cache_write: str,
+    web_search: str = "0",
+) -> ModelPricing:
+    return ModelPricing(
+        *(
+            Decimal(value)
+            for value in (input_, output, cache_read, cache_write, web_search)
+        )
+    )
+
+
+# Prices are deliberately keyed by the same normalized ids as model capabilities.
+# Updating a vendor rate is one reviewed table edit; historical ledger rows retain
+# the price actually applied when their request completed.
+_CLAUDE_PLATFORM_PRICING = {
+    "claude-opus-5": _price("5", "25", "0.50", "6.25", "0.01"),
+    "claude-sonnet-5": _price("2", "10", "0.20", "2.50", "0.01"),
+    "claude-haiku-4-5": _price("1", "5", "0.10", "1.25", "0.01"),
+}
+
+_OPENROUTER_PRICING = {
+    "openai/gpt-5.6-sol": _price("2", "10", "0.20", "2.50"),
+    "openai/gpt-5.6-terra": _price("2", "12", "0.20", "2.50"),
+    "openai/gpt-5.6-luna": _price("0.20", "1.20", "0.02", "0.25"),
+    "google/gemini-3.1-pro-preview": _price("2", "12", "0.20", "0.375"),
+    "google/gemini-3.7-flash": _price("0.75", "3.75", "0.075", "0.04167"),
+    "x-ai/grok-4.6": _price("2", "6", "0.50", "2"),
+    "deepseek/deepseek-v4-pro-0813": _price("0.66", "1.98", "0.022", "0.66"),
+    "moonshotai/kimi-k3": _price("2.55", "12.75", "0.256", "2.55"),
+}
+
+_PROVIDER_PRICING = {
+    "claude_platform": _CLAUDE_PLATFORM_PRICING,
+    "openrouter": _OPENROUTER_PRICING,
+}
+
+
+def model_pricing(provider: str, model_id: str) -> ModelPricing | None:
+    """Return reviewed pricing, or ``None`` when a model is unpriced."""
+    return _PROVIDER_PRICING.get(provider, {}).get(_normalized(model_id))
+
+
+def cost_microusd(provider: str, model_id: str, usage: TurnUsage) -> int | None:
+    """Price one normalized provider turn in integer micro-USD.
+
+    A missing provider counter is treated as zero; an absent pricing row is
+    different and returns ``None`` so budgeted users can be refused safely.
+    """
+    pricing = model_pricing(provider, model_id)
+    if pricing is None:
+        return None
+    total = sum(
+        (
+            Decimal(tokens or 0) * rate
+            for tokens, rate in (
+                (usage.input_tokens, pricing.input_usd_per_mtok),
+                (usage.output_tokens, pricing.output_usd_per_mtok),
+                (usage.cache_read_tokens, pricing.cache_read_usd_per_mtok),
+                (usage.cache_write_tokens, pricing.cache_write_usd_per_mtok),
+            )
+        ),
+        Decimal(0),
+    )
+    total += (
+        Decimal(usage.web_search_requests or 0)
+        * pricing.web_search_usd_per_request
+        * Decimal(1_000_000)
+    )
+    # rate ($ / MTok) * tokens is numerically micro-USD.
+    return int(total.quantize(Decimal(1), rounding=ROUND_HALF_UP))
+
+
+def cost_multiplier(ref: str) -> Decimal | None:
+    """Blended input/output price relative to the cheapest catalog model."""
+    provider, model_id = split_model_ref(ref)
+    pricing = model_pricing(provider, model_id or "")
+    if pricing is None:
+        return None
+    reviewed = [
+        price
+        for provider_prices in _PROVIDER_PRICING.values()
+        for price in provider_prices.values()
+    ]
+    cheapest = min(
+        price.input_usd_per_mtok + price.output_usd_per_mtok for price in reviewed
+    )
+    blended = pricing.input_usd_per_mtok + pricing.output_usd_per_mtok
+    return (blended / cheapest).quantize(Decimal("0.1"), rounding=ROUND_HALF_UP)

--- a/src/research_ai/services/agent/providers/base.py
+++ b/src/research_ai/services/agent/providers/base.py
@@ -20,7 +20,12 @@ from collections.abc import Callable
 from typing import Any
 
 from research_ai.services.agent.tools import Tool
-from research_ai.services.agent.types import AssistantTurn, Message, ProviderStreamEvent
+from research_ai.services.agent.types import (
+    AssistantTurn,
+    Message,
+    ProviderStreamEvent,
+    TurnUsage,
+)
 
 
 class LLMProvider(ABC):
@@ -53,6 +58,7 @@ class LLMProvider(ABC):
         max_tokens: int | None,
         temperature: float,
         before_retry: Callable[[], None] | None = None,
+        on_usage: Callable[[TurnUsage], None] | None = None,
     ) -> AssistantTurn:
         """Run one model turn and return the parsed ``AssistantTurn``.
 
@@ -60,7 +66,10 @@ class LLMProvider(ABC):
         provider; it is passed through opaquely. ``max_tokens=None`` means the
         adapter's own output ceiling for its model. A provider that retries
         internally must invoke ``before_retry`` immediately before spending on
-        another request, when supplied.
+        another request, when supplied. It must invoke ``on_usage`` once for
+        every completed provider response carrying usage, before parsing that
+        response into a turn, so billable malformed or discarded responses are
+        still observable.
         """
         raise NotImplementedError
 
@@ -74,6 +83,7 @@ class LLMProvider(ABC):
         temperature: float,
         on_event: Callable[[ProviderStreamEvent], None] | None = None,
         before_retry: Callable[[], None] | None = None,
+        on_usage: Callable[[TurnUsage], None] | None = None,
     ) -> AssistantTurn:
         """Run one turn, optionally reporting normalized incremental output.
 
@@ -88,4 +98,5 @@ class LLMProvider(ABC):
             max_tokens=max_tokens,
             temperature=temperature,
             before_retry=before_retry,
+            on_usage=on_usage,
         )

--- a/src/research_ai/services/agent/providers/bedrock.py
+++ b/src/research_ai/services/agent/providers/bedrock.py
@@ -111,6 +111,7 @@ class BedrockProvider(LLMProvider):
         max_tokens: int | None,
         temperature: float,
         before_retry: Callable[[], None] | None = None,
+        on_usage: Callable[[TurnUsage], None] | None = None,
     ) -> AssistantTurn:
         inference_config: dict = {
             "maxTokens": MAX_OUTPUT_TOKENS if max_tokens is None else max_tokens
@@ -139,6 +140,9 @@ class BedrockProvider(LLMProvider):
             raise ProviderError(f"Bedrock complete failed: {e}") from e
 
         self._log_usage(response)
+        usage = self._parse_usage(response)
+        if usage is not None and on_usage is not None:
+            on_usage(usage)
         return self._parse_turn(response)
 
     # -- private helpers --------------------------------------------------

--- a/src/research_ai/services/agent/providers/claude_platform.py
+++ b/src/research_ai/services/agent/providers/claude_platform.py
@@ -401,6 +401,7 @@ class ClaudePlatformProvider(LLMProvider):
         max_tokens: int | None,
         temperature: float,
         before_retry: Callable[[], None] | None = None,
+        on_usage: Callable[[TurnUsage], None] | None = None,
     ) -> AssistantTurn:
         return self.complete_with_events(
             system_prompt=system_prompt,
@@ -409,6 +410,7 @@ class ClaudePlatformProvider(LLMProvider):
             max_tokens=max_tokens,
             temperature=temperature,
             before_retry=before_retry,
+            on_usage=on_usage,
         )
 
     def complete_with_events(
@@ -421,6 +423,7 @@ class ClaudePlatformProvider(LLMProvider):
         temperature: float,
         on_event: Callable[[ProviderStreamEvent], None] | None = None,
         before_retry: Callable[[], None] | None = None,
+        on_usage: Callable[[TurnUsage], None] | None = None,
     ) -> AssistantTurn:
         if self._client is None:
             raise ProviderError(
@@ -491,6 +494,9 @@ class ClaudePlatformProvider(LLMProvider):
                 ) from e
             responses.append(response)
             self._log_usage(response)
+            usage = self._parse_usage(response)
+            if usage is not None and on_usage is not None:
+                on_usage(usage)
             self._log_continuation_state(response)
             if not self._response_missing_required_container(
                 response, request_container_id=kwargs.get("container")

--- a/src/research_ai/services/agent/providers/claude_platform.py
+++ b/src/research_ai/services/agent/providers/claude_platform.py
@@ -760,11 +760,12 @@ class ClaudePlatformProvider(LLMProvider):
             return
         logger.info(
             "claude platform usage: input=%s cache_read=%s cache_write=%s "
-            "output=%s container_returned=%s",
+            "output=%s web_searches=%s container_returned=%s",
             getattr(usage, "input_tokens", None),
             getattr(usage, "cache_read_input_tokens", None),
             getattr(usage, "cache_creation_input_tokens", None),
             getattr(usage, "output_tokens", None),
+            self._server_tool_usage(usage, "web_search_requests"),
             getattr(response, "container", None) is not None,
         )
 
@@ -829,6 +830,7 @@ class ClaudePlatformProvider(LLMProvider):
             output_tokens=total("output_tokens"),
             cache_read_tokens=total("cache_read_tokens"),
             cache_write_tokens=total("cache_write_tokens"),
+            web_search_requests=total("web_search_requests"),
         )
 
     def _parse_turn(self, response: Any, *, latency_ms: int | None = None):
@@ -930,4 +932,12 @@ class ClaudePlatformProvider(LLMProvider):
             output_tokens=getattr(usage, "output_tokens", None),
             cache_read_tokens=getattr(usage, "cache_read_input_tokens", None),
             cache_write_tokens=getattr(usage, "cache_creation_input_tokens", None),
+            web_search_requests=self._server_tool_usage(usage, "web_search_requests"),
         )
+
+    @staticmethod
+    def _server_tool_usage(usage: Any, name: str) -> int | None:
+        server_usage = getattr(usage, "server_tool_use", None)
+        if isinstance(server_usage, dict):
+            return server_usage.get(name)
+        return getattr(server_usage, name, None)

--- a/src/research_ai/services/agent/providers/openrouter.py
+++ b/src/research_ai/services/agent/providers/openrouter.py
@@ -367,15 +367,31 @@ class OpenRouterProvider(LLMProvider):
         usage = getattr(response, "usage", None)
         if usage is None:
             return None
+        prompt_tokens = getattr(usage, "prompt_tokens", None)
+        cache_read_tokens = self._cache_detail(usage, "cached_tokens")
+        cache_write_tokens = self._cache_detail(usage, "cache_write_tokens")
+        uncached_input_tokens = (
+            max(
+                0,
+                prompt_tokens - (cache_read_tokens or 0) - (cache_write_tokens or 0),
+            )
+            if prompt_tokens is not None
+            else None
+        )
         return TurnUsage(
-            input_tokens=getattr(usage, "prompt_tokens", None),
+            input_tokens=uncached_input_tokens,
             output_tokens=getattr(usage, "completion_tokens", None),
-            cache_read_tokens=self._cached_tokens(usage),
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
         )
 
     @staticmethod
     def _cached_tokens(usage: Any) -> int | None:
+        return OpenRouterProvider._cache_detail(usage, "cached_tokens")
+
+    @staticmethod
+    def _cache_detail(usage: Any, name: str) -> int | None:
         details = getattr(usage, "prompt_tokens_details", None)
         if details is None:
             return None
-        return getattr(details, "cached_tokens", None)
+        return getattr(details, name, None)

--- a/src/research_ai/services/agent/providers/openrouter.py
+++ b/src/research_ai/services/agent/providers/openrouter.py
@@ -182,6 +182,7 @@ class OpenRouterProvider(LLMProvider):
         max_tokens: int | None,
         temperature: float,
         before_retry: Callable[[], None] | None = None,
+        on_usage: Callable[[TurnUsage], None] | None = None,
     ) -> AssistantTurn:
         if self._client is None:
             raise ProviderError(
@@ -229,6 +230,9 @@ class OpenRouterProvider(LLMProvider):
         latency_ms = int((time.perf_counter() - started) * 1000)
 
         self._log_usage(response)
+        usage = self._parse_usage(response)
+        if usage is not None and on_usage is not None:
+            on_usage(usage)
         return self._parse_turn(response, latency_ms=latency_ms)
 
     # -- private helpers --------------------------------------------------

--- a/src/research_ai/services/agent/recorder.py
+++ b/src/research_ai/services/agent/recorder.py
@@ -63,3 +63,6 @@ class AgentRecorder(Protocol):
         required of observers that cannot be pre-empted.
         """
         ...
+
+    def before_model_call(self) -> None:
+        """Optional pre-spend hook, called before each request and retry."""

--- a/src/research_ai/services/agent/recorder.py
+++ b/src/research_ai/services/agent/recorder.py
@@ -1,14 +1,15 @@
 """Transcript recording hook for the agent loop.
 
-An ``AgentRecorder`` observes a run as it happens: the loop calls
-``record_message`` at each point a ``Message`` is appended to the conversation
-(the seed user turn, each assistant turn, each tool-result turn), then exactly
-one of ``on_run_finished`` / ``on_run_failed`` when the run ends.
+An ``AgentRecorder`` observes a run as it happens: providers report each
+completed response through ``record_usage``, the loop calls ``record_message``
+at each point a ``Message`` is appended to the conversation (the seed user
+turn, each assistant turn, each tool-result turn), then exactly one of
+``on_run_finished`` / ``on_run_failed`` when the run ends.
 
 This module defines only the protocol -- implementations live outside the
 ``agent`` package and are injected by callers, keeping the core Django-free.
-Message-hook failures are best-effort unless an implementation opts into the
-``requires_durable_messages`` contract; terminal-hook failures are logged
+Usage- and message-hook failures are best-effort unless an implementation opts
+into the corresponding durability contract; terminal-hook failures are logged
 without masking the original run outcome.
 """
 
@@ -16,7 +17,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol
 
-from research_ai.services.agent.types import AssistantTurn, Message
+from research_ai.services.agent.types import AssistantTurn, Message, TurnUsage
 
 if TYPE_CHECKING:
     from research_ai.services.agent.loop import AgentResult
@@ -24,6 +25,15 @@ if TYPE_CHECKING:
 
 class AgentRecorder(Protocol):
     """Observes messages and the terminal outcome of one agent run."""
+
+    def record_usage(self, usage: TurnUsage) -> None:
+        """Record one completed provider response's billable usage.
+
+        This hook runs before response parsing and independently of message
+        persistence. A recorder that sets ``requires_durable_usage`` may
+        propagate failures so a run cannot continue after losing accounting.
+        """
+        ...
 
     def record_message(
         self, message: Message, *, turn: AssistantTurn | None = None

--- a/src/research_ai/services/agent/types.py
+++ b/src/research_ai/services/agent/types.py
@@ -133,9 +133,9 @@ class Message:
 
 @dataclass(frozen=True)
 class TurnUsage:
-    """Normalized token accounting for a single model turn.
+    """Normalized billable accounting for a single model turn.
 
-    Each adapter maps its provider's usage shape onto these four counters; a
+    Each adapter maps its provider's usage shape onto these counters; a
     counter the provider did not report stays ``None`` (distinct from a
     reported zero).
     """
@@ -144,6 +144,7 @@ class TurnUsage:
     output_tokens: int | None = None
     cache_read_tokens: int | None = None
     cache_write_tokens: int | None = None
+    web_search_requests: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/research_ai/services/usage_budget/__init__.py
+++ b/src/research_ai/services/usage_budget/__init__.py
@@ -1,0 +1,36 @@
+from .config import TierPolicy, tier_policies
+from .recorder import AgentLoopBudgetRecorder
+from .service import (
+    BudgetExceededError,
+    BudgetStatus,
+    ModelNotAllowedError,
+    UsageLimitExceededError,
+    UsageWorkInProgressError,
+    atomic_turn_admission,
+    budget_status,
+    check_budget_admission,
+    check_turn_admission,
+    effective_generation_options,
+    record,
+    resolve_ai_tier,
+    resolve_default_model,
+)
+
+__all__ = [
+    "AgentLoopBudgetRecorder",
+    "BudgetExceededError",
+    "BudgetStatus",
+    "ModelNotAllowedError",
+    "TierPolicy",
+    "UsageLimitExceededError",
+    "UsageWorkInProgressError",
+    "atomic_turn_admission",
+    "budget_status",
+    "check_budget_admission",
+    "check_turn_admission",
+    "effective_generation_options",
+    "record",
+    "resolve_ai_tier",
+    "resolve_default_model",
+    "tier_policies",
+]

--- a/src/research_ai/services/usage_budget/config.py
+++ b/src/research_ai/services/usage_budget/config.py
@@ -1,0 +1,60 @@
+"""Code-owned Research AI tier policies."""
+
+from dataclasses import dataclass, replace
+
+DEFAULT_OPEN_WEIGHT_MODEL = "openrouter:deepseek/deepseek-v4-pro-0813"
+BUDGETS_ENFORCED = True
+DEFAULT_DAILY_BUDGET_MICROUSD = 250_000
+DEFAULT_DAILY_TURN_CAP = 10
+INVITED_DAILY_BUDGET_MICROUSD = 10_000_000
+INVITED_DAILY_TURN_CAP = 200
+PRIVILEGED_DAILY_BUDGET_MICROUSD = 100_000_000
+PRIVILEGED_DAILY_TURN_CAP = 2000
+
+
+@dataclass(frozen=True)
+class TierPolicy:
+    name: str
+    daily_budget_microusd: int | None
+    daily_turn_cap: int | None
+    allowed_model_refs: tuple[str, ...] | None
+    default_model_ref: str | None
+    max_effort: str | None = None
+    allowed_thinking_modes: tuple[str, ...] | None = None
+
+    @property
+    def is_budgeted(self) -> bool:
+        return self.daily_budget_microusd is not None or self.daily_turn_cap is not None
+
+
+def tier_policies() -> dict[str, TierPolicy]:
+    """Build fresh policy values for each resolution."""
+    default = TierPolicy(
+        name="default",
+        daily_budget_microusd=DEFAULT_DAILY_BUDGET_MICROUSD,
+        daily_turn_cap=DEFAULT_DAILY_TURN_CAP,
+        allowed_model_refs=(DEFAULT_OPEN_WEIGHT_MODEL,),
+        default_model_ref=DEFAULT_OPEN_WEIGHT_MODEL,
+        max_effort="none",
+        allowed_thinking_modes=("disabled",),
+    )
+    invited = TierPolicy(
+        name="invited",
+        daily_budget_microusd=INVITED_DAILY_BUDGET_MICROUSD,
+        daily_turn_cap=INVITED_DAILY_TURN_CAP,
+        allowed_model_refs=None,
+        default_model_ref=None,
+    )
+    privileged = TierPolicy(
+        name="privileged",
+        daily_budget_microusd=PRIVILEGED_DAILY_BUDGET_MICROUSD,
+        daily_turn_cap=PRIVILEGED_DAILY_TURN_CAP,
+        allowed_model_refs=None,
+        default_model_ref=None,
+    )
+    blocked = TierPolicy("blocked", 0, 0, (), None)
+    # ``replace`` keeps policies independent even if future defaults share fields.
+    return {
+        policy.name: replace(policy)
+        for policy in (blocked, privileged, invited, default)
+    }

--- a/src/research_ai/services/usage_budget/recorder.py
+++ b/src/research_ai/services/usage_budget/recorder.py
@@ -1,0 +1,82 @@
+"""Budget accounting wrapper for calls made by the modern agent loop."""
+
+from research_ai.services.agent.types import AssistantTurn, Message
+from research_ai.services.usage_budget.service import ensure_budget_available, record
+
+
+class AgentLoopBudgetRecorder:
+    """Add per-call budget checks and accounting to an optional loop recorder.
+
+    The wrapper is deliberately attached at ``AgentService`` call sites. Direct
+    provider integrations and legacy LLM workflows never receive it and remain
+    outside this budget rollout.
+    """
+
+    def __init__(
+        self,
+        *,
+        user,
+        feature: str,
+        provider: str,
+        model_id: str,
+        recorder=None,
+        execution=None,
+    ):
+        self.user = user
+        self.feature = feature
+        self.provider = provider
+        self.model_id = model_id
+        self._recorder = recorder
+        self.execution = execution or getattr(recorder, "execution", None)
+        # Losing a usage row would silently reopen budget that was actually
+        # spent, so accounting writes are required even without a transcript.
+        self.requires_durable_messages = True
+
+    def __getattr__(self, name):
+        if self._recorder is None:
+            raise AttributeError(name)
+        return getattr(self._recorder, name)
+
+    def is_active(self) -> bool:
+        callback = getattr(self._recorder, "is_active", None)
+        return True if callback is None else callback()
+
+    def before_model_call(self) -> None:
+        if self.user is not None:
+            ensure_budget_available(self.user)
+        callback = getattr(self._recorder, "before_model_call", None)
+        if callback is not None:
+            callback()
+
+    def record_message(
+        self, message: Message, *, turn: AssistantTurn | None = None
+    ) -> None:
+        if self.user is not None and turn is not None and turn.usage is not None:
+            record(
+                self.user,
+                self.feature,
+                self.provider,
+                self.model_id,
+                turn.usage,
+                execution=self.execution,
+            )
+        if self._recorder is not None:
+            self._recorder.record_message(message, turn=turn)
+
+    def on_run_finished(self, result):
+        callback = getattr(self._recorder, "on_run_finished", None)
+        return None if callback is None else callback(result)
+
+    def on_run_failed(self, error: Exception):
+        callback = getattr(self._recorder, "on_run_failed", None)
+        return None if callback is None else callback(error)
+
+    def record_stream_event(self, iteration, event) -> None:
+        callback = getattr(self._recorder, "record_stream_event", None)
+        if callback is not None:
+            callback(iteration, event)
+
+    def flush_stream_events(self) -> None:
+        callback = getattr(self._recorder, "flush_stream_events", None)
+        if callback is not None:
+            callback()

--- a/src/research_ai/services/usage_budget/recorder.py
+++ b/src/research_ai/services/usage_budget/recorder.py
@@ -1,6 +1,6 @@
 """Budget accounting wrapper for calls made by the modern agent loop."""
 
-from research_ai.services.agent.types import AssistantTurn, Message
+from research_ai.services.agent.types import AssistantTurn, Message, TurnUsage
 from research_ai.services.usage_budget.service import ensure_budget_available, record
 
 
@@ -30,7 +30,7 @@ class AgentLoopBudgetRecorder:
         self.execution = execution or getattr(recorder, "execution", None)
         # Losing a usage row would silently reopen budget that was actually
         # spent, so accounting writes are required even without a transcript.
-        self.requires_durable_messages = True
+        self.requires_durable_usage = True
 
     def __getattr__(self, name):
         if self._recorder is None:
@@ -48,18 +48,23 @@ class AgentLoopBudgetRecorder:
         if callback is not None:
             callback()
 
-    def record_message(
-        self, message: Message, *, turn: AssistantTurn | None = None
-    ) -> None:
-        if self.user is not None and turn is not None and turn.usage is not None:
+    def record_usage(self, usage: TurnUsage) -> None:
+        if self.user is not None:
             record(
                 self.user,
                 self.feature,
                 self.provider,
                 self.model_id,
-                turn.usage,
+                usage,
                 execution=self.execution,
             )
+        callback = getattr(self._recorder, "record_usage", None)
+        if callback is not None:
+            callback(usage)
+
+    def record_message(
+        self, message: Message, *, turn: AssistantTurn | None = None
+    ) -> None:
         if self._recorder is not None:
             self._recorder.record_message(message, turn=turn)
 

--- a/src/research_ai/services/usage_budget/service.py
+++ b/src/research_ai/services/usage_budget/service.py
@@ -95,6 +95,8 @@ def resolve_ai_tier(user) -> TierPolicy:
     if (
         user is None
         or not getattr(user, "is_authenticated", False)
+        or not getattr(user, "is_active", False)
+        or getattr(user, "is_removed", False)
         or getattr(user, "is_suspended", False)
         or getattr(user, "probable_spammer", False)
     ):
@@ -311,7 +313,17 @@ def record(
 
 def ensure_budget_available(user) -> None:
     """Between-call guard used by budget-aware modern agent-loop recorders."""
+    user_id = getattr(user, "pk", None)
+    if user_id is not None:
+        manager = getattr(type(user), "all_objects", type(user)._default_manager)
+        try:
+            user = manager.get(pk=user_id)
+        except type(user).DoesNotExist:
+            user = None
+
     policy = resolve_ai_tier(user)
+    if policy.name == "blocked":
+        raise BudgetExceededError("Research AI access is blocked")
     if not policy.is_budgeted or not BUDGETS_ENFORCED:
         return
     status = budget_status(user)

--- a/src/research_ai/services/usage_budget/service.py
+++ b/src/research_ai/services/usage_budget/service.py
@@ -1,0 +1,319 @@
+"""Tier resolution, accounting, and admission for Research AI spend."""
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime, time, timedelta
+from decimal import Decimal
+
+from django.db import transaction
+from django.db.models import BigIntegerField, Count, Sum
+from django.db.models.functions import Coalesce
+from django.utils import timezone
+
+from research_ai.models import (
+    AgentExecution,
+    Expert,
+    LLMUsageEvent,
+    ProposalDraft,
+)
+from research_ai.services.agent.errors import BudgetExceededError
+from research_ai.services.agent.model_capabilities import EFFORT_LEVELS
+from research_ai.services.agent.model_catalog import available_models
+from research_ai.services.agent.model_pricing import cost_microusd, model_pricing
+from research_ai.services.agent.providers.registry import (
+    generator_model_ref,
+    split_model_ref,
+)
+from research_ai.services.agent.types import TurnUsage
+from research_ai.services.usage_budget.config import (
+    BUDGETS_ENFORCED,
+    TierPolicy,
+    tier_policies,
+)
+
+
+class ModelNotAllowedError(ValueError):
+    code = "model_not_allowed"
+
+
+class UsageLimitExceededError(RuntimeError):
+    code = "usage_limit_exceeded"
+
+    def __init__(self, status: "BudgetStatus"):
+        super().__init__("Daily Research AI usage limit exceeded")
+        self.status = status
+
+
+class UsageWorkInProgressError(RuntimeError):
+    code = "usage_work_in_progress"
+
+
+@dataclass(frozen=True)
+class BudgetStatus:
+    tier: str
+    daily_budget_microusd: int | None
+    spent_today_microusd: int
+    turns_used: int
+    turn_cap: int | None
+    resets_at: datetime
+
+    @property
+    def remaining_microusd(self) -> int | None:
+        if self.daily_budget_microusd is None:
+            return None
+        return max(0, self.daily_budget_microusd - self.spent_today_microusd)
+
+    @property
+    def exhausted(self) -> bool:
+        budget_hit = (
+            self.daily_budget_microusd is not None
+            and self.spent_today_microusd >= self.daily_budget_microusd
+        )
+        cap_hit = self.turn_cap is not None and self.turns_used >= self.turn_cap
+        return budget_hit or cap_hit
+
+    @staticmethod
+    def _usd(value: int | None) -> str | None:
+        if value is None:
+            return None
+        return format(Decimal(value) / Decimal(1000000), "f")
+
+    def as_dict(self) -> dict:
+        return {
+            "tier": self.tier,
+            "daily_budget": self._usd(self.daily_budget_microusd),
+            "spent_today": self._usd(self.spent_today_microusd),
+            "remaining": self._usd(self.remaining_microusd),
+            "turns_used": self.turns_used,
+            "turn_cap": self.turn_cap,
+            "resets_at": self.resets_at.isoformat().replace("+00:00", "Z"),
+        }
+
+
+def resolve_ai_tier(user) -> TierPolicy:
+    policies = tier_policies()
+    if (
+        user is None
+        or not getattr(user, "is_authenticated", False)
+        or getattr(user, "is_suspended", False)
+        or getattr(user, "probable_spammer", False)
+    ):
+        return policies["blocked"]
+    elevated_role = getattr(user, "is_moderator_or_editor", None)
+    if getattr(user, "is_staff", False) or (
+        callable(elevated_role) and elevated_role()
+    ):
+        return policies["privileged"]
+    if (
+        getattr(user, "pk", None)
+        and Expert.objects.filter(registered_user=user).exists()
+    ):
+        return policies["invited"]
+    return policies["default"]
+
+
+def _utc_window(now: datetime | None = None) -> tuple[datetime, datetime]:
+    now = now or timezone.now()
+    utc_now = now.astimezone(UTC)
+    start = datetime.combine(utc_now.date(), time.min, tzinfo=UTC)
+    return start, start + timedelta(days=1)
+
+
+def budget_status(user, *, now: datetime | None = None) -> BudgetStatus:
+    policy = resolve_ai_tier(user)
+    start, reset = _utc_window(now)
+    usage = LLMUsageEvent.objects.filter(
+        user=user, created_date__gte=start, created_date__lt=reset
+    ).aggregate(
+        spent=Coalesce(Sum("cost_microusd"), 0, output_field=BigIntegerField()),
+        turns=Count("id"),
+    )
+    return BudgetStatus(
+        tier=policy.name,
+        daily_budget_microusd=policy.daily_budget_microusd,
+        spent_today_microusd=int(usage["spent"] or 0),
+        turns_used=int(usage["turns"] or 0),
+        turn_cap=policy.daily_turn_cap,
+        resets_at=reset,
+    )
+
+
+def _validate_model(policy: TierPolicy, model_ref: str) -> None:
+    if policy.name == "blocked":
+        raise ModelNotAllowedError("Research AI access is blocked")
+    if (
+        policy.allowed_model_refs is not None
+        and model_ref not in policy.allowed_model_refs
+    ):
+        raise ModelNotAllowedError(
+            f"model {model_ref!r} is not allowed for tier {policy.name!r}"
+        )
+    provider, model_id = split_model_ref(model_ref)
+    if policy.is_budgeted and model_pricing(provider, model_id or "") is None:
+        raise ModelNotAllowedError(f"model {model_ref!r} has no reviewed pricing")
+    if model_ref not in {option.ref for option in available_models()}:
+        raise ModelNotAllowedError(f"model {model_ref!r} is not configured")
+
+
+def resolve_default_model(policy: TierPolicy) -> str:
+    """Choose a configured, priced model allowed by ``policy``."""
+    candidates = []
+    for option in available_models():
+        entitled = (
+            policy.allowed_model_refs is None or option.ref in policy.allowed_model_refs
+        )
+        provider, model_id = split_model_ref(option.ref)
+        priced = model_pricing(provider, model_id or "") is not None
+        if entitled and (not policy.is_budgeted or priced):
+            candidates.append(option.ref)
+
+    preferred = policy.default_model_ref or generator_model_ref()
+    if preferred in candidates:
+        return preferred
+    if candidates:
+        return candidates[0]
+    raise ModelNotAllowedError(
+        f"No configured model is available for tier {policy.name!r}"
+    )
+
+
+def effective_generation_options(
+    policy: TierPolicy,
+    *,
+    effort: str | None,
+    thinking: str | None,
+) -> tuple[str | None, str | None]:
+    """Apply tier defaults and reject controls above its ceiling."""
+    if policy.max_effort is not None:
+        maximum = EFFORT_LEVELS.index(policy.max_effort)
+        effective_effort = effort if effort is not None else policy.max_effort
+        if (
+            effective_effort not in EFFORT_LEVELS
+            or EFFORT_LEVELS.index(effective_effort) > maximum
+        ):
+            raise ModelNotAllowedError(
+                f"effort {effective_effort!r} is not allowed for tier {policy.name!r}"
+            )
+        effort = effective_effort
+    if policy.allowed_thinking_modes is not None:
+        thinking = (
+            thinking if thinking is not None else policy.allowed_thinking_modes[0]
+        )
+        if thinking not in policy.allowed_thinking_modes:
+            raise ModelNotAllowedError(
+                f"thinking {thinking!r} is not allowed for tier {policy.name!r}"
+            )
+    return effort, thinking
+
+
+def check_turn_admission(
+    user,
+    model_ref: str,
+    *,
+    effort: str | None = None,
+    thinking: str | None = None,
+) -> BudgetStatus:
+    policy = resolve_ai_tier(user)
+    _validate_model(policy, model_ref)
+    effective_generation_options(policy, effort=effort, thinking=thinking)
+    status = budget_status(user)
+    if BUDGETS_ENFORCED and status.exhausted:
+        raise UsageLimitExceededError(status)
+    return status
+
+
+def check_budget_admission(user) -> BudgetStatus:
+    """Check only the dollar/turn counters for a fixed-model feature."""
+    status = budget_status(user)
+    if BUDGETS_ENFORCED and status.exhausted:
+        raise UsageLimitExceededError(status)
+    return status
+
+
+def _has_in_flight_work(user) -> bool:
+    """Whether a budgeted user already has spend-producing work reserved."""
+    return (
+        AgentExecution.objects.filter(
+            conversation__user=user,
+            status__in=[
+                AgentExecution.Status.PENDING,
+                AgentExecution.Status.RUNNING,
+            ],
+        ).exists()
+        or ProposalDraft.objects.filter(
+            created_by=user,
+            status__in=[
+                ProposalDraft.Status.PENDING,
+                ProposalDraft.Status.PROCESSING,
+            ],
+        ).exists()
+    )
+
+
+@contextmanager
+def atomic_turn_admission(
+    user,
+    model_ref: str | None = None,
+    *,
+    effort: str | None = None,
+    thinking: str | None = None,
+):
+    """Atomically reserve one in-flight budgeted job for ``user``.
+
+    The caller must create its pending execution or draft before leaving
+    this context. That row is the reservation observed by the next admission.
+    Restricting budgeted users to one in-flight top-level job keeps soft
+    enforcement's overshoot bounded to the currently running provider call.
+    """
+    with transaction.atomic():
+        locked_user = type(user)._default_manager.select_for_update().get(pk=user.pk)
+        policy = resolve_ai_tier(locked_user)
+        if BUDGETS_ENFORCED and policy.is_budgeted and _has_in_flight_work(locked_user):
+            raise UsageWorkInProgressError(
+                "Another Research AI request is still in progress"
+            )
+        status = (
+            check_turn_admission(
+                locked_user,
+                model_ref,
+                effort=effort,
+                thinking=thinking,
+            )
+            if model_ref is not None
+            else check_budget_admission(locked_user)
+        )
+        yield status
+
+
+def record(
+    user,
+    feature: str,
+    provider: str,
+    model_id: str,
+    usage: TurnUsage,
+    *,
+    execution=None,
+) -> LLMUsageEvent:
+    return LLMUsageEvent.objects.create(
+        user=user,
+        feature=feature,
+        provider=provider,
+        model=model_id,
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        cache_read_tokens=usage.cache_read_tokens,
+        cache_write_tokens=usage.cache_write_tokens,
+        web_search_requests=usage.web_search_requests,
+        cost_microusd=cost_microusd(provider, model_id, usage),
+        execution=execution,
+    )
+
+
+def ensure_budget_available(user) -> None:
+    """Between-call guard used by budget-aware modern agent-loop recorders."""
+    policy = resolve_ai_tier(user)
+    if not policy.is_budgeted or not BUDGETS_ENFORCED:
+        return
+    status = budget_status(user)
+    if status.exhausted:
+        raise BudgetExceededError("Daily Research AI usage limit exceeded")

--- a/src/research_ai/tests/agent/test_claude_platform_provider.py
+++ b/src/research_ai/tests/agent/test_claude_platform_provider.py
@@ -178,6 +178,7 @@ def _complete(
     max_tokens=100,
     temperature=0.0,
     before_retry=None,
+    on_usage=None,
 ):
     return provider.complete(
         system_prompt="sys",
@@ -186,6 +187,7 @@ def _complete(
         max_tokens=max_tokens,
         temperature=temperature,
         before_retry=before_retry,
+        on_usage=on_usage,
     )
 
 
@@ -1225,12 +1227,20 @@ class ServerSideToolTests(SimpleTestCase):
                 _build_response([unresolved], stop_reason="pause_turn"),
             ]
         )
+        observed_usage = []
 
         # Act / Assert: the provider fails before returning an AssistantTurn,
-        # so the agent recorder cannot append either unreplayable response.
+        # but both completed responses still report their billable usage.
         with self.assertRaisesMessage(ProviderError, "unreplayable response"):
-            _complete(provider)
+            _complete(provider, on_usage=observed_usage.append)
         self.assertEqual(len(provider._client.messages.calls), 2)
+        self.assertEqual(
+            observed_usage,
+            [
+                TurnUsage(input_tokens=10, output_tokens=3),
+                TurnUsage(input_tokens=10, output_tokens=3),
+            ],
+        )
 
     def test_cancellation_probe_stops_missing_container_retry(self):
         # Arrange

--- a/src/research_ai/tests/agent/test_claude_platform_provider.py
+++ b/src/research_ai/tests/agent/test_claude_platform_provider.py
@@ -610,6 +610,25 @@ class CompleteAndParseTests(SimpleTestCase):
         )
         self.assertIsNotNone(turn.latency_ms)
 
+    def test_usage_includes_billed_web_search_requests(self):
+        # Arrange
+        provider = _build_provider([])
+        response = SimpleNamespace(
+            usage=SimpleNamespace(
+                input_tokens=10,
+                output_tokens=3,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=0,
+                server_tool_use=SimpleNamespace(web_search_requests=2),
+            )
+        )
+
+        # Act
+        usage = provider._parse_usage(response)
+
+        # Assert
+        self.assertEqual(usage.web_search_requests, 2)
+
     def test_refusal_stop_reason_maps_to_content_filtered(self):
         # Arrange: a policy decline is a 200 with empty content, not an error.
         provider = _build_provider([_build_response([], stop_reason="refusal")])

--- a/src/research_ai/tests/agent/test_loop.py
+++ b/src/research_ai/tests/agent/test_loop.py
@@ -19,6 +19,7 @@ from research_ai.services.agent.types import (
     TextStreamDelta,
     ThinkingBlock,
     ToolUseBlock,
+    TurnUsage,
 )
 
 
@@ -96,8 +97,12 @@ class RecordingRecorder:
         self.messages = []  # (message, turn) pairs, in recording order
         self.finished = []
         self.failed = []
+        self.usages = []
         self.stream_events = []
         self.stream_flushes = 0
+
+    def record_usage(self, usage):
+        self.usages.append(usage)
 
     def record_message(self, message, *, turn=None):
         self.messages.append((message, turn))
@@ -175,6 +180,32 @@ class ServerResultSummaryTests(SimpleTestCase):
 
 
 class AgentLoopTests(SimpleTestCase):
+    def test_provider_usage_reaches_recorder_before_provider_failure(self):
+        # Arrange: a provider received a billable response but rejected it
+        # before it could return an AssistantTurn to the loop.
+        usage = TurnUsage(input_tokens=10, output_tokens=3)
+
+        class RespondingThenFailingProvider(FakeProvider):
+            def complete(self, *, on_usage, **kwargs):
+                on_usage(usage)
+                raise ProviderError("response could not be replayed")
+
+        recorder = RecordingRecorder()
+        agent = _build_agent(
+            RespondingThenFailingProvider([]),
+            _build_toolset(),
+            recorder=recorder,
+        )
+
+        # Act
+        with self.assertRaises(ProviderError):
+            agent.run("research")
+
+        # Assert
+        self.assertEqual(recorder.usages, [usage])
+        self.assertEqual(recorder.messages[0][0].role, "user")
+        self.assertEqual(len(recorder.messages), 1)
+
     def test_provider_retry_rechecks_execution_activity(self):
         # Arrange: the run is active before its first provider request, then is
         # cancelled while that request is in flight.

--- a/src/research_ai/tests/agent/test_model_pricing.py
+++ b/src/research_ai/tests/agent/test_model_pricing.py
@@ -1,0 +1,43 @@
+from decimal import Decimal
+
+from django.test import SimpleTestCase
+
+from research_ai.services.agent.model_pricing import cost_microusd, cost_multiplier
+from research_ai.services.agent.types import TurnUsage
+
+
+class ModelPricingTests(SimpleTestCase):
+    def test_prices_all_four_usage_buckets_in_microusd(self):
+        # Arrange
+        usage = TurnUsage(1_000_000, 1_000_000, 1_000_000, 1_000_000)
+
+        # Act
+        cost = cost_microusd("openrouter", "deepseek/deepseek-v4-pro-0813", usage)
+
+        # Assert
+        self.assertEqual(cost, 3_322_000)
+
+    def test_unpriced_model_returns_none(self):
+        self.assertIsNone(cost_microusd("openrouter", "unknown/model", TurnUsage(1, 1)))
+
+    def test_claude_web_search_requests_add_one_cent_each(self):
+        # Arrange
+        usage = TurnUsage(web_search_requests=2)
+
+        # Act
+        cost = cost_microusd("claude_platform", "claude-opus-5", usage)
+
+        # Assert
+        self.assertEqual(cost, 20_000)
+
+    def test_cheapest_catalog_model_is_one_x(self):
+        self.assertEqual(
+            cost_multiplier("openrouter:openai/gpt-5.6-luna"),
+            Decimal("1.0"),
+        )
+
+    def test_multiplier_is_relative_to_cheapest_catalog_model(self):
+        self.assertEqual(
+            cost_multiplier("openrouter:deepseek/deepseek-v4-pro-0813"),
+            Decimal("1.9"),
+        )

--- a/src/research_ai/tests/agent/test_openrouter_provider.py
+++ b/src/research_ai/tests/agent/test_openrouter_provider.py
@@ -405,7 +405,10 @@ class ParseTurnTests(SimpleTestCase):
         usage = SimpleNamespace(
             prompt_tokens=100,
             completion_tokens=20,
-            prompt_tokens_details=SimpleNamespace(cached_tokens=80),
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=80,
+                cache_write_tokens=10,
+            ),
         )
         provider = _build_provider([_response(content="ok", usage=usage)])
 
@@ -413,9 +416,10 @@ class ParseTurnTests(SimpleTestCase):
         turn = _complete(provider)
 
         # Assert
-        self.assertEqual(turn.usage.input_tokens, 100)
+        self.assertEqual(turn.usage.input_tokens, 10)
         self.assertEqual(turn.usage.output_tokens, 20)
         self.assertEqual(turn.usage.cache_read_tokens, 80)
+        self.assertEqual(turn.usage.cache_write_tokens, 10)
 
     def test_reasoning_details_are_preserved_for_replay(self):
         # Arrange

--- a/src/research_ai/tests/test_model_views.py
+++ b/src/research_ai/tests/test_model_views.py
@@ -20,7 +20,7 @@ class AvailableModelsViewTests(APITestCase):
         # Assert
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_requires_editor_or_moderator(self):
+    def test_default_user_receives_tier_catalog(self):
         # Arrange
         self.client.force_authenticate(self.user)
 
@@ -28,7 +28,11 @@ class AvailableModelsViewTests(APITestCase):
         response = self.client.get(URL)
 
         # Assert
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json()["default"],
+            "openrouter:deepseek/deepseek-v4-pro-0813",
+        )
 
     def test_lists_models_and_the_default(self):
         # Arrange
@@ -47,7 +51,15 @@ class AvailableModelsViewTests(APITestCase):
         for model in data["models"]:
             self.assertEqual(
                 sorted(model),
-                ["capabilities", "description", "label", "provider", "ref"],
+                [
+                    "allowed",
+                    "capabilities",
+                    "description",
+                    "label",
+                    "multiplier",
+                    "provider",
+                    "ref",
+                ],
             )
 
         opus = next(

--- a/src/research_ai/tests/test_permissions.py
+++ b/src/research_ai/tests/test_permissions.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory, TestCase
 
-from research_ai.permissions import ResearchAIPermission
+from research_ai.permissions import ResearchAIBudgetPermission, ResearchAIPermission
 from user.tests.helpers import create_random_authenticated_user
 
 
@@ -33,3 +33,28 @@ class ResearchAIPermissionTests(TestCase):
         request = self.factory.get("/")
         request.user = user
         self.assertTrue(self.permission.is_authorized(request, None, None))
+
+
+class ResearchAIBudgetPermissionTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.permission = ResearchAIBudgetPermission()
+
+    def test_authenticated_default_user_is_allowed(self):
+        # Arrange
+        request = self.factory.get("/")
+        request.user = create_random_authenticated_user("budget-permission")
+
+        # Act / Assert
+        self.assertTrue(self.permission.has_permission(request, None))
+
+    def test_blocked_user_is_denied_without_changing_legacy_permission(self):
+        # Arrange
+        request = self.factory.get("/")
+        request.user = create_random_authenticated_user("blocked-budget-permission")
+        request.user.probable_spammer = True
+        request.user.save(update_fields=["probable_spammer"])
+
+        # Act / Assert
+        self.assertFalse(self.permission.has_permission(request, None))
+        self.assertTrue(ResearchAIPermission().has_permission(request, None))

--- a/src/research_ai/tests/test_usage_budget.py
+++ b/src/research_ai/tests/test_usage_budget.py
@@ -16,6 +16,7 @@ from research_ai.services.agent.types import (
 )
 from research_ai.services.usage_budget import (
     AgentLoopBudgetRecorder,
+    BudgetExceededError,
     UsageLimitExceededError,
     UsageWorkInProgressError,
     atomic_turn_admission,
@@ -38,6 +39,15 @@ class TierResolutionTests(TestCase):
         self.user.save(update_fields=["is_staff", "probable_spammer"])
 
         # Act / Assert
+        self.assertEqual(resolve_ai_tier(self.user).name, "blocked")
+
+    def test_inactive_and_removed_users_are_blocked(self):
+        # Arrange / Act / Assert
+        self.user.is_active = False
+        self.assertEqual(resolve_ai_tier(self.user).name, "blocked")
+
+        self.user.is_active = True
+        self.user.is_removed = True
         self.assertEqual(resolve_ai_tier(self.user).name, "blocked")
 
     def test_staff_and_moderators_are_privileged(self):
@@ -138,7 +148,7 @@ class AgentLoopBudgetRecorderTests(TestCase):
     def setUp(self):
         self.user = create_random_authenticated_user("loop-budget")
 
-    def test_records_only_assistant_turn_usage(self):
+    def test_records_provider_usage_without_double_counting_assistant_message(self):
         # Arrange
         recorder = AgentLoopBudgetRecorder(
             user=self.user,
@@ -154,6 +164,7 @@ class AgentLoopBudgetRecorderTests(TestCase):
         )
 
         # Act
+        recorder.record_usage(turn.usage)
         recorder.record_message(
             Message(role="assistant", content=[TextBlock(text="done")]),
             turn=turn,
@@ -164,6 +175,25 @@ class AgentLoopBudgetRecorderTests(TestCase):
         self.assertEqual(event.user, self.user)
         self.assertEqual(event.feature, "notebook_chat")
         self.assertEqual(event.input_tokens, 100)
+        self.assertEqual(LLMUsageEvent.objects.count(), 1)
+
+    def test_pre_spend_guard_reloads_a_soft_deleted_user(self):
+        # Arrange: keep the stale instance a running job would hold while a
+        # separate request changes the authoritative database row.
+        get_user_model().all_objects.filter(pk=self.user.pk).update(
+            is_active=False,
+            is_removed=True,
+        )
+        recorder = AgentLoopBudgetRecorder(
+            user=self.user,
+            feature="notebook_chat",
+            provider="openrouter",
+            model_id="deepseek/deepseek-v4-pro-0813",
+        )
+
+        # Act / Assert
+        with self.assertRaisesMessage(BudgetExceededError, "access is blocked"):
+            recorder.before_model_call()
 
 
 class AtomicAdmissionTests(TransactionTestCase):

--- a/src/research_ai/tests/test_usage_budget.py
+++ b/src/research_ai/tests/test_usage_budget.py
@@ -1,0 +1,259 @@
+from threading import Event, Thread
+
+from django.contrib.auth import get_user_model
+from django.db import close_old_connections
+from django.test import TestCase, TransactionTestCase, override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from research_ai.models import AgentConversation, AgentExecution, Expert, LLMUsageEvent
+from research_ai.services.agent.types import (
+    AssistantTurn,
+    Message,
+    StopReason,
+    TextBlock,
+    TurnUsage,
+)
+from research_ai.services.usage_budget import (
+    AgentLoopBudgetRecorder,
+    UsageLimitExceededError,
+    UsageWorkInProgressError,
+    atomic_turn_admission,
+    budget_status,
+    check_turn_admission,
+    record,
+    resolve_ai_tier,
+)
+from user.tests.helpers import create_hub_editor, create_random_authenticated_user
+
+
+class TierResolutionTests(TestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("budget-tier")
+
+    def test_blocked_precedes_all_other_tiers(self):
+        # Arrange
+        self.user.is_staff = True
+        self.user.probable_spammer = True
+        self.user.save(update_fields=["is_staff", "probable_spammer"])
+
+        # Act / Assert
+        self.assertEqual(resolve_ai_tier(self.user).name, "blocked")
+
+    def test_staff_and_moderators_are_privileged(self):
+        # Arrange / Act / Assert
+        self.user.is_staff = True
+        self.user.save(update_fields=["is_staff"])
+        self.assertEqual(resolve_ai_tier(self.user).name, "privileged")
+
+        self.user.is_staff = False
+        self.user.moderator = True
+        self.user.save(update_fields=["is_staff", "moderator"])
+        self.assertEqual(resolve_ai_tier(self.user).name, "privileged")
+
+    def test_hub_editors_are_privileged(self):
+        # Arrange
+        editor, _hub = create_hub_editor("budget-editor", "Budget Editor Hub")
+
+        # Act / Assert
+        policy = resolve_ai_tier(editor)
+        self.assertEqual(policy.name, "privileged")
+        self.assertEqual(policy.daily_budget_microusd, 100_000_000)
+
+    def test_registered_experts_receive_invited_tier(self):
+        # Arrange
+        Expert.objects.create(email="invitee@example.com", registered_user=self.user)
+
+        # Act / Assert
+        policy = resolve_ai_tier(self.user)
+        self.assertEqual(policy.name, "invited")
+        self.assertEqual(policy.daily_budget_microusd, 10_000_000)
+
+    def test_privileged_role_precedes_invited_tier(self):
+        # Arrange
+        Expert.objects.create(email="staff@example.com", registered_user=self.user)
+        self.user.is_staff = True
+        self.user.save(update_fields=["is_staff"])
+
+        # Act / Assert
+        self.assertEqual(resolve_ai_tier(self.user).name, "privileged")
+
+
+@override_settings(OPENROUTER_API_KEY="or-test")
+class UsageBudgetTests(TestCase):
+    MODEL = "openrouter:deepseek/deepseek-v4-pro-0813"
+
+    def setUp(self):
+        self.user = create_random_authenticated_user("budget-usage")
+
+    def test_record_prices_and_status_aggregates_usage(self):
+        # Act
+        event = record(
+            self.user,
+            "notebook_chat",
+            "openrouter",
+            "deepseek/deepseek-v4-pro-0813",
+            TurnUsage(input_tokens=1_000, output_tokens=500),
+        )
+        status = budget_status(self.user)
+
+        # Assert
+        self.assertEqual(event.cost_microusd, 1_650)
+        self.assertEqual(status.spent_today_microusd, 1_650)
+        self.assertEqual(status.turns_used, 1)
+        self.assertEqual(status.remaining_microusd, 248_350)
+
+    def test_admission_raises_when_daily_turn_cap_is_spent(self):
+        # Arrange
+        LLMUsageEvent.objects.bulk_create(
+            [
+                LLMUsageEvent(
+                    user=self.user,
+                    feature="notebook_chat",
+                    provider="openrouter",
+                    model="deepseek/deepseek-v4-pro-0813",
+                    cost_microusd=1,
+                )
+                for _ in range(10)
+            ]
+        )
+
+        # Act / Assert
+        with self.assertRaises(UsageLimitExceededError) as raised:
+            check_turn_admission(
+                self.user, self.MODEL, effort="none", thinking="disabled"
+            )
+        self.assertEqual(raised.exception.status.turns_used, 10)
+
+    def test_default_tier_rejects_locked_model(self):
+        with self.assertRaisesRegex(ValueError, "not allowed"):
+            check_turn_admission(
+                self.user,
+                "claude_platform:claude-opus-5",
+            )
+
+
+@override_settings(OPENROUTER_API_KEY="or-test")
+class AgentLoopBudgetRecorderTests(TestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("loop-budget")
+
+    def test_records_only_assistant_turn_usage(self):
+        # Arrange
+        recorder = AgentLoopBudgetRecorder(
+            user=self.user,
+            feature="notebook_chat",
+            provider="openrouter",
+            model_id="deepseek/deepseek-v4-pro-0813",
+        )
+        turn = AssistantTurn(
+            text_blocks=[TextBlock(text="done")],
+            tool_calls=[],
+            stop_reason=StopReason.END_TURN,
+            usage=TurnUsage(input_tokens=100, output_tokens=50),
+        )
+
+        # Act
+        recorder.record_message(
+            Message(role="assistant", content=[TextBlock(text="done")]),
+            turn=turn,
+        )
+
+        # Assert
+        event = LLMUsageEvent.objects.get()
+        self.assertEqual(event.user, self.user)
+        self.assertEqual(event.feature, "notebook_chat")
+        self.assertEqual(event.input_tokens, 100)
+
+
+class AtomicAdmissionTests(TransactionTestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("budget-concurrent")
+
+    def test_concurrent_jobs_cannot_share_the_same_budget_snapshot(self):
+        # Arrange
+        first_created = Event()
+        second_started = Event()
+        allow_first_commit = Event()
+        errors = []
+        admissions = []
+
+        def admit_first():
+            close_old_connections()
+            user = get_user_model().objects.get(pk=self.user.pk)
+            try:
+                with atomic_turn_admission(user):
+                    conversation = AgentConversation.objects.create(
+                        user=user,
+                        workflow="notebook_chat",
+                    )
+                    AgentExecution.objects.create(
+                        conversation=conversation,
+                        status=AgentExecution.Status.PENDING,
+                        attempt=1,
+                    )
+                    first_created.set()
+                    allow_first_commit.wait(timeout=10)
+            except Exception as error:  # noqa: BLE001 - asserted in main thread
+                errors.append(error)
+            finally:
+                close_old_connections()
+
+        def admit_second():
+            first_created.wait(timeout=10)
+            close_old_connections()
+            user = get_user_model().objects.get(pk=self.user.pk)
+            second_started.set()
+            try:
+                with atomic_turn_admission(user):
+                    admissions.append("second")
+            except Exception as error:  # noqa: BLE001 - asserted in main thread
+                errors.append(error)
+            finally:
+                close_old_connections()
+
+        first = Thread(target=admit_first)
+        second = Thread(target=admit_second)
+
+        # Act
+        first.start()
+        self.assertTrue(first_created.wait(timeout=10))
+        second.start()
+        self.assertTrue(second_started.wait(timeout=10))
+        allow_first_commit.set()
+        first.join(timeout=10)
+        second.join(timeout=10)
+
+        # Assert
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        self.assertEqual(admissions, [])
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], UsageWorkInProgressError)
+
+
+class UsageBudgetAPITests(TestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("budget-api")
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
+
+    def test_status_endpoint_returns_meter_shape(self):
+        # Act
+        response = self.client.get("/api/research_ai/usage-budget/")
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            sorted(response.json()),
+            [
+                "daily_budget",
+                "remaining",
+                "resets_at",
+                "spent_today",
+                "tier",
+                "turn_cap",
+                "turns_used",
+            ],
+        )
+        self.assertEqual(response.json()["tier"], "default")

--- a/src/research_ai/urls.py
+++ b/src/research_ai/urls.py
@@ -20,7 +20,7 @@ from research_ai.views.expert_finder_views import (
     InvitedExpertEditorsOverviewView,
     InvitedExpertOverviewView,
 )
-from research_ai.views.model_views import AvailableModelsView
+from research_ai.views.model_views import AvailableModelsView, UsageBudgetStatusView
 from research_ai.views.notebook_chat_views import (
     NotebookChatCancelView,
     NotebookChatDetailView,
@@ -36,6 +36,7 @@ from research_ai.views.template_views import TemplateDetailView, TemplateListVie
 
 urlpatterns = [
     path("models/", AvailableModelsView.as_view()),
+    path("usage-budget/", UsageBudgetStatusView.as_view()),
     path("expert-finder/searches/", ExpertSearchListCreateView.as_view()),
     path(
         "expert-finder/searches/<int:search_id>/",

--- a/src/research_ai/views/model_views.py
+++ b/src/research_ai/views/model_views.py
@@ -10,9 +10,17 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from research_ai.permissions import ResearchAIPermission
-from research_ai.services.agent import available_models, default_model_ref
-from user.permissions import IsModerator, UserIsEditor
+from research_ai.permissions import ResearchAIBudgetPermission
+from research_ai.services.agent import available_models
+from research_ai.services.agent.model_capabilities import EFFORT_LEVELS
+from research_ai.services.agent.model_pricing import cost_multiplier, model_pricing
+from research_ai.services.agent.providers.registry import split_model_ref
+from research_ai.services.usage_budget import (
+    ModelNotAllowedError,
+    budget_status,
+    resolve_ai_tier,
+    resolve_default_model,
+)
 
 
 class AvailableModelsView(APIView):
@@ -20,23 +28,69 @@ class AvailableModelsView(APIView):
 
     permission_classes = [
         IsAuthenticated,
-        ResearchAIPermission,
-        UserIsEditor | IsModerator,
+        ResearchAIBudgetPermission,
     ]
 
     def get(self, request):
+        policy = resolve_ai_tier(request.user)
+        try:
+            tier_default = resolve_default_model(policy)
+        except ModelNotAllowedError:
+            tier_default = None
+
+        def capabilities(option):
+            payload = option.capabilities.as_dict()
+            if policy.max_effort is not None:
+                maximum = EFFORT_LEVELS.index(policy.max_effort)
+                payload["effort"] = [
+                    value
+                    for value in payload["effort"]
+                    if EFFORT_LEVELS.index(value) <= maximum
+                ]
+            if policy.allowed_thinking_modes is not None:
+                payload["thinking"] = [
+                    value
+                    for value in payload["thinking"]
+                    if value in policy.allowed_thinking_modes
+                ]
+            return payload
+
+        def allowed(option):
+            entitled = (
+                policy.allowed_model_refs is None
+                or option.ref in policy.allowed_model_refs
+            )
+            provider, model_id = split_model_ref(option.ref)
+            priced = model_pricing(provider, model_id or "") is not None
+            return entitled and (not policy.is_budgeted or priced)
+
         return Response(
             {
-                "default": default_model_ref(),
+                "default": tier_default,
                 "models": [
                     {
                         "ref": option.ref,
                         "label": option.label,
                         "description": option.description,
                         "provider": option.provider,
-                        "capabilities": option.capabilities.as_dict(),
+                        "capabilities": capabilities(option),
+                        "allowed": allowed(option),
+                        "multiplier": (
+                            str(multiplier)
+                            if (multiplier := cost_multiplier(option.ref)) is not None
+                            else None
+                        ),
                     }
                     for option in available_models()
                 ],
             }
         )
+
+
+class UsageBudgetStatusView(APIView):
+    """Return today's UTC budget meter for the authenticated user."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        return Response(budget_status(request.user).as_dict())


### PR DESCRIPTION
## Summary
- normalize provider usage accounting, including cache and web-search billing
- add reviewed model pricing and cost multipliers
- persist per-call usage in an LLM usage ledger
- add code-owned tier policies, budget status, model admission, and concurrency guards
- expose tier-aware model metadata and the usage-budget status endpoint
- add reusable agent-loop pre-spend and metering hooks

## Stack
First of two draft PRs replacing #4060. The workflow rollout PR is stacked on this branch.

## Testing
- Ruff lint passed for all changed files
- Ruff formatting check passed for all changed files
- 87 provider and pricing tests passed

Database-backed tests require the project database configuration and are left to CI.