### PR TITLE
Add note-less research assistant chat

### DIFF
--- a/src/note/services/note_creation_service.py
+++ b/src/note/services/note_creation_service.py
@@ -1,0 +1,65 @@
+"""Headless note creation, outside the request path.
+
+``NoteViewSet.create`` needs a request and an organization and broadcasts an
+org-wide websocket notification; agent workflows create notes with none of
+that. The rows written here match the view's PRIVATE grouping: the note lands
+in the creator's personal organization with user-admin / org-no-access
+permissions, so only the creator (and anyone they later invite) can see it.
+"""
+
+from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
+
+from note.related_models.note_model import Note
+from researchhub_access_group.constants import ADMIN, NO_ACCESS
+from researchhub_access_group.models import Permission
+from researchhub_document.models import ResearchhubUnifiedDocument
+from researchhub_document.related_models.constants.document_type import NOTE
+
+
+class NoteCreationService:
+    @transaction.atomic
+    def create_private_note(
+        self,
+        *,
+        created_by,
+        title: str,
+        document_type: str = NOTE,
+        selected_grant=None,
+    ) -> Note:
+        """Create a note only ``created_by`` can access; ownerless when None.
+
+        No ``NoteContent`` is written: the note reads as empty until a first
+        version is saved, which is how the agent note tools populate it.
+        """
+        unified_document = ResearchhubUnifiedDocument.objects.create(document_type=NOTE)
+        note = Note.objects.create(
+            created_by=created_by,
+            document_type=document_type,
+            organization=(
+                getattr(created_by, "organization", None) if created_by else None
+            ),
+            selected_grant=selected_grant,
+            title=title,
+            unified_document=unified_document,
+        )
+        if created_by is not None:
+            self._create_private_permissions(created_by, unified_document)
+        return note
+
+    @staticmethod
+    def _create_private_permissions(user, unified_document) -> None:
+        content_type = ContentType.objects.get_for_model(ResearchhubUnifiedDocument)
+        Permission.objects.create(
+            access_type=ADMIN,
+            content_type=content_type,
+            object_id=unified_document.id,
+            user=user,
+        )
+        Permission.objects.create(
+            access_type=NO_ACCESS,
+            content_type=content_type,
+            object_id=unified_document.id,
+            organization=getattr(user, "organization", None),
+            user=user,
+        )

--- a/src/note/tests/test_note_creation_service.py
+++ b/src/note/tests/test_note_creation_service.py
@@ -1,0 +1,67 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from note.services.note_creation_service import NoteCreationService
+from researchhub_access_group.constants import ADMIN, NO_ACCESS
+from researchhub_document.related_models.constants.document_type import (
+    NOTE,
+    PREREGISTRATION,
+)
+
+
+class NoteCreationServiceTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="owner@researchhub_test.com",
+            password="password",
+            email="owner@researchhub_test.com",
+        )
+        self.other = get_user_model().objects.create_user(
+            username="other@researchhub_test.com",
+            password="password",
+            email="other@researchhub_test.com",
+        )
+
+    def test_creates_a_private_empty_note_in_the_users_personal_org(self):
+        # Act
+        note = NoteCreationService().create_private_note(
+            created_by=self.user, title="Ideas"
+        )
+
+        # Assert
+        self.assertEqual(note.title, "Ideas")
+        self.assertEqual(note.document_type, NOTE)
+        self.assertEqual(note.created_by, self.user)
+        self.assertEqual(note.organization, self.user.organization)
+        self.assertIsNone(note.latest_version)
+        self.assertEqual(note.unified_document.document_type, NOTE)
+        permissions = note.unified_document.permissions
+        self.assertTrue(permissions.filter(user=self.user, access_type=ADMIN).exists())
+        self.assertTrue(
+            permissions.filter(
+                organization=self.user.organization, access_type=NO_ACCESS
+            ).exists()
+        )
+        self.assertTrue(permissions.has_user(self.user))
+        self.assertFalse(permissions.has_user(self.other))
+
+    def test_document_type_and_grant_are_recorded(self):
+        # Act
+        note = NoteCreationService().create_private_note(
+            created_by=self.user, title="Proposal", document_type=PREREGISTRATION
+        )
+
+        # Assert
+        self.assertEqual(note.document_type, PREREGISTRATION)
+        self.assertIsNone(note.selected_grant)
+
+    def test_ownerless_note_has_no_permissions(self):
+        # Act
+        note = NoteCreationService().create_private_note(
+            created_by=None, title="System"
+        )
+
+        # Assert
+        self.assertIsNone(note.created_by)
+        self.assertIsNone(note.organization)
+        self.assertFalse(note.unified_document.permissions.exists())

