### PR TITLE
Update Research AI model catalog

### DIFF
--- a/src/research_ai/services/agent/model_capabilities.py
+++ b/src/research_ai/services/agent/model_capabilities.py
@@ -66,6 +66,11 @@ _OPENROUTER_GROK = ModelCapabilities(
     thinking=("adaptive",),
     temperature=True,
 )
+_OPENROUTER_MANDATORY_REASONING = ModelCapabilities(
+    effort=("low", "high", "max"),
+    thinking=("adaptive",),
+    temperature=True,
+)
 _OPENROUTER_OPEN_WEIGHT = ModelCapabilities(
     effort=("none", "low", "high", "max"),
     thinking=THINKING_MODES,
@@ -126,9 +131,10 @@ _OPENROUTER_MODELS = {
     "openai/gpt-5.6-sol": _model(_OPENROUTER_REASONING, 128_000),
     "openai/gpt-5.6-terra": _model(_OPENROUTER_REASONING, 128_000),
     "openai/gpt-5.6-luna": _model(_OPENROUTER_REASONING, 128_000),
-    "google/gemini-3.1-pro-preview": _model(_OPENROUTER_GEMINI, 65_536),
-    "google/gemini-3.7-flash": _model(_OPENROUTER_GEMINI, 65_536),
+    "google/gemini-3.8-flash": _model(_OPENROUTER_GEMINI, 65_536),
     "x-ai/grok-4.6": _model(_OPENROUTER_GROK, 450_000),
+    "z-ai/glm-5.3-flash": _model(_OPENROUTER_MANDATORY_REASONING, 131_072),
+    "deepseek/deepseek-v4-flash-0731": _model(_OPENROUTER_OPEN_WEIGHT, 393_216),
     "deepseek/deepseek-v4-pro-0813": _model(_OPENROUTER_OPEN_WEIGHT, 384_000),
     "moonshotai/kimi-k3": _model(_OPENROUTER_OPEN_WEIGHT, 943_718),
 }

--- a/src/research_ai/services/agent/model_capabilities.py
+++ b/src/research_ai/services/agent/model_capabilities.py
@@ -131,6 +131,9 @@ _OPENROUTER_MODELS = {
     "openai/gpt-5.6-sol": _model(_OPENROUTER_REASONING, 128_000),
     "openai/gpt-5.6-terra": _model(_OPENROUTER_REASONING, 128_000),
     "openai/gpt-5.6-luna": _model(_OPENROUTER_REASONING, 128_000),
+    # No longer selectable, but retained for conversations pinned before removal.
+    "google/gemini-3.1-pro-preview": _model(_OPENROUTER_GEMINI, 65_536),
+    "google/gemini-3.7-flash": _model(_OPENROUTER_GEMINI, 65_536),
     "google/gemini-3.8-flash": _model(_OPENROUTER_GEMINI, 65_536),
     "x-ai/grok-4.6": _model(_OPENROUTER_GROK, 450_000),
     "z-ai/glm-5.3-flash": _model(_OPENROUTER_MANDATORY_REASONING, 131_072),

--- a/src/research_ai/services/agent/model_catalog.py
+++ b/src/research_ai/services/agent/model_catalog.py
@@ -80,19 +80,24 @@ _CATALOG: tuple[ModelOption, ...] = (
         description="OpenAI's fast, cost-efficient model.",
     ),
     ModelOption(
-        ref=f"{OPENROUTER}:google/gemini-3.1-pro-preview",
-        label="Gemini 3.1 Pro",
-        description="Google's frontier reasoning model.",
-    ),
-    ModelOption(
-        ref=f"{OPENROUTER}:google/gemini-3.7-flash",
-        label="Gemini 3.7 Flash",
+        ref=f"{OPENROUTER}:google/gemini-3.8-flash",
+        label="Gemini 3.8 Flash",
         description="Google's fast, low-cost model.",
     ),
     ModelOption(
         ref=f"{OPENROUTER}:x-ai/grok-4.6",
         label="Grok 4.6",
         description="xAI's frontier model.",
+    ),
+    ModelOption(
+        ref=f"{OPENROUTER}:z-ai/glm-5.3-flash",
+        label="GLM 5.3 Flash",
+        description="Z.ai's fast, cost-efficient open-weight model.",
+    ),
+    ModelOption(
+        ref=f"{OPENROUTER}:deepseek/deepseek-v4-flash-0731",
+        label="DeepSeek V4 Flash",
+        description="DeepSeek's fast, cost-efficient open-weight model.",
     ),
     ModelOption(
         ref=f"{OPENROUTER}:deepseek/deepseek-v4-pro-0813",

--- a/src/research_ai/services/agent/model_pricing.py
+++ b/src/research_ai/services/agent/model_pricing.py
@@ -47,9 +47,11 @@ _OPENROUTER_PRICING = {
     "openai/gpt-5.6-sol": _price("2", "10", "0.20", "2.50"),
     "openai/gpt-5.6-terra": _price("2", "12", "0.20", "2.50"),
     "openai/gpt-5.6-luna": _price("0.20", "1.20", "0.02", "0.25"),
-    "google/gemini-3.1-pro-preview": _price("2", "12", "0.20", "0.375"),
-    "google/gemini-3.7-flash": _price("0.75", "3.75", "0.075", "0.04167"),
+    "google/gemini-3.8-flash": _price("0.75", "3.75", "0.075", "0.04167"),
     "x-ai/grok-4.6": _price("2", "6", "0.50", "2"),
+    # Use GLM's undiscounted rates; its launch discount expires September 9, 2026.
+    "z-ai/glm-5.3-flash": _price("0.15", "0.50", "0.03", "0.15"),
+    "deepseek/deepseek-v4-flash-0731": _price("0.05", "0.16", "0.013", "0.05"),
     "deepseek/deepseek-v4-pro-0813": _price("0.66", "1.98", "0.022", "0.66"),
     "moonshotai/kimi-k3": _price("2.55", "12.75", "0.256", "2.55"),
 }

--- a/src/research_ai/services/agent/model_pricing.py
+++ b/src/research_ai/services/agent/model_pricing.py
@@ -47,6 +47,9 @@ _OPENROUTER_PRICING = {
     "openai/gpt-5.6-sol": _price("2", "10", "0.20", "2.50"),
     "openai/gpt-5.6-terra": _price("2", "12", "0.20", "2.50"),
     "openai/gpt-5.6-luna": _price("0.20", "1.20", "0.02", "0.25"),
+    # No longer selectable, but retained for usage from previously pinned models.
+    "google/gemini-3.1-pro-preview": _price("2", "12", "0.20", "0.375"),
+    "google/gemini-3.7-flash": _price("0.75", "3.75", "0.075", "0.04167"),
     "google/gemini-3.8-flash": _price("0.75", "3.75", "0.075", "0.04167"),
     "x-ai/grok-4.6": _price("2", "6", "0.50", "2"),
     # Use GLM's undiscounted rates; its launch discount expires September 9, 2026.

--- a/src/research_ai/services/usage_budget/config.py
+++ b/src/research_ai/services/usage_budget/config.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, replace
 
-DEFAULT_OPEN_WEIGHT_MODEL = "openrouter:deepseek/deepseek-v4-pro-0813"
+DEFAULT_OPEN_WEIGHT_MODEL = "openrouter:deepseek/deepseek-v4-flash-0731"
 BUDGETS_ENFORCED = True
 DEFAULT_DAILY_BUDGET_MICROUSD = 250_000
 DEFAULT_DAILY_TURN_CAP = 10

--- a/src/research_ai/tests/agent/test_model_catalog.py
+++ b/src/research_ai/tests/agent/test_model_catalog.py
@@ -129,6 +129,15 @@ class CapabilityLookupTests(SimpleTestCase):
                     model_capabilities(provider, model_id).max_output_tokens
                 )
 
+    def test_glm_flash_requires_reasoning(self):
+        # Act
+        capabilities = model_capabilities("openrouter", "z-ai/glm-5.3-flash")
+
+        # Assert
+        self.assertEqual(capabilities.effort, ("low", "high", "max"))
+        self.assertEqual(capabilities.thinking, ("adaptive",))
+        self.assertEqual(capabilities.max_output_tokens, 131_072)
+
 
 @override_settings(**NO_PROVIDER_CREDENTIALS)
 class ValidateModelRefTests(SimpleTestCase):

--- a/src/research_ai/tests/agent/test_model_pricing.py
+++ b/src/research_ai/tests/agent/test_model_pricing.py
@@ -32,12 +32,12 @@ class ModelPricingTests(SimpleTestCase):
 
     def test_cheapest_catalog_model_is_one_x(self):
         self.assertEqual(
-            cost_multiplier("openrouter:openai/gpt-5.6-luna"),
+            cost_multiplier("openrouter:deepseek/deepseek-v4-flash-0731"),
             Decimal("1.0"),
         )
 
     def test_multiplier_is_relative_to_cheapest_catalog_model(self):
         self.assertEqual(
             cost_multiplier("openrouter:deepseek/deepseek-v4-pro-0813"),
-            Decimal("1.9"),
+            Decimal("12.6"),
         )

--- a/src/research_ai/tests/agent/test_openrouter_provider.py
+++ b/src/research_ai/tests/agent/test_openrouter_provider.py
@@ -218,19 +218,6 @@ class CompleteRequestTests(SimpleTestCase):
             _complete(provider)
         self.assertEqual(provider._client.calls, [])
 
-    def test_retired_models_remain_runnable_for_pinned_conversations(self):
-        # Arrange / Act / Assert
-        for model_id in (
-            "google/gemini-3.1-pro-preview",
-            "google/gemini-3.7-flash",
-        ):
-            with self.subTest(model_id=model_id):
-                provider = _build_provider([_response(content="ok")], model_id=model_id)
-                turn = _complete(provider)
-
-                self.assertEqual(turn.text, "ok")
-                self.assertEqual(provider._client.calls[0]["model"], model_id)
-
     def test_default_effort_is_sent_for_a_capable_model(self):
         # Arrange
         provider = _build_provider(

--- a/src/research_ai/tests/agent/test_openrouter_provider.py
+++ b/src/research_ai/tests/agent/test_openrouter_provider.py
@@ -218,6 +218,19 @@ class CompleteRequestTests(SimpleTestCase):
             _complete(provider)
         self.assertEqual(provider._client.calls, [])
 
+    def test_retired_models_remain_runnable_for_pinned_conversations(self):
+        # Arrange / Act / Assert
+        for model_id in (
+            "google/gemini-3.1-pro-preview",
+            "google/gemini-3.7-flash",
+        ):
+            with self.subTest(model_id=model_id):
+                provider = _build_provider([_response(content="ok")], model_id=model_id)
+                turn = _complete(provider)
+
+                self.assertEqual(turn.text, "ok")
+                self.assertEqual(provider._client.calls[0]["model"], model_id)
+
     def test_default_effort_is_sent_for_a_capable_model(self):
         # Arrange
         provider = _build_provider(

--- a/src/research_ai/tests/agent/test_openrouter_provider.py
+++ b/src/research_ai/tests/agent/test_openrouter_provider.py
@@ -56,7 +56,7 @@ def _tool_call(call_id="call-1", name="search", arguments='{"q": 1}'):
     )
 
 
-def _build_provider(responses=None, model_id="google/gemini-3.7-flash", **kwargs):
+def _build_provider(responses=None, model_id="google/gemini-3.8-flash", **kwargs):
     """Build an OpenRouterProvider with a fake client so no HTTP client exists."""
     return OpenRouterProvider(
         client=FakeChatCompletionsClient(responses or []),
@@ -203,7 +203,7 @@ class CompleteRequestTests(SimpleTestCase):
 
         # Assert
         kwargs = provider._client.calls[0]
-        self.assertEqual(kwargs["model"], "google/gemini-3.7-flash")
+        self.assertEqual(kwargs["model"], "google/gemini-3.8-flash")
         self.assertEqual(kwargs["max_tokens"], 100)
         self.assertEqual(kwargs["temperature"], 0.5)
         self.assertEqual(kwargs["tools"], rendered_tools)
@@ -221,7 +221,7 @@ class CompleteRequestTests(SimpleTestCase):
     def test_default_effort_is_sent_for_a_capable_model(self):
         # Arrange
         provider = _build_provider(
-            [_response(content="ok")], model_id="google/gemini-3.1-pro-preview"
+            [_response(content="ok")], model_id="google/gemini-3.8-flash"
         )
 
         # Act
@@ -289,7 +289,7 @@ class CompleteRequestTests(SimpleTestCase):
         )
 
     def test_max_tokens_is_clamped_to_the_model_output_ceiling(self):
-        # Arrange: Gemini 3.7 Flash caps output at 65,536.
+        # Arrange: Gemini 3.8 Flash caps output at 65,536.
         provider = _build_provider([_response(content="ok")])
 
         # Act
@@ -483,7 +483,7 @@ class ErrorTests(SimpleTestCase):
     @override_settings(OPENROUTER_API_KEY="")
     def test_missing_api_key_raises_provider_error_on_complete(self):
         # Arrange
-        provider = OpenRouterProvider(model_id="google/gemini-3.7-flash")
+        provider = OpenRouterProvider(model_id="google/gemini-3.8-flash")
 
         # Act / Assert
         with self.assertRaises(ProviderError):
@@ -501,7 +501,7 @@ class ErrorTests(SimpleTestCase):
                 raise RuntimeError("boom")
 
         provider = OpenRouterProvider(
-            client=ExplodingClient(), model_id="google/gemini-3.7-flash"
+            client=ExplodingClient(), model_id="google/gemini-3.8-flash"
         )
 
         # Act / Assert
@@ -558,7 +558,7 @@ class ErrorTests(SimpleTestCase):
                 raise rate_limited
 
         provider = OpenRouterProvider(
-            client=ExplodingClient(), model_id="google/gemini-3.7-flash"
+            client=ExplodingClient(), model_id="google/gemini-3.8-flash"
         )
 
         # Act

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -157,7 +157,7 @@ class NotebookChatServiceTests(TestCase):
     def test_submit_message_accepts_temperature_for_gemini(self):
         # Act
         execution, _delay = self._submit(
-            model_ref="openrouter:google/gemini-3.1-pro-preview",
+            model_ref="openrouter:google/gemini-3.8-flash",
             temperature=0.4,
         )
 

--- a/src/research_ai/tests/test_model_views.py
+++ b/src/research_ai/tests/test_model_views.py
@@ -31,7 +31,7 @@ class AvailableModelsViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.json()["default"],
-            "openrouter:deepseek/deepseek-v4-pro-0813",
+            "openrouter:deepseek/deepseek-v4-flash-0731",
         )
 
     def test_lists_models_and_the_default(self):

--- a/src/research_ai/tests/test_usage_budget.py
+++ b/src/research_ai/tests/test_usage_budget.py
@@ -91,7 +91,7 @@ class TierResolutionTests(TestCase):
 
 @override_settings(OPENROUTER_API_KEY="or-test")
 class UsageBudgetTests(TestCase):
-    MODEL = "openrouter:deepseek/deepseek-v4-pro-0813"
+    MODEL = "openrouter:deepseek/deepseek-v4-flash-0731"
 
     def setUp(self):
         self.user = create_random_authenticated_user("budget-usage")


### PR DESCRIPTION
## Summary
- replace Gemini 3.7 Flash with Gemini 3.8 Flash and remove Gemini 3.1 Pro
- add GLM 5.3 Flash and DeepSeek V4 Flash with reviewed capabilities and pricing
- make DeepSeek V4 Flash the default model for regular budget-tier users

## Testing
- Ruff lint and format checks
- 50 model catalog, pricing, and OpenRouter provider tests
- 16 model API and usage-budget tests