### PR TITLE
Reclaim orphaned agent runs with a worker liveness lease

### DIFF
--- a/src/research_ai/services/agent_persistence/__init__.py
+++ b/src/research_ai/services/agent_persistence/__init__.py
@@ -12,6 +12,11 @@ from .execution_service import (
     AgentExecutionService,
     AgentStaleRetryError,
 )
+from .liveness_service import (
+    WORKER_LOST_STOP_REASON,
+    AgentExecutionLivenessService,
+    WorkerLostError,
+)
 from .recorder import DatabaseAgentRecorder
 from .retention_service import AgentRetentionService
 from .run_details_service import (
@@ -20,11 +25,13 @@ from .run_details_service import (
 )
 
 __all__ = [
+    "WORKER_LOST_STOP_REASON",
     "AgentChatService",
     "AgentContextService",
     "AgentConversationBusyError",
     "AgentConversationService",
     "AgentExecutionCancelService",
+    "AgentExecutionLivenessService",
     "AgentExecutionService",
     "AgentRetentionService",
     "AgentRunDetails",
@@ -33,4 +40,5 @@ __all__ = [
     "DatabaseAgentRecorder",
     "NoteAgentConversationService",
     "PreparedAgentExecution",
+    "WorkerLostError",
 ]

--- a/src/research_ai/services/agent_persistence/cancel_service.py
+++ b/src/research_ai/services/agent_persistence/cancel_service.py
@@ -3,9 +3,10 @@
 A conversation permits one active execution, so one that never reaches a
 terminal status refuses every later turn as busy -- what happens when a worker
 dies before recording an outcome, or the broker never delivers a queued attempt.
-Cancelling unsticks it, and is deliberately the only way: no timeout is guessed
-at here, because one provider call can retry inside the vendor SDK for over an
-hour, so silence says nothing about whether a run is alive.
+Cancelling unsticks it at once; ``AgentExecutionLivenessService`` reclaims it
+anyway once the worker's liveness lease lapses. Neither guesses at a timeout on
+loop progress: one provider call can retry inside the vendor SDK for over an
+hour, so only the worker's heartbeat says whether a run is alive.
 
 It does not reach into the worker. The run stops before its next tool call,
 where the loop checks it still owns the execution, or at its next durable write,
@@ -14,13 +15,7 @@ neither: its claim is a conditional update, so a task delivered afterwards finds
 nothing left to claim.
 
 Stopping partway through leaves the record disagreeing with the conversation the
-user can see, in both directions, and cancelling reconciles the two. A turn
-cancelled before it ran never recorded the prompt that started it, though the
-chat shows it; a turn cancelled just after its last answer recorded that answer
-but never published it, and never will, because publication requires a
-``SUCCEEDED`` execution. Left alone, the next turn -- which continues from this
-execution's context -- would answer a conversation missing a message the user
-sent, or resume from one they never received.
+user can see; ``reconciliation`` repairs that in both directions.
 """
 
 import logging
@@ -28,10 +23,10 @@ import logging
 from django.db import transaction
 from django.utils import timezone
 
-from research_ai.models import AgentContextMessage, AgentExecution
-from research_ai.services.agent.types import Message, TextBlock
-from research_ai.services.agent_persistence.content import serialize_context_message
-from research_ai.services.usage_budget.reservation import reservation_deadline
+from research_ai.models import AgentExecution
+from research_ai.services.agent_persistence.reconciliation import (
+    reconcile_stopped_run,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,13 +40,13 @@ class AgentExecutionCancelService:
         """Mark an active execution ``CANCELLED``; report whether it landed.
 
         No error fields are written: a cancellation is the user's own decision,
-        not a failure, and the status alone says so. A queued execution releases
-        its usage reservation here because no provider call started. A running
-        execution keeps a renewable lease until its worker observes the
-        cancellation and unwinds. If the worker died, that lease expires instead
-        of blocking the user forever. Returns ``False`` when the execution already
-        reached a terminal state, which is the ordinary race of cancelling a turn
-        that was finishing anyway.
+        not a failure. A queued execution releases its usage reservation here
+        because no provider call started. A running execution keeps its
+        liveness lease: the worker renews it while its in-flight provider call
+        may still be spending and clears it when it unwinds, and a dead
+        worker's lease lapses on its own. Returns ``False`` when the execution
+        already reached a terminal state, which is the ordinary race of
+        cancelling a turn that was finishing anyway.
         """
         with transaction.atomic():
             locked = (
@@ -73,99 +68,22 @@ class AgentExecutionCancelService:
             locked.stop_reason = CANCELLED_STOP_REASON
             locked.finished_at = now
             locked.last_activity_at = now
-            # Set this from the claimed state rather than preserving the old
-            # value so executions already running during a rolling deployment
-            # receive the same protection as newly admitted work.
-            locked.usage_reservation_expires_at = (
-                None if was_pending else reservation_deadline(now)
-            )
+            update_fields = [
+                "status",
+                "stop_reason",
+                "finished_at",
+                "last_activity_at",
+                "duration_ms",
+                "updated_date",
+            ]
+            if was_pending:
+                locked.usage_reservation_expires_at = None
+                update_fields.append("usage_reservation_expires_at")
             if locked.started_at is not None:
                 locked.duration_ms = max(
                     0, round((now - locked.started_at).total_seconds() * 1000)
                 )
-            locked.save(
-                update_fields=[
-                    "status",
-                    "stop_reason",
-                    "finished_at",
-                    "last_activity_at",
-                    "duration_ms",
-                    "usage_reservation_expires_at",
-                    "updated_date",
-                ]
-            )
-            self._preserve_trigger_prompt(locked)
-            self._drop_unpublished_answer(locked)
+            locked.save(update_fields=update_fields)
+            reconcile_stopped_run(locked)
         execution.refresh_from_db()
         return True
-
-    def _drop_unpublished_answer(self, execution: AgentExecution) -> None:
-        """Forget a final answer this turn recorded but never delivered.
-
-        The mirror of :meth:`_preserve_trigger_prompt`. A run cancelled between
-        recording its closing assistant turn and transitioning to ``SUCCEEDED``
-        keeps that answer in its context but never publishes it -- publication
-        requires ``SUCCEEDED``, so not even the repair path will pick it up later.
-        The next turn would then continue from a reply the user never saw, and
-        answer as though it had already said something it never did.
-
-        Only a *closing* answer goes. An assistant turn holding tool calls is
-        load-bearing lineage: a later turn seals its open calls, and dropping it
-        would leave tool results with nothing to attach to.
-
-        Nothing here needs to ask whether the answer was published. Publishing
-        requires a ``SUCCEEDED`` execution, and a succeeded one is terminal, so
-        the caller has already returned before reaching this -- an answer that
-        was delivered is one this method never sees.
-        """
-        if not execution.publish_output_to_chat:
-            # No chat to diverge from -- a headless workflow's context is only
-            # ever read by the model, so there is no answer "the user missed".
-            return
-        last = execution.context_messages.order_by("-sequence").first()
-        if last is None or last.role != "assistant":
-            return
-        blocks = last.content if isinstance(last.content, list) else []
-        if any(
-            isinstance(block, dict) and block.get("type") == "tool_use"
-            for block in blocks
-        ):
-            return
-        last.delete()
-        logger.info(
-            "dropped an unpublished answer from a cancelled turn",
-            extra={"execution_id": execution.id},
-        )
-
-    def _preserve_trigger_prompt(self, execution: AgentExecution) -> None:
-        """Seed the context with the prompt this turn never got to record.
-
-        A cancelled execution is a continuation parent, and reconstruction reads
-        context rows only -- so whatever is missing here the model never sees
-        again. A ``RUNNING`` turn already recorded its seed prompt, but one
-        cancelled while still ``PENDING`` never ran, and its prompt lives only in
-        the chat message that triggered it. Left alone, the next turn would
-        inherit a conversation with a user message visible on screen and absent
-        from the model's view of it.
-        """
-        if execution.context_messages.exists():
-            return
-        trigger = execution.trigger_message
-        if trigger is None or not (trigger.content or "").strip():
-            return
-        content, provider_state, is_compacted, original_size = (
-            serialize_context_message(
-                Message(role="user", content=[TextBlock(text=trigger.content)])
-            )
-        )
-        AgentContextMessage.objects.create(
-            execution=execution,
-            sequence=execution.next_context_sequence,
-            role="user",
-            content=content,
-            provider_state=provider_state,
-            is_compacted=is_compacted,
-            original_size_bytes=original_size if is_compacted else None,
-        )
-        execution.next_context_sequence += 1
-        execution.save(update_fields=["next_context_sequence", "updated_date"])

--- a/src/research_ai/services/agent_persistence/chat_service.py
+++ b/src/research_ai/services/agent_persistence/chat_service.py
@@ -20,6 +20,9 @@ from research_ai.services.agent_persistence.conversation_service import (
 from research_ai.services.agent_persistence.execution_service import (
     AgentExecutionService,
 )
+from research_ai.services.agent_persistence.liveness_service import (
+    WORKER_LOST_STOP_REASON,
+)
 from research_ai.services.agent_persistence.recorder import DatabaseAgentRecorder
 from research_ai.services.agent_persistence.replacement import (
     superseded_execution_ids,
@@ -235,6 +238,17 @@ class AgentChatService:
         """
         if not execution.error_type:
             return None
+        if execution.stop_reason == WORKER_LOST_STOP_REASON:
+            # The worker died or lost the database mid-run; nothing about the
+            # request itself failed, so a retry is worth one.
+            return {
+                "code": "agent_failed",
+                "retryable": True,
+                "message": (
+                    "The assistant stopped unexpectedly before it could finish. "
+                    "Try again."
+                ),
+            }
         if execution.status == AgentExecution.Status.INTERRUPTED:
             # The worker observed the user's own stop mid-run -- named for
             # the client, but not offered for retry.

--- a/src/research_ai/services/agent_persistence/liveness_service.py
+++ b/src/research_ai/services/agent_persistence/liveness_service.py
@@ -1,0 +1,99 @@
+"""Reclaiming executions whose worker stopped heartbeating."""
+
+import logging
+
+from django.db import transaction
+from django.utils import timezone
+
+from research_ai.models import AgentExecution
+from research_ai.services.agent_persistence.execution_service import (
+    AgentExecutionService,
+)
+from research_ai.services.agent_persistence.reconciliation import (
+    reconcile_stopped_run,
+)
+from research_ai.services.agent_persistence.recorder import DatabaseAgentRecorder
+
+logger = logging.getLogger(__name__)
+
+WORKER_LOST_STOP_REASON = "worker_lost"
+
+_ACTIVE_STATUSES = (AgentExecution.Status.PENDING, AgentExecution.Status.RUNNING)
+
+
+class WorkerLostError(RuntimeError):
+    """Sealed onto an execution whose worker's liveness lease lapsed."""
+
+    stop_reason = WORKER_LOST_STOP_REASON
+
+    def __init__(self, message: str = "the worker stopped heartbeating mid-run"):
+        super().__init__(message)
+
+
+class AgentExecutionLivenessService:
+    """Seals active executions whose worker is gone, so they stop blocking.
+
+    A lapsed lease is the only evidence used: a live worker renews its lease
+    from a heartbeat thread regardless of loop progress, so silence longer
+    than one lease means the process is dead or cut off from the database.
+    """
+
+    def __init__(self, *, recorder_factory=None):
+        self.recorder_factory = (
+            DatabaseAgentRecorder if recorder_factory is None else recorder_factory
+        )
+        self.executions = AgentExecutionService(recorder_factory=self.recorder_factory)
+
+    def reclaim_lost(self, *, user=None, now=None) -> list[AgentExecution]:
+        """Fail every active execution whose lease lapsed, optionally one user's."""
+        current = now or timezone.now()
+        candidates = AgentExecution.objects.filter(
+            status__in=_ACTIVE_STATUSES,
+            usage_reservation_expires_at__lt=current,
+        )
+        if user is not None:
+            candidates = candidates.filter(conversation__user=user)
+        reclaimed = []
+        for execution in candidates.order_by("id"):
+            sealed = self._seal(execution.id, now=current, require_lapsed_lease=True)
+            if sealed is not None:
+                reclaimed.append(sealed)
+        return reclaimed
+
+    def seal_lost(self, execution: AgentExecution) -> bool:
+        """Fail one active execution whose worker the caller knows is gone."""
+        return (
+            self._seal(execution.id, now=timezone.now(), require_lapsed_lease=False)
+            is not None
+        )
+
+    def _seal(self, execution_id: int, *, now, require_lapsed_lease: bool):
+        # Re-checked under the row lock: a slow worker may have renewed since the scan.
+        lease_filter = (
+            {"usage_reservation_expires_at__lt": now} if require_lapsed_lease else {}
+        )
+        with transaction.atomic():
+            locked = (
+                AgentExecution.objects.select_for_update()
+                .filter(id=execution_id, status__in=_ACTIVE_STATUSES, **lease_filter)
+                .first()
+            )
+            if locked is None:
+                return None
+            if locked.status == AgentExecution.Status.PENDING:
+                # Claim then fail, as an undeliverable turn is: only RUNNING seals.
+                recorder = self.executions.claim_pending(locked)
+            else:
+                recorder = self.recorder_factory(locked)
+            if recorder is None or not recorder.on_run_failed(WorkerLostError()):
+                return None
+            reconcile_stopped_run(locked)
+        locked.refresh_from_db()
+        logger.warning(
+            "reclaimed an agent execution whose worker was lost",
+            extra={
+                "execution_id": locked.id,
+                "conversation_id": locked.conversation_id,
+            },
+        )
+        return locked

--- a/src/research_ai/services/agent_persistence/reconciliation.py
+++ b/src/research_ai/services/agent_persistence/reconciliation.py
@@ -1,0 +1,74 @@
+"""Reconcile a stopped run's durable context with the chat the user can see.
+
+A run stopped partway leaves the two disagreeing in either direction: a turn
+stopped before it ran never recorded the prompt the chat shows, and a turn
+stopped just after its last answer recorded an answer the chat never received.
+The next turn continues from this context, so both are repaired here.
+"""
+
+import logging
+
+from research_ai.models import AgentContextMessage, AgentExecution
+from research_ai.services.agent.types import Message, TextBlock
+from research_ai.services.agent_persistence.content import serialize_context_message
+
+logger = logging.getLogger(__name__)
+
+
+def reconcile_stopped_run(execution: AgentExecution) -> None:
+    """Apply both repairs to a run just sealed from outside its worker."""
+    preserve_trigger_prompt(execution)
+    drop_unpublished_answer(execution)
+
+
+def preserve_trigger_prompt(execution: AgentExecution) -> None:
+    """Seed an empty context with the chat prompt the run never recorded.
+
+    A ``RUNNING`` turn records its prompt first thing, but one stopped while
+    still ``PENDING`` never ran, and its prompt lives only in the chat message
+    that triggered it.
+    """
+    if execution.context_messages.exists():
+        return
+    trigger = execution.trigger_message
+    if trigger is None or not (trigger.content or "").strip():
+        return
+    content, provider_state, is_compacted, original_size = serialize_context_message(
+        Message(role="user", content=[TextBlock(text=trigger.content)])
+    )
+    AgentContextMessage.objects.create(
+        execution=execution,
+        sequence=execution.next_context_sequence,
+        role="user",
+        content=content,
+        provider_state=provider_state,
+        is_compacted=is_compacted,
+        original_size_bytes=original_size if is_compacted else None,
+    )
+    execution.next_context_sequence += 1
+    execution.save(update_fields=["next_context_sequence", "updated_date"])
+
+
+def drop_unpublished_answer(execution: AgentExecution) -> None:
+    """Forget a closing answer the run recorded but never published.
+
+    Publication requires ``SUCCEEDED``, so a run sealed any other way never
+    delivers its last answer. Only a *closing* answer goes: an assistant turn
+    holding tool calls is lineage a later turn seals, and dropping it would
+    leave tool results with nothing to attach to.
+    """
+    if not execution.publish_output_to_chat:
+        return
+    last = execution.context_messages.order_by("-sequence").first()
+    if last is None or last.role != "assistant":
+        return
+    blocks = last.content if isinstance(last.content, list) else []
+    if any(
+        isinstance(block, dict) and block.get("type") == "tool_use" for block in blocks
+    ):
+        return
+    last.delete()
+    logger.info(
+        "dropped an unpublished answer from a stopped turn",
+        extra={"execution_id": execution.id},
+    )

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -19,7 +19,9 @@ is split across two processes:
   composes the note + research toolset with
   the conversation owner's permissions, and drives
   ``Agent.continue_conversation``. The recorder persists the trace, marks the
-  terminal status, and publishes the assistant's reply to the chat.
+  terminal status, and publishes the assistant's reply to the chat. A
+  heartbeat thread renews the turn's budget lease for as long as the worker
+  is alive; ``reclaim_lost_turns`` fails a turn whose heartbeat stopped.
 
 The agent acts strictly as the conversation's user and only on the
 conversation's note: ``NoteToolset`` enforces note view/edit permissions per
@@ -68,6 +70,7 @@ from research_ai.services.agent_persistence import (
     AgentConversationBusyError,
     AgentConversationService,
     AgentExecutionCancelService,
+    AgentExecutionLivenessService,
     NoteAgentConversationService,
 )
 from research_ai.services.agent_persistence.activity import (
@@ -85,6 +88,7 @@ from research_ai.services.notebook_chat.activity import (
 from research_ai.services.notebook_chat.config import NotebookChatConfig
 from research_ai.services.notebook_chat.events import (
     TURN_CANCELLED,
+    TURN_FAILED,
     TURN_QUEUED,
     ConversationEventPublisher,
     PublishingRecorder,
@@ -104,12 +108,13 @@ from research_ai.services.notebook_chat.toolset import (
 from research_ai.services.researcher_profile.openalex_tools import OpenAlexToolset
 from research_ai.services.usage_budget import (
     AgentLoopBudgetRecorder,
+    ReservationHeartbeat,
     atomic_turn_admission,
     effective_generation_options,
     resolve_ai_tier,
     resolve_default_model,
 )
-from research_ai.services.usage_budget.reservation import reservation_deadline
+from research_ai.services.usage_budget.reservation import claim_deadline
 from research_ai.services.user_profile_tools import UserProfileToolset
 from researchhub_document.related_models.constants.document_type import PREREGISTRATION
 from utils.openalex import OpenAlex
@@ -199,6 +204,7 @@ class NotebookChatService:
         note_conversation_service: NoteAgentConversationService | None = None,
         context_service: AgentContextService | None = None,
         cancel_service: AgentExecutionCancelService | None = None,
+        liveness_service: AgentExecutionLivenessService | None = None,
         config: NotebookChatConfig | None = None,
         event_publisher: ConversationEventPublisher | None = None,
         stream_store: ExecutionStreamStore | None = None,
@@ -235,6 +241,11 @@ class NotebookChatService:
         )
         self.cancels = (
             AgentExecutionCancelService() if cancel_service is None else cancel_service
+        )
+        self.liveness = (
+            AgentExecutionLivenessService()
+            if liveness_service is None
+            else liveness_service
         )
         self.events = (
             ConversationEventPublisher() if event_publisher is None else event_publisher
@@ -498,6 +509,9 @@ class NotebookChatService:
         # inherit that snapshot even if the configured default or catalog
         # changes, and an explicit attempt to switch is rejected.
         selected_model = validate_model_ref(model_ref)
+        # A turn whose worker died would otherwise hold both busy checks; its
+        # lapsed lease is what lets this request take its place.
+        self.reclaim_lost_turns(user=conversation.user)
         with transaction.atomic():
             # Keep model resolution in the same conversation lock as turn
             # preparation. Two first-message requests with different models
@@ -575,7 +589,8 @@ class NotebookChatService:
                     configuration=configuration,
                     system_prompt=self._system_prompt(note, locked_conversation),
                 )
-                prepared.execution.usage_reservation_expires_at = reservation_deadline()
+                # Held until a worker claims the turn and takes over renewal.
+                prepared.execution.usage_reservation_expires_at = claim_deadline()
                 prepared.execution.save(
                     update_fields=["usage_reservation_expires_at", "updated_date"]
                 )
@@ -631,6 +646,26 @@ class NotebookChatService:
         self.events.publish(conversation.id, execution.id, TURN_CANCELLED)
         return execution
 
+    def reclaim_lost_turns(self, *, user=None) -> list[AgentExecution]:
+        """Fail turns whose worker stopped heartbeating, and tell their chats.
+
+        Sealing is the liveness service's; this adds what the worker would have
+        done had it failed the turn itself: drop the transient preview and
+        publish the terminal event.
+        """
+        reclaimed = self.liveness.reclaim_lost(user=user)
+        for execution in reclaimed:
+            try:
+                self.streams.clear(execution.id)
+            except Exception:  # noqa: BLE001 - preview cleanup is optional
+                logger.warning(
+                    "notebook chat stream clear failed while reclaiming turn %s",
+                    execution.id,
+                    exc_info=True,
+                )
+            self.events.publish(execution.conversation_id, execution.id, TURN_FAILED)
+        return reclaimed
+
     def _schedule_turn(self, execution_id: int) -> None:
         """Queue the worker turn, failing the execution if the broker refuses.
 
@@ -683,25 +718,30 @@ class NotebookChatService:
         # recorder, so wrapping it here is what pushes the whole turn's
         # progress to subscribed clients.
         recorder = self._publishing_recorder(recorder, execution)
-        try:
-            return self._run_turn(execution, recorder)
-        except Exception as exc:
-            # Terminal safety net: whatever escapes before or around the agent
-            # loop (provider resolution, toolset build, a bug) still lands the
-            # execution in FAILED -- a row stuck RUNNING blocks every later
-            # turn on the conversation.
-            logger.exception("notebook chat turn %s crashed", execution.id)
-            if not recorder.terminal_observed:
-                try:
-                    recorder.on_run_failed(exc)
-                except Exception:  # noqa: BLE001 - keep the original failure
-                    logger.warning(
-                        "could not finalize crashed notebook chat turn",
-                        exc_info=True,
-                    )
-            return {"execution_id": execution.id, "error": str(exc)}
+        # Renews the budget lease from its own thread until the turn returns,
+        # whatever the loop is blocked on; a dead worker's lease simply lapses.
+        with ReservationHeartbeat((execution,)) as heartbeat:
+            try:
+                return self._run_turn(execution, recorder, heartbeat)
+            except Exception as exc:
+                # Terminal safety net: whatever escapes before or around the
+                # agent loop (provider resolution, toolset build, a bug) still
+                # lands the execution in FAILED -- a row stuck RUNNING blocks
+                # every later turn on the conversation.
+                logger.exception("notebook chat turn %s crashed", execution.id)
+                if not recorder.terminal_observed:
+                    try:
+                        recorder.on_run_failed(exc)
+                    except Exception:  # noqa: BLE001 - keep the original failure
+                        logger.warning(
+                            "could not finalize crashed notebook chat turn",
+                            exc_info=True,
+                        )
+                return {"execution_id": execution.id, "error": str(exc)}
 
-    def _run_turn(self, execution: AgentExecution, recorder) -> dict:
+    def _run_turn(
+        self, execution: AgentExecution, recorder, heartbeat: ReservationHeartbeat
+    ) -> dict:
         conversation = execution.conversation
         trigger = execution.trigger_message
         stored_configuration = execution.configuration or {}
@@ -759,6 +799,7 @@ class NotebookChatService:
             model_id=accounting_model or "",
             recorder=recorder,
             execution=execution,
+            heartbeat=heartbeat,
         )
         agent = AgentService(
             provider=provider, max_iterations=config.max_iterations

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -509,9 +509,9 @@ class NotebookChatService:
         # inherit that snapshot even if the configured default or catalog
         # changes, and an explicit attempt to switch is rejected.
         selected_model = validate_model_ref(model_ref)
-        # A turn whose worker died would otherwise hold both busy checks; its
-        # lapsed lease is what lets this request take its place.
-        self.reclaim_lost_turns(user=conversation.user)
+        # A turn or draft whose worker died would otherwise hold the busy
+        # checks; its lapsed lease is what lets this request take its place.
+        self.reclaim_lost_work(user=conversation.user)
         with transaction.atomic():
             # Keep model resolution in the same conversation lock as turn
             # preparation. Two first-message requests with different models
@@ -665,6 +665,17 @@ class NotebookChatService:
                 )
             self.events.publish(execution.conversation_id, execution.id, TURN_FAILED)
         return reclaimed
+
+    def reclaim_lost_work(self, *, user) -> None:
+        """Fail the user's lost turns and drafts; either kind holds admission."""
+        # Imported here, not at module top: ``proposal_draft`` reclaims turns
+        # through this service, so a top-level import would be a cycle.
+        from research_ai.services.proposal_draft.liveness_service import (
+            ProposalDraftLivenessService,
+        )
+
+        self.reclaim_lost_turns(user=user)
+        ProposalDraftLivenessService().reclaim_lost(user=user)
 
     def _schedule_turn(self, execution_id: int) -> None:
         """Queue the worker turn, failing the execution if the broker refuses.

--- a/src/research_ai/services/proposal_draft/cancel_service.py
+++ b/src/research_ai/services/proposal_draft/cancel_service.py
@@ -34,7 +34,6 @@ from django.db import transaction
 
 from research_ai.models import AgentExecution, ProposalDraft
 from research_ai.services.agent_persistence import AgentExecutionCancelService
-from research_ai.services.usage_budget.reservation import reservation_deadline
 
 logger = logging.getLogger(__name__)
 
@@ -90,19 +89,13 @@ class ProposalDraftCancelService:
                 # to, so the record still shows how far it had gone.
                 was_pending = locked.status == ProposalDraft.Status.PENDING
                 locked.status = ProposalDraft.Status.CANCELLED
-                # A queued job has no worker/provider call to wait for. Set the
-                # processing case explicitly so jobs already running during a
-                # rolling deployment gain a bounded reservation too.
-                locked.usage_reservation_expires_at = (
-                    None if was_pending else reservation_deadline()
-                )
-                locked.save(
-                    update_fields=[
-                        "status",
-                        "usage_reservation_expires_at",
-                        "updated_date",
-                    ]
-                )
+                update_fields = ["status", "updated_date"]
+                if was_pending:
+                    # A queued job has no worker or provider call to wait for; a
+                    # running one keeps the lease its worker's heartbeat renews.
+                    locked.usage_reservation_expires_at = None
+                    update_fields.append("usage_reservation_expires_at")
+                locked.save(update_fields=update_fields)
         draft.refresh_from_db()
         if already_terminal:
             # Only for a draft someone already cancelled: a COMPLETED or FAILED

--- a/src/research_ai/services/proposal_draft/create_service.py
+++ b/src/research_ai/services/proposal_draft/create_service.py
@@ -8,6 +8,7 @@ from django.db import IntegrityError
 from research_ai.models import ProposalDraft, SearchExpert
 from research_ai.services.agent import split_model_ref
 from research_ai.services.agent.model_capabilities import validate_generation_options
+from research_ai.services.notebook_chat import NotebookChatService
 from research_ai.services.proposal_draft.liveness_service import (
     ProposalDraftLivenessService,
 )
@@ -70,8 +71,9 @@ class ProposalDraftCreateService:
         temperature: float | None = None,
     ) -> ProposalDraft:
         """Create and enqueue a draft, or raise a domain/admission exception."""
-        # A draft whose worker died would otherwise hold both checks below.
+        # A draft or turn whose worker died would otherwise hold the checks below.
         self.liveness.reclaim_lost(user=created_by)
+        NotebookChatService().reclaim_lost_turns(user=created_by)
         active = self._active_draft_for(search_expert)
         if active is not None:
             raise ProposalDraftAlreadyActiveError(active)

--- a/src/research_ai/services/proposal_draft/create_service.py
+++ b/src/research_ai/services/proposal_draft/create_service.py
@@ -8,13 +8,16 @@ from django.db import IntegrityError
 from research_ai.models import ProposalDraft, SearchExpert
 from research_ai.services.agent import split_model_ref
 from research_ai.services.agent.model_capabilities import validate_generation_options
+from research_ai.services.proposal_draft.liveness_service import (
+    ProposalDraftLivenessService,
+)
 from research_ai.services.usage_budget import (
     atomic_turn_admission,
     effective_generation_options,
     resolve_ai_tier,
     resolve_default_model,
 )
-from research_ai.services.usage_budget.reservation import reservation_deadline
+from research_ai.services.usage_budget.reservation import claim_deadline
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +46,18 @@ def _enqueue_proposal_draft(draft_id: int) -> None:
 class ProposalDraftCreateService:
     """Apply policy, reserve budget, persist, and enqueue one proposal draft."""
 
-    def __init__(self, enqueue: Callable[[int], None] | None = None):
+    def __init__(
+        self,
+        enqueue: Callable[[int], None] | None = None,
+        *,
+        liveness_service: ProposalDraftLivenessService | None = None,
+    ):
         self.enqueue = enqueue if enqueue is not None else _enqueue_proposal_draft
+        self.liveness = (
+            ProposalDraftLivenessService()
+            if liveness_service is None
+            else liveness_service
+        )
 
     def create(
         self,
@@ -57,6 +70,8 @@ class ProposalDraftCreateService:
         temperature: float | None = None,
     ) -> ProposalDraft:
         """Create and enqueue a draft, or raise a domain/admission exception."""
+        # A draft whose worker died would otherwise hold both checks below.
+        self.liveness.reclaim_lost(user=created_by)
         active = self._active_draft_for(search_expert)
         if active is not None:
             raise ProposalDraftAlreadyActiveError(active)
@@ -99,7 +114,8 @@ class ProposalDraftCreateService:
                     step=ProposalDraft.Step.QUEUED,
                     model_ref=effective_model_ref,
                     run_config=run_config,
-                    usage_reservation_expires_at=reservation_deadline(),
+                    # Held until a worker claims the job and takes over renewal.
+                    usage_reservation_expires_at=claim_deadline(),
                 )
         except IntegrityError:
             active = self._active_draft_for(search_expert)

--- a/src/research_ai/services/proposal_draft/liveness_service.py
+++ b/src/research_ai/services/proposal_draft/liveness_service.py
@@ -1,0 +1,91 @@
+"""Reclaiming proposal drafts whose worker stopped heartbeating."""
+
+import logging
+
+from django.db import transaction
+from django.utils import timezone
+
+from research_ai.models import AgentExecution, ProposalDraft
+from research_ai.services.agent_persistence import AgentExecutionLivenessService
+from research_ai.services.proposal_draft.cancel_service import ACTIVE_STATUSES
+
+logger = logging.getLogger(__name__)
+
+WORKER_LOST_MESSAGE = "The drafting worker stopped before the run finished."
+
+
+class ProposalDraftLivenessService:
+    """Fails queued or running drafts whose lease lapsed, freeing admission."""
+
+    def __init__(
+        self, *, execution_liveness_service: AgentExecutionLivenessService | None = None
+    ):
+        self.executions = (
+            AgentExecutionLivenessService()
+            if execution_liveness_service is None
+            else execution_liveness_service
+        )
+
+    def reclaim_lost(self, *, user=None, now=None) -> list[ProposalDraft]:
+        """Fail every active draft whose lease lapsed, optionally one user's."""
+        current = now or timezone.now()
+        candidates = ProposalDraft.objects.filter(
+            status__in=ACTIVE_STATUSES,
+            usage_reservation_expires_at__lt=current,
+        )
+        if user is not None:
+            candidates = candidates.filter(created_by=user)
+        return [
+            draft
+            for draft in candidates.order_by("id")
+            if self._reclaim(draft, now=current)
+        ]
+
+    def _reclaim(self, draft: ProposalDraft, *, now) -> bool:
+        # Conditional on the lease still being lapsed, like every other write
+        # that moves a draft's status: a slow worker may have renewed since the scan.
+        with transaction.atomic():
+            updated = ProposalDraft.objects.filter(
+                id=draft.id,
+                status__in=ACTIVE_STATUSES,
+                usage_reservation_expires_at__lt=now,
+            ).update(
+                status=ProposalDraft.Status.FAILED,
+                error_message=WORKER_LOST_MESSAGE,
+                usage_reservation_expires_at=None,
+                updated_date=now,
+            )
+        if not updated:
+            return False
+        draft.refresh_from_db()
+        self._seal_execution(draft)
+        logger.warning(
+            "reclaimed a proposal draft whose worker was lost",
+            extra={"draft_id": draft.id, "step": draft.step},
+        )
+        return True
+
+    def _seal_execution(self, draft: ProposalDraft) -> None:
+        """Seal the trace execution too; best-effort, as its creation was."""
+        conversation = draft.agent_conversation
+        if conversation is None:
+            return
+        try:
+            execution = (
+                conversation.executions.filter(
+                    status__in=[
+                        AgentExecution.Status.PENDING,
+                        AgentExecution.Status.RUNNING,
+                    ]
+                )
+                .order_by("-attempt")
+                .first()
+            )
+            if execution is not None:
+                self.executions.seal_lost(execution)
+        except Exception:  # noqa: BLE001 - the draft is already failed
+            logger.warning(
+                "could not seal the lost proposal draft's agent execution",
+                extra={"draft_id": draft.id},
+                exc_info=True,
+            )

--- a/src/research_ai/services/proposal_draft/liveness_service.py
+++ b/src/research_ai/services/proposal_draft/liveness_service.py
@@ -35,30 +35,42 @@ class ProposalDraftLivenessService:
         )
         if user is not None:
             candidates = candidates.filter(created_by=user)
-        return [
-            draft
-            for draft in candidates.order_by("id")
-            if self._reclaim(draft, now=current)
-        ]
+        reclaimed = []
+        for draft in candidates.order_by("id"):
+            try:
+                if self._reclaim(draft, now=current):
+                    reclaimed.append(draft)
+            except Exception:  # noqa: BLE001 - one draft must not stop the sweep
+                # Nothing was written for this draft; the next sweep retries it.
+                logger.exception(
+                    "could not reclaim a lost proposal draft",
+                    extra={"draft_id": draft.id},
+                )
+        return reclaimed
 
     def _reclaim(self, draft: ProposalDraft, *, now) -> bool:
-        # Conditional on the lease still being lapsed, like every other write
-        # that moves a draft's status: a slow worker may have renewed since the scan.
+        # One transaction, trace first: a terminal draft whose trace still ran
+        # would block admission with no lease left for any sweep to act on.
         with transaction.atomic():
-            updated = ProposalDraft.objects.filter(
-                id=draft.id,
-                status__in=ACTIVE_STATUSES,
-                usage_reservation_expires_at__lt=now,
-            ).update(
+            locked = (
+                ProposalDraft.objects.select_for_update()
+                .filter(
+                    id=draft.id,
+                    status__in=ACTIVE_STATUSES,
+                    usage_reservation_expires_at__lt=now,
+                )
+                .first()
+            )
+            if locked is None:
+                return False
+            self._seal_execution(locked)
+            ProposalDraft.objects.filter(id=locked.id).update(
                 status=ProposalDraft.Status.FAILED,
                 error_message=WORKER_LOST_MESSAGE,
                 usage_reservation_expires_at=None,
                 updated_date=now,
             )
-        if not updated:
-            return False
         draft.refresh_from_db()
-        self._seal_execution(draft)
         logger.warning(
             "reclaimed a proposal draft whose worker was lost",
             extra={"draft_id": draft.id, "step": draft.step},
@@ -66,26 +78,19 @@ class ProposalDraftLivenessService:
         return True
 
     def _seal_execution(self, draft: ProposalDraft) -> None:
-        """Seal the trace execution too; best-effort, as its creation was."""
+        """Seal the draft's active trace execution, if it has one."""
         conversation = draft.agent_conversation
         if conversation is None:
             return
-        try:
-            execution = (
-                conversation.executions.filter(
-                    status__in=[
-                        AgentExecution.Status.PENDING,
-                        AgentExecution.Status.RUNNING,
-                    ]
-                )
-                .order_by("-attempt")
-                .first()
+        execution = (
+            conversation.executions.filter(
+                status__in=[
+                    AgentExecution.Status.PENDING,
+                    AgentExecution.Status.RUNNING,
+                ]
             )
-            if execution is not None:
-                self.executions.seal_lost(execution)
-        except Exception:  # noqa: BLE001 - the draft is already failed
-            logger.warning(
-                "could not seal the lost proposal draft's agent execution",
-                extra={"draft_id": draft.id},
-                exc_info=True,
-            )
+            .order_by("-attempt")
+            .first()
+        )
+        if execution is not None:
+            self.executions.seal_lost(execution)

--- a/src/research_ai/services/proposal_draft/runner.py
+++ b/src/research_ai/services/proposal_draft/runner.py
@@ -126,8 +126,11 @@ class _ProposalDraftRunner:
         conversation_service: AgentConversationService | None = None,
         execution_service: AgentExecutionService | None = None,
         note_conversation_service: NoteAgentConversationService | None = None,
+        heartbeat=None,
     ):
         self.search_expert = search_expert
+        # The task's liveness heartbeat on the draft's budget lease, when run by one.
+        self.heartbeat = heartbeat
         self.expert = search_expert.expert
         self.provider = provider
         self.model_ref = model_ref
@@ -439,6 +442,7 @@ class _ProposalDraftRunner:
             recorder=recorder,
             execution=execution,
             reservation_targets=(self.recorder.draft,),
+            heartbeat=self.heartbeat,
         )
 
     def _compose_toolset(self, provider) -> Toolset:
@@ -707,6 +711,7 @@ def run_proposal_draft(
     conversation_service: AgentConversationService | None = None,
     execution_service: AgentExecutionService | None = None,
     note_conversation_service: NoteAgentConversationService | None = None,
+    heartbeat=None,
 ) -> dict:
     """Run a headless proposal-drafting job for one ``SearchExpert``.
 
@@ -774,5 +779,6 @@ def run_proposal_draft(
         conversation_service=conversation_service,
         execution_service=execution_service,
         note_conversation_service=note_conversation_service,
+        heartbeat=heartbeat,
     )
     return runner.run()

--- a/src/research_ai/services/usage_budget/__init__.py
+++ b/src/research_ai/services/usage_budget/__init__.py
@@ -1,4 +1,5 @@
 from .config import TierPolicy, tier_policies
+from .heartbeat import ReservationHeartbeat
 from .recorder import AgentLoopBudgetRecorder
 from .service import (
     BudgetExceededError,
@@ -21,6 +22,7 @@ __all__ = [
     "BudgetExceededError",
     "BudgetStatus",
     "ModelNotAllowedError",
+    "ReservationHeartbeat",
     "TierPolicy",
     "UsageLimitExceededError",
     "UsageWorkInProgressError",

--- a/src/research_ai/services/usage_budget/heartbeat.py
+++ b/src/research_ai/services/usage_budget/heartbeat.py
@@ -1,0 +1,99 @@
+"""Worker-side liveness heartbeat for Research AI budget reservations."""
+
+import logging
+import threading
+from datetime import datetime, timedelta
+
+from django.db import connection
+from django.utils import timezone
+
+from research_ai.services.usage_budget.reservation import (
+    USAGE_RESERVATION_RENEW_INTERVAL,
+    renew_live_reservation,
+)
+
+logger = logging.getLogger(__name__)
+
+# How long ``stop`` waits for a beat already talking to the database.
+_STOP_TIMEOUT_SECONDS = 5.0
+
+
+class ReservationHeartbeat:
+    """Renew budget leases from a background thread while a worker runs.
+
+    Renewal is independent of loop progress: a process blocked in a long
+    provider read keeps its lease, and a dead process loses it within one
+    lease period. ``lost`` turns true once a beat finds no live lease to
+    extend, after which the run must not start another provider call.
+    """
+
+    def __init__(
+        self,
+        targets,
+        *,
+        interval: timedelta = USAGE_RESERVATION_RENEW_INTERVAL,
+        renew=renew_live_reservation,
+    ):
+        # Only rows holding a reservation take part; the rest have nothing to renew.
+        self.targets = tuple(
+            target
+            for target in targets
+            if target is not None and target.usage_reservation_expires_at is not None
+        )
+        self.interval = interval
+        self._renew = renew
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.lost = False
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.stop()
+
+    def start(self) -> None:
+        if not self.targets or self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run, name="usage-reservation-heartbeat", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=_STOP_TIMEOUT_SECONDS)
+            self._thread = None
+
+    def beat(self, *, now: datetime | None = None) -> bool:
+        """Renew every target once; ``False`` (and ``lost``) once a lease has lapsed."""
+        current = now or timezone.now()
+        alive = True
+        for target in self.targets:
+            try:
+                renewed = self._renew(target, now=current)
+            except Exception:  # noqa: BLE001 - the lease tolerates a missed beat
+                logger.warning(
+                    "usage reservation heartbeat failed",
+                    extra={
+                        "target_type": type(target).__name__,
+                        "target_id": target.id,
+                    },
+                    exc_info=True,
+                )
+                continue
+            if not renewed:
+                alive = False
+        if not alive:
+            self.lost = True
+        return alive
+
+    def _run(self) -> None:
+        try:
+            while not self._stop.wait(self.interval.total_seconds()):
+                self.beat()
+        finally:
+            # This thread's own connection; the task thread keeps its own.
+            connection.close()

--- a/src/research_ai/services/usage_budget/recorder.py
+++ b/src/research_ai/services/usage_budget/recorder.py
@@ -7,11 +7,7 @@ from django.utils import timezone
 from research_ai.services.agent.errors import ProviderError
 from research_ai.services.agent.model_pricing import model_pricing
 from research_ai.services.agent.types import AssistantTurn, Message, TurnUsage
-from research_ai.services.usage_budget.reservation import (
-    USAGE_RESERVATION_RENEW_INTERVAL,
-    renew_active_reservation,
-    renew_live_reservation,
-)
+from research_ai.services.usage_budget.reservation import renew_active_reservation
 from research_ai.services.usage_budget.service import ensure_budget_available, record
 
 logger = logging.getLogger(__name__)
@@ -22,7 +18,8 @@ class AgentLoopBudgetRecorder:
 
     The wrapper is deliberately attached at ``AgentService`` call sites. Direct
     provider integrations and legacy LLM workflows never receive it and remain
-    outside this budget rollout.
+    outside this budget rollout. Liveness of ``reservation_targets`` is the
+    ``heartbeat``'s job, so callers that reserve budget should pass one.
     """
 
     def __init__(
@@ -35,6 +32,7 @@ class AgentLoopBudgetRecorder:
         recorder=None,
         execution=None,
         reservation_targets=None,
+        heartbeat=None,
     ):
         self.user = user
         self.feature = feature
@@ -48,7 +46,7 @@ class AgentLoopBudgetRecorder:
             else (self.execution,)
         )
         self._reservation_targets = tuple(target for target in targets if target)
-        self._next_reservation_renewal_at = None
+        self._heartbeat = heartbeat
         # Losing a usage row would silently reopen budget that was actually
         # spent, so accounting writes are required even without a transcript.
         self.requires_durable_usage = True
@@ -58,7 +56,12 @@ class AgentLoopBudgetRecorder:
             raise AttributeError(name)
         return getattr(self._recorder, name)
 
+    def _lease_lost(self) -> bool:
+        return self._heartbeat is not None and self._heartbeat.lost
+
     def is_active(self) -> bool:
+        if self._lease_lost():
+            return False
         callback = getattr(self._recorder, "is_active", None)
         return True if callback is None else callback()
 
@@ -72,11 +75,13 @@ class AgentLoopBudgetRecorder:
             )
         if self.user is not None:
             ensure_budget_available(self.user)
+        # A lapsed lease may already have admitted another job for this user.
+        if self._lease_lost():
+            raise InterruptedError("usage reservation lease was lost")
         now = timezone.now()
         for target in self._reservation_targets:
             if not renew_active_reservation(target, now=now):
                 raise InterruptedError("usage reservation owner is no longer active")
-        self._next_reservation_renewal_at = now + USAGE_RESERVATION_RENEW_INTERVAL
         callback = getattr(self._recorder, "before_model_call", None)
         if callback is not None:
             callback()
@@ -110,24 +115,6 @@ class AgentLoopBudgetRecorder:
         return None if callback is None else callback(error)
 
     def record_stream_event(self, iteration, event) -> None:
-        now = timezone.now()
-        if (
-            self._next_reservation_renewal_at is None
-            or now >= self._next_reservation_renewal_at
-        ):
-            for target in self._reservation_targets:
-                try:
-                    renew_live_reservation(target, now=now)
-                except Exception:  # noqa: BLE001 - lease refresh cannot break a turn
-                    logger.warning(
-                        "could not renew usage reservation from stream activity",
-                        extra={
-                            "target_type": type(target).__name__,
-                            "target_id": target.id,
-                        },
-                        exc_info=True,
-                    )
-            self._next_reservation_renewal_at = now + USAGE_RESERVATION_RENEW_INTERVAL
         callback = getattr(self._recorder, "record_stream_event", None)
         if callback is not None:
             callback(iteration, event)

--- a/src/research_ai/services/usage_budget/reservation.py
+++ b/src/research_ai/services/usage_budget/reservation.py
@@ -6,8 +6,12 @@ from django.utils import timezone
 
 from research_ai.models import AgentExecution, ProposalDraft
 
-USAGE_RESERVATION_LEASE = timedelta(hours=2)
-USAGE_RESERVATION_RENEW_INTERVAL = timedelta(minutes=10)
+# A running worker renews its lease from a background heartbeat, independent of
+# loop progress, so a dead worker is recognised within one lease period.
+USAGE_RESERVATION_LEASE = timedelta(minutes=3)
+USAGE_RESERVATION_RENEW_INTERVAL = timedelta(seconds=30)
+# How long a queued job may wait for a worker to claim it before it is presumed lost.
+USAGE_RESERVATION_CLAIM_DEADLINE = timedelta(minutes=30)
 
 ReservationTarget = AgentExecution | ProposalDraft
 
@@ -24,8 +28,13 @@ _ACTIVE_STATUSES = {
 
 
 def reservation_deadline(now: datetime | None = None) -> datetime:
-    """Return the expiry used for a newly acquired or renewed lease."""
+    """Return the expiry used for a newly claimed or renewed lease."""
     return (now or timezone.now()) + USAGE_RESERVATION_LEASE
+
+
+def claim_deadline(now: datetime | None = None) -> datetime:
+    """Return the expiry a queued job holds until a worker claims it."""
+    return (now or timezone.now()) + USAGE_RESERVATION_CLAIM_DEADLINE
 
 
 def renew_active_reservation(
@@ -46,12 +55,12 @@ def renew_active_reservation(
 def renew_live_reservation(
     target: ReservationTarget, *, now: datetime | None = None
 ) -> bool:
-    """Extend an unexpired lease while an already-started call emits activity.
+    """Extend an unexpired lease from a live worker's heartbeat.
 
-    This deliberately permits a cancelled row: streaming after cancellation is
-    proof that its worker and paid provider call are still alive. Requiring the
-    old lease to remain current prevents a delayed zombie worker from reviving a
-    reservation after admission has already treated it as expired.
+    A cancelled row is deliberately permitted: a heartbeat after cancellation
+    means the worker, and possibly its paid provider call, is still alive.
+    Refusing an expired lease keeps a delayed zombie from reviving a slot that
+    admission has already treated as released.
     """
     current = now or timezone.now()
     return bool(

--- a/src/research_ai/tasks.py
+++ b/src/research_ai/tasks.py
@@ -24,11 +24,21 @@ from research_ai.services.outreach.rfp_email_context import (
 )
 from research_ai.services.proposal_draft import run_proposal_draft
 from research_ai.services.proposal_draft.cancel_service import ACTIVE_STATUSES
+from research_ai.services.proposal_draft.liveness_service import (
+    ProposalDraftLivenessService,
+)
+from research_ai.services.usage_budget import ReservationHeartbeat
 from research_ai.services.usage_budget.reservation import reservation_deadline
 from researchhub.celery import QUEUE_AGENTS, app
 from user.models import User
 
 logger = logging.getLogger(__name__)
+
+# Ceilings against a runaway live worker, not liveness: a killed task's run is
+# reclaimed by ``reclaim_lost_agent_runs`` once its lease lapses.
+NOTEBOOK_CHAT_TURN_TIME_LIMIT = 2 * 60 * 60
+PROPOSAL_DRAFT_TIME_LIMIT = 4 * 60 * 60
+HARD_TIME_LIMIT_GRACE = 5 * 60
 
 
 def _update_search_progress(
@@ -238,7 +248,11 @@ def run_expert_finder_search(
         raise
 
 
-@app.task(queue=QUEUE_AGENTS)
+@app.task(
+    queue=QUEUE_AGENTS,
+    soft_time_limit=NOTEBOOK_CHAT_TURN_TIME_LIMIT,
+    time_limit=NOTEBOOK_CHAT_TURN_TIME_LIMIT + HARD_TIME_LIMIT_GRACE,
+)
 def run_notebook_chat_turn_task(execution_id: int):
     """
     Background task to run one prepared notebook chat turn.
@@ -254,6 +268,23 @@ def run_notebook_chat_turn_task(execution_id: int):
 
 
 @app.task(queue=QUEUE_AGENTS)
+def reclaim_lost_agent_runs():
+    """
+    Fail queued or running Research AI jobs whose worker stopped heartbeating.
+    """
+    executions = NotebookChatService().reclaim_lost_turns()
+    drafts = ProposalDraftLivenessService().reclaim_lost()
+    return {
+        "executions": [execution.id for execution in executions],
+        "proposal_drafts": [draft.id for draft in drafts],
+    }
+
+
+@app.task(
+    queue=QUEUE_AGENTS,
+    soft_time_limit=PROPOSAL_DRAFT_TIME_LIMIT,
+    time_limit=PROPOSAL_DRAFT_TIME_LIMIT + HARD_TIME_LIMIT_GRACE,
+)
 def run_proposal_draft_task(draft_id: int):
     """
     Background task to run one headless proposal-drafting job.
@@ -283,6 +314,8 @@ def run_proposal_draft_task(draft_id: int):
             "skipped": "already_claimed",
         }
 
+    # The claim above set the lease the heartbeat renews; load it.
+    draft.refresh_from_db()
     logger.info("Starting proposal draft", extra={"draft_id": draft_id})
     start_time = timezone.now()
     try:
@@ -291,12 +324,14 @@ def run_proposal_draft_task(draft_id: int):
             for key in ("effort", "thinking", "temperature")
             if key in draft.run_config
         }
-        result = run_proposal_draft(
-            draft.search_expert_id,
-            draft_id=draft.id,
-            model_ref=draft.model_ref or None,
-            **generation_options,
-        )
+        with ReservationHeartbeat((draft,)) as heartbeat:
+            result = run_proposal_draft(
+                draft.search_expert_id,
+                draft_id=draft.id,
+                model_ref=draft.model_ref or None,
+                heartbeat=heartbeat,
+                **generation_options,
+            )
     except Exception as e:
         logger.exception("Proposal draft task failed", extra={"draft_id": draft_id})
         # Conditional on the draft still being active, like every write the

--- a/src/research_ai/tests/agent/test_persistence_cancellation.py
+++ b/src/research_ai/tests/agent/test_persistence_cancellation.py
@@ -85,17 +85,35 @@ class AgentCancellationTests(TestCase):
         self.assertIsNotNone(execution.finished_at)
 
     def test_running_cancellation_reserves_budget_until_worker_unwinds(self):
-        # Arrange: this execution owns the budgeted user's single-flight slot.
+        # Arrange: this execution owns the budgeted user's single-flight slot,
+        # under the lease its worker's heartbeat keeps renewing.
         recorder = self._running()
+        lease = reservation_deadline()
+        AgentExecution.objects.filter(id=recorder.execution.id).update(
+            usage_reservation_expires_at=lease
+        )
+
         # Act: the request reports cancellation before the provider call returns.
         self.cancels.cancel(recorder.execution)
 
-        # Assert: admission remains reserved until the worker reaches its
-        # terminal hook, which represents the in-flight call having returned.
+        # Assert: the lease is neither released nor extended -- the worker owns
+        # it -- and admission opens when the worker reaches its terminal hook,
+        # which represents the in-flight call having returned.
         execution = AgentExecution.objects.get(id=recorder.execution.id)
-        self.assertIsNotNone(execution.usage_reservation_expires_at)
+        self.assertEqual(execution.usage_reservation_expires_at, lease)
         self.assertFalse(recorder.on_run_failed(InterruptedError("cancelled")))
         execution.refresh_from_db()
+        self.assertIsNone(execution.usage_reservation_expires_at)
+
+    def test_cancelling_a_run_without_a_reservation_adds_none(self):
+        # Arrange: a directly started run never reserved budget.
+        recorder = self._running()
+
+        # Act
+        self.cancels.cancel(recorder.execution)
+
+        # Assert
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
         self.assertIsNone(execution.usage_reservation_expires_at)
 
     def test_pending_cancellation_releases_budget_immediately(self):

--- a/src/research_ai/tests/agent/test_persistence_liveness.py
+++ b/src/research_ai/tests/agent/test_persistence_liveness.py
@@ -1,0 +1,192 @@
+"""Reclaiming executions whose worker stopped heartbeating."""
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from research_ai.models import AgentConversation, AgentExecution
+from research_ai.services.agent.types import Message, TextBlock
+from research_ai.services.agent_persistence import (
+    AgentChatService,
+    AgentExecutionLivenessService,
+    AgentExecutionService,
+)
+from research_ai.services.usage_budget import (
+    UsageWorkInProgressError,
+    atomic_turn_admission,
+)
+from user.tests.helpers import create_random_authenticated_user
+
+
+class AgentExecutionLivenessTests(TestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("liveness")
+        self.conversation = AgentConversation.objects.create(
+            user=self.user, workflow="notebook_chat"
+        )
+        self.liveness = AgentExecutionLivenessService()
+        self.lapsed = timezone.now() - timedelta(seconds=1)
+        self.live = timezone.now() + timedelta(minutes=1)
+
+    def _queued_turn(self, *, lease, conversation=None, text="Summarize the note"):
+        prepared = AgentChatService().prepare_turn(
+            conversation or self.conversation, text, pending=True
+        )
+        AgentExecution.objects.filter(id=prepared.execution.id).update(
+            usage_reservation_expires_at=lease
+        )
+        prepared.execution.refresh_from_db()
+        return prepared.execution
+
+    def _claimed_turn(self, *, lease, conversation=None):
+        execution = self._queued_turn(lease=lease, conversation=conversation)
+        recorder = AgentExecutionService().claim_pending(execution)
+        AgentExecution.objects.filter(id=execution.id).update(
+            usage_reservation_expires_at=lease
+        )
+        recorder.execution.refresh_from_db()
+        return recorder
+
+    def test_a_running_turn_whose_lease_lapsed_is_failed_as_worker_lost(self):
+        # Arrange
+        execution = self._claimed_turn(lease=self.lapsed).execution
+
+        # Act
+        reclaimed = self.liveness.reclaim_lost()
+
+        # Assert
+        self.assertEqual([item.id for item in reclaimed], [execution.id])
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, AgentExecution.Status.FAILED)
+        self.assertEqual(execution.stop_reason, "worker_lost")
+        self.assertEqual(execution.error_type, "WorkerLostError")
+        self.assertIsNone(execution.usage_reservation_expires_at)
+        self.assertIsNotNone(execution.finished_at)
+
+    def test_a_running_turn_with_a_live_lease_is_left_alone(self):
+        # Arrange
+        execution = self._claimed_turn(lease=self.live).execution
+
+        # Act
+        reclaimed = self.liveness.reclaim_lost()
+
+        # Assert
+        self.assertEqual(reclaimed, [])
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, AgentExecution.Status.RUNNING)
+
+    def test_a_run_that_never_reserved_budget_is_not_a_candidate(self):
+        # Arrange: a directly started run holds no lease, so silence says nothing.
+        recorder = AgentExecutionService().start(self.conversation)
+
+        # Act
+        reclaimed = self.liveness.reclaim_lost()
+
+        # Assert
+        self.assertEqual(reclaimed, [])
+        recorder.execution.refresh_from_db()
+        self.assertEqual(recorder.execution.status, AgentExecution.Status.RUNNING)
+
+    def test_a_queued_turn_past_its_claim_deadline_is_failed_and_keeps_its_prompt(
+        self,
+    ):
+        # Arrange
+        execution = self._queued_turn(lease=self.lapsed)
+
+        # Act
+        reclaimed = self.liveness.reclaim_lost()
+
+        # Assert: sealed, its prompt preserved for the next turn's context, and
+        # nothing left for a task delivered later to claim.
+        self.assertEqual([item.id for item in reclaimed], [execution.id])
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, AgentExecution.Status.FAILED)
+        self.assertEqual(execution.stop_reason, "worker_lost")
+        self.assertEqual(
+            [message.role for message in execution.context_messages.all()], ["user"]
+        )
+        self.assertIsNone(AgentExecutionService().claim_pending(execution))
+
+    def test_reclaiming_can_be_scoped_to_one_user(self):
+        # Arrange
+        other = AgentConversation.objects.create(
+            user=create_random_authenticated_user("liveness-other"),
+            workflow="notebook_chat",
+        )
+        mine = self._claimed_turn(lease=self.lapsed).execution
+        theirs = self._claimed_turn(lease=self.lapsed, conversation=other).execution
+
+        # Act
+        reclaimed = self.liveness.reclaim_lost(user=self.user)
+
+        # Assert
+        self.assertEqual([item.id for item in reclaimed], [mine.id])
+        theirs.refresh_from_db()
+        self.assertEqual(theirs.status, AgentExecution.Status.RUNNING)
+
+    def test_reclaiming_forgets_an_answer_the_user_never_received(self):
+        # Arrange: the worker recorded the prompt and its closing answer, then
+        # died before publishing the answer.
+        recorder = self._claimed_turn(lease=self.lapsed)
+        recorder.record_message(
+            Message(role="user", content=[TextBlock(text="Summarize the note")])
+        )
+        recorder.record_message(
+            Message(role="assistant", content=[TextBlock(text="Here is a summary.")])
+        )
+
+        # Act
+        self.liveness.reclaim_lost()
+
+        # Assert
+        roles = [message.role for message in recorder.execution.context_messages.all()]
+        self.assertEqual(roles, ["user"])
+
+    def test_a_reclaimed_turn_frees_admission_and_the_conversation(self):
+        # Arrange
+        execution = self._claimed_turn(lease=self.lapsed).execution
+        with (
+            self.assertRaises(UsageWorkInProgressError),
+            atomic_turn_admission(self.user),
+        ):
+            pass
+
+        # Act
+        self.liveness.reclaim_lost(user=self.user)
+
+        # Assert
+        with atomic_turn_admission(self.user):
+            pass
+        prepared = AgentChatService().prepare_turn(
+            self.conversation, "Try again", pending=True
+        )
+        self.assertEqual(prepared.execution.context_parent_id, execution.id)
+
+    def test_seal_lost_fails_an_active_execution_whatever_its_lease(self):
+        # Arrange: a trace execution with no reservation of its own, whose
+        # owning job's worker is known to be gone.
+        recorder = AgentExecutionService().start(self.conversation)
+
+        # Act
+        sealed = self.liveness.seal_lost(recorder.execution)
+
+        # Assert
+        self.assertTrue(sealed)
+        recorder.execution.refresh_from_db()
+        self.assertEqual(recorder.execution.status, AgentExecution.Status.FAILED)
+        self.assertEqual(recorder.execution.stop_reason, "worker_lost")
+        self.assertFalse(self.liveness.seal_lost(recorder.execution))
+
+    def test_a_reclaimed_turn_renders_a_retryable_public_error(self):
+        # Arrange
+        self._claimed_turn(lease=self.lapsed)
+        self.liveness.reclaim_lost()
+
+        # Act
+        (entry,) = AgentChatService().representation(self.conversation)["executions"]
+
+        # Assert
+        self.assertEqual(entry["error"]["code"], "agent_failed")
+        self.assertTrue(entry["error"]["retryable"])
+        self.assertNotIn("heartbeat", entry["error"]["message"])

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -1,9 +1,11 @@
 import json
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, TransactionTestCase, override_settings
+from django.utils import timezone
 
 from note.tests.helpers import create_note
 from research_ai.models import (
@@ -30,7 +32,11 @@ from research_ai.services.notebook_chat.events import (
     ConversationEventPublisher,
 )
 from research_ai.services.notebook_chat.service import TITLE_MAX_CHARS
-from research_ai.services.usage_budget import UsageWorkInProgressError, budget_status
+from research_ai.services.usage_budget import (
+    ReservationHeartbeat,
+    UsageWorkInProgressError,
+    budget_status,
+)
 from research_ai.tests.agent.persistence_test_helpers import (
     FakeProvider,
     text_turn,
@@ -295,6 +301,61 @@ class NotebookChatServiceTests(TestCase):
         # Act / Assert
         with self.assertRaises(UsageWorkInProgressError):
             self._submit("Different thread", conversation=second)
+
+    def _lose_worker(self, execution):
+        """Leave ``execution`` as a dead worker does: RUNNING, lease lapsed."""
+        AgentExecution.objects.filter(id=execution.id).update(
+            status=AgentExecution.Status.RUNNING,
+            usage_reservation_expires_at=timezone.now() - timedelta(seconds=1),
+        )
+
+    def test_submit_message_replaces_a_turn_whose_worker_was_lost(self):
+        # Arrange
+        lost, _delay = self._submit()
+        self._lose_worker(lost)
+
+        # Act: neither the chat's busy check nor budget admission refuses.
+        execution, _delay = self._submit("Still there?")
+
+        # Assert: the lost turn is sealed and the new one continues from it.
+        lost.refresh_from_db()
+        self.assertEqual(lost.status, AgentExecution.Status.FAILED)
+        self.assertEqual(lost.stop_reason, "worker_lost")
+        self.assertEqual(execution.status, AgentExecution.Status.PENDING)
+        self.assertEqual(execution.context_parent_id, lost.id)
+
+    def test_a_lost_turn_in_another_chat_stops_blocking_the_user(self):
+        # Arrange
+        lost, _delay = self._submit()
+        self._lose_worker(lost)
+        second = self.service.create_conversation(self.note, self.user)
+
+        # Act
+        execution, _delay = self._submit("Different thread", conversation=second)
+
+        # Assert
+        self.assertEqual(execution.status, AgentExecution.Status.PENDING)
+        lost.refresh_from_db()
+        self.assertEqual(lost.status, AgentExecution.Status.FAILED)
+
+    def test_run_turn_heartbeats_the_turns_lease_while_it_runs(self):
+        # Arrange
+        execution, _delay = self._submit()
+        service = _make_service(provider=FakeProvider([text_turn("Answer")]))
+
+        # Act
+        with (
+            patch.object(ReservationHeartbeat, "start", autospec=True) as start,
+            patch.object(ReservationHeartbeat, "stop", autospec=True) as stop,
+        ):
+            service.run_turn(execution.id)
+
+        # Assert: the claimed turn's lease is what the heartbeat renews.
+        (heartbeat,) = start.call_args.args
+        self.assertEqual([target.id for target in heartbeat.targets], [execution.id])
+        stop.assert_called_once()
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, AgentExecution.Status.SUCCEEDED)
 
     def test_run_turn_edits_note_and_publishes_reply(self):
         # Arrange
@@ -1024,6 +1085,24 @@ class NotebookChatEventEmissionTests(TestCase):
         for conversation_id, execution_id, _ in events:
             self.assertEqual(conversation_id, self.conversation.id)
             self.assertEqual(execution_id, execution.id)
+
+    def test_reclaiming_a_lost_turn_publishes_turn_failed(self):
+        # Arrange: the worker died mid-run and its lease lapsed.
+        execution = self._submit()
+        AgentExecution.objects.filter(id=execution.id).update(
+            status=AgentExecution.Status.RUNNING,
+            usage_reservation_expires_at=timezone.now() - timedelta(seconds=1),
+        )
+        self.publisher.reset_mock()
+
+        # Act
+        reclaimed = self.service.reclaim_lost_turns(user=self.user)
+
+        # Assert
+        self.assertEqual([item.id for item in reclaimed], [execution.id])
+        self.publisher.publish.assert_called_once_with(
+            self.conversation.id, execution.id, TURN_FAILED
+        )
 
     def test_run_turn_provider_failure_publishes_turn_failed(self):
         # Arrange

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -11,7 +11,11 @@ from note.tests.helpers import create_note
 from research_ai.models import (
     AgentConversation,
     AgentExecution,
+    Expert,
+    ExpertSearch,
     NoteAgentConversation,
+    ProposalDraft,
+    SearchExpert,
 )
 from research_ai.services.agent.types import StopReason, TurnUsage
 from research_ai.services.agent_persistence import (
@@ -337,6 +341,30 @@ class NotebookChatServiceTests(TestCase):
         self.assertEqual(execution.status, AgentExecution.Status.PENDING)
         lost.refresh_from_db()
         self.assertEqual(lost.status, AgentExecution.Status.FAILED)
+
+    def test_submit_message_replaces_a_draft_whose_worker_was_lost(self):
+        # Arrange: the user's proposal draft died mid-run; it, too, holds the
+        # user's single budget slot.
+        search_expert = SearchExpert.objects.create(
+            expert_search=ExpertSearch.objects.create(
+                created_by=self.user, query="protein folding"
+            ),
+            expert=Expert.objects.create(email="jane@example.edu"),
+        )
+        lost = ProposalDraft.objects.create(
+            search_expert=search_expert,
+            created_by=self.user,
+            status=ProposalDraft.Status.PROCESSING,
+            usage_reservation_expires_at=timezone.now() - timedelta(seconds=1),
+        )
+
+        # Act
+        execution, _delay = self._submit()
+
+        # Assert
+        self.assertEqual(execution.status, AgentExecution.Status.PENDING)
+        lost.refresh_from_db()
+        self.assertEqual(lost.status, ProposalDraft.Status.FAILED)
 
     def test_run_turn_heartbeats_the_turns_lease_while_it_runs(self):
         # Arrange

--- a/src/research_ai/tests/proposal_draft/test_create_service.py
+++ b/src/research_ai/tests/proposal_draft/test_create_service.py
@@ -1,8 +1,10 @@
 """Tests for proposal-draft creation outside the HTTP boundary."""
 
+from datetime import timedelta
 from unittest.mock import Mock
 
 from django.test import TestCase, override_settings
+from django.utils import timezone
 
 from research_ai.models import Expert, ExpertSearch, ProposalDraft, SearchExpert
 from research_ai.services.proposal_draft.create_service import (
@@ -87,6 +89,28 @@ class ProposalDraftCreateServiceTests(TestCase):
             )
         self.assertFalse(ProposalDraft.objects.exists())
         enqueue.assert_not_called()
+
+    def test_create_replaces_a_draft_whose_worker_was_lost(self):
+        # Arrange: the expert's last draft is stuck PROCESSING with a lapsed lease.
+        lost = ProposalDraft.objects.create(
+            search_expert=self.search_expert,
+            created_by=self.user,
+            status=ProposalDraft.Status.PROCESSING,
+            usage_reservation_expires_at=timezone.now() - timedelta(seconds=1),
+        )
+        enqueue = Mock()
+
+        # Act
+        draft = ProposalDraftCreateService(enqueue=enqueue).create(
+            search_expert=self.search_expert,
+            created_by=self.user,
+        )
+
+        # Assert
+        lost.refresh_from_db()
+        self.assertEqual(lost.status, ProposalDraft.Status.FAILED)
+        self.assertEqual(draft.status, ProposalDraft.Status.PENDING)
+        enqueue.assert_called_once_with(draft.id)
 
     def test_create_rejects_an_expert_with_active_draft(self):
         # Arrange

--- a/src/research_ai/tests/proposal_draft/test_create_service.py
+++ b/src/research_ai/tests/proposal_draft/test_create_service.py
@@ -6,7 +6,14 @@ from unittest.mock import Mock
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
-from research_ai.models import Expert, ExpertSearch, ProposalDraft, SearchExpert
+from research_ai.models import (
+    AgentConversation,
+    AgentExecution,
+    Expert,
+    ExpertSearch,
+    ProposalDraft,
+    SearchExpert,
+)
 from research_ai.services.proposal_draft.create_service import (
     ProposalDraftAlreadyActiveError,
     ProposalDraftCreateService,
@@ -109,6 +116,33 @@ class ProposalDraftCreateServiceTests(TestCase):
         # Assert
         lost.refresh_from_db()
         self.assertEqual(lost.status, ProposalDraft.Status.FAILED)
+        self.assertEqual(draft.status, ProposalDraft.Status.PENDING)
+        enqueue.assert_called_once_with(draft.id)
+
+    def test_create_replaces_a_chat_turn_whose_worker_was_lost(self):
+        # Arrange: the user's notebook turn died mid-run; it, too, holds the
+        # user's single budget slot.
+        conversation = AgentConversation.objects.create(
+            user=self.user, workflow="notebook_chat"
+        )
+        lost = AgentExecution.objects.create(
+            conversation=conversation,
+            status=AgentExecution.Status.RUNNING,
+            attempt=1,
+            usage_reservation_expires_at=timezone.now() - timedelta(seconds=1),
+        )
+        enqueue = Mock()
+
+        # Act
+        draft = ProposalDraftCreateService(enqueue=enqueue).create(
+            search_expert=self.search_expert,
+            created_by=self.user,
+        )
+
+        # Assert
+        lost.refresh_from_db()
+        self.assertEqual(lost.status, AgentExecution.Status.FAILED)
+        self.assertEqual(lost.stop_reason, "worker_lost")
         self.assertEqual(draft.status, ProposalDraft.Status.PENDING)
         enqueue.assert_called_once_with(draft.id)
 

--- a/src/research_ai/tests/proposal_draft/test_proposal_draft_liveness.py
+++ b/src/research_ai/tests/proposal_draft/test_proposal_draft_liveness.py
@@ -1,6 +1,7 @@
 """Reclaiming proposal drafts whose worker stopped heartbeating."""
 
 from datetime import timedelta
+from unittest.mock import Mock
 
 from django.test import TestCase
 from django.utils import timezone
@@ -112,6 +113,32 @@ class ProposalDraftLivenessTests(TestCase):
         self.assertEqual(execution.stop_reason, "worker_lost")
         draft.refresh_from_db()
         self.assertEqual(draft.status, ProposalDraft.Status.FAILED)
+
+    def test_a_draft_whose_trace_cannot_be_sealed_waits_for_the_next_sweep(self):
+        # Arrange: releasing the draft while its trace stayed RUNNING would block
+        # admission for good, since the trace holds no lease of its own.
+        conversation = AgentConversation.objects.create(workflow="proposal_draft")
+        draft = self._draft(lease=self.lapsed, conversation=conversation)
+        recorder = AgentExecutionService().start(
+            conversation, provider="fake", model="fake-model-v1"
+        )
+        liveness = ProposalDraftLivenessService(
+            execution_liveness_service=Mock(
+                seal_lost=Mock(side_effect=RuntimeError("database unavailable"))
+            )
+        )
+
+        # Act
+        reclaimed = liveness.reclaim_lost()
+
+        # Assert: nothing landed for this draft, so the lapsed lease still
+        # selects it next time.
+        self.assertEqual(reclaimed, [])
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, ProposalDraft.Status.PROCESSING)
+        self.assertEqual(draft.usage_reservation_expires_at, self.lapsed)
+        recorder.execution.refresh_from_db()
+        self.assertEqual(recorder.execution.status, AgentExecution.Status.RUNNING)
 
     def test_reclaiming_can_be_scoped_to_one_user(self):
         # Arrange

--- a/src/research_ai/tests/proposal_draft/test_proposal_draft_liveness.py
+++ b/src/research_ai/tests/proposal_draft/test_proposal_draft_liveness.py
@@ -1,0 +1,152 @@
+"""Reclaiming proposal drafts whose worker stopped heartbeating."""
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from research_ai.models import (
+    AgentConversation,
+    AgentExecution,
+    Expert,
+    ExpertSearch,
+    ProposalDraft,
+    SearchExpert,
+)
+from research_ai.services.agent_persistence import AgentExecutionService
+from research_ai.services.proposal_draft.liveness_service import (
+    WORKER_LOST_MESSAGE,
+    ProposalDraftLivenessService,
+)
+from research_ai.services.usage_budget import (
+    UsageWorkInProgressError,
+    atomic_turn_admission,
+)
+from user.tests.helpers import create_random_default_user
+
+
+class ProposalDraftLivenessTests(TestCase):
+    def setUp(self):
+        self.user = create_random_default_user("draft-liveness")
+        self.expert = Expert.objects.create(email="jane@example.edu")
+        self.expert_search = ExpertSearch.objects.create(
+            created_by=self.user, query="protein folding"
+        )
+        self.search_expert = SearchExpert.objects.create(
+            expert_search=self.expert_search, expert=self.expert
+        )
+        self.liveness = ProposalDraftLivenessService()
+        self.lapsed = timezone.now() - timedelta(seconds=1)
+        self.live = timezone.now() + timedelta(minutes=1)
+
+    def _draft(
+        self,
+        *,
+        lease,
+        status=ProposalDraft.Status.PROCESSING,
+        conversation=None,
+        created_by=None,
+        search_expert=None,
+    ):
+        return ProposalDraft.objects.create(
+            search_expert=search_expert or self.search_expert,
+            created_by=created_by or self.user,
+            status=status,
+            step=ProposalDraft.Step.JUDGING,
+            agent_conversation=conversation,
+            usage_reservation_expires_at=lease,
+        )
+
+    def test_a_running_draft_whose_lease_lapsed_is_failed(self):
+        # Arrange
+        draft = self._draft(lease=self.lapsed)
+
+        # Act
+        reclaimed = self.liveness.reclaim_lost()
+
+        # Assert
+        self.assertEqual([item.id for item in reclaimed], [draft.id])
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, ProposalDraft.Status.FAILED)
+        self.assertEqual(draft.error_message, WORKER_LOST_MESSAGE)
+        self.assertIsNone(draft.usage_reservation_expires_at)
+        self.assertEqual(draft.step, ProposalDraft.Step.JUDGING)
+
+    def test_a_draft_with_a_live_lease_is_left_alone(self):
+        # Arrange
+        draft = self._draft(lease=self.live)
+
+        # Act
+        reclaimed = self.liveness.reclaim_lost()
+
+        # Assert
+        self.assertEqual(reclaimed, [])
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, ProposalDraft.Status.PROCESSING)
+
+    def test_a_queued_draft_past_its_claim_deadline_is_failed(self):
+        # Arrange
+        draft = self._draft(lease=self.lapsed, status=ProposalDraft.Status.PENDING)
+
+        # Act
+        self.liveness.reclaim_lost()
+
+        # Assert
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, ProposalDraft.Status.FAILED)
+
+    def test_reclaiming_also_seals_the_traced_agent_execution(self):
+        # Arrange
+        conversation = AgentConversation.objects.create(workflow="proposal_draft")
+        draft = self._draft(lease=self.lapsed, conversation=conversation)
+        recorder = AgentExecutionService().start(
+            conversation, provider="fake", model="fake-model-v1"
+        )
+
+        # Act
+        self.liveness.reclaim_lost()
+
+        # Assert
+        execution = AgentExecution.objects.get(id=recorder.execution.id)
+        self.assertEqual(execution.status, AgentExecution.Status.FAILED)
+        self.assertEqual(execution.stop_reason, "worker_lost")
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, ProposalDraft.Status.FAILED)
+
+    def test_reclaiming_can_be_scoped_to_one_user(self):
+        # Arrange
+        other_user = create_random_default_user("draft-liveness-other")
+        other_search = SearchExpert.objects.create(
+            expert_search=ExpertSearch.objects.create(
+                created_by=other_user, query="enzymes"
+            ),
+            expert=self.expert,
+        )
+        mine = self._draft(lease=self.lapsed)
+        theirs = self._draft(
+            lease=self.lapsed, created_by=other_user, search_expert=other_search
+        )
+
+        # Act
+        reclaimed = self.liveness.reclaim_lost(user=self.user)
+
+        # Assert
+        self.assertEqual([item.id for item in reclaimed], [mine.id])
+        theirs.refresh_from_db()
+        self.assertEqual(theirs.status, ProposalDraft.Status.PROCESSING)
+
+    def test_a_reclaimed_draft_frees_admission(self):
+        # Arrange
+        self._draft(lease=self.lapsed)
+        with (
+            self.assertRaises(UsageWorkInProgressError),
+            atomic_turn_admission(self.user),
+        ):
+            pass
+
+        # Act
+        self.liveness.reclaim_lost(user=self.user)
+
+        # Assert
+        with atomic_turn_admission(self.user):
+            pass

--- a/src/research_ai/tests/test_reservation_heartbeat.py
+++ b/src/research_ai/tests/test_reservation_heartbeat.py
@@ -1,0 +1,218 @@
+"""The worker heartbeat that keeps a budget lease alive independent of the loop."""
+
+from datetime import timedelta
+from threading import Event
+from unittest.mock import Mock
+
+from django.test import SimpleTestCase, TestCase
+from django.utils import timezone
+
+from research_ai.models import AgentConversation, AgentExecution
+from research_ai.services.usage_budget import (
+    AgentLoopBudgetRecorder,
+    ReservationHeartbeat,
+)
+from user.tests.helpers import create_random_authenticated_user
+
+
+class _Target:
+    """The one attribute the heartbeat reads off a reservation row."""
+
+    def __init__(self, id, expires_at):
+        self.id = id
+        self.usage_reservation_expires_at = expires_at
+
+
+class ReservationHeartbeatThreadTests(SimpleTestCase):
+    def test_beats_from_its_own_thread_until_stopped(self):
+        # Arrange
+        beaten = Event()
+
+        def renew(target, *, now):
+            beaten.set()
+            return True
+
+        heartbeat = ReservationHeartbeat(
+            [_Target(1, timezone.now())],
+            interval=timedelta(milliseconds=10),
+            renew=Mock(side_effect=renew),
+        )
+
+        # Act
+        with heartbeat:
+            first_beat = beaten.wait(timeout=5)
+
+        # Assert
+        self.assertTrue(first_beat)
+        self.assertFalse(heartbeat.lost)
+
+    def test_rows_without_a_reservation_take_no_part(self):
+        # Arrange
+        renew = Mock(return_value=True)
+        heartbeat = ReservationHeartbeat([_Target(1, None), None], renew=renew)
+
+        # Act
+        with heartbeat:
+            heartbeat.beat()
+
+        # Assert
+        self.assertEqual(heartbeat.targets, ())
+        renew.assert_not_called()
+
+    def test_a_beat_that_finds_no_live_lease_marks_it_lost(self):
+        # Arrange
+        heartbeat = ReservationHeartbeat(
+            [_Target(1, timezone.now())], renew=Mock(return_value=False)
+        )
+
+        # Act
+        alive = heartbeat.beat()
+
+        # Assert
+        self.assertFalse(alive)
+        self.assertTrue(heartbeat.lost)
+
+    def test_a_failing_beat_is_tolerated(self):
+        # Arrange: the lease outlives several missed beats, so a database hiccup
+        # is retried on the next tick rather than treated as a lost lease.
+        heartbeat = ReservationHeartbeat(
+            [_Target(1, timezone.now())],
+            renew=Mock(side_effect=RuntimeError("database hiccup")),
+        )
+
+        # Act
+        alive = heartbeat.beat()
+
+        # Assert
+        self.assertTrue(alive)
+        self.assertFalse(heartbeat.lost)
+
+
+class ReservationHeartbeatLeaseTests(TestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("heartbeat")
+
+    def _execution(self, *, status, expires_at):
+        conversation = AgentConversation.objects.create(
+            user=self.user, workflow="notebook_chat"
+        )
+        return AgentExecution.objects.create(
+            conversation=conversation,
+            status=status,
+            attempt=1,
+            usage_reservation_expires_at=expires_at,
+        )
+
+    def test_a_beat_renews_a_running_workers_lease(self):
+        # Arrange
+        old_expiry = timezone.now() + timedelta(minutes=1)
+        execution = self._execution(
+            status=AgentExecution.Status.RUNNING, expires_at=old_expiry
+        )
+
+        # Act
+        alive = ReservationHeartbeat((execution,)).beat()
+
+        # Assert
+        execution.refresh_from_db()
+        self.assertTrue(alive)
+        self.assertGreater(execution.usage_reservation_expires_at, old_expiry)
+
+    def test_a_beat_keeps_a_cancelled_in_flight_call_reserved(self):
+        # Arrange: cancellation landed, but the worker -- and possibly its paid
+        # provider call -- is demonstrably still alive.
+        old_expiry = timezone.now() + timedelta(minutes=1)
+        execution = self._execution(
+            status=AgentExecution.Status.CANCELLED, expires_at=old_expiry
+        )
+
+        # Act
+        ReservationHeartbeat((execution,)).beat()
+
+        # Assert
+        execution.refresh_from_db()
+        self.assertGreater(execution.usage_reservation_expires_at, old_expiry)
+
+    def test_a_late_beat_cannot_revive_a_lapsed_lease(self):
+        # Arrange: admission may already have handed the slot to another job.
+        old_expiry = timezone.now() - timedelta(seconds=1)
+        execution = self._execution(
+            status=AgentExecution.Status.CANCELLED, expires_at=old_expiry
+        )
+        heartbeat = ReservationHeartbeat((execution,))
+
+        # Act
+        alive = heartbeat.beat()
+
+        # Assert
+        execution.refresh_from_db()
+        self.assertFalse(alive)
+        self.assertTrue(heartbeat.lost)
+        self.assertEqual(execution.usage_reservation_expires_at, old_expiry)
+
+    def test_a_straggling_beat_leaves_a_released_lease_released(self):
+        # Arrange: the worker unwound and cleared the lease before its
+        # heartbeat thread observed the stop.
+        execution = self._execution(
+            status=AgentExecution.Status.RUNNING,
+            expires_at=timezone.now() + timedelta(minutes=1),
+        )
+        heartbeat = ReservationHeartbeat((execution,))
+        AgentExecution.objects.filter(id=execution.id).update(
+            usage_reservation_expires_at=None
+        )
+
+        # Act
+        heartbeat.beat()
+
+        # Assert
+        execution.refresh_from_db()
+        self.assertIsNone(execution.usage_reservation_expires_at)
+
+
+class AgentLoopBudgetRecorderHeartbeatTests(TestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("heartbeat-recorder")
+        conversation = AgentConversation.objects.create(
+            user=self.user, workflow="notebook_chat"
+        )
+        self.execution = AgentExecution.objects.create(
+            conversation=conversation,
+            status=AgentExecution.Status.RUNNING,
+            attempt=1,
+            usage_reservation_expires_at=timezone.now() + timedelta(minutes=1),
+        )
+
+    def _recorder(self, heartbeat):
+        return AgentLoopBudgetRecorder(
+            user=self.user,
+            feature="notebook_chat",
+            provider="openrouter",
+            model_id="deepseek/deepseek-v4-pro-0813",
+            execution=self.execution,
+            heartbeat=heartbeat,
+        )
+
+    def test_a_lost_lease_stops_the_run_before_its_next_model_call(self):
+        # Arrange: the process lost the database for longer than the lease.
+        heartbeat = ReservationHeartbeat((self.execution,))
+        AgentExecution.objects.filter(id=self.execution.id).update(
+            usage_reservation_expires_at=timezone.now() - timedelta(seconds=1)
+        )
+        heartbeat.beat()
+        recorder = self._recorder(heartbeat)
+
+        # Act / Assert
+        self.assertFalse(recorder.is_active())
+        with self.assertRaises(InterruptedError):
+            recorder.before_model_call()
+
+    def test_a_live_heartbeat_lets_the_run_spend(self):
+        # Arrange
+        heartbeat = ReservationHeartbeat((self.execution,))
+        heartbeat.beat()
+        recorder = self._recorder(heartbeat)
+
+        # Act / Assert
+        self.assertTrue(recorder.is_active())
+        recorder.before_model_call()

--- a/src/research_ai/tests/test_tasks.py
+++ b/src/research_ai/tests/test_tasks.py
@@ -1,19 +1,25 @@
 """Tests for research_ai.tasks: expert search, bulk email, send queued emails."""
 
-from unittest.mock import patch
+from datetime import timedelta
+from unittest.mock import ANY, patch
 
 from django.test import TestCase, override_settings
+from django.utils import timezone
 
 from research_ai.models import (
+    AgentConversation,
+    AgentExecution,
     Expert,
     ExpertSearch,
     GeneratedEmail,
     ProposalDraft,
     SearchExpert,
 )
+from research_ai.services.usage_budget import ReservationHeartbeat
 from research_ai.tasks import (
     _update_search_progress,
     process_bulk_generate_emails_task,
+    reclaim_lost_agent_runs,
     run_proposal_draft_task,
     send_queued_emails_task,
 )
@@ -350,11 +356,24 @@ class RunProposalDraftTaskTests(TestCase):
 
         # Assert
         mock_run.assert_called_once_with(
-            self.search_expert.id, draft_id=self.draft.id, model_ref=None
+            self.search_expert.id, draft_id=self.draft.id, model_ref=None, heartbeat=ANY
         )
         self.assertEqual(result["status"], ProposalDraft.Status.COMPLETED)
         self.draft.refresh_from_db()
         self.assertIsNotNone(self.draft.processing_time)
+
+    @patch("research_ai.tasks.run_proposal_draft")
+    def test_runs_the_draft_under_a_heartbeat_on_its_lease(self, mock_run):
+        # Arrange: the claim sets the lease the heartbeat renews.
+        mock_run.return_value = {"status": ProposalDraft.Status.COMPLETED}
+
+        # Act
+        run_proposal_draft_task.apply(args=[self.draft.id]).get()
+
+        # Assert
+        heartbeat = mock_run.call_args.kwargs["heartbeat"]
+        self.assertIsInstance(heartbeat, ReservationHeartbeat)
+        self.assertEqual([target.id for target in heartbeat.targets], [self.draft.id])
 
     @patch("research_ai.tasks.run_proposal_draft")
     def test_forwards_the_drafts_selected_model(self, mock_run):
@@ -374,6 +393,7 @@ class RunProposalDraftTaskTests(TestCase):
             self.search_expert.id,
             draft_id=self.draft.id,
             model_ref="claude_platform:claude-sonnet-5",
+            heartbeat=ANY,
         )
 
     @patch("research_ai.tasks.run_proposal_draft")
@@ -398,6 +418,7 @@ class RunProposalDraftTaskTests(TestCase):
             self.search_expert.id,
             draft_id=self.draft.id,
             model_ref=None,
+            heartbeat=ANY,
             effort="high",
             thinking="disabled",
             temperature=0.4,
@@ -435,3 +456,68 @@ class RunProposalDraftTaskTests(TestCase):
         mock_run.assert_not_called()
         self.assertEqual(result["status"], ProposalDraft.Status.PROCESSING)
         self.assertEqual(result["skipped"], "already_claimed")
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+class ReclaimLostAgentRunsTaskTests(TestCase):
+    def setUp(self):
+        self.user = create_random_authenticated_user("reclaim_user")
+        self.lapsed = timezone.now() - timedelta(seconds=1)
+
+    def test_fails_turns_and_drafts_whose_worker_stopped_heartbeating(self):
+        # Arrange
+        conversation = AgentConversation.objects.create(
+            user=self.user, workflow="notebook_chat"
+        )
+        execution = AgentExecution.objects.create(
+            conversation=conversation,
+            status=AgentExecution.Status.RUNNING,
+            attempt=1,
+            usage_reservation_expires_at=self.lapsed,
+        )
+        expert = Expert.objects.create(email="reclaim-expert@example.edu")
+        search_expert = SearchExpert.objects.create(
+            expert_search=ExpertSearch.objects.create(
+                created_by=self.user, query="protein folding"
+            ),
+            expert=expert,
+        )
+        draft = ProposalDraft.objects.create(
+            search_expert=search_expert,
+            created_by=self.user,
+            status=ProposalDraft.Status.PROCESSING,
+            usage_reservation_expires_at=self.lapsed,
+        )
+
+        # Act
+        result = reclaim_lost_agent_runs.apply().get()
+
+        # Assert
+        self.assertEqual(
+            result, {"executions": [execution.id], "proposal_drafts": [draft.id]}
+        )
+        execution.refresh_from_db()
+        draft.refresh_from_db()
+        self.assertEqual(execution.status, AgentExecution.Status.FAILED)
+        self.assertEqual(execution.stop_reason, "worker_lost")
+        self.assertEqual(draft.status, ProposalDraft.Status.FAILED)
+
+    def test_leaves_live_work_alone(self):
+        # Arrange
+        conversation = AgentConversation.objects.create(
+            user=self.user, workflow="notebook_chat"
+        )
+        execution = AgentExecution.objects.create(
+            conversation=conversation,
+            status=AgentExecution.Status.RUNNING,
+            attempt=1,
+            usage_reservation_expires_at=timezone.now() + timedelta(minutes=1),
+        )
+
+        # Act
+        result = reclaim_lost_agent_runs.apply().get()
+
+        # Assert
+        self.assertEqual(result, {"executions": [], "proposal_drafts": []})
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, AgentExecution.Status.RUNNING)

--- a/src/research_ai/tests/test_usage_budget.py
+++ b/src/research_ai/tests/test_usage_budget.py
@@ -275,56 +275,18 @@ class AgentLoopBudgetRecorderTests(TestCase):
             recorder.before_model_call()
         self.assertEqual(LLMUsageEvent.objects.filter(user=self.user).count(), 10)
 
-    def test_stream_activity_renews_a_cancelled_in_flight_lease(self):
-        # Arrange
+    def test_stream_activity_leaves_the_lease_to_the_heartbeat(self):
+        # Arrange: liveness is the worker heartbeat's job, so a burst of stream
+        # events must not stand in for one.
         old_expiry = timezone.now() + timedelta(minutes=1)
         execution = self._execution(
-            status=AgentExecution.Status.CANCELLED,
+            status=AgentExecution.Status.RUNNING,
             expires_at=old_expiry,
         )
 
         # Act
         self._recorder(execution).record_stream_event(
             1, TextStreamDelta(block_index=0, text="still running")
-        )
-
-        # Assert
-        execution.refresh_from_db()
-        self.assertGreater(execution.usage_reservation_expires_at, old_expiry)
-
-    def test_stream_activity_throttles_lease_renewals(self):
-        # Arrange
-        execution = self._execution(
-            status=AgentExecution.Status.RUNNING,
-            expires_at=timezone.now() + timedelta(minutes=1),
-        )
-        recorder = self._recorder(execution)
-
-        # Act
-        with patch(
-            "research_ai.services.usage_budget.recorder.renew_live_reservation"
-        ) as renew:
-            recorder.record_stream_event(
-                1, TextStreamDelta(block_index=0, text="first event")
-            )
-            recorder.record_stream_event(
-                1, TextStreamDelta(block_index=0, text="second event")
-            )
-
-        # Assert
-        renew.assert_called_once()
-
-    def test_expired_lease_cannot_be_resurrected_by_a_zombie_worker(self):
-        # Arrange
-        old_expiry = timezone.now() - timedelta(seconds=1)
-        execution = self._execution(
-            status=AgentExecution.Status.CANCELLED,
-            expires_at=old_expiry,
-        )
-
-        # Act
-        self._recorder(execution).record_stream_event(
-            1, TextStreamDelta(block_index=0, text="late event")
         )
 
         # Assert

--- a/src/researchhub/celery.py
+++ b/src/researchhub/celery.py
@@ -202,6 +202,17 @@ app.conf.beat_schedule = {
             "queue": QUEUE_PAPER_MISC,
         },
     },
+    # Research AI
+    "research-ai-reclaim-lost-agent-runs": {
+        "task": "research_ai.tasks.reclaim_lost_agent_runs",
+        "schedule": crontab(minute="*"),
+        "options": {
+            "priority": 1,
+            "queue": QUEUE_AGENTS,
+            # A sweep that waited a minute behind a backlog is superseded.
+            "expires": 55,
+        },
+    },
     # Paper ingestion tasks
     "paper-fetch-all": {
         "task": "paper.ingestion.pipeline.fetch_all_papers",


### PR DESCRIPTION
## Summary

A cancelled or orphaned Research AI turn could block the user for up to two hours. The budget lease was the only liveness signal, it was renewed by loop progress, and a live provider call can be silent for over an hour (600 s per attempt and up to 8 retries on Claude Platform; Bedrock and OpenRouter calls are not streamed), so the lease was sized at two hours. Cancelling a running turn reset it to a fresh two hours, and nothing reclaimed a run whose worker had died.

This makes the lease track worker liveness instead of loop progress, so the single-flight slot is held exactly while a process could still be spending:

- **Heartbeat thread** (`usage_budget/heartbeat.py`): renews the lease every 30 s from its own thread while a notebook turn or proposal draft runs; the lease is now 3 minutes. A process blocked in a long provider read stays reserved, a dead one lapses in three minutes. A beat that finds no live lease flags the run and the budget recorder refuses its next model call.
- **Cancel leaves the lease alone**: a running turn keeps whatever its worker last set, and the worker clears it when it unwinds (already the case). A queued turn still releases immediately.
- **Reclaim** (`agent_persistence/liveness_service.py`, `proposal_draft/liveness_service.py`): active executions and drafts whose lease lapsed are failed with stop reason `worker_lost`, re-checked under a row lock so a slow worker that renewed in between is spared. Queued jobs get a 30-minute claim deadline. The prompt and unpublished-answer reconciliation that cancel already performed now lives in `reconciliation.py` and runs here too.
- **Two triggers**: a beat task `reclaim_lost_agent_runs` every minute on the agents queue, plus an inline reclaim of the user's lost turns and drafts before admission in `submit_message` and draft creation, so the same chat resumes immediately and the fix does not depend on beat.
- **User-facing**: a reclaimed turn renders as `agent_failed`, `retryable: true`, "The assistant stopped unexpectedly before it could finish. Try again.", and `turn_failed` is published to the chat.
- **Time limits**: soft and hard limits on the two agent tasks (2 h for a notebook turn, 4 h for a draft, plus a 5 min hard grace). These are ceilings against runaway live workers, not liveness, and the values are guesses to tune.

Why not release the slot on cancel: spend lands only when a provider call returns, so the daily budget cannot see in-flight calls, and single-flight is what bounds that invisible spend to one call. Cancel does not stop the HTTP call, so releasing on cancel lets request, cancel, request stack calls that are all billed. With the heartbeat, the second request gets a 409 until the first call actually returns, and that call is billed when it does. The attacker's throughput is one call per call duration, the same as normal use.

## Relationship to #4076

#4076 (closed in favour of this PR) took the other route: release the concurrency slot on cancel and pre-record each provider call as an `LLMUsageEvent` before dispatch so the daily turn cap counts in-flight calls. The differences, for the record:

- #4076 bounds cancel-and-resubmit by the turn cap (200 calls a day on the invited tier), not by dollars, since an in-flight call has no cost until it returns. This PR keeps one in-flight call per user.
- #4076 does not recover a run whose worker died until the user presses cancel; this PR reclaims it within about a minute and fails it visibly.
- Pre-recording usage rows before dispatch is compatible with this PR and would still be worth adding as defense in depth.

## Test plan

- [x] `research_ai` suite passes: 1282 tests (1247 before, 35 new)
- [x] New: heartbeat thread and lease tests, execution and draft liveness services, beat task, inline reclaim in submit and draft create, `run_turn` heartbeat wiring
- [x] Updated: cancellation keeps the worker's lease, stream activity no longer renews it, the draft task passes a heartbeat
- [x] `ruff check`, `ruff format --check`, `makemigrations --check` clean
- [ ] Deploy: runs in flight during the rollout keep their old two-hour lease once; confirm RedBeat picks up `research-ai-reclaim-lost-agent-runs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