--- a/src/research_ai/consumers.py
+++ b/src/research_ai/consumers.py
@@ -1,7 +1,9 @@
 """WebSocket consumers for research AI features.
 
 ``NotebookChatConsumer`` subscribes one client to one chat's turn events
-(``ws/notebook/notes/<note_id>/chats/<conversation_id>/``). Lifecycle events
+(``ws/notebook/notes/<note_id>/chats/<conversation_id>/``);
+``AssistantChatConsumer`` does the same for a note-less assistant chat
+(``ws/assistant/chats/<conversation_id>/``). Lifecycle events
 are small refetch nudges; ``stream_delta`` events append transient text or
 readable thinking to the matching active execution. The payload is forwarded
 verbatim. The ``?activity=live`` projection remains the recovery path: it
@@ -26,6 +28,7 @@ from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
 
 from note.related_models.note_model import Note
+from research_ai.services.assistant_chat import AssistantChatService
 from research_ai.services.notebook_chat import NotebookChatService
 from research_ai.services.notebook_chat.events import conversation_group
 from research_ai.services.usage_budget import resolve_ai_tier
@@ -37,18 +40,25 @@ CLOSE_FORBIDDEN = 4403
 CLOSE_NOT_FOUND = 4404
 
 
-@database_sync_to_async
-def _rejection_code(user, note_id: int, conversation_id: int) -> int | None:
-    """Why ``user`` may not watch this chat, or ``None`` to admit them.
-
-    One database hop covering the REST permission stack: the Research AI tier
-    and editor-or-moderator rollout gates, then note visibility and
-    conversation ownership exactly as the views resolve them.
-    """
+def _gate_rejection_code(user) -> int | None:
+    """The Research AI tier and editor-or-moderator rollout gates."""
     if resolve_ai_tier(user).name == "blocked":
         return CLOSE_FORBIDDEN
     if not (user.moderator or user.is_hub_editor()):
         return CLOSE_FORBIDDEN
+    return None
+
+
+@database_sync_to_async
+def _notebook_rejection_code(user, note_id: int, conversation_id: int) -> int | None:
+    """Why ``user`` may not watch this notebook chat, or ``None`` to admit them.
+
+    One database hop covering the REST permission stack: the gates, then note
+    visibility and conversation ownership exactly as the views resolve them.
+    """
+    rejection = _gate_rejection_code(user)
+    if rejection is not None:
+        return rejection
     note = Note.objects.filter(id=note_id, unified_document__is_removed=False).first()
     if note is None or not note.permissions.has_user(user):
         return CLOSE_NOT_FOUND
@@ -58,7 +68,23 @@ def _rejection_code(user, note_id: int, conversation_id: int) -> int | None:
     return None
 
 
-class NotebookChatConsumer(AsyncWebsocketConsumer):
+@database_sync_to_async
+def _assistant_rejection_code(user, conversation_id: int) -> int | None:
+    """Why ``user`` may not watch this assistant chat, or ``None`` to admit them."""
+    rejection = _gate_rejection_code(user)
+    if rejection is not None:
+        return rejection
+    if AssistantChatService().get_conversation(user, conversation_id) is None:
+        return CLOSE_NOT_FOUND
+    return None
+
+
+class _ConversationConsumer(AsyncWebsocketConsumer):
+    """Admit the owner of one chat and forward its turn events."""
+
+    async def rejection_code(self, user, kwargs: dict) -> int | None:
+        raise NotImplementedError
+
     async def connect(self):
         user = self.scope.get("user")
         # ``is_active`` alongside ``is_anonymous``: deactivating an account
@@ -68,19 +94,18 @@ class NotebookChatConsumer(AsyncWebsocketConsumer):
             await self.close(code=CLOSE_UNAUTHENTICATED)
             return
 
-        kwargs = self.scope["url_route"]["kwargs"]
-        # The route constrains both to digits; the casts normalize away
+        # The routes constrain ids to digits; the casts normalize away
         # artifacts like leading zeros so the group name always matches the
         # one the publisher derives from model ids.
-        note_id = int(kwargs["note_id"])
-        conversation_id = int(kwargs["conversation_id"])
-
-        rejection = await _rejection_code(user, note_id, conversation_id)
+        kwargs = {
+            key: int(value) for key, value in self.scope["url_route"]["kwargs"].items()
+        }
+        rejection = await self.rejection_code(user, kwargs)
         if rejection is not None:
             await self.close(code=rejection)
             return
 
-        self.group_name = conversation_group(conversation_id)
+        self.group_name = conversation_group(kwargs["conversation_id"])
         await self.channel_layer.group_add(self.group_name, self.channel_name)
         # The client offers ("Token", <key>) as subprotocols for
         # TokenAuthMiddleware; echo the name back like the other consumers.
@@ -93,3 +118,15 @@ class NotebookChatConsumer(AsyncWebsocketConsumer):
     async def notebook_chat_event(self, event):
         """Forward one published turn event to the client."""
         await self.send(text_data=json.dumps(event["data"]))
+
+
+class NotebookChatConsumer(_ConversationConsumer):
+    async def rejection_code(self, user, kwargs: dict) -> int | None:
+        return await _notebook_rejection_code(
+            user, kwargs["note_id"], kwargs["conversation_id"]
+        )
+
+
+class AssistantChatConsumer(_ConversationConsumer):
+    async def rejection_code(self, user, kwargs: dict) -> int | None:
+        return await _assistant_rejection_code(user, kwargs["conversation_id"])

--- a/src/research_ai/prompts/assistant_chat_prompts.py
+++ b/src/research_ai/prompts/assistant_chat_prompts.py
@@ -1,0 +1,28 @@
+"""Prompt builder for the note-less research assistant chat.
+
+The system prompt states that the chat is attached to no document, lists the
+notes this conversation has created so far (so later turns know their ids),
+and gives the same research and note-editing tool contract as the notebook
+assistant plus ``create_note``.
+"""
+
+from collections.abc import Iterable
+
+from research_ai.prompts._loader import load_template
+
+_NO_NOTES = (
+    "This chat has not created any notes yet. You have no access to the "
+    "user's other notes."
+)
+_NOTES_HEADER = (
+    "This chat has created the notes below; they are the only notes you can "
+    "read or edit. Use these ids with read_note and edit_note."
+)
+
+
+def build_assistant_chat_system_prompt(notes: Iterable) -> str:
+    """The system prompt for a conversation with ``notes`` created so far."""
+    template = load_template("assistant_chat_system.txt")
+    lines = [f'- note {note.id} ("{note.title or "Untitled"}")' for note in notes]
+    section = f"{_NOTES_HEADER}\n\n" + "\n".join(lines) if lines else _NO_NOTES
+    return template.replace("{{NOTES_SECTION}}", section)

--- a/src/research_ai/prompts/assistant_chat_system.txt
+++ b/src/research_ai/prompts/assistant_chat_system.txt
@@ -1,0 +1,70 @@
+You are the ResearchHub research assistant: a research collaborator working
+with a user in a chat that is not attached to any particular document. You help
+them research topics, find literature and funding, and -- when they want
+something written down -- draft it into a notebook note.
+
+## Notes
+
+{{NOTES_SECTION}}
+
+Do not create a note for a question that a chat reply answers well. Create one
+when the user asks you to draft, write up, save, or keep something as a
+document, or when a reply would otherwise be a long structured document. Tell
+the user which note you created or changed so they can open it.
+
+## What you can do
+
+- **Use the user's profile.** Call get_user_profile when the request benefits
+  from knowing the user's background, expertise, affiliation, publications, or
+  public pages. Profile URLs are leads, not proof of what those external pages
+  currently say; use the literature or web tools to verify claims when needed.
+- **Ground in their researcher profile.** Call get_researcher_profile when
+  drafting or personalizing content in the user's name: when ResearchHub holds
+  an expert profile for this user, it carries their resolved OpenAlex identity,
+  key works, and demonstrated lab capabilities backed by their papers -- the
+  real bounds of what a draft in their name can credibly claim. It may be
+  absent, partial, or unresolved; then work from get_user_profile and the
+  literature tools instead, and never invent a track record.
+- **Answer and research.** Use search_institutions, search_authors, get_author,
+  and cursor-paginated get_author_works to discover real literature from
+  OpenAlex. Work listings are compact: call get_work_abstract for a promising
+  paper's abstract, then search_work_fulltext with a focused query when you need
+  evidence from the paper itself. Follow next_cursor when one page does not give
+  adequate candidate coverage. Use web_search for facts outside the literature.
+  Never invent a citation, DOI, author, or finding: if a claim needs a source,
+  find it with a tool first, and say so plainly when you cannot.
+- **Find funding.** Use search_grants when the user wants grants or RFPs. Its
+  results are compact cards; call get_grant_details before judging the exact
+  fit or requirements of a promising result, and distinguish promising matches
+  from confirmed eligibility; the user must verify the full RFP terms before
+  applying.
+- **Write and edit notes.** Create a note with create_note when needed, then
+  read it with read_note and change it with edit_note. You can only read and
+  edit notes created in this chat.
+
+## Editing rules
+
+1. Long notes may require several bounded read_note calls. Continue from
+   next_start_block until you have read every block relevant to the request,
+   passing the first response's version_id on every continuation read. Edit
+   from your latest read_note or edit_note result; a stale rejection means the
+   note changed -- read it again and re-apply.
+2. edit_note applies block operations (insert, replace, delete) to the note as
+   you read it. Send only the blocks you are changing; every block you do not
+   name stays exactly as stored. Batch all operations for one change into one
+   edit_note call -- indices always refer to the numbering you read, and never
+   shift within a call. A freshly created note has no version: populate it
+   with a single insert at position 0 and expected_version_id null.
+3. Make the edit the user asked for -- no more. When adding researched
+   material, attribute it in the text (authors, year, venue) so the user can
+   verify it.
+4. If the user's request is ambiguous or destructive (for example, deleting a
+   large section), state your understanding in your reply and make the
+   conservative edit rather than guessing broadly.
+
+## How to reply
+
+After tool use, always finish with a short plain-text reply to the user: what
+you found, created, or changed, and anything they should verify. Do not paste
+a whole note back into the chat; summarize the change. Keep replies concise and
+concrete.

--- a/src/research_ai/routing.py
+++ b/src/research_ai/routing.py
@@ -6,5 +6,9 @@ websocket_urlpatterns = [
     re_path(
         r"ws/notebook/notes/(?P<note_id>[0-9]+)/chats/(?P<conversation_id>[0-9]+)/$",
         consumers.NotebookChatConsumer.as_asgi(),
-    )
+    ),
+    re_path(
+        r"ws/assistant/chats/(?P<conversation_id>[0-9]+)/$",
+        consumers.AssistantChatConsumer.as_asgi(),
+    ),
 ]

--- a/src/research_ai/services/assistant_chat/__init__.py
+++ b/src/research_ai/services/assistant_chat/__init__.py
@@ -1,0 +1,8 @@
+"""The note-less research assistant chat flow."""
+
+from research_ai.services.assistant_chat.service import (
+    WORKFLOW,
+    AssistantChatService,
+)
+
+__all__ = ["WORKFLOW", "AssistantChatService"]

--- a/src/research_ai/services/assistant_chat/service.py
+++ b/src/research_ai/services/assistant_chat/service.py
@@ -1,0 +1,100 @@
+"""The research assistant chat: the notebook agent without a routed note.
+
+A user keeps any number of assistant chats, workflow ``assistant_chat``, each
+an ``AgentConversation`` scoped to its owner and resolved by id. Turns run on
+the notebook chat engine (``NotebookChatService``) with no note: the agent
+researches with the same tools and may call ``create_note``, which creates a
+private note in the user's notebook and attaches it to the conversation. The
+attached notes are the only ones the chat can read or edit, and they are
+reported on the chat representation so a client can link to them.
+
+The notebook chat list for a note filters on its own workflow, so a note this
+flow created does not show the assistant chat among that note's chats.
+"""
+
+from research_ai.models import AgentConversation, AgentExecution
+from research_ai.services.notebook_chat.service import (
+    ACTIVITY_ALL,
+    ASSISTANT_WORKFLOW,
+    NotebookChatService,
+)
+
+WORKFLOW = ASSISTANT_WORKFLOW
+
+
+class AssistantChatService:
+    """User-scoped chat operations over the shared turn engine.
+
+    ``engine`` is injectable for tests; every other keyword argument is
+    passed through to ``NotebookChatService``.
+    """
+
+    def __init__(self, *, engine: NotebookChatService | None = None, **engine_kwargs):
+        self.engine = (
+            NotebookChatService(workflow=WORKFLOW, **engine_kwargs)
+            if engine is None
+            else engine
+        )
+
+    # -- request path -----------------------------------------------------
+
+    def get_conversation(self, user, conversation_id: int) -> AgentConversation | None:
+        """The user's assistant chat ``conversation_id``, if any."""
+        return AgentConversation.objects.filter(
+            workflow=WORKFLOW, user=user, id=conversation_id
+        ).first()
+
+    def list_conversations(self, user) -> list[dict]:
+        """The user's assistant chats, newest activity first."""
+        conversations = self.engine.listing(
+            AgentConversation.objects.filter(workflow=WORKFLOW, user=user).order_by(
+                "-updated_date", "-id"
+            )
+        )
+        return [
+            {
+                "id": conversation.id,
+                "title": conversation.title,
+                "created_date": conversation.created_date,
+                "updated_date": conversation.updated_date,
+                "last_message_preview": conversation.last_message_preview,
+                "has_active_turn": conversation.has_active_turn,
+            }
+            for conversation in conversations
+        ]
+
+    def create_conversation(self, user, title: str = "") -> AgentConversation:
+        return self.engine.conversations.create(
+            user=user, workflow=WORKFLOW, title=title
+        )
+
+    def rename_conversation(
+        self, conversation: AgentConversation, title: str
+    ) -> AgentConversation:
+        return self.engine.rename_conversation(conversation, title)
+
+    def representation(
+        self, conversation: AgentConversation, *, activity_scope: str = ACTIVITY_ALL
+    ) -> dict:
+        """The notebook chat projection plus the notes this chat created."""
+        data = self.engine.representation(conversation, activity_scope=activity_scope)
+        data["notes"] = [
+            {"id": note.id, "title": note.title}
+            for note in self.engine._linked_notes(conversation)
+        ]
+        return data
+
+    def submit_message(
+        self, conversation: AgentConversation, text: str, **options
+    ) -> AgentExecution:
+        return self.engine.submit_message(None, conversation, text, **options)
+
+    def cancel_active_turn(
+        self, conversation: AgentConversation
+    ) -> AgentExecution | None:
+        return self.engine.cancel_active_turn(conversation)
+
+    # -- worker path ------------------------------------------------------
+
+    def run_turn(self, execution_id: int) -> dict:
+        return self.engine.run_turn(execution_id)

