### PR TITLE
Fix personalized feed test ID collision

### DIFF
--- a/src/feed/tests/views/test_personalized_feed.py
+++ b/src/feed/tests/views/test_personalized_feed.py
@@ -422,10 +422,9 @@ class TestPersonalizedFeed(APITestCase):
         # Assert
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        result_ids = [r["content_object"]["id"] for r in response.data["results"]]
-        content_types = [r["content_type"] for r in response.data["results"]]
-
-        self.assertIn(self.paper.id, result_ids)
-        self.assertNotIn(self.post.id, result_ids)
-        self.assertIn("PAPER", content_types)
-        self.assertNotIn("RESEARCHHUBPOST", content_types)
+        # Paper and post IDs can overlap because they belong to separate tables.
+        result_objects = [
+            (r["content_type"], r["content_object"]["id"])
+            for r in response.data["results"]
+        ]
+        self.assertEqual(result_objects, [("PAPER", self.paper.id)])


### PR DESCRIPTION
## Summary

- Compare `(content_type, id)` pairs in `test_personalized_feed_filters_only_papers` instead of comparing bare IDs across the Paper and ResearchhubPost tables.
- Assert the complete result is exactly the expected paper, preserving coverage that posts are excluded.
- No production code changes.

## Cause

Paper and post primary keys are generated independently and can overlap. In the [failing CI run](https://github.com/ResearchHub/researchhub-backend/actions/runs/33787969725), both IDs were 132, so a correctly returned paper triggered `assertNotIn(self.post.id, result_ids)`. The old assertion depended on test database sequence state.

## Validation

- Passed: Ruff lint and formatting checks for the changed file.
- Passed: `git diff --check`.
- Attempted the focused Django test; it could not start because this worktree lacks `config_local/db.py` (`ImportError: cannot import name 'db' from 'config_local'`). CI validation is still required.