### PR TITLE
Updating Community Matched amounts to reflect all funded Proposals

### DIFF
--- a/src/purchase/services/funding_overview_service.py
+++ b/src/purchase/services/funding_overview_service.py
@@ -10,37 +10,24 @@ from user.models import User
 
 
 class FundingOverviewService(OverviewMixin):
-    """Funding portfolio dashboard metrics for grant creators."""
+    """Funding portfolio dashboard metrics for funders."""
 
     def get_funding_overview(self, user: User) -> dict:
         """Return funding overview metrics for a given user."""
-        grant_fundraise_ids = self._grant_fundraise_ids(user)
-        all_funded_ids = list(get_funded_fundraise_ids(user.id))
+        funded_fundraise_ids = list(get_funded_fundraise_ids(user.id))
 
         return {
             "matched_funds": self._matched_contributions_breakdown(
-                user.id, grant_fundraise_ids
+                user.id, funded_fundraise_ids
             ),
             "distributed_funds": self._user_contributions_breakdown(
-                user.id, all_funded_ids
+                user.id, funded_fundraise_ids
             ),
-            "supported_proposals": self._supported_proposals(user.id, all_funded_ids),
-            "supported_nonprofits": self._supported_nonprofits(all_funded_ids),
+            "supported_proposals": self._supported_proposals(
+                user.id, funded_fundraise_ids
+            ),
+            "supported_nonprofits": self._supported_nonprofits(funded_fundraise_ids),
         }
-
-    def _grant_fundraise_ids(self, user: User) -> list[int]:
-        """Fundraise IDs for proposals that applied to this user's grants."""
-        return list(
-            GrantApplication.objects.for_user_grants(user)
-            .exclude(
-                preregistration_post__unified_document__fundraises__id__isnull=True
-            )
-            .values_list(
-                "preregistration_post__unified_document__fundraises__id",
-                flat=True,
-            )
-            .distinct()
-        )
 
     def _supported_proposals(
         self, user_id: int, funded_fundraise_ids: list[int]

--- a/src/purchase/tests/test_funding_overview_service.py
+++ b/src/purchase/tests/test_funding_overview_service.py
@@ -127,11 +127,30 @@ class TestFundingOverviewService(TestCase):
         self.assertEqual(result["distributed_funds"]["rsc"], 170.0)
         self.assertAlmostEqual(result["distributed_funds"]["rsc_usd_snapshot"], 30.0)
 
-    def test_matched_funds_tracks_others_contributions(self):
+    def test_matched_funds_tracks_only_contributions_to_user_funded_proposals(
+        self,
+    ) -> None:
+        """Matched funds include co-funding only for proposals the user has funded."""
         # Arrange
-        _, _, fundraise, _ = self._create_grant_with_proposal()
-        other_user = create_random_authenticated_user("other")
-        self._contribute(other_user, fundraise, rsc=200, usd_cents=10000)
+        applicant = create_random_authenticated_user("standalone_applicant")
+        standalone_proposal = create_post(
+            created_by=applicant, document_type=PREREGISTRATION
+        )
+        user_funded_fundraise = Fundraise.objects.create(
+            created_by=applicant,
+            unified_document=standalone_proposal.unified_document,
+            goal_amount=Decimal(1000),
+            goal_currency="USD",
+        )
+        _, _, grant_linked_fundraise, _ = self._create_grant_with_proposal()
+        community_member = create_random_authenticated_user("community_member")
+        self._contribute(self.user, user_funded_fundraise, rsc=50)
+        self._contribute(
+            community_member, user_funded_fundraise, rsc=200, usd_cents=10000
+        )
+        self._contribute(
+            community_member, grant_linked_fundraise, rsc=400, usd_cents=20000
+        )
 
         # Act
         result = self.service.get_funding_overview(self.user)
@@ -139,13 +158,15 @@ class TestFundingOverviewService(TestCase):
         # Assert
         self.assertEqual(result["matched_funds"]["rsc"], 200.0)
         self.assertEqual(result["matched_funds"]["usd"], 100.0)
-        # No rsc_usd_rate captured -> falls back to current rate (0.5): 200 * 0.5 = 100
+        # Missing captured rate falls back to the current $0.50 rate.
         self.assertAlmostEqual(result["matched_funds"]["rsc_usd_snapshot"], 100.0)
 
-    def test_matched_funds_uses_captured_rsc_usd_rate_for_snapshot(self):
+    def test_matched_funds_uses_captured_rsc_usd_rate_for_snapshot(self) -> None:
+        """Matched funds preserve captured rates for qualifying contributions."""
         # Arrange
         _, _, fundraise, _ = self._create_grant_with_proposal()
         other_user = create_random_authenticated_user("other")
+        self._contribute(self.user, fundraise, rsc=1)
         # 200 RSC at $0.05 -> $10 snapshot
         self._contribute(other_user, fundraise, rsc=200, rsc_usd_rate=0.05)
         # 100 RSC at $0.20 -> $20 snapshot

--- a/src/purchase/tests/test_funding_overview_service.py
+++ b/src/purchase/tests/test_funding_overview_service.py
@@ -127,9 +127,7 @@ class TestFundingOverviewService(TestCase):
         self.assertEqual(result["distributed_funds"]["rsc"], 170.0)
         self.assertAlmostEqual(result["distributed_funds"]["rsc_usd_snapshot"], 30.0)
 
-    def test_matched_funds_tracks_only_contributions_to_user_funded_proposals(
-        self,
-    ) -> None:
+    def test_proposal_cofunded_counts_towards_matched_fund_stat(self) -> None:
         """Matched funds include co-funding only for proposals the user has funded."""
         # Arrange
         applicant = create_random_authenticated_user("standalone_applicant")
@@ -179,7 +177,10 @@ class TestFundingOverviewService(TestCase):
         self.assertEqual(result["matched_funds"]["rsc"], 300.0)
         self.assertAlmostEqual(result["matched_funds"]["rsc_usd_snapshot"], 30.0)
 
-    def test_matched_funds_excludes_funder_contributions(self):
+    def test_proposal_not_cofunded_does_not_count_towards_matched_fund_stat(
+        self,
+    ) -> None:
+        """A proposal funded only by the user does not add matched funds."""
         # Arrange
         _, _, fundraise, _ = self._create_grant_with_proposal()
         self._contribute(self.user, fundraise, rsc=100, rsc_usd_rate=0.10)


### PR DESCRIPTION
## Overview ##

This PR updates the community matched section of the My Funding Page to include all proposals funded by the user, not just ones attached to RFP's they created