--- a/src/research_ai/services/note_tools.py
+++ b/src/research_ai/services/note_tools.py
@@ -22,11 +22,13 @@ reads use the ``HasAccessPermission`` predicate (any non-NO_ACCESS
 permission), writes the stricter ``HasEditingPermission`` one (editor or
 admin). A toolset built for a single-note surface can additionally be
 scoped with ``note_ids``; notes outside the scope get the same not-found
-error as inaccessible ones.
+error as inaccessible ones. A surface that starts without a note can pass a
+``note_creator`` to expose ``create_note``; a note it creates joins the scope
+for the rest of the turn.
 """
 
 import logging
-from collections.abc import Collection
+from collections.abc import Callable, Collection
 
 from django.db import transaction
 
@@ -44,7 +46,9 @@ logger = logging.getLogger(__name__)
 
 READ_NOTE = "read_note"
 EDIT_NOTE = "edit_note"
+CREATE_NOTE = "create_note"
 _MAX_BLOCKS_PER_READ = 50
+_MAX_TITLE_CHARS = 255
 
 _BLOCK_FORMAT = (
     "Blocks use a compact Tiptap form: a bare string at block level is a "
@@ -57,7 +61,9 @@ class NoteToolset:
     """Note read/edit tools acting with ``user``'s permissions.
 
     ``note_ids``, when given, restricts every tool to those notes regardless
-    of what else the user could access.
+    of what else the user could access. ``note_creator``, when given, adds a
+    ``create_note`` tool: it is called with the title and must return the new
+    ``Note`` (owned by ``user``); the toolset widens ``note_ids`` to include it.
 
     Best-effort contract: handlers never raise; failures come back to the
     model as ``{"error": ...}`` so a bad note id or a stale edit is a turn
@@ -70,15 +76,43 @@ class NoteToolset:
         user,
         service: NoteContentService | None = None,
         note_ids: Collection[int] | None = None,
+        note_creator: Callable[[str], Note] | None = None,
     ):
         self._user = user
         self._service = service or NoteContentService()
-        self._note_ids = None if note_ids is None else frozenset(note_ids)
+        self._note_ids = None if note_ids is None else set(note_ids)
+        self._note_creator = note_creator
 
     # -- tool construction ------------------------------------------------
 
     def build_tools(self) -> list[Tool]:
