### PR TITLE
Remove Haiku from selectable models

### DIFF
--- a/src/research_ai/services/agent/model_catalog.py
+++ b/src/research_ai/services/agent/model_catalog.py
@@ -65,11 +65,6 @@ _CATALOG: tuple[ModelOption, ...] = (
         description="Anthropic's balanced model; near-flagship quality, faster.",
     ),
     ModelOption(
-        ref=f"{CLAUDE_PLATFORM}:claude-haiku-4-5",
-        label="Claude Haiku 4.5",
-        description="Anthropic's fast, low-cost model for quick turns.",
-    ),
-    ModelOption(
         ref=f"{OPENROUTER}:openai/gpt-5.6-sol",
         label="GPT-5.6 Sol",
         description="OpenAI's flagship generalist.",

--- a/src/research_ai/tests/agent/test_model_catalog.py
+++ b/src/research_ai/tests/agent/test_model_catalog.py
@@ -58,22 +58,6 @@ class AvailableModelsTests(SimpleTestCase):
         self.assertTrue(options)
         self.assertEqual(unreviewed, [])
 
-    def test_haiku_advertises_temperature_but_not_effort_or_thinking(self):
-        # Arrange
-        option = next(
-            option
-            for option in available_models()
-            if option.ref == "claude_platform:claude-haiku-4-5"
-        )
-
-        # Act
-        capabilities = option.capabilities
-
-        # Assert
-        self.assertEqual(capabilities.effort, ())
-        self.assertEqual(capabilities.thinking, ())
-        self.assertTrue(capabilities.temperature)
-
     def test_openrouter_gpt_advertises_reasoning_but_not_temperature(self):
         # Arrange
         option = next(

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -154,33 +154,15 @@ class NotebookChatServiceTests(TestCase):
         self.assertEqual(execution.configuration["effort"], "high")
         self.assertEqual(execution.configuration["thinking"], "disabled")
 
-    @override_settings(
-        ANTHROPIC_AWS_WORKSPACE_ID="ws-test", AWS_REGION_NAME="us-east-1"
-    )
-    def test_submit_message_accepts_temperature_for_haiku(self):
+    def test_submit_message_accepts_temperature_for_gemini(self):
         # Act
         execution, _delay = self._submit(
-            model_ref="claude_platform:claude-haiku-4-5",
+            model_ref="openrouter:google/gemini-3.1-pro-preview",
             temperature=0.4,
         )
 
         # Assert
         self.assertEqual(execution.configuration["temperature"], 0.4)
-
-    @override_settings(
-        ANTHROPIC_AWS_WORKSPACE_ID="ws-test", AWS_REGION_NAME="us-east-1"
-    )
-    def test_submit_message_rejects_effort_for_haiku(self):
-        # Act / Assert
-        with self.assertRaisesRegex(ValueError, "does not support effort"):
-            self.service.submit_message(
-                self.note,
-                self.conversation,
-                "hi",
-                model_ref="claude_platform:claude-haiku-4-5",
-                effort="high",
-            )
-        self.assertFalse(AgentExecution.objects.exists())
 
     def test_submit_message_rejects_a_model_outside_the_catalog(self):
         # Act & Assert

--- a/src/research_ai/tests/proposal_draft/test_proposal_draft_views.py
+++ b/src/research_ai/tests/proposal_draft/test_proposal_draft_views.py
@@ -114,31 +114,6 @@ class ProposalDraftCreateViewTests(APITestCase):
         )
         mock_delay.assert_called_once_with(draft.id)
 
-    @override_settings(
-        ANTHROPIC_AWS_WORKSPACE_ID="ws-test", AWS_REGION_NAME="us-east-1"
-    )
-    @patch("research_ai.views.proposal_draft_views.run_proposal_draft_task.delay")
-    def test_create_rejects_effort_for_haiku(self, mock_delay):
-        # Arrange
-        self.client.force_authenticate(self.moderator)
-
-        # Act
-        response = self.client.post(
-            BASE_URL,
-            {
-                "search_expert_id": self.search_expert.id,
-                "model": "claude_platform:claude-haiku-4-5",
-                "effort": "high",
-            },
-            format="json",
-        )
-
-        # Assert
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("does not support effort", response.json()["detail"])
-        self.assertFalse(ProposalDraft.objects.exists())
-        mock_delay.assert_not_called()
-
     @patch("research_ai.views.proposal_draft_views.run_proposal_draft_task.delay")
     def test_create_with_unknown_model_returns_400(self, mock_delay):
         # Arrange


### PR DESCRIPTION
## Summary
- remove Claude Haiku 4.5 from the user-selectable model catalog
- remove obsolete Haiku-specific selection tests
- keep temperature coverage using Gemini

## Testing
- `uv run ruff check` on changed files
- `uv run ruff format --check --diff` on changed files
- 14 model catalog unit tests