### PR TITLE
Release AI usage lock immediately on cancellation

### DIFF
--- a/src/research_ai/models/usage_event.py
+++ b/src/research_ai/models/usage_event.py
@@ -4,7 +4,7 @@ from utils.models import DefaultModel
 
 
 class LLMUsageEvent(DefaultModel):
-    """Immutable accounting row for one provider model call."""
+    """Accounting row created before one provider model call is dispatched."""
 
     user = models.ForeignKey(
         "user.User",

--- a/src/research_ai/services/agent_persistence/cancel_service.py
+++ b/src/research_ai/services/agent_persistence/cancel_service.py
@@ -31,7 +31,6 @@ from django.utils import timezone
 from research_ai.models import AgentContextMessage, AgentExecution
 from research_ai.services.agent.types import Message, TextBlock
 from research_ai.services.agent_persistence.content import serialize_context_message
-from research_ai.services.usage_budget.reservation import reservation_deadline
 
 logger = logging.getLogger(__name__)
 
@@ -45,11 +44,10 @@ class AgentExecutionCancelService:
         """Mark an active execution ``CANCELLED``; report whether it landed.
 
         No error fields are written: a cancellation is the user's own decision,
-        not a failure, and the status alone says so. A queued execution releases
-        its usage reservation here because no provider call started. A running
-        execution keeps a renewable lease until its worker observes the
-        cancellation and unwinds. If the worker died, that lease expires instead
-        of blocking the user forever. Returns ``False`` when the execution already
+        not a failure, and the status alone says so. Cancellation releases the
+        usage reservation immediately so the user can resume without waiting
+        for the worker. Usage from a provider call already in flight is still
+        recorded when it returns. Returns ``False`` when the execution already
         reached a terminal state, which is the ordinary race of cancelling a turn
         that was finishing anyway.
         """
@@ -68,17 +66,11 @@ class AgentExecutionCancelService:
             if locked is None:
                 return False
             now = timezone.now()
-            was_pending = locked.status == AgentExecution.Status.PENDING
             locked.status = AgentExecution.Status.CANCELLED
             locked.stop_reason = CANCELLED_STOP_REASON
             locked.finished_at = now
             locked.last_activity_at = now
-            # Set this from the claimed state rather than preserving the old
-            # value so executions already running during a rolling deployment
-            # receive the same protection as newly admitted work.
-            locked.usage_reservation_expires_at = (
-                None if was_pending else reservation_deadline(now)
-            )
+            locked.usage_reservation_expires_at = None
             if locked.started_at is not None:
                 locked.duration_ms = max(
                     0, round((now - locked.started_at).total_seconds() * 1000)

--- a/src/research_ai/services/agent_persistence/cancel_service.py
+++ b/src/research_ai/services/agent_persistence/cancel_service.py
@@ -31,7 +31,6 @@ from django.utils import timezone
 from research_ai.models import AgentContextMessage, AgentExecution
 from research_ai.services.agent.types import Message, TextBlock
 from research_ai.services.agent_persistence.content import serialize_context_message
-from research_ai.services.usage_budget.reservation import reservation_deadline
 
 logger = logging.getLogger(__name__)
 
@@ -45,10 +44,10 @@ class AgentExecutionCancelService:
         """Mark an active execution ``CANCELLED``; report whether it landed.
 
         No error fields are written: a cancellation is the user's own decision,
-        not a failure, and the status alone says so. A queued execution releases
-        its reservation immediately. A running one keeps a renewable lease until
-        its worker unwinds, while admission permits one replacement handoff.
-        Returns ``False`` when the execution already
+        not a failure, and the status alone says so. Cancellation releases the
+        execution's concurrency reservation immediately; provider-call attempts
+        are recorded separately before spend begins. Returns ``False`` when the
+        execution already
         reached a terminal state, which is the ordinary race of cancelling a turn
         that was finishing anyway.
         """
@@ -67,14 +66,11 @@ class AgentExecutionCancelService:
             if locked is None:
                 return False
             now = timezone.now()
-            was_pending = locked.status == AgentExecution.Status.PENDING
             locked.status = AgentExecution.Status.CANCELLED
             locked.stop_reason = CANCELLED_STOP_REASON
             locked.finished_at = now
             locked.last_activity_at = now
-            locked.usage_reservation_expires_at = (
-                None if was_pending else reservation_deadline(now)
-            )
+            locked.usage_reservation_expires_at = None
             if locked.started_at is not None:
                 locked.duration_ms = max(
                     0, round((now - locked.started_at).total_seconds() * 1000)

--- a/src/research_ai/services/agent_persistence/cancel_service.py
+++ b/src/research_ai/services/agent_persistence/cancel_service.py
@@ -31,6 +31,7 @@ from django.utils import timezone
 from research_ai.models import AgentContextMessage, AgentExecution
 from research_ai.services.agent.types import Message, TextBlock
 from research_ai.services.agent_persistence.content import serialize_context_message
+from research_ai.services.usage_budget.reservation import reservation_deadline
 
 logger = logging.getLogger(__name__)
 
@@ -44,10 +45,10 @@ class AgentExecutionCancelService:
         """Mark an active execution ``CANCELLED``; report whether it landed.
 
         No error fields are written: a cancellation is the user's own decision,
-        not a failure, and the status alone says so. Cancellation releases the
-        usage reservation immediately so the user can resume without waiting
-        for the worker. Usage from a provider call already in flight is still
-        recorded when it returns. Returns ``False`` when the execution already
+        not a failure, and the status alone says so. A queued execution releases
+        its reservation immediately. A running one keeps a renewable lease until
+        its worker unwinds, while admission permits one replacement handoff.
+        Returns ``False`` when the execution already
         reached a terminal state, which is the ordinary race of cancelling a turn
         that was finishing anyway.
         """
@@ -66,11 +67,14 @@ class AgentExecutionCancelService:
             if locked is None:
                 return False
             now = timezone.now()
+            was_pending = locked.status == AgentExecution.Status.PENDING
             locked.status = AgentExecution.Status.CANCELLED
             locked.stop_reason = CANCELLED_STOP_REASON
             locked.finished_at = now
             locked.last_activity_at = now
-            locked.usage_reservation_expires_at = None
+            locked.usage_reservation_expires_at = (
+                None if was_pending else reservation_deadline(now)
+            )
             if locked.started_at is not None:
                 locked.duration_ms = max(
                     0, round((now - locked.started_at).total_seconds() * 1000)

--- a/src/research_ai/services/proposal_draft/cancel_service.py
+++ b/src/research_ai/services/proposal_draft/cancel_service.py
@@ -34,6 +34,7 @@ from django.db import transaction
 
 from research_ai.models import AgentExecution, ProposalDraft
 from research_ai.services.agent_persistence import AgentExecutionCancelService
+from research_ai.services.usage_budget.reservation import reservation_deadline
 
 logger = logging.getLogger(__name__)
 
@@ -87,10 +88,11 @@ class ProposalDraftCancelService:
                 # writing a failure string for a deliberate stop is what
                 # CANCELLED exists to avoid. ``step`` is left where the run got
                 # to, so the record still shows how far it had gone.
+                was_pending = locked.status == ProposalDraft.Status.PENDING
                 locked.status = ProposalDraft.Status.CANCELLED
-                # Release admission immediately; an in-flight call still has
-                # its usage accounted for when the worker unwinds.
-                locked.usage_reservation_expires_at = None
+                locked.usage_reservation_expires_at = (
+                    None if was_pending else reservation_deadline()
+                )
                 locked.save(
                     update_fields=[
                         "status",

--- a/src/research_ai/services/proposal_draft/cancel_service.py
+++ b/src/research_ai/services/proposal_draft/cancel_service.py
@@ -34,7 +34,6 @@ from django.db import transaction
 
 from research_ai.models import AgentExecution, ProposalDraft
 from research_ai.services.agent_persistence import AgentExecutionCancelService
-from research_ai.services.usage_budget.reservation import reservation_deadline
 
 logger = logging.getLogger(__name__)
 
@@ -88,11 +87,8 @@ class ProposalDraftCancelService:
                 # writing a failure string for a deliberate stop is what
                 # CANCELLED exists to avoid. ``step`` is left where the run got
                 # to, so the record still shows how far it had gone.
-                was_pending = locked.status == ProposalDraft.Status.PENDING
                 locked.status = ProposalDraft.Status.CANCELLED
-                locked.usage_reservation_expires_at = (
-                    None if was_pending else reservation_deadline()
-                )
+                locked.usage_reservation_expires_at = None
                 locked.save(
                     update_fields=[
                         "status",

--- a/src/research_ai/services/proposal_draft/cancel_service.py
+++ b/src/research_ai/services/proposal_draft/cancel_service.py
@@ -34,7 +34,6 @@ from django.db import transaction
 
 from research_ai.models import AgentExecution, ProposalDraft
 from research_ai.services.agent_persistence import AgentExecutionCancelService
-from research_ai.services.usage_budget.reservation import reservation_deadline
 
 logger = logging.getLogger(__name__)
 
@@ -88,14 +87,10 @@ class ProposalDraftCancelService:
                 # writing a failure string for a deliberate stop is what
                 # CANCELLED exists to avoid. ``step`` is left where the run got
                 # to, so the record still shows how far it had gone.
-                was_pending = locked.status == ProposalDraft.Status.PENDING
                 locked.status = ProposalDraft.Status.CANCELLED
-                # A queued job has no worker/provider call to wait for. Set the
-                # processing case explicitly so jobs already running during a
-                # rolling deployment gain a bounded reservation too.
-                locked.usage_reservation_expires_at = (
-                    None if was_pending else reservation_deadline()
-                )
+                # Release admission immediately; an in-flight call still has
+                # its usage accounted for when the worker unwinds.
+                locked.usage_reservation_expires_at = None
                 locked.save(
                     update_fields=[
                         "status",

--- a/src/research_ai/services/usage_budget/recorder.py
+++ b/src/research_ai/services/usage_budget/recorder.py
@@ -12,7 +12,12 @@ from research_ai.services.usage_budget.reservation import (
     renew_active_reservation,
     renew_live_reservation,
 )
-from research_ai.services.usage_budget.service import ensure_budget_available, record
+from research_ai.services.usage_budget.service import (
+    ensure_budget_available,
+    record,
+    record_call_start,
+    settle_call,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +54,7 @@ class AgentLoopBudgetRecorder:
         )
         self._reservation_targets = tuple(target for target in targets if target)
         self._next_reservation_renewal_at = None
+        self._pending_usage_event = None
         # Losing a usage row would silently reopen budget that was actually
         # spent, so accounting writes are required even without a transcript.
         self.requires_durable_usage = True
@@ -80,17 +86,29 @@ class AgentLoopBudgetRecorder:
         callback = getattr(self._recorder, "before_model_call", None)
         if callback is not None:
             callback()
-
-    def record_usage(self, usage: TurnUsage) -> None:
         if self.user is not None:
-            record(
+            self._pending_usage_event = record_call_start(
                 self.user,
                 self.feature,
                 self.provider,
                 self.model_id,
-                usage,
                 execution=self.execution,
             )
+
+    def record_usage(self, usage: TurnUsage) -> None:
+        if self.user is not None:
+            if self._pending_usage_event is None:
+                record(
+                    self.user,
+                    self.feature,
+                    self.provider,
+                    self.model_id,
+                    usage,
+                    execution=self.execution,
+                )
+            else:
+                settle_call(self._pending_usage_event, usage)
+                self._pending_usage_event = None
         callback = getattr(self._recorder, "record_usage", None)
         if callback is not None:
             callback(usage)

--- a/src/research_ai/services/usage_budget/reservation.py
+++ b/src/research_ai/services/usage_budget/reservation.py
@@ -48,15 +48,16 @@ def renew_live_reservation(
 ) -> bool:
     """Extend an unexpired lease while an already-started call emits activity.
 
-    Only active rows can renew: late stream events must not revive a cancelled
-    reservation. An expired lease likewise cannot be revived by stream activity.
+    This deliberately permits a cancelled row: streaming after cancellation is
+    proof that its worker and paid provider call are still alive. Requiring the
+    old lease to remain current prevents a delayed zombie worker from reviving a
+    reservation after admission has already treated it as expired.
     """
     current = now or timezone.now()
     return bool(
         type(target)
         .objects.filter(
             id=target.id,
-            status__in=_ACTIVE_STATUSES[type(target)],
             usage_reservation_expires_at__gt=current,
         )
         .update(usage_reservation_expires_at=reservation_deadline(current))

--- a/src/research_ai/services/usage_budget/reservation.py
+++ b/src/research_ai/services/usage_budget/reservation.py
@@ -48,16 +48,15 @@ def renew_live_reservation(
 ) -> bool:
     """Extend an unexpired lease while an already-started call emits activity.
 
-    This deliberately permits a cancelled row: streaming after cancellation is
-    proof that its worker and paid provider call are still alive. Requiring the
-    old lease to remain current prevents a delayed zombie worker from reviving a
-    reservation after admission has already treated it as expired.
+    Only active rows can renew: late stream events must not revive a cancelled
+    execution's concurrency reservation.
     """
     current = now or timezone.now()
     return bool(
         type(target)
         .objects.filter(
             id=target.id,
+            status__in=_ACTIVE_STATUSES[type(target)],
             usage_reservation_expires_at__gt=current,
         )
         .update(usage_reservation_expires_at=reservation_deadline(current))

--- a/src/research_ai/services/usage_budget/reservation.py
+++ b/src/research_ai/services/usage_budget/reservation.py
@@ -48,16 +48,15 @@ def renew_live_reservation(
 ) -> bool:
     """Extend an unexpired lease while an already-started call emits activity.
 
-    This deliberately permits a cancelled row: streaming after cancellation is
-    proof that its worker and paid provider call are still alive. Requiring the
-    old lease to remain current prevents a delayed zombie worker from reviving a
-    reservation after admission has already treated it as expired.
+    Only active rows can renew: late stream events must not revive a cancelled
+    reservation. An expired lease likewise cannot be revived by stream activity.
     """
     current = now or timezone.now()
     return bool(
         type(target)
         .objects.filter(
             id=target.id,
+            status__in=_ACTIVE_STATUSES[type(target)],
             usage_reservation_expires_at__gt=current,
         )
         .update(usage_reservation_expires_at=reservation_deadline(current))

--- a/src/research_ai/services/usage_budget/service.py
+++ b/src/research_ai/services/usage_budget/service.py
@@ -49,12 +49,6 @@ class UsageWorkInProgressError(RuntimeError):
     code = "usage_work_in_progress"
 
 
-# One cancelled provider call may overlap its immediate replacement. A second
-# outstanding call closes the handoff until either worker unwinds or its lease
-# expires, bounding repeated cancel-and-resubmit cycles to two paid calls.
-MAX_OUTSTANDING_CANCELLED_CALLS = 1
-
-
 @dataclass(frozen=True)
 class BudgetStatus:
     tier: str
@@ -245,47 +239,23 @@ def check_budget_admission(user) -> BudgetStatus:
 
 
 def _has_in_flight_work(user) -> bool:
-    """Whether a budgeted user has an active job blocking admission.
-
-    One cancelled-but-still-unwinding provider call is allowed as a handoff.
-    Active work always blocks, and a second outstanding cancellation blocks
-    another replacement until a worker clears its lease or the lease expires.
-    """
-    now = timezone.now()
-    active_execution = AgentExecution.objects.filter(
-        conversation__user=user,
-        status__in=[
-            AgentExecution.Status.PENDING,
-            AgentExecution.Status.RUNNING,
-        ],
-    ).exists()
-    active_draft = ProposalDraft.objects.filter(
-        created_by=user,
-        status__in=[
-            ProposalDraft.Status.PENDING,
-            ProposalDraft.Status.PROCESSING,
-        ],
-    ).exists()
-    if active_execution or active_draft:
-        return True
-
-    cancelled_executions = (
+    """Whether a budgeted user already has an active top-level job."""
+    return (
         AgentExecution.objects.filter(
             conversation__user=user,
-            status=AgentExecution.Status.CANCELLED,
-            usage_reservation_expires_at__gt=now,
-        )
-        # Proposal drafting reserves its parent draft rather than the optional
-        # trace execution, so counting both would treat one job as two calls.
-        .exclude(conversation__workflow="proposal_draft")
-        .count()
+            status__in=[
+                AgentExecution.Status.PENDING,
+                AgentExecution.Status.RUNNING,
+            ],
+        ).exists()
+        or ProposalDraft.objects.filter(
+            created_by=user,
+            status__in=[
+                ProposalDraft.Status.PENDING,
+                ProposalDraft.Status.PROCESSING,
+            ],
+        ).exists()
     )
-    cancelled_drafts = ProposalDraft.objects.filter(
-        created_by=user,
-        status=ProposalDraft.Status.CANCELLED,
-        usage_reservation_expires_at__gt=now,
-    ).count()
-    return cancelled_executions + cancelled_drafts > MAX_OUTSTANDING_CANCELLED_CALLS
 
 
 @contextmanager
@@ -300,9 +270,9 @@ def atomic_turn_admission(
 
     The caller must create its pending execution or draft before leaving
     this context. That row is the reservation observed by the next admission.
-    Budgeted users may have one active top-level job. One cancelled provider
-    call can overlap its immediate replacement while unwinding; a second
-    cancellation blocks further admission until a lease clears or expires.
+    Provider calls are counted against the daily turn cap before dispatch, so a
+    cancelled job can release this concurrency slot immediately without hiding
+    rapid cancel-and-resubmit attempts from subsequent admission checks.
     """
     with transaction.atomic():
         locked_user = type(user)._default_manager.select_for_update().get(pk=user.pk)
@@ -346,6 +316,46 @@ def record(
         cost_microusd=cost_microusd(provider, model_id, usage),
         execution=execution,
     )
+
+
+def record_call_start(
+    user,
+    feature: str,
+    provider: str,
+    model_id: str,
+    *,
+    execution=None,
+) -> LLMUsageEvent:
+    """Persist a provider-call attempt before dispatch so it counts immediately."""
+    return LLMUsageEvent.objects.create(
+        user=user,
+        feature=feature,
+        provider=provider,
+        model=model_id,
+        execution=execution,
+    )
+
+
+def settle_call(event: LLMUsageEvent, usage: TurnUsage) -> LLMUsageEvent:
+    """Fill a call-attempt row with the exact usage returned by its provider."""
+    event.input_tokens = usage.input_tokens
+    event.output_tokens = usage.output_tokens
+    event.cache_read_tokens = usage.cache_read_tokens
+    event.cache_write_tokens = usage.cache_write_tokens
+    event.web_search_requests = usage.web_search_requests
+    event.cost_microusd = cost_microusd(event.provider, event.model, usage)
+    event.save(
+        update_fields=[
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "web_search_requests",
+            "cost_microusd",
+            "updated_date",
+        ]
+    )
+    return event
 
 
 def ensure_budget_available(user) -> None:

--- a/src/research_ai/services/usage_budget/service.py
+++ b/src/research_ai/services/usage_budget/service.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime, time, timedelta
 from decimal import Decimal
 
 from django.db import transaction
-from django.db.models import BigIntegerField, Count, Q, Sum
+from django.db.models import BigIntegerField, Count, Sum
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 
@@ -239,41 +239,26 @@ def check_budget_admission(user) -> BudgetStatus:
 
 
 def _has_in_flight_work(user) -> bool:
-    """Whether a budgeted user already has spend-producing work reserved."""
-    now = timezone.now()
+    """Whether a budgeted user has an active job blocking admission.
+
+    Cancelled jobs never block a new task, including older rows that still
+    carry a reservation deadline from before cancellation released it.
+    """
     return (
         AgentExecution.objects.filter(
             conversation__user=user,
-        )
-        .filter(
-            Q(
-                status__in=[
-                    AgentExecution.Status.PENDING,
-                    AgentExecution.Status.RUNNING,
-                ]
-            )
-            | Q(
-                status=AgentExecution.Status.CANCELLED,
-                usage_reservation_expires_at__gt=now,
-            )
-        )
-        .exists()
+            status__in=[
+                AgentExecution.Status.PENDING,
+                AgentExecution.Status.RUNNING,
+            ],
+        ).exists()
         or ProposalDraft.objects.filter(
             created_by=user,
-        )
-        .filter(
-            Q(
-                status__in=[
-                    ProposalDraft.Status.PENDING,
-                    ProposalDraft.Status.PROCESSING,
-                ]
-            )
-            | Q(
-                status=ProposalDraft.Status.CANCELLED,
-                usage_reservation_expires_at__gt=now,
-            )
-        )
-        .exists()
+            status__in=[
+                ProposalDraft.Status.PENDING,
+                ProposalDraft.Status.PROCESSING,
+            ],
+        ).exists()
     )
 
 
@@ -289,8 +274,9 @@ def atomic_turn_admission(
 
     The caller must create its pending execution or draft before leaving
     this context. That row is the reservation observed by the next admission.
-    Restricting budgeted users to one in-flight top-level job keeps soft
-    enforcement's overshoot bounded to the currently running provider call.
+    Budgeted users may have one active top-level job. Cancellation releases
+    that slot immediately; any already-started provider call can overlap its
+    replacement while unwinding, and its eventual usage is still charged.
     """
     with transaction.atomic():
         locked_user = type(user)._default_manager.select_for_update().get(pk=user.pk)

--- a/src/research_ai/services/usage_budget/service.py
+++ b/src/research_ai/services/usage_budget/service.py
@@ -49,6 +49,12 @@ class UsageWorkInProgressError(RuntimeError):
     code = "usage_work_in_progress"
 
 
+# One cancelled provider call may overlap its immediate replacement. A second
+# outstanding call closes the handoff until either worker unwinds or its lease
+# expires, bounding repeated cancel-and-resubmit cycles to two paid calls.
+MAX_OUTSTANDING_CANCELLED_CALLS = 1
+
+
 @dataclass(frozen=True)
 class BudgetStatus:
     tier: str
@@ -241,25 +247,45 @@ def check_budget_admission(user) -> BudgetStatus:
 def _has_in_flight_work(user) -> bool:
     """Whether a budgeted user has an active job blocking admission.
 
-    Cancelled jobs never block a new task, including older rows that still
-    carry a reservation deadline from before cancellation released it.
+    One cancelled-but-still-unwinding provider call is allowed as a handoff.
+    Active work always blocks, and a second outstanding cancellation blocks
+    another replacement until a worker clears its lease or the lease expires.
     """
-    return (
+    now = timezone.now()
+    active_execution = AgentExecution.objects.filter(
+        conversation__user=user,
+        status__in=[
+            AgentExecution.Status.PENDING,
+            AgentExecution.Status.RUNNING,
+        ],
+    ).exists()
+    active_draft = ProposalDraft.objects.filter(
+        created_by=user,
+        status__in=[
+            ProposalDraft.Status.PENDING,
+            ProposalDraft.Status.PROCESSING,
+        ],
+    ).exists()
+    if active_execution or active_draft:
+        return True
+
+    cancelled_executions = (
         AgentExecution.objects.filter(
             conversation__user=user,
-            status__in=[
-                AgentExecution.Status.PENDING,
-                AgentExecution.Status.RUNNING,
-            ],
-        ).exists()
-        or ProposalDraft.objects.filter(
-            created_by=user,
-            status__in=[
-                ProposalDraft.Status.PENDING,
-                ProposalDraft.Status.PROCESSING,
-            ],
-        ).exists()
+            status=AgentExecution.Status.CANCELLED,
+            usage_reservation_expires_at__gt=now,
+        )
+        # Proposal drafting reserves its parent draft rather than the optional
+        # trace execution, so counting both would treat one job as two calls.
+        .exclude(conversation__workflow="proposal_draft")
+        .count()
     )
+    cancelled_drafts = ProposalDraft.objects.filter(
+        created_by=user,
+        status=ProposalDraft.Status.CANCELLED,
+        usage_reservation_expires_at__gt=now,
+    ).count()
+    return cancelled_executions + cancelled_drafts > MAX_OUTSTANDING_CANCELLED_CALLS
 
 
 @contextmanager
@@ -274,9 +300,9 @@ def atomic_turn_admission(
 
     The caller must create its pending execution or draft before leaving
     this context. That row is the reservation observed by the next admission.
-    Budgeted users may have one active top-level job. Cancellation releases
-    that slot immediately; any already-started provider call can overlap its
-    replacement while unwinding, and its eventual usage is still charged.
+    Budgeted users may have one active top-level job. One cancelled provider
+    call can overlap its immediate replacement while unwinding; a second
+    cancellation blocks further admission until a lease clears or expires.
     """
     with transaction.atomic():
         locked_user = type(user)._default_manager.select_for_update().get(pk=user.pk)

--- a/src/research_ai/tests/agent/test_persistence_cancellation.py
+++ b/src/research_ai/tests/agent/test_persistence_cancellation.py
@@ -84,15 +84,15 @@ class AgentCancellationTests(TestCase):
         self.assertEqual(execution.error_type, "")
         self.assertIsNotNone(execution.finished_at)
 
-    def test_running_cancellation_reserves_budget_until_worker_unwinds(self):
+    def test_running_cancellation_releases_concurrency_reservation(self):
         # Arrange: this execution owns the budgeted user's single-flight slot.
         recorder = self._running()
         # Act: the request reports cancellation before the provider call returns.
         self.cancels.cancel(recorder.execution)
 
-        # Assert: the lease tracks the in-flight call until its worker returns.
+        # Assert: its call attempt is accounted separately, so this lock can go.
         execution = AgentExecution.objects.get(id=recorder.execution.id)
-        self.assertIsNotNone(execution.usage_reservation_expires_at)
+        self.assertIsNone(execution.usage_reservation_expires_at)
         self.assertFalse(recorder.on_run_failed(InterruptedError("cancelled")))
         execution.refresh_from_db()
         self.assertIsNone(execution.usage_reservation_expires_at)

--- a/src/research_ai/tests/agent/test_persistence_cancellation.py
+++ b/src/research_ai/tests/agent/test_persistence_cancellation.py
@@ -84,16 +84,15 @@ class AgentCancellationTests(TestCase):
         self.assertEqual(execution.error_type, "")
         self.assertIsNotNone(execution.finished_at)
 
-    def test_running_cancellation_reserves_budget_until_worker_unwinds(self):
+    def test_running_cancellation_releases_budget_before_worker_unwinds(self):
         # Arrange: this execution owns the budgeted user's single-flight slot.
         recorder = self._running()
         # Act: the request reports cancellation before the provider call returns.
         self.cancels.cancel(recorder.execution)
 
-        # Assert: admission remains reserved until the worker reaches its
-        # terminal hook, which represents the in-flight call having returned.
+        # Assert: admission is released before the in-flight call returns.
         execution = AgentExecution.objects.get(id=recorder.execution.id)
-        self.assertIsNotNone(execution.usage_reservation_expires_at)
+        self.assertIsNone(execution.usage_reservation_expires_at)
         self.assertFalse(recorder.on_run_failed(InterruptedError("cancelled")))
         execution.refresh_from_db()
         self.assertIsNone(execution.usage_reservation_expires_at)

--- a/src/research_ai/tests/agent/test_persistence_cancellation.py
+++ b/src/research_ai/tests/agent/test_persistence_cancellation.py
@@ -84,15 +84,15 @@ class AgentCancellationTests(TestCase):
         self.assertEqual(execution.error_type, "")
         self.assertIsNotNone(execution.finished_at)
 
-    def test_running_cancellation_releases_budget_before_worker_unwinds(self):
+    def test_running_cancellation_reserves_budget_until_worker_unwinds(self):
         # Arrange: this execution owns the budgeted user's single-flight slot.
         recorder = self._running()
         # Act: the request reports cancellation before the provider call returns.
         self.cancels.cancel(recorder.execution)
 
-        # Assert: admission is released before the in-flight call returns.
+        # Assert: the lease tracks the in-flight call until its worker returns.
         execution = AgentExecution.objects.get(id=recorder.execution.id)
-        self.assertIsNone(execution.usage_reservation_expires_at)
+        self.assertIsNotNone(execution.usage_reservation_expires_at)
         self.assertFalse(recorder.on_run_failed(InterruptedError("cancelled")))
         execution.refresh_from_db()
         self.assertIsNone(execution.usage_reservation_expires_at)

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -324,18 +324,15 @@ class NotebookChatServiceTests(TestCase):
                 # Assert: the next task is admitted and scheduled immediately.
                 execution.refresh_from_db()
                 self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
-                self.assertGreater(execution.usage_reservation_expires_at, expires_at)
+                self.assertIsNone(execution.usage_reservation_expires_at)
                 self.assertEqual(next_execution.status, AgentExecution.Status.PENDING)
                 delay.assert_called_once_with(next_execution.id)
                 if same_chat:
                     self.assertEqual(next_execution.context_parent_id, execution.id)
                 self.service.cancel_active_turn(next_chat)
-                AgentExecution.objects.filter(pk=execution.pk).update(
-                    usage_reservation_expires_at=None
-                )
 
-    def test_one_outstanding_cancellation_allows_immediate_handoff(self):
-        # Arrange: a cancelled provider call is still unwinding.
+    def test_old_cancelled_reservations_do_not_block_resuming(self):
+        # Arrange: an earlier deployment left a lease on a cancelled turn.
         execution, _ = self._submit()
         expires_at = timezone.now() + timedelta(minutes=5)
         AgentExecution.objects.filter(pk=execution.pk).update(
@@ -350,8 +347,8 @@ class NotebookChatServiceTests(TestCase):
         self.assertEqual(next_execution.status, AgentExecution.Status.PENDING)
         delay.assert_called_once_with(next_execution.id)
 
-    def test_two_outstanding_cancellations_block_another_handoff(self):
-        # Arrange: two paid calls are still unwinding after cancellation.
+    def test_multiple_cancelled_reservations_do_not_lock_conversation(self):
+        # Arrange: call starts already count through their usage-event rows.
         for attempt in (1, 2):
             AgentExecution.objects.create(
                 conversation=self.conversation,
@@ -361,8 +358,9 @@ class NotebookChatServiceTests(TestCase):
             )
 
         # Act / Assert
-        with self.assertRaises(UsageWorkInProgressError):
-            self._submit("Try a third call")
+        next_execution, delay = self._submit("Try another call")
+        self.assertEqual(next_execution.status, AgentExecution.Status.PENDING)
+        delay.assert_called_once_with(next_execution.id)
 
     def test_run_turn_edits_note_and_publishes_reply(self):
         # Arrange

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -1,9 +1,11 @@
 import json
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, TransactionTestCase, override_settings
+from django.utils import timezone
 
 from note.tests.helpers import create_note
 from research_ai.models import (
@@ -295,6 +297,55 @@ class NotebookChatServiceTests(TestCase):
         # Act / Assert
         with self.assertRaises(UsageWorkInProgressError):
             self._submit("Different thread", conversation=second)
+
+    def test_cancel_running_turn_allows_resuming_or_starting_another_chat(self):
+        for same_chat in (True, False):
+            with self.subTest(same_chat=same_chat):
+                # Arrange: the running turn has nearly its full lease remaining.
+                conversation = self.service.create_conversation(self.note, self.user)
+                execution, _ = self._submit(conversation=conversation)
+                expires_at = timezone.now() + timedelta(hours=2)
+                AgentExecution.objects.filter(pk=execution.pk).update(
+                    status=AgentExecution.Status.RUNNING,
+                    usage_reservation_expires_at=expires_at,
+                )
+                next_chat = (
+                    conversation
+                    if same_chat
+                    else self.service.create_conversation(self.note, self.user)
+                )
+
+                # Act: cancel without a worker available to release the lease.
+                self.service.cancel_active_turn(conversation)
+                next_execution, delay = self._submit(
+                    "Continue with the second task", conversation=next_chat
+                )
+
+                # Assert: the next task is admitted and scheduled immediately.
+                execution.refresh_from_db()
+                self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
+                self.assertIsNone(execution.usage_reservation_expires_at)
+                self.assertEqual(next_execution.status, AgentExecution.Status.PENDING)
+                delay.assert_called_once_with(next_execution.id)
+                if same_chat:
+                    self.assertEqual(next_execution.context_parent_id, execution.id)
+                self.service.cancel_active_turn(next_chat)
+
+    def test_resume_ignores_reservation_from_an_older_cancellation(self):
+        # Arrange: an earlier deployment cancelled the turn but kept its lease.
+        execution, _ = self._submit()
+        expires_at = timezone.now() + timedelta(minutes=5)
+        AgentExecution.objects.filter(pk=execution.pk).update(
+            status=AgentExecution.Status.CANCELLED,
+            usage_reservation_expires_at=expires_at,
+        )
+
+        # Act
+        next_execution, delay = self._submit("Continue")
+
+        # Assert: no second cancellation or wait for expiry is necessary.
+        self.assertEqual(next_execution.status, AgentExecution.Status.PENDING)
+        delay.assert_called_once_with(next_execution.id)
 
     def test_run_turn_edits_note_and_publishes_reply(self):
         # Arrange

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -324,15 +324,18 @@ class NotebookChatServiceTests(TestCase):
                 # Assert: the next task is admitted and scheduled immediately.
                 execution.refresh_from_db()
                 self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
-                self.assertIsNone(execution.usage_reservation_expires_at)
+                self.assertGreater(execution.usage_reservation_expires_at, expires_at)
                 self.assertEqual(next_execution.status, AgentExecution.Status.PENDING)
                 delay.assert_called_once_with(next_execution.id)
                 if same_chat:
                     self.assertEqual(next_execution.context_parent_id, execution.id)
                 self.service.cancel_active_turn(next_chat)
+                AgentExecution.objects.filter(pk=execution.pk).update(
+                    usage_reservation_expires_at=None
+                )
 
-    def test_resume_ignores_reservation_from_an_older_cancellation(self):
-        # Arrange: an earlier deployment cancelled the turn but kept its lease.
+    def test_one_outstanding_cancellation_allows_immediate_handoff(self):
+        # Arrange: a cancelled provider call is still unwinding.
         execution, _ = self._submit()
         expires_at = timezone.now() + timedelta(minutes=5)
         AgentExecution.objects.filter(pk=execution.pk).update(
@@ -346,6 +349,20 @@ class NotebookChatServiceTests(TestCase):
         # Assert: no second cancellation or wait for expiry is necessary.
         self.assertEqual(next_execution.status, AgentExecution.Status.PENDING)
         delay.assert_called_once_with(next_execution.id)
+
+    def test_two_outstanding_cancellations_block_another_handoff(self):
+        # Arrange: two paid calls are still unwinding after cancellation.
+        for attempt in (1, 2):
+            AgentExecution.objects.create(
+                conversation=self.conversation,
+                attempt=attempt,
+                status=AgentExecution.Status.CANCELLED,
+                usage_reservation_expires_at=timezone.now() + timedelta(hours=1),
+            )
+
+        # Act / Assert
+        with self.assertRaises(UsageWorkInProgressError):
+            self._submit("Try a third call")
 
     def test_run_turn_edits_note_and_publishes_reply(self):
         # Arrange

--- a/src/research_ai/tests/proposal_draft/test_proposal_draft_cancel.py
+++ b/src/research_ai/tests/proposal_draft/test_proposal_draft_cancel.py
@@ -66,7 +66,7 @@ class ProposalDraftCancelServiceTests(TestCase):
         self.assertEqual(draft.error_message, "")
         self.assertEqual(draft.step, ProposalDraft.Step.JUDGING)
 
-    def test_running_cancellation_releases_budget_before_worker_unwinds(self):
+    def test_running_cancellation_reserves_budget_until_worker_unwinds(self):
         # Arrange
         draft = self._draft()
         draft.usage_reservation_expires_at = reservation_deadline()
@@ -77,9 +77,9 @@ class ProposalDraftCancelServiceTests(TestCase):
         # Act: cancellation lands while provider work is still in flight.
         self.cancels.cancel(draft)
 
-        # Assert: no worker acknowledgement is required to release admission.
+        # Assert: the lease remains until the worker acknowledges cancellation.
         draft.refresh_from_db()
-        self.assertIsNone(draft.usage_reservation_expires_at)
+        self.assertIsNotNone(draft.usage_reservation_expires_at)
         recorder.cancelled_result()
         draft.refresh_from_db()
         self.assertIsNone(draft.usage_reservation_expires_at)
@@ -97,7 +97,7 @@ class ProposalDraftCancelServiceTests(TestCase):
         draft.refresh_from_db()
         self.assertIsNone(draft.usage_reservation_expires_at)
 
-    def test_cancelling_running_draft_and_trace_releases_reservations(self):
+    def test_cancelling_running_draft_allows_one_replacement_handoff(self):
         # Arrange: both reservations still have two hours remaining.
         conversation = AgentConversation.objects.create(
             user=self.user, workflow="proposal_draft"
@@ -116,18 +116,18 @@ class ProposalDraftCancelServiceTests(TestCase):
         # Act
         self.cancels.cancel(draft)
 
-        # Assert: neither reservation prevents the user's next task.
+        # Assert: the trace is part of the same job, so this is one handoff.
         draft.refresh_from_db()
         execution.refresh_from_db()
         self.assertEqual(draft.status, ProposalDraft.Status.CANCELLED)
         self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
-        self.assertIsNone(draft.usage_reservation_expires_at)
-        self.assertIsNone(execution.usage_reservation_expires_at)
+        self.assertGreater(draft.usage_reservation_expires_at, expires_at)
+        self.assertGreater(execution.usage_reservation_expires_at, expires_at)
         with atomic_turn_admission(self.user):
             pass
 
-    def test_older_cancelled_draft_reservation_does_not_block_admission(self):
-        # Arrange: an earlier deployment left the reservation after cancellation.
+    def test_one_cancelled_draft_reservation_allows_handoff(self):
+        # Arrange: one cancelled draft is still unwinding.
         draft = self._draft(status=ProposalDraft.Status.CANCELLED)
         draft.usage_reservation_expires_at = reservation_deadline()
         draft.save(update_fields=["usage_reservation_expires_at"])

--- a/src/research_ai/tests/proposal_draft/test_proposal_draft_cancel.py
+++ b/src/research_ai/tests/proposal_draft/test_proposal_draft_cancel.py
@@ -66,7 +66,7 @@ class ProposalDraftCancelServiceTests(TestCase):
         self.assertEqual(draft.error_message, "")
         self.assertEqual(draft.step, ProposalDraft.Step.JUDGING)
 
-    def test_running_cancellation_reserves_budget_until_worker_unwinds(self):
+    def test_running_cancellation_releases_concurrency_reservation(self):
         # Arrange
         draft = self._draft()
         draft.usage_reservation_expires_at = reservation_deadline()
@@ -77,9 +77,9 @@ class ProposalDraftCancelServiceTests(TestCase):
         # Act: cancellation lands while provider work is still in flight.
         self.cancels.cancel(draft)
 
-        # Assert: the lease remains until the worker acknowledges cancellation.
+        # Assert: its provider attempts are accounted separately, so this lock goes.
         draft.refresh_from_db()
-        self.assertIsNotNone(draft.usage_reservation_expires_at)
+        self.assertIsNone(draft.usage_reservation_expires_at)
         recorder.cancelled_result()
         draft.refresh_from_db()
         self.assertIsNone(draft.usage_reservation_expires_at)
@@ -97,7 +97,7 @@ class ProposalDraftCancelServiceTests(TestCase):
         draft.refresh_from_db()
         self.assertIsNone(draft.usage_reservation_expires_at)
 
-    def test_cancelling_running_draft_allows_one_replacement_handoff(self):
+    def test_cancelling_running_draft_and_trace_releases_reservations(self):
         # Arrange: both reservations still have two hours remaining.
         conversation = AgentConversation.objects.create(
             user=self.user, workflow="proposal_draft"
@@ -116,18 +116,18 @@ class ProposalDraftCancelServiceTests(TestCase):
         # Act
         self.cancels.cancel(draft)
 
-        # Assert: the trace is part of the same job, so this is one handoff.
+        # Assert: neither lifecycle reservation blocks another task.
         draft.refresh_from_db()
         execution.refresh_from_db()
         self.assertEqual(draft.status, ProposalDraft.Status.CANCELLED)
         self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
-        self.assertGreater(draft.usage_reservation_expires_at, expires_at)
-        self.assertGreater(execution.usage_reservation_expires_at, expires_at)
+        self.assertIsNone(draft.usage_reservation_expires_at)
+        self.assertIsNone(execution.usage_reservation_expires_at)
         with atomic_turn_admission(self.user):
             pass
 
-    def test_one_cancelled_draft_reservation_allows_handoff(self):
-        # Arrange: one cancelled draft is still unwinding.
+    def test_old_cancelled_draft_reservation_does_not_block_admission(self):
+        # Arrange: an earlier deployment left a cancelled draft lease behind.
         draft = self._draft(status=ProposalDraft.Status.CANCELLED)
         draft.usage_reservation_expires_at = reservation_deadline()
         draft.save(update_fields=["usage_reservation_expires_at"])

--- a/src/research_ai/tests/proposal_draft/test_proposal_draft_cancel.py
+++ b/src/research_ai/tests/proposal_draft/test_proposal_draft_cancel.py
@@ -1,8 +1,10 @@
 """Cancelling a queued or in-flight proposal-drafting job."""
 
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.test import TestCase
+from django.utils import timezone
 
 from note.tests.helpers import create_note
 from research_ai.models import (
@@ -21,6 +23,7 @@ from research_ai.services.proposal_draft.cancel_service import (
 from research_ai.services.proposal_draft.config import ProposalDraftConfig
 from research_ai.services.proposal_draft.draft_recorder import DraftRecorder
 from research_ai.services.proposal_draft.run_state import ProposalRunState
+from research_ai.services.usage_budget import atomic_turn_admission
 from research_ai.services.usage_budget.reservation import reservation_deadline
 from research_ai.tasks import run_proposal_draft_task
 from user.tests.helpers import create_random_default_user
@@ -63,7 +66,7 @@ class ProposalDraftCancelServiceTests(TestCase):
         self.assertEqual(draft.error_message, "")
         self.assertEqual(draft.step, ProposalDraft.Step.JUDGING)
 
-    def test_running_cancellation_reserves_budget_until_worker_unwinds(self):
+    def test_running_cancellation_releases_budget_before_worker_unwinds(self):
         # Arrange
         draft = self._draft()
         draft.usage_reservation_expires_at = reservation_deadline()
@@ -74,9 +77,9 @@ class ProposalDraftCancelServiceTests(TestCase):
         # Act: cancellation lands while provider work is still in flight.
         self.cancels.cancel(draft)
 
-        # Assert: only the worker's cancelled result releases admission.
+        # Assert: no worker acknowledgement is required to release admission.
         draft.refresh_from_db()
-        self.assertIsNotNone(draft.usage_reservation_expires_at)
+        self.assertIsNone(draft.usage_reservation_expires_at)
         recorder.cancelled_result()
         draft.refresh_from_db()
         self.assertIsNone(draft.usage_reservation_expires_at)
@@ -93,6 +96,45 @@ class ProposalDraftCancelServiceTests(TestCase):
         # Assert
         draft.refresh_from_db()
         self.assertIsNone(draft.usage_reservation_expires_at)
+
+    def test_cancelling_running_draft_and_trace_releases_reservations(self):
+        # Arrange: both reservations still have two hours remaining.
+        conversation = AgentConversation.objects.create(
+            user=self.user, workflow="proposal_draft"
+        )
+        draft = self._draft(conversation=conversation)
+        expires_at = timezone.now() + timedelta(hours=2)
+        draft.usage_reservation_expires_at = expires_at
+        draft.save(update_fields=["usage_reservation_expires_at"])
+        execution = AgentExecution.objects.create(
+            conversation=conversation,
+            attempt=1,
+            status=AgentExecution.Status.RUNNING,
+            usage_reservation_expires_at=expires_at,
+        )
+
+        # Act
+        self.cancels.cancel(draft)
+
+        # Assert: neither reservation prevents the user's next task.
+        draft.refresh_from_db()
+        execution.refresh_from_db()
+        self.assertEqual(draft.status, ProposalDraft.Status.CANCELLED)
+        self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
+        self.assertIsNone(draft.usage_reservation_expires_at)
+        self.assertIsNone(execution.usage_reservation_expires_at)
+        with atomic_turn_admission(self.user):
+            pass
+
+    def test_older_cancelled_draft_reservation_does_not_block_admission(self):
+        # Arrange: an earlier deployment left the reservation after cancellation.
+        draft = self._draft(status=ProposalDraft.Status.CANCELLED)
+        draft.usage_reservation_expires_at = reservation_deadline()
+        draft.save(update_fields=["usage_reservation_expires_at"])
+
+        # Act / Assert
+        with atomic_turn_admission(self.user):
+            pass
 
     def test_cancelling_also_stops_the_traced_agent_execution(self):
         # Arrange: a run whose agent trace exists, so the loop has something to

--- a/src/research_ai/tests/test_usage_budget.py
+++ b/src/research_ai/tests/test_usage_budget.py
@@ -275,7 +275,7 @@ class AgentLoopBudgetRecorderTests(TestCase):
             recorder.before_model_call()
         self.assertEqual(LLMUsageEvent.objects.filter(user=self.user).count(), 10)
 
-    def test_stream_activity_renews_a_cancelled_in_flight_lease(self):
+    def test_stream_activity_does_not_renew_cancelled_concurrency_lease(self):
         # Arrange
         old_expiry = timezone.now() + timedelta(minutes=1)
         execution = self._execution(
@@ -290,15 +290,41 @@ class AgentLoopBudgetRecorderTests(TestCase):
 
         # Assert
         execution.refresh_from_db()
-        self.assertGreater(execution.usage_reservation_expires_at, old_expiry)
+        self.assertEqual(execution.usage_reservation_expires_at, old_expiry)
 
-    def test_late_usage_is_charged_without_reacquiring_cancelled_reservation(self):
-        # Arrange: cancellation already released this call's reservation.
+    def test_model_call_counts_toward_turn_cap_before_provider_returns(self):
+        # Arrange
         execution = self._execution(
-            status=AgentExecution.Status.CANCELLED,
-            expires_at=None,
+            status=AgentExecution.Status.RUNNING,
+            expires_at=timezone.now() + timedelta(minutes=1),
         )
         recorder = self._recorder(execution)
+
+        # Act: this runs immediately before provider dispatch.
+        recorder.before_model_call()
+
+        # Assert: admission sees the attempt while its exact cost is pending.
+        event = LLMUsageEvent.objects.get(execution=execution)
+        self.assertIsNone(event.cost_microusd)
+        self.assertEqual(budget_status(self.user).turns_used, 1)
+
+        recorder.record_usage(TurnUsage(input_tokens=100, output_tokens=50))
+        event.refresh_from_db()
+        self.assertGreater(event.cost_microusd, 0)
+        self.assertEqual(budget_status(self.user).turns_used, 1)
+
+    def test_late_usage_is_charged_without_reacquiring_cancelled_reservation(self):
+        # Arrange: record the call start, then cancel while the provider runs.
+        execution = self._execution(
+            status=AgentExecution.Status.RUNNING,
+            expires_at=timezone.now() + timedelta(minutes=1),
+        )
+        recorder = self._recorder(execution)
+        recorder.before_model_call()
+        AgentExecution.objects.filter(pk=execution.pk).update(
+            status=AgentExecution.Status.CANCELLED,
+            usage_reservation_expires_at=None,
+        )
 
         # Act: the provider's last stream event and usage arrive after cancel.
         recorder.record_stream_event(
@@ -431,7 +457,7 @@ class AtomicAdmissionTests(TransactionTestCase):
         self.assertEqual(len(errors), 1)
         self.assertIsInstance(errors[0], UsageWorkInProgressError)
 
-    def test_one_cancelled_call_allows_replacement_handoff(self):
+    def test_cancelled_call_does_not_block_admission(self):
         # Arrange: cancellation is visible immediately, but the provider call
         # that was already in flight has not returned to its worker yet.
         conversation = AgentConversation.objects.create(
@@ -449,13 +475,13 @@ class AtomicAdmissionTests(TransactionTestCase):
         with atomic_turn_admission(self.user):
             pass
 
-    def test_second_cancelled_call_blocks_until_a_lease_expires(self):
-        # Arrange: two provider calls have been cancelled while in flight.
+    def test_multiple_cancelled_calls_do_not_block_admission(self):
+        # Arrange: provider starts are accounted through usage-event rows.
         conversation = AgentConversation.objects.create(
             user=self.user,
             workflow="notebook_chat",
         )
-        executions = AgentExecution.objects.bulk_create(
+        AgentExecution.objects.bulk_create(
             [
                 AgentExecution(
                     conversation=conversation,
@@ -467,18 +493,7 @@ class AtomicAdmissionTests(TransactionTestCase):
             ]
         )
 
-        # Act / Assert: a third call is refused while both are outstanding.
-        with (
-            self.assertRaises(UsageWorkInProgressError),
-            atomic_turn_admission(self.user),
-        ):
-            pass
-
-        # A dead worker cannot hold admission forever: its lease expires.
-        executions[0].usage_reservation_expires_at = timezone.now() - timedelta(
-            seconds=1
-        )
-        executions[0].save(update_fields=["usage_reservation_expires_at"])
+        # Act / Assert
         with atomic_turn_admission(self.user):
             pass
 

--- a/src/research_ai/tests/test_usage_budget.py
+++ b/src/research_ai/tests/test_usage_budget.py
@@ -275,7 +275,7 @@ class AgentLoopBudgetRecorderTests(TestCase):
             recorder.before_model_call()
         self.assertEqual(LLMUsageEvent.objects.filter(user=self.user).count(), 10)
 
-    def test_stream_activity_does_not_renew_a_cancelled_in_flight_lease(self):
+    def test_stream_activity_renews_a_cancelled_in_flight_lease(self):
         # Arrange
         old_expiry = timezone.now() + timedelta(minutes=1)
         execution = self._execution(
@@ -290,7 +290,7 @@ class AgentLoopBudgetRecorderTests(TestCase):
 
         # Assert
         execution.refresh_from_db()
-        self.assertEqual(execution.usage_reservation_expires_at, old_expiry)
+        self.assertGreater(execution.usage_reservation_expires_at, old_expiry)
 
     def test_late_usage_is_charged_without_reacquiring_cancelled_reservation(self):
         # Arrange: cancellation already released this call's reservation.
@@ -431,7 +431,7 @@ class AtomicAdmissionTests(TransactionTestCase):
         self.assertEqual(len(errors), 1)
         self.assertIsInstance(errors[0], UsageWorkInProgressError)
 
-    def test_cancelled_call_does_not_block_admission_with_unexpired_reservation(self):
+    def test_one_cancelled_call_allows_replacement_handoff(self):
         # Arrange: cancellation is visible immediately, but the provider call
         # that was already in flight has not returned to its worker yet.
         conversation = AgentConversation.objects.create(
@@ -446,6 +446,39 @@ class AtomicAdmissionTests(TransactionTestCase):
         )
 
         # Act & Assert
+        with atomic_turn_admission(self.user):
+            pass
+
+    def test_second_cancelled_call_blocks_until_a_lease_expires(self):
+        # Arrange: two provider calls have been cancelled while in flight.
+        conversation = AgentConversation.objects.create(
+            user=self.user,
+            workflow="notebook_chat",
+        )
+        executions = AgentExecution.objects.bulk_create(
+            [
+                AgentExecution(
+                    conversation=conversation,
+                    status=AgentExecution.Status.CANCELLED,
+                    attempt=attempt,
+                    usage_reservation_expires_at=timezone.now() + timedelta(hours=1),
+                )
+                for attempt in (1, 2)
+            ]
+        )
+
+        # Act / Assert: a third call is refused while both are outstanding.
+        with (
+            self.assertRaises(UsageWorkInProgressError),
+            atomic_turn_admission(self.user),
+        ):
+            pass
+
+        # A dead worker cannot hold admission forever: its lease expires.
+        executions[0].usage_reservation_expires_at = timezone.now() - timedelta(
+            seconds=1
+        )
+        executions[0].save(update_fields=["usage_reservation_expires_at"])
         with atomic_turn_admission(self.user):
             pass
 

--- a/src/research_ai/tests/test_usage_budget.py
+++ b/src/research_ai/tests/test_usage_budget.py
@@ -275,7 +275,7 @@ class AgentLoopBudgetRecorderTests(TestCase):
             recorder.before_model_call()
         self.assertEqual(LLMUsageEvent.objects.filter(user=self.user).count(), 10)
 
-    def test_stream_activity_renews_a_cancelled_in_flight_lease(self):
+    def test_stream_activity_does_not_renew_a_cancelled_in_flight_lease(self):
         # Arrange
         old_expiry = timezone.now() + timedelta(minutes=1)
         execution = self._execution(
@@ -290,7 +290,30 @@ class AgentLoopBudgetRecorderTests(TestCase):
 
         # Assert
         execution.refresh_from_db()
-        self.assertGreater(execution.usage_reservation_expires_at, old_expiry)
+        self.assertEqual(execution.usage_reservation_expires_at, old_expiry)
+
+    def test_late_usage_is_charged_without_reacquiring_cancelled_reservation(self):
+        # Arrange: cancellation already released this call's reservation.
+        execution = self._execution(
+            status=AgentExecution.Status.CANCELLED,
+            expires_at=None,
+        )
+        recorder = self._recorder(execution)
+
+        # Act: the provider's last stream event and usage arrive after cancel.
+        recorder.record_stream_event(
+            1, TextStreamDelta(block_index=0, text="late result")
+        )
+        recorder.record_usage(TurnUsage(input_tokens=100, output_tokens=50))
+
+        # Assert: spend is accounted for, but cancellation remains authoritative.
+        event = LLMUsageEvent.objects.get(execution=execution)
+        self.assertGreater(event.cost_microusd, 0)
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, AgentExecution.Status.CANCELLED)
+        self.assertIsNone(execution.usage_reservation_expires_at)
+        with atomic_turn_admission(self.user):
+            pass
 
     def test_stream_activity_throttles_lease_renewals(self):
         # Arrange
@@ -408,14 +431,14 @@ class AtomicAdmissionTests(TransactionTestCase):
         self.assertEqual(len(errors), 1)
         self.assertIsInstance(errors[0], UsageWorkInProgressError)
 
-    def test_cancelled_call_blocks_admission_until_its_reservation_is_released(self):
+    def test_cancelled_call_does_not_block_admission_with_unexpired_reservation(self):
         # Arrange: cancellation is visible immediately, but the provider call
         # that was already in flight has not returned to its worker yet.
         conversation = AgentConversation.objects.create(
             user=self.user,
             workflow="notebook_chat",
         )
-        execution = AgentExecution.objects.create(
+        AgentExecution.objects.create(
             conversation=conversation,
             status=AgentExecution.Status.CANCELLED,
             attempt=1,
@@ -423,15 +446,6 @@ class AtomicAdmissionTests(TransactionTestCase):
         )
 
         # Act & Assert
-        with (
-            self.assertRaises(UsageWorkInProgressError),
-            atomic_turn_admission(self.user),
-        ):
-            pass
-
-        # The worker releases the separate reservation after the call returns.
-        execution.usage_reservation_expires_at = None
-        execution.save(update_fields=["usage_reservation_expires_at"])
         with atomic_turn_admission(self.user):
             pass
 


### PR DESCRIPTION
Cancelling a running Research AI task marked it terminal but retained its usage reservation, so the next task could remain blocked for up to two hours. Cancellation now releases that lifecycle reservation immediately, allowing the user to resume without waiting for the worker or lease expiry.

Every provider-call attempt now creates its `LLMUsageEvent` immediately before network dispatch. That row counts against the daily turn allowance while its dollar cost is pending. When the provider response returns, the same row is settled with exact token usage and cost, including after execution cancellation. This deliberately avoids blocking a replacement based on the call's theoretical maximum cost; rapid cancel-and-resubmit attempts remain durable and bounded by the existing daily turn cap and per-request output limit.

Validation:

- `ruff check` and `ruff format --check` on all changed files
- 116 cancellation, notebook-chat, proposal-draft, and usage-budget tests