-        return [
+        tools = []
+        if self._note_creator is not None:
+            tools.append(
+                Tool(
+                    name=CREATE_NOTE,
+                    description=(
+                        "Create a new, empty notebook note owned by the user "
+                        "and return its note_id. Use it when the user wants "
+                        "something drafted, saved, or kept as a document "
+                        "rather than answered in chat, and no suitable note "
+                        "exists yet. The note has no content: populate it "
+                        "with an edit_note insert (expected_version_id null)."
+                    ),
+                    input_schema={
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string",
+                                "description": "A short title for the note.",
+                            }
+                        },
+                        "required": ["title"],
+                    },
+                    handler=self._create_note,
+                )
+            )
+        return tools + [
             Tool(
                 name=READ_NOTE,
                 description=(
@@ -215,6 +249,29 @@ class NoteToolset:
         return Toolset(self.build_tools())
 
     # -- handlers ---------------------------------------------------------
+
+    def _create_note(self, input: dict) -> dict:
+        if self._user is None or getattr(self._user, "is_anonymous", False):
+            return {"error": "a signed-in user is required to create a note"}
+        title = input.get("title")
+        if not isinstance(title, str) or not title.strip():
+            return {"error": "title must be a non-empty string"}
+        title = " ".join(title.split())
+        if len(title) > _MAX_TITLE_CHARS:
+            return {"error": f"title must be at most {_MAX_TITLE_CHARS} characters"}
+        try:
+            note = self._note_creator(title)
+        except Exception as exc:  # noqa: BLE001 - reported to the model
+            logger.exception("create_note failed for user %s", self._user.id)
+            return {"error": f"could not create the note: {exc}"}
+        if self._note_ids is not None:
+            self._note_ids.add(note.id)
+        return {
+            "note_id": note.id,
+            "title": note.title,
+            "version_id": None,
+            "created": True,
+        }
 
     def _read_note(self, input: dict) -> dict:
         note = self._get_readable_note(input.get("note_id"))

--- a/src/research_ai/services/notebook_chat/__init__.py
+++ b/src/research_ai/services/notebook_chat/__init__.py
@@ -18,6 +18,7 @@ from research_ai.services.notebook_chat.researcher_profile_tools import (
 from research_ai.services.notebook_chat.service import (
     ACTIVITY_ALL,
     ACTIVITY_LIVE,
+    ASSISTANT_WORKFLOW,
     WORKFLOW,
     NotebookChatService,
 )
@@ -29,6 +30,7 @@ from research_ai.services.notebook_chat.toolset import (
 __all__ = [
     "ACTIVITY_ALL",
     "ACTIVITY_LIVE",
+    "ASSISTANT_WORKFLOW",
     "GET_RESEARCHER_PROFILE",
     "READ_SELECTED_RFP",
     "SET_SELECTED_RFP",

--- a/src/research_ai/services/notebook_chat/activity.py
+++ b/src/research_ai/services/notebook_chat/activity.py
@@ -3,7 +3,8 @@
 A curated projection of :func:`conversation_activity_events` into fixed public
 shapes. Tool calls carry tool, label, status and timestamps, plus the
 enrichments the frontend renders: the note version an edit produced, so an open
-editor knows to reload, a human detail line (the search query or author searched
+editor knows to reload, the id and title of a note the turn created so the
+client can link to it, a human detail line (the search query or author searched
 for), and title/url ``sources`` for citations. Sources come from every tool that
 yields citable items -- web search and the scholarly tools alike -- in one
 shape, so the frontend renders one citation list. Narration events carry the
@@ -29,7 +30,7 @@ from research_ai.services.agent_persistence.activity import (
     ThinkingEvent,
     ToolCallEvent,
 )
-from research_ai.services.note_tools import EDIT_NOTE, READ_NOTE
+from research_ai.services.note_tools import CREATE_NOTE, EDIT_NOTE, READ_NOTE
 from research_ai.services.notebook_chat.grant_tools import (
     GET_GRANT_DETAILS,
     READ_SELECTED_RFP,
@@ -52,6 +53,7 @@ GET_AUTHOR = "get_author"
 GET_AUTHOR_WORKS = "get_author_works"
 
 _LABELS = {
+    CREATE_NOTE: "Created a note",
     READ_NOTE: "Read the note",
     EDIT_NOTE: "Edited the note",
     WEB_SEARCH: "Searched the web",
@@ -71,6 +73,7 @@ _LABELS = {
 # What each tool is doing while the call is still open, for the live phase.
 # Distinct from _LABELS, which reads as a completed step.
 _ACTIVE_LABELS = {
+    CREATE_NOTE: "Creating a note",
     READ_NOTE: "Reading the note",
     EDIT_NOTE: "Editing the note",
     WEB_SEARCH: "Searching the web",
@@ -237,6 +240,12 @@ def _public_tool_call(event: ToolCallEvent, execution_active: bool) -> dict:
         version_id = (event.result or {}).get("version_id")
         if isinstance(version_id, int):
             public["note_version_id"] = version_id
+    if succeeded and event.tool == CREATE_NOTE:
+        result = event.result or {}
+        note_id = result.get("note_id")
+        if isinstance(note_id, int):
+            public["note_id"] = note_id
+            public["note_title"] = str(result.get("title") or "")
     if succeeded:
         sources = _sources(event)
         if sources:

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -26,6 +26,12 @@ conversation's note: ``NoteToolset`` enforces note view/edit permissions per
 call, so a viewer can chat and research but the edit tool refuses to write for
 them, and it is scoped to the routed note, so the model cannot be talked into
 touching another note the same user could access.
+
+The same engine serves the note-less research assistant (workflow
+``assistant_chat``, see ``services.assistant_chat``): a conversation created
+without a note runs with ``create_note`` in its toolset, and every note that
+tool creates is attached to the conversation, so later turns can read and edit
+exactly those notes and nothing else.
 """
 
 import logging
@@ -37,12 +43,16 @@ from django.db.models.functions import Left
 from django.utils import timezone
 
 from note.related_models.note_model import Note
+from note.services.note_creation_service import NoteCreationService
 from research_ai.models import (
     AgentConversation,
     AgentConversationMessage,
     AgentExecution,
 )
 from research_ai.models.agent import AgentExecutionMessage
+from research_ai.prompts.assistant_chat_prompts import (
+    build_assistant_chat_system_prompt,
+)
 from research_ai.prompts.notebook_chat_prompts import build_notebook_chat_system_prompt
 from research_ai.services.agent import (
     AgentRunError,
@@ -107,6 +117,7 @@ from utils.openalex import OpenAlex
 logger = logging.getLogger(__name__)
 
 WORKFLOW = "notebook_chat"
+ASSISTANT_WORKFLOW = "assistant_chat"
 
 # Activity projection scopes for ``NotebookChatService.representation``.
 ACTIVITY_ALL = "all"
@@ -191,7 +202,10 @@ class NotebookChatService:
         config: NotebookChatConfig | None = None,
         event_publisher: ConversationEventPublisher | None = None,
         stream_store: ExecutionStreamStore | None = None,
+        note_creation_service: NoteCreationService | None = None,
+        workflow: str = WORKFLOW,
     ):
+        self.workflow = workflow
         self._provider = provider
         self._oa_client = oa_client
         self._web_search_client = web_search_client
@@ -226,6 +240,11 @@ class NotebookChatService:
             ConversationEventPublisher() if event_publisher is None else event_publisher
         )
         self.streams = ExecutionStreamStore() if stream_store is None else stream_store
+        self.note_creation = (
+            NoteCreationService()
+            if note_creation_service is None
+            else note_creation_service
+        )
         self._config = config
 
     @property
@@ -245,7 +264,7 @@ class NotebookChatService:
         """
         return (
             self.note_conversations.for_note(note)
-            .filter(workflow=WORKFLOW, user=user, id=conversation_id)
+            .filter(workflow=self.workflow, user=user, id=conversation_id)
             .first()
         )
 
@@ -258,28 +277,9 @@ class NotebookChatService:
         repair. ``has_active_turn`` is what lets a chat picker show a spinner
         without fetching any chat's full state.
         """
-        last_message = (
-            AgentConversationMessage.objects.filter(
-                conversation=OuterRef("pk"), is_active=True
-            )
-            .order_by("-sequence")
-            .annotate(preview=Left("content", LIST_PREVIEW_CHARS))
-            .values("preview")[:1]
-        )
-        conversations = (
-            self.note_conversations.for_note(note)
-            .filter(workflow=WORKFLOW, user=user)
-            .annotate(
-                last_message_preview=Subquery(last_message),
-                has_active_turn=Exists(
-                    AgentExecution.objects.filter(
-                        conversation=OuterRef("pk"),
-                        status__in=[
-                            AgentExecution.Status.PENDING,
-                            AgentExecution.Status.RUNNING,
-                        ],
-                    )
-                ),
+        conversations = self.listing(
+            self.note_conversations.for_note(note).filter(
+                workflow=self.workflow, user=user
             )
         )
         return [
@@ -293,6 +293,30 @@ class NotebookChatService:
             }
             for conversation in conversations
         ]
+
+    @staticmethod
+    def listing(conversations):
+        """Annotate a conversation queryset for a chat picker, in one query."""
+        last_message = (
+            AgentConversationMessage.objects.filter(
+                conversation=OuterRef("pk"), is_active=True
+            )
+            .order_by("-sequence")
+            .annotate(preview=Left("content", LIST_PREVIEW_CHARS))
+            .values("preview")[:1]
+        )
+        return conversations.annotate(
+            last_message_preview=Subquery(last_message),
+            has_active_turn=Exists(
+                AgentExecution.objects.filter(
+                    conversation=OuterRef("pk"),
+                    status__in=[
+                        AgentExecution.Status.PENDING,
+                        AgentExecution.Status.RUNNING,
+                    ],
+                )
+            ),
+        )
 
     def representation(
         self, conversation: AgentConversation, *, activity_scope: str = ACTIVITY_ALL
@@ -425,7 +449,7 @@ class NotebookChatService:
         """
         with transaction.atomic():
             conversation = self.conversations.create(
-                user=user, workflow=WORKFLOW, title=title
+                user=user, workflow=self.workflow, title=title
             )
             self.note_conversations.attach(conversation, note)
         return conversation
@@ -438,7 +462,7 @@ class NotebookChatService:
 
     def submit_message(
         self,
-        note: Note,
+        note: Note | None,
         conversation: AgentConversation,
         text: str,
         *,
@@ -450,7 +474,9 @@ class NotebookChatService:
         """Record the user's message on ``conversation`` and schedule the turn.
 
         ``conversation`` must have been resolved through ``get_conversation``
-        so it is known to belong to ``note``. A chat still untitled takes its
+        so it is known to belong to ``note``. ``note`` is ``None`` for a
+        note-less assistant conversation, whose turn runs with ``create_note``
+        against the notes attached to it. A chat still untitled takes its
         name from this message. ``model_ref`` selects the model for the first
         turn. Later turns reuse that model; requesting a different provider or
         model raises ``ValueError``.
@@ -530,8 +556,11 @@ class NotebookChatService:
                     "temperature": (
                         config.temperature if temperature is None else temperature
                     ),
-                    "note_id": note.id,
                 }
+                # A recorded note pins the worker to it; its absence is what
+                # marks the execution as a note-less turn.
+                if note is not None:
+                    configuration["note_id"] = note.id
                 if effort is not None:
                     configuration["effort"] = effort
                 if thinking is not None:
@@ -544,7 +573,7 @@ class NotebookChatService:
                     provider=provider_name,
                     model=model,
                     configuration=configuration,
-                    system_prompt=build_notebook_chat_system_prompt(note),
+                    system_prompt=self._system_prompt(note, locked_conversation),
                 )
                 prepared.execution.usage_reservation_expires_at = reservation_deadline()
                 prepared.execution.save(
@@ -674,16 +703,25 @@ class NotebookChatService:
 
     def _run_turn(self, execution: AgentExecution, recorder) -> dict:
         conversation = execution.conversation
-        note = self._note_for(conversation)
         trigger = execution.trigger_message
-        if note is None or conversation.user is None or trigger is None:
+        stored_configuration = execution.configuration or {}
+        # The note the turn was submitted on, when it was. A recorded id that
+        # no longer resolves is a broken row; no id at all is a note-less
+        # assistant turn, which works on whatever notes the chat has created.
+        pinned_note_id = stored_configuration.get("note_id")
+        note = (
+            self._note_for(conversation, pinned_note_id)
+            if pinned_note_id is not None
+            else None
+        )
+        note_missing = pinned_note_id is not None and note is None
+        if note_missing or conversation.user is None or trigger is None:
             error = AgentRunError(
                 "notebook chat execution is missing its note, user, or message"
             )
             recorder.on_run_failed(error)
             return {"execution_id": execution.id, "error": str(error)}
 
-        stored_configuration = execution.configuration or {}
         provider_options = {
             key: stored_configuration[key]
             for key in ("effort", "thinking")
@@ -695,7 +733,7 @@ class NotebookChatService:
             **provider_options,
         )
         toolset = compose_notebook_toolset(
-            note_toolset=NoteToolset(user=conversation.user, note_ids={note.id}),
+            note_toolset=self._note_toolset(conversation, note),
             user_profile_toolset=UserProfileToolset(user=conversation.user),
             researcher_profile_toolset=self._researcher_profile_toolset_factory(
                 user=conversation.user
@@ -703,7 +741,7 @@ class NotebookChatService:
             grant_toolset=self._grant_toolset_factory(user=conversation.user),
             selected_rfp_toolset=(
                 SelectedRFPToolset(note=note, user=conversation.user)
-                if note.document_type == PREREGISTRATION
+                if note is not None and note.document_type == PREREGISTRATION
                 else None
             ),
             openalex_toolset=OpenAlexToolset(client=self._oa_client or OpenAlex()),
@@ -714,7 +752,9 @@ class NotebookChatService:
         accounting_provider, accounting_model = split_model_ref(execution.model)
         budget_recorder = AgentLoopBudgetRecorder(
             user=conversation.user,
-            feature=WORKFLOW,
+            # From the row, not ``self.workflow``: one worker task runs turns
+            # for every workflow and must account each to its own feature.
+            feature=conversation.workflow or self.workflow,
             provider=execution.provider or accounting_provider,
             model_id=accounting_model or "",
             recorder=recorder,
@@ -794,6 +834,53 @@ class NotebookChatService:
             max_message_chars=defaults.max_message_chars,
         )
 
-    def _note_for(self, conversation: AgentConversation) -> Note | None:
-        link = conversation.note_links.select_related("note").order_by("id").first()
+    def _system_prompt(self, note: Note | None, conversation) -> str:
+        if note is not None:
+            return build_notebook_chat_system_prompt(note)
+        return build_assistant_chat_system_prompt(self._linked_notes(conversation))
+
+    def _note_toolset(
+        self, conversation: AgentConversation, note: Note | None
+    ) -> NoteToolset:
+        """Note tools scoped to the routed note, or to the chat's own notes.
+
+        A note-less turn may create notes; each one is attached to the
+        conversation as it is created, so it stays in scope for later turns
+        and for a listing of what the chat produced.
+        """
+        if note is not None:
+            return NoteToolset(user=conversation.user, note_ids={note.id})
+        return NoteToolset(
+            user=conversation.user,
+            note_ids={linked.id for linked in self._linked_notes(conversation)},
+            note_creator=lambda title: self._create_note(conversation, title),
+        )
+
+    def _create_note(self, conversation: AgentConversation, title: str) -> Note:
+        with transaction.atomic():
+            note = self.note_creation.create_private_note(
+                created_by=conversation.user, title=title
+            )
+            self.note_conversations.attach(conversation, note)
+        return note
+
+    @staticmethod
+    def _linked_notes(conversation: AgentConversation) -> list[Note]:
+        """Live notes attached to ``conversation``, oldest first."""
+        return [
+            link.note
+            for link in conversation.note_links.filter(
+                note__unified_document__is_removed=False
+            )
+            .select_related("note")
+            .order_by("id")
+        ]
+
+    def _note_for(self, conversation: AgentConversation, note_id: int) -> Note | None:
+        """The attached note ``note_id``, or ``None`` if it is not linked."""
+        link = (
+            conversation.note_links.filter(note_id=note_id)
+            .select_related("note")
+            .first()
+        )
         return link.note if link else None

--- a/src/research_ai/services/proposal_draft/note_writer.py
+++ b/src/research_ai/services/proposal_draft/note_writer.py
@@ -2,15 +2,11 @@
 
 import json
 
-from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 
 from note.models import Note, NoteContent
-from researchhub_access_group.constants import ADMIN, NO_ACCESS
-from researchhub_access_group.models import Permission
-from researchhub_document.models import ResearchhubUnifiedDocument
+from note.services.note_creation_service import NoteCreationService
 from researchhub_document.related_models.constants.document_type import (
-    NOTE,
     PREREGISTRATION,
 )
 
@@ -21,12 +17,9 @@ def write_proposal_note(
 ) -> Note:
     """Create the Note directly (headless: no notifications).
 
-    The view paths require an auth user + org and fire org-scoped websocket
-    notifications, so we create the rows directly. When ``created_by`` is
-    given (the user who triggered the draft), the note lands privately in
-    their notebook: owned by them, in their personal org, with user-admin /
-    org-no-access permissions. For system/automatic runs it stays ownerless.
-    The ``NoteContent`` post_save signal sets ``note.latest_version``.
+    When ``created_by`` is given (the user who triggered the draft), the note
+    lands privately in their notebook; for system/automatic runs it stays
+    ownerless. The ``NoteContent`` post_save signal sets ``note.latest_version``.
 
     The note is a PREREGISTRATION carrying ``selected_grant`` -- the RFP the
     whole draft was written against. Both are what the notebook reads to treat
@@ -35,17 +28,12 @@ def write_proposal_note(
     """
     sections = submitted.get("sections") or {}
     title = str(sections.get("title") or "").strip() or "Untitled proposal"
-    unified_document = ResearchhubUnifiedDocument.objects.create(document_type=NOTE)
-    note = Note.objects.create(
+    note = NoteCreationService().create_private_note(
         created_by=created_by,
-        document_type=PREREGISTRATION,
-        organization=created_by.organization if created_by else None,
-        selected_grant=selected_grant,
         title=title,
-        unified_document=unified_document,
+        document_type=PREREGISTRATION,
+        selected_grant=selected_grant,
     )
-    if created_by is not None:
-        _create_private_permissions(created_by, unified_document)
     prosemirror = submitted.get("prosemirror")
     NoteContent.objects.create(
         note=note,
@@ -60,21 +48,3 @@ def write_proposal_note(
     )
     note.refresh_from_db()
     return note
-
-
-def _create_private_permissions(user, unified_document) -> None:
-    """Grant the user private admin access to the note document."""
-    content_type = ContentType.objects.get_for_model(ResearchhubUnifiedDocument)
-    Permission.objects.create(
-        access_type=ADMIN,
-        content_type=content_type,
-        object_id=unified_document.id,
-        user=user,
-    )
-    Permission.objects.create(
-        access_type=NO_ACCESS,
-        content_type=content_type,
-        object_id=unified_document.id,
-        organization=user.organization,
-        user=user,
-    )

--- a/src/research_ai/tests/assistant_chat/test_assistant_chat_consumer.py
+++ b/src/research_ai/tests/assistant_chat/test_assistant_chat_consumer.py
@@ -1,0 +1,118 @@
+import json
+from unittest.mock import patch
+
+from channels.layers import get_channel_layer
+from channels.routing import URLRouter
+from channels.testing import WebsocketCommunicator
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import TransactionTestCase
+
+import research_ai.routing
+from research_ai.consumers import (
+    CLOSE_FORBIDDEN,
+    CLOSE_NOT_FOUND,
+    CLOSE_UNAUTHENTICATED,
+)
+from research_ai.services.assistant_chat import AssistantChatService
+from research_ai.services.notebook_chat.events import EVENT_TYPE, conversation_group
+
+application = URLRouter(research_ai.routing.websocket_urlpatterns)
+
+
+class AssistantChatConsumerTests(TransactionTestCase):
+    """Admission mirrors the REST contract; events are forwarded verbatim."""
+
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="owner@researchhub_test.com",
+            password="password",
+            email="owner@researchhub_test.com",
+        )
+        self.user.moderator = True
+        self.user.save(update_fields=["moderator"])
+        self.other_user = user_model.objects.create_user(
+            username="other@researchhub_test.com",
+            password="password",
+            email="other@researchhub_test.com",
+        )
+        service = AssistantChatService()
+        self.conversation = service.create_conversation(self.user)
+        self.other_conversation = service.create_conversation(self.other_user)
+
+    async def _connect(self, user, *, conversation_id=None):
+        conversation_id = (
+            self.conversation.id if conversation_id is None else conversation_id
+        )
+        communicator = WebsocketCommunicator(
+            application, f"/ws/assistant/chats/{conversation_id}/"
+        )
+        communicator.scope["user"] = user
+        connected, detail = await communicator.connect()
+        return communicator, connected, detail
+
+    async def test_anonymous_connection_is_rejected(self):
+        # Act
+        _communicator, connected, code = await self._connect(AnonymousUser())
+
+        # Assert
+        self.assertFalse(connected)
+        self.assertEqual(code, CLOSE_UNAUTHENTICATED)
+
+    async def test_user_outside_the_rollout_gate_is_rejected(self):
+        # Act: authenticated, but neither editor nor moderator.
+        _communicator, connected, code = await self._connect(
+            self.other_user, conversation_id=self.other_conversation.id
+        )
+
+        # Assert
+        self.assertFalse(connected)
+        self.assertEqual(code, CLOSE_FORBIDDEN)
+
+    async def test_someone_elses_conversation_reads_as_not_found(self):
+        # Arrange: a moderator who does not own the chat.
+        self.other_user.moderator = True
+        await self.other_user.asave(update_fields=["moderator"])
+
+        # Act
+        _communicator, connected, code = await self._connect(self.other_user)
+
+        # Assert
+        self.assertFalse(connected)
+        self.assertEqual(code, CLOSE_NOT_FOUND)
+
+    async def test_hub_editor_passes_the_rollout_gate(self):
+        # Arrange
+        user_model = get_user_model()
+
+        # Act
+        with patch.object(user_model, "is_hub_editor", return_value=True):
+            communicator, connected, _detail = await self._connect(
+                self.other_user, conversation_id=self.other_conversation.id
+            )
+
+        # Assert
+        self.assertTrue(connected)
+        await communicator.disconnect()
+
+    async def test_owner_connects_and_receives_published_events(self):
+        # Arrange
+        communicator, connected, subprotocol = await self._connect(self.user)
+        self.assertTrue(connected)
+        self.assertEqual(subprotocol, "Token")
+        event = {
+            "conversation_id": self.conversation.id,
+            "execution_id": 5,
+            "kind": "turn_progress",
+        }
+
+        # Act
+        await get_channel_layer().group_send(
+            conversation_group(self.conversation.id),
+            {"type": EVENT_TYPE, "data": event},
+        )
+
+        # Assert
+        self.assertEqual(json.loads(await communicator.receive_from()), event)
+        await communicator.disconnect()

--- a/src/research_ai/tests/assistant_chat/test_assistant_chat_service.py
+++ b/src/research_ai/tests/assistant_chat/test_assistant_chat_service.py
@@ -1,0 +1,229 @@
+import json
+from unittest.mock import Mock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+
+from note.models import Note
+from note.tests.helpers import create_note
+from research_ai.models import AgentExecution
+from research_ai.services.agent.types import TurnUsage
+from research_ai.services.assistant_chat import WORKFLOW, AssistantChatService
+from research_ai.services.notebook_chat import NotebookChatService
+from research_ai.services.usage_budget import budget_status
+from research_ai.tests.agent.persistence_test_helpers import (
+    FakeProvider,
+    text_turn,
+    tool_turn,
+)
+from researchhub_access_group.constants import ADMIN, NO_ACCESS
+
+MODEL_SETTINGS = {
+    "ANTHROPIC_AWS_WORKSPACE_ID": "ws-test",
+    "AWS_REGION_NAME": "us-east-1",
+    "OPENROUTER_API_KEY": "or-test",
+}
+INSERT_BODY = [{"op": "insert", "at": 0, "blocks": ["Drafted by the assistant"]}]
+
+
+class LazyProvider(FakeProvider):
+    """A fake whose turns may be callables built once earlier turns ran.
+
+    A real model reads the created note's id from the create_note result;
+    the fake builds its edit_note turn from the database instead.
+    """
+
+    def complete(self, **kwargs):
+        if callable(self.turns[0]):
+            self.turns[0] = self.turns[0]()
+        return super().complete(**kwargs)
+
+
+def _make_service(provider=None, **kwargs):
+    return AssistantChatService(
+        provider=provider,
+        oa_client=Mock(),
+        web_search_client=Mock(configured=False),
+        **kwargs,
+    )
+
+
+@override_settings(**MODEL_SETTINGS)
+class AssistantChatServiceTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="owner@researchhub_test.com",
+            password="password",
+            email="owner@researchhub_test.com",
+            is_staff=True,
+        )
+        self.service = _make_service()
+        self.conversation = self.service.create_conversation(self.user)
+
+    def _submit(self, text="Draft a proposal outline.", **kwargs):
+        with (
+            patch("research_ai.tasks.run_notebook_chat_turn_task.delay") as delay,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            execution = self.service.submit_message(self.conversation, text, **kwargs)
+        return execution, delay
+
+    def _run(self, execution, turns):
+        result = _make_service(provider=LazyProvider(turns)).run_turn(execution.id)
+        execution.refresh_from_db()
+        return result
+
+    def _activity(self, attempt_index):
+        representation = self.service.representation(self.conversation)
+        return representation["executions"][attempt_index]["activity"]
+
+    def test_submit_message_prepares_a_note_less_turn(self):
+        # Act
+        execution, delay = self._submit()
+
+        # Assert
+        self.assertEqual(execution.conversation.workflow, WORKFLOW)
+        self.assertEqual(execution.conversation.user, self.user)
+        self.assertEqual(execution.status, AgentExecution.Status.PENDING)
+        self.assertNotIn("note_id", execution.configuration)
+        self.assertIn("create_note", execution.system_prompt)
+        self.assertIn("has not created any notes yet", execution.system_prompt)
+        self.conversation.refresh_from_db()
+        self.assertEqual(self.conversation.title, "Draft a proposal outline.")
+        delay.assert_called_once_with(execution.id)
+
+    def test_run_turn_can_create_and_populate_a_note(self):
+        # Arrange: the model creates a note, writes into it, and replies.
+        execution, _delay = self._submit()
+
+        def edit_the_new_note():
+            note = Note.objects.get(title="Proposal outline")
+            return tool_turn(
+                "t2",
+                "edit_note",
+                {
+                    "note_id": note.id,
+                    "expected_version_id": None,
+                    "edits": INSERT_BODY,
+                },
+            )
+
+        # Act
+        result = self._run(
+            execution,
+            [
+                tool_turn("t1", "create_note", {"title": "  Proposal   outline "}),
+                edit_the_new_note,
+                text_turn("I drafted the outline into a new note."),
+            ],
+        )
+
+        # Assert: the note exists, is private to the user, holds the body,
+        # and is attached to the conversation.
+        self.assertEqual(execution.status, AgentExecution.Status.SUCCEEDED)
+        self.assertEqual(result["final_text"], "I drafted the outline into a new note.")
+        note = Note.objects.get(title="Proposal outline")
+        self.assertEqual(note.created_by, self.user)
+        self.assertEqual(note.organization, self.user.organization)
+        self.assertEqual(json.loads(note.latest_version.json)["type"], "doc")
+        self.assertEqual(note.latest_version.plain_text, "Drafted by the assistant")
+        permissions = note.unified_document.permissions
+        self.assertTrue(permissions.filter(user=self.user, access_type=ADMIN).exists())
+        self.assertTrue(
+            permissions.filter(
+                organization=self.user.organization, access_type=NO_ACCESS
+            ).exists()
+        )
+        self.assertTrue(self.conversation.note_links.filter(note=note).exists())
+        representation = self.service.representation(self.conversation)
+        self.assertEqual(
+            representation["notes"], [{"id": note.id, "title": "Proposal outline"}]
+        )
+        created = [
+            event for event in self._activity(0) if event.get("tool") == "create_note"
+        ]
+        self.assertEqual(created[0]["label"], "Created a note")
+        self.assertEqual(created[0]["note_id"], note.id)
+        self.assertEqual(created[0]["note_title"], "Proposal outline")
+
+    def test_later_turns_see_the_created_notes_and_nothing_else(self):
+        # Arrange: one note created by this chat, one the user owns otherwise.
+        execution, _delay = self._submit()
+        self._run(execution, [tool_turn("t1", "create_note", {"title": "Mine"})])
+        own_note = self.conversation.note_links.get().note
+        other_note, _content = create_note(self.user, organization=None)
+
+        # Act
+        second, _delay = self._submit("Read both notes.")
+        result = self._run(
+            second,
+            [
+                tool_turn("t2", "read_note", {"note_id": other_note.id}),
+                tool_turn("t3", "read_note", {"note_id": own_note.id}),
+                text_turn("Done."),
+            ],
+        )
+
+        # Assert: the prompt names the created note; the other note is
+        # invisible even though the user could open it in the notebook.
+        self.assertIn(f"note {own_note.id}", second.system_prompt)
+        self.assertNotIn(f"note {other_note.id}", second.system_prompt)
+        self.assertEqual(result["final_text"], "Done.")
+        reads = [
+            event for event in self._activity(1) if event.get("tool") == "read_note"
+        ]
+        self.assertEqual([event["status"] for event in reads], ["failed", "succeeded"])
+
+    def test_created_note_does_not_list_the_assistant_chat_on_the_note(self):
+        # Arrange
+        execution, _delay = self._submit()
+        self._run(execution, [tool_turn("t1", "create_note", {"title": "Mine"})])
+        note = self.conversation.note_links.get().note
+
+        # Act
+        notebook_chats = NotebookChatService().list_conversations(note, self.user)
+
+        # Assert
+        self.assertEqual(notebook_chats, [])
+
+    def test_run_turn_accounts_usage_to_the_assistant_feature(self):
+        # Arrange
+        execution, _delay = self._submit(model_ref="claude_platform:claude-opus-5")
+
+        class UsageReportingProvider(FakeProvider):
+            def complete(self, **kwargs):
+                turn = super().complete(**kwargs)
+                kwargs["on_usage"](turn.usage)
+                return turn
+
+        provider = UsageReportingProvider(
+            [text_turn("Done.", usage=TurnUsage(input_tokens=1000, output_tokens=100))]
+        )
+
+        # Act
+        _make_service(provider=provider).run_turn(execution.id)
+
+        # Assert
+        event = execution.usage_events.get()
+        self.assertEqual(event.feature, WORKFLOW)
+        self.assertEqual(budget_status(self.user).as_dict()["credits"]["used"], "7.5")
+
+    def test_get_conversation_is_scoped_to_owner_and_workflow(self):
+        # Arrange
+        user_model = get_user_model()
+        other = user_model.objects.create_user(
+            username="other@researchhub_test.com",
+            password="password",
+            email="other@researchhub_test.com",
+        )
+        note, _content = create_note(self.user, organization=None)
+        notebook_chat = NotebookChatService().create_conversation(note, self.user)
+
+        # Act / Assert
+        self.assertEqual(
+            self.service.get_conversation(self.user, self.conversation.id),
+            self.conversation,
+        )
+        self.assertIsNone(self.service.get_conversation(other, self.conversation.id))
+        self.assertIsNone(self.service.get_conversation(self.user, notebook_chat.id))

--- a/src/research_ai/tests/assistant_chat/test_assistant_chat_views.py
+++ b/src/research_ai/tests/assistant_chat/test_assistant_chat_views.py
@@ -1,0 +1,247 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from rest_framework.test import APITestCase
+
+from note.tests.helpers import create_note
+from research_ai.models import AgentExecution
+from research_ai.services.notebook_chat import NotebookChatService
+
+MODEL_SETTINGS = {
+    "ANTHROPIC_AWS_WORKSPACE_ID": "ws-test",
+    "AWS_REGION_NAME": "us-east-1",
+    "OPENROUTER_API_KEY": "or-test",
+}
+
+CHATS_URL = "/api/research_ai/assistant/chats/"
+
+
+@override_settings(**MODEL_SETTINGS)
+class AssistantChatViewTests(APITestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.owner = user_model.objects.create_user(
+            username="owner@researchhub_test.com",
+            password="password",
+            email="owner@researchhub_test.com",
+        )
+        self.other = user_model.objects.create_user(
+            username="other@researchhub_test.com",
+            password="password",
+            email="other@researchhub_test.com",
+        )
+        # Neither editor nor moderator: exercises the rollout gate.
+        self.regular_user = user_model.objects.create_user(
+            username="regular@researchhub_test.com",
+            password="password",
+            email="regular@researchhub_test.com",
+        )
+        for user in (self.owner, self.other):
+            user.moderator = True
+            user.save(update_fields=["moderator"])
+
+    def _chat_url(self, conversation_id):
+        return f"{CHATS_URL}{conversation_id}/"
+
+    def _create_chat_id(self, **payload):
+        response = self.client.post(CHATS_URL, payload, format="json")
+        self.assertEqual(response.status_code, 201)
+        return response.data["conversation_id"]
+
+    def _post_message(self, conversation_id, text="Find papers on CRISPR", **extra):
+        with patch("research_ai.tasks.run_notebook_chat_turn_task.delay") as delay:
+            response = self.client.post(
+                f"{self._chat_url(conversation_id)}messages/",
+                {"message": text, **extra},
+                format="json",
+            )
+        return response, delay
+
+    # -- creating and listing ---------------------------------------------
+
+    def test_create_chat_returns_an_empty_representation_with_no_notes(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+
+        # Act
+        response = self.client.post(CHATS_URL, {"title": "Grants"}, format="json")
+
+        # Assert
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["title"], "Grants")
+        self.assertEqual(response.data["messages"], [])
+        self.assertEqual(response.data["executions"], [])
+        self.assertEqual(response.data["notes"], [])
+
+    def test_gate_blocks_regular_users(self):
+        # Arrange
+        self.client.force_authenticate(self.regular_user)
+
+        # Act
+        response = self.client.post(CHATS_URL, {}, format="json")
+
+        # Assert
+        self.assertEqual(response.status_code, 403)
+
+    def test_requires_authentication(self):
+        # Act
+        response = self.client.get(CHATS_URL)
+
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_list_chats_is_scoped_to_the_user(self):
+        # Arrange: the owner has one busy chat and one idle chat; another
+        # user has a chat of their own.
+        self.client.force_authenticate(self.owner)
+        idle_chat = self._create_chat_id()
+        busy_chat = self._create_chat_id()
+        self._post_message(busy_chat, "Compare the cited methods")
+        self.client.force_authenticate(self.other)
+        self._create_chat_id()
+
+        # Act
+        self.client.force_authenticate(self.owner)
+        response = self.client.get(CHATS_URL)
+
+        # Assert: newest activity first, nobody else's chats.
+        busy, idle = response.data["chats"]
+        self.assertEqual(busy["id"], busy_chat)
+        self.assertEqual(busy["title"], "Compare the cited methods")
+        self.assertTrue(busy["has_active_turn"])
+        self.assertEqual(idle["id"], idle_chat)
+        self.assertFalse(idle["has_active_turn"])
+
+    def test_assistant_chats_do_not_appear_among_notebook_chats(self):
+        # Arrange: an assistant chat and a notebook chat for the same user.
+        self.client.force_authenticate(self.owner)
+        self._create_chat_id()
+        note, _content = create_note(self.owner, organization=None)
+        NotebookChatService().create_conversation(note, self.owner)
+
+        # Act
+        listing = self.client.get(CHATS_URL)
+
+        # Assert: the notebook chat is not an assistant chat, and the
+        # assistant chat is not on the note either.
+        self.assertEqual(len(listing.data["chats"]), 1)
+        self.assertEqual(
+            len(NotebookChatService().list_conversations(note, self.owner)), 1
+        )
+
+    # -- messages -----------------------------------------------------------
+
+    def test_post_message_starts_a_note_less_turn(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
+
+        # Act
+        response, _delay = self._post_message(chat_id)
+
+        # Assert
+        self.assertEqual(response.status_code, 202)
+        execution = AgentExecution.objects.get(id=response.data["execution_id"])
+        self.assertEqual(execution.status, AgentExecution.Status.PENDING)
+        self.assertNotIn("note_id", execution.configuration)
+        self.assertIn("create_note", execution.system_prompt)
+
+    def test_post_message_to_another_users_chat_is_not_found(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
+        self.client.force_authenticate(self.other)
+
+        # Act
+        response, _delay = self._post_message(chat_id)
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_post_while_turn_is_running_returns_conflict(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
+        first, _delay = self._post_message(chat_id)
+        self.assertEqual(first.status_code, 202)
+
+        # Act
+        second, _delay = self._post_message(chat_id, "another")
+
+        # Assert
+        self.assertEqual(second.status_code, 409)
+
+    def test_busy_notebook_chat_blocks_the_assistant_chat(self):
+        # Arrange: budget admission is per user, across workflows.
+        self.client.force_authenticate(self.owner)
+        note, _content = create_note(self.owner, organization=None)
+        notebook_chat = NotebookChatService().create_conversation(note, self.owner)
+        with patch("research_ai.tasks.run_notebook_chat_turn_task.delay"):
+            NotebookChatService().submit_message(note, notebook_chat, "Busy")
+        chat_id = self._create_chat_id()
+
+        # Act
+        response, _delay = self._post_message(chat_id)
+
+        # Assert
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.data["code"], "usage_work_in_progress")
+
+    # -- detail, cancel, rename ---------------------------------------------
+
+    def test_get_chat_returns_its_representation(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
+        self._post_message(chat_id, "Hello")
+
+        # Act
+        response = self.client.get(self._chat_url(chat_id))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["conversation_id"], chat_id)
+        self.assertEqual(response.data["messages"][0]["content"], "Hello")
+        self.assertEqual(response.data["notes"], [])
+
+    def test_get_another_users_chat_is_not_found(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
+        self.client.force_authenticate(self.other)
+
+        # Act
+        response = self.client.get(self._chat_url(chat_id))
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_cancel_stops_the_running_turn(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
+        posted, _delay = self._post_message(chat_id)
+
+        # Act
+        response = self.client.post(f"{self._chat_url(chat_id)}cancel/")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["cancelled"])
+        execution = AgentExecution.objects.get(id=posted.data["execution_id"])
+        self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
+
+    def test_rename_chat(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
+
+        # Act
+        response = self.client.patch(
+            self._chat_url(chat_id), {"title": "Funding"}, format="json"
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["title"], "Funding")

--- a/src/research_ai/tests/test_note_tools.py
+++ b/src/research_ai/tests/test_note_tools.py
@@ -6,7 +6,12 @@ from django.test import TestCase
 
 from note.models import NoteContent
 from note.tests.helpers import create_note
-from research_ai.services.note_tools import EDIT_NOTE, READ_NOTE, NoteToolset
+from research_ai.services.note_tools import (
+    CREATE_NOTE,
+    EDIT_NOTE,
+    READ_NOTE,
+    NoteToolset,
+)
 from researchhub_access_group.constants import ADMIN, VIEWER
 from researchhub_access_group.models import Permission
 from researchhub_document.models import ResearchhubUnifiedDocument
@@ -522,3 +527,77 @@ class NoteToolsetTests(TestCase):
         self.assertIn("not found or not accessible", edit_result["error"])
         other_note.refresh_from_db()
         self.assertEqual(other_note.latest_version_id, other_content.id)
+
+
+class NoteToolsetCreateNoteTests(TestCase):
+    def setUp(self):
+        self.owner = get_user_model().objects.create_user(
+            username="owner@researchhub_test.com",
+            password="password",
+            email="owner@researchhub_test.com",
+        )
+        self.created = []
+
+        def creator(title):
+            note, _content = create_note(self.owner, organization=None, title=title)
+            Permission.objects.create(
+                access_type=ADMIN,
+                content_type=ContentType.objects.get_for_model(
+                    ResearchhubUnifiedDocument
+                ),
+                object_id=note.unified_document.id,
+                user=self.owner,
+            )
+            self.created.append(note)
+            return note
+
+        self.toolset = NoteToolset(
+            user=self.owner, note_ids=set(), note_creator=creator
+        )
+        self.tools = {tool.name: tool for tool in self.toolset.build_tools()}
+
+    def test_create_note_is_offered_only_with_a_creator(self):
+        # Act
+        without = {tool.name for tool in NoteToolset(user=self.owner).build_tools()}
+
+        # Assert
+        self.assertIn(CREATE_NOTE, self.tools)
+        self.assertNotIn(CREATE_NOTE, without)
+
+    def test_create_note_returns_the_note_and_widens_the_scope(self):
+        # Arrange
+        outside, _content = create_note(self.owner, organization=None)
+
+        # Act
+        result = self.tools[CREATE_NOTE].handler({"title": "  New   idea "})
+        read = self.tools[READ_NOTE].handler({"note_id": result["note_id"]})
+        outside_read = self.tools[READ_NOTE].handler({"note_id": outside.id})
+
+        # Assert
+        self.assertEqual(result["title"], "New idea")
+        self.assertEqual(result["note_id"], self.created[0].id)
+        self.assertIsNone(result["version_id"])
+        self.assertEqual(read["title"], "New idea")
+        self.assertIn("error", outside_read)
+
+    def test_create_note_rejects_a_blank_title(self):
+        # Act
+        result = self.tools[CREATE_NOTE].handler({"title": "   "})
+
+        # Assert
+        self.assertIn("error", result)
+        self.assertEqual(self.created, [])
+
+    def test_create_note_reports_creator_failures_to_the_model(self):
+        # Arrange
+        def failing(title):
+            raise RuntimeError("database is away")
+
+        toolset = NoteToolset(user=self.owner, note_ids=set(), note_creator=failing)
+        create = {tool.name: tool for tool in toolset.build_tools()}[CREATE_NOTE]
+
+        # Act
+        result = create.handler({"title": "Anything"})
+
+        # Assert
+        self.assertIn("database is away", result["error"])

--- a/src/research_ai/urls.py
+++ b/src/research_ai/urls.py
@@ -1,5 +1,11 @@
 from django.urls import path
 
+from research_ai.views.assistant_chat_views import (
+    AssistantChatCancelView,
+    AssistantChatDetailView,
+    AssistantChatListCreateView,
+    AssistantChatMessageView,
+)
 from research_ai.views.email_views import (
     BulkGenerateEmailView,
     GeneratedEmailDetailView,
@@ -127,5 +133,18 @@ urlpatterns = [
     path(
         "notebook/notes/<int:note_id>/chats/<int:conversation_id>/cancel/",
         NotebookChatCancelView.as_view(),
+    ),
+    path("assistant/chats/", AssistantChatListCreateView.as_view()),
+    path(
+        "assistant/chats/<int:conversation_id>/",
+        AssistantChatDetailView.as_view(),
+    ),
+    path(
+        "assistant/chats/<int:conversation_id>/messages/",
+        AssistantChatMessageView.as_view(),
+    ),
+    path(
+        "assistant/chats/<int:conversation_id>/cancel/",
+        AssistantChatCancelView.as_view(),
     ),
 ]

--- a/src/research_ai/views/assistant_chat_views.py
+++ b/src/research_ai/views/assistant_chat_views.py
@@ -1,0 +1,162 @@
+"""API for the research assistant chat.
+
+The assistant is the notebook chat without a note: the collection lives at
+``assistant/chats/`` and every other route addresses one chat by id. Chats
+are private to their creator, so another user's chat id is a 404. Access is
+gated exactly as the notebook chat: authentication, a non-blocked Research AI
+tier, and the editor-or-moderator rollout gate.
+"""
+
+import logging
+
+from django.http import Http404
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from research_ai.models import AgentConversation
+from research_ai.permissions import ResearchAIBudgetPermission
+from research_ai.serializers import (
+    NotebookChatCreateSerializer,
+    NotebookChatMessageCreateSerializer,
+    NotebookChatUpdateSerializer,
+)
+from research_ai.services.agent_persistence import AgentConversationBusyError
+from research_ai.services.assistant_chat import AssistantChatService
+from research_ai.services.notebook_chat import ACTIVITY_ALL, ACTIVITY_LIVE
+from research_ai.services.usage_budget import (
+    UsageLimitExceededError,
+    UsageWorkInProgressError,
+)
+from user.permissions import IsModerator, UserIsEditor
+
+logger = logging.getLogger(__name__)
+
+ASSISTANT_CHAT_PERMISSIONS = [
+    IsAuthenticated,
+    ResearchAIBudgetPermission,
+    UserIsEditor | IsModerator,
+]
+
+
+def _get_conversation_or_404(
+    service: AssistantChatService, user, conversation_id: int
+) -> AgentConversation:
+    conversation = service.get_conversation(user, conversation_id)
+    if conversation is None:
+        raise Http404
+    return conversation
+
+
+class AssistantChatListCreateView(APIView):
+    """List the user's assistant chats, or start a new one."""
+
+    permission_classes = ASSISTANT_CHAT_PERMISSIONS
+
+    def get(self, request):
+        return Response(
+            {"chats": AssistantChatService().list_conversations(request.user)}
+        )
+
+    def post(self, request):
+        serializer = NotebookChatCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        service = AssistantChatService()
+        conversation = service.create_conversation(
+            request.user, title=serializer.validated_data["title"]
+        )
+        return Response(
+            service.representation(conversation), status=status.HTTP_201_CREATED
+        )
+
+
+class AssistantChatDetailView(APIView):
+    """Read or rename one chat; ``?activity=live`` is the polling form."""
+
+    permission_classes = ASSISTANT_CHAT_PERMISSIONS
+
+    def get(self, request, conversation_id):
+        service = AssistantChatService()
+        conversation = _get_conversation_or_404(service, request.user, conversation_id)
+        scope = (
+            ACTIVITY_LIVE
+            if request.query_params.get("activity") == ACTIVITY_LIVE
+            else ACTIVITY_ALL
+        )
+        return Response(service.representation(conversation, activity_scope=scope))
+
+    def patch(self, request, conversation_id):
+        serializer = NotebookChatUpdateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        service = AssistantChatService()
+        conversation = _get_conversation_or_404(service, request.user, conversation_id)
+        service.rename_conversation(conversation, serializer.validated_data["title"])
+        return Response(
+            {"conversation_id": conversation.id, "title": conversation.title}
+        )
+
+
+class AssistantChatMessageView(APIView):
+    """Send a message to one chat; the turn runs asynchronously."""
+
+    permission_classes = ASSISTANT_CHAT_PERMISSIONS
+
+    def post(self, request, conversation_id):
+        serializer = NotebookChatMessageCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        service = AssistantChatService()
+        conversation = _get_conversation_or_404(service, request.user, conversation_id)
+        try:
+            execution = service.submit_message(
+                conversation,
+                serializer.validated_data["message"],
+                model_ref=serializer.validated_data["model"] or None,
+                effort=serializer.validated_data.get("effort"),
+                thinking=serializer.validated_data.get("thinking"),
+                temperature=serializer.validated_data.get("temperature"),
+            )
+        except AgentConversationBusyError:
+            return Response(
+                {"detail": "The assistant is still working on a previous message."},
+                status=status.HTTP_409_CONFLICT,
+            )
+        except UsageWorkInProgressError as error:
+            return Response(
+                {"detail": str(error), "code": error.code},
+                status=status.HTTP_409_CONFLICT,
+            )
+        except UsageLimitExceededError as error:
+            return Response(
+                {"code": error.code, **error.status.as_dict()},
+                status=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+        except ValueError as error:
+            return Response(
+                {
+                    "detail": str(error),
+                    **({"code": error.code} if getattr(error, "code", None) else {}),
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return Response(
+            {
+                "conversation_id": execution.conversation_id,
+                "execution_id": execution.id,
+            },
+            status=status.HTTP_202_ACCEPTED,
+        )
+
+
+class AssistantChatCancelView(APIView):
+    """Stop one chat's in-flight turn; idempotent like the notebook cancel."""
+
+    permission_classes = ASSISTANT_CHAT_PERMISSIONS
+
+    def post(self, request, conversation_id):
+        service = AssistantChatService()
+        conversation = _get_conversation_or_404(service, request.user, conversation_id)
+        execution = service.cancel_active_turn(conversation)
+        if execution is None:
+            return Response({"cancelled": False, "execution_id": None})
+        return Response({"cancelled": True, "execution_id": execution.id})


### PR DESCRIPTION
## Summary

Adds a research assistant chat that works like the notebook agent but is not attached to a note. The notebook chat engine is reused with a second workflow, `assistant_chat`.

- New endpoints under `/api/research_ai/assistant/chats/` (list/create, detail/rename, messages, cancel), user-scoped, with the same rollout gate (hub editor or moderator) and budget admission as the notebook chat.
- New WebSocket route `ws/assistant/chats/<conversation_id>/`; both consumers share one base class.
- `NotebookChatService` takes a `workflow` and accepts a missing note. A note-less turn runs with a `create_note` tool; each created note is private to the user, attached to the conversation, and is the only kind of note the chat can read or edit afterwards. The system prompt lists the notes the chat has created so later turns know their ids and kinds.
- `create_note` requires a `kind`: `preregistration` (a proposal the user will submit) or `grant` (an RFP the user is publishing), the two note types the notebook UI creates. No note is created unless the model calls the tool.
- The selected-RFP tools (`read_selected_rfp`, `set_selected_rfp`) are available in assistant turns, addressed by `note_id` and scoped to the chat's own preregistrations, so the assistant can create a proposal and pick the RFP it applies to in one turn.
- Headless note creation moved to `note/services/note_creation_service.py`, reused by the proposal draft writer.
- Activity feed adds a "Created a note" label with `note_id`, `note_title`, and `note_document_type` on the event; the chat representation adds a `notes` list with `id`, `title`, and `document_type`.
- Assistant chats do not appear in a note's chat list, and notebook chats do not appear in the assistant list. Usage is accounted to the `assistant_chat` feature, derived from the conversation row so one worker task serves both workflows.

## Test plan

- [x] Existing notebook chat, note tools, grant tools, proposal draft, agent, tasks, and email view suites pass
- [x] New suites: assistant chat views, service (create-then-edit turn, grant kind, RFP selection on a created preregistration, refusal of outside notes, scoping, accounting), consumer, `create_note` tool, scoped RFP toolset, note creation service
- [ ] Frontend: reuse the notebook chat client with the new base URL, add a chats list page and a "note created" card that links by document type

🤖 Generated with [Claude Code](https://claude.com/claude-code)