### PR TITLE
Add FundingPool contributions and auto-create on grant create

### DIFF
--- a/src/purchase/serializers/__init__.py
+++ b/src/purchase/serializers/__init__.py
@@ -1,5 +1,9 @@
 from .balance_serializer import BalanceSerializer, BalanceSourceRelatedField
 from .funding_overview_serializer import FundingOverviewSerializer
+from .funding_pool_serializer import (
+    DynamicFundingPoolSerializer,
+    FundingPoolContributionSerializer,
+)
 from .fundraise_create_serializer import FundraiseCreateSerializer
 from .fundraise_serializer import DynamicFundraiseSerializer, FundraiseSerializer
 from .grant_create_serializer import GrantCreateSerializer
@@ -16,10 +20,12 @@ from .wallet_serializer import WalletSerializer
 __all__ = [
     "BalanceSerializer",
     "BalanceSourceRelatedField",
+    "DynamicFundingPoolSerializer",
     "DynamicFundraiseSerializer",
     "DynamicGrantSerializer",
     "DynamicPurchaseSerializer",
     "FundingOverviewSerializer",
+    "FundingPoolContributionSerializer",
     "FundraiseCreateSerializer",
     "FundraiseSerializer",
     "GrantCreateSerializer",

--- a/src/purchase/serializers/funding_pool_serializer.py
+++ b/src/purchase/serializers/funding_pool_serializer.py
@@ -1,0 +1,58 @@
+from rest_framework import serializers
+
+from purchase.models import FundingPool
+from purchase.related_models.constants.currency import RSC
+from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
+from researchhub.serializers import DynamicModelFieldSerializer
+from user.serializers import DynamicUserSerializer
+
+
+class FundingPoolContributionSerializer(serializers.Serializer):
+    """Input validation for POST /api/funding_pool/{id}/create_contribution/."""
+
+    amount = serializers.DecimalField(max_digits=19, decimal_places=10)
+    amount_currency = serializers.ChoiceField(choices=[(RSC, RSC)], default=RSC)
+    use_credits = serializers.BooleanField(default=True)
+
+    def validate_amount(self, value):
+        if value <= 0:
+            raise serializers.ValidationError("Amount must be greater than zero.")
+        return value
+
+
+class DynamicFundingPoolSerializer(DynamicModelFieldSerializer):
+    created_by = serializers.SerializerMethodField()
+    amount_holding = serializers.SerializerMethodField()
+    amount_distributed = serializers.SerializerMethodField()
+    amount_raised = serializers.SerializerMethodField()
+
+    class Meta:
+        model = FundingPool
+        fields = "__all__"
+
+    def get_created_by(self, pool):
+        context = self.context
+        _context_fields = context.get("pch_dfps_get_created_by", {})
+        serializer = DynamicUserSerializer(
+            pool.created_by, context=context, **_context_fields
+        )
+        return serializer.data
+
+    def _amount_currency_dict(self, rsc_amount):
+        try:
+            usd_amount = RscExchangeRate.rsc_to_usd(float(rsc_amount))
+        except AttributeError:
+            usd_amount = None
+        return {
+            "rsc": rsc_amount,
+            "usd": usd_amount,
+        }
+
+    def get_amount_holding(self, pool):
+        return self._amount_currency_dict(pool.amount_holding)
+
+    def get_amount_distributed(self, pool):
+        return self._amount_currency_dict(pool.amount_distributed)
+
+    def get_amount_raised(self, pool):
+        return self._amount_currency_dict(pool.amount_raised)

--- a/src/purchase/serializers/grant_create_serializer.py
+++ b/src/purchase/serializers/grant_create_serializer.py
@@ -1,9 +1,11 @@
 from decimal import Decimal, InvalidOperation
 
+from django.db import transaction
 from rest_framework import serializers
 
 from purchase.models import Grant
 from purchase.related_models.constants.currency import USD
+from purchase.services.funding_pool_service import FundingPoolService
 from researchhub_document.models import ResearchhubPost, ResearchhubUnifiedDocument
 
 
@@ -100,12 +102,17 @@ class GrantCreateSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         contact_ids = validated_data.pop("contact_ids", [])
-        grant = super().create(validated_data)
+        with transaction.atomic():
+            validated_data.pop("unified_document_id", None)
+            validated_data.pop("post_id", None)
+            grant = super().create(validated_data)
 
-        if contact_ids:
-            from user.models import User
+            if contact_ids:
+                from user.models import User
 
-            contacts = User.objects.filter(id__in=contact_ids)
-            grant.contacts.set(contacts)
+                contacts = User.objects.filter(id__in=contact_ids)
+                grant.contacts.set(contacts)
+
+            FundingPoolService().create_pool_for_grant(grant)
 
         return grant

--- a/src/purchase/serializers/payment_intent_serializer.py
+++ b/src/purchase/serializers/payment_intent_serializer.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from purchase.related_models.constants import MINIMUM_FUNDRAISE_CONTRIBUTION_AMOUNT_RSC
+from purchase.related_models.funding_pool_model import FundingPool
 from purchase.related_models.fundraise_model import Fundraise
 
 
@@ -8,8 +9,8 @@ class PaymentIntentSerializer(serializers.Serializer):
     """
     Serializer for RSC purchase payment intent creation.
 
-    Optionally accepts a fundraise_id to automatically contribute
-    the purchased RSC to a fundraise once the payment is processed.
+    Optionally accepts a fundraise_id or funding_pool_id (mutually exclusive)
+    to automatically contribute the purchased RSC once the payment is processed.
     """
 
     amount = serializers.DecimalField(
@@ -22,6 +23,11 @@ class PaymentIntentSerializer(serializers.Serializer):
         required=False,
         allow_null=True,
         help_text="Optional fundraise ID to auto-contribute to after purchase",
+    )
+    funding_pool_id = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        help_text="Optional funding pool ID to auto-contribute to after purchase",
     )
 
     def validate_fundraise_id(self, value):
@@ -43,6 +49,22 @@ class PaymentIntentSerializer(serializers.Serializer):
 
         return value
 
+    def validate_funding_pool_id(self, value):
+        if value is None:
+            return value
+
+        try:
+            pool = FundingPool.objects.get(id=value)
+        except FundingPool.DoesNotExist:
+            raise serializers.ValidationError("Funding pool not found.")
+
+        if pool.status != FundingPool.OPEN:
+            raise serializers.ValidationError(
+                "Funding pool is not open for contributions."
+            )
+
+        return value
+
     def validate(self, attrs):
         amount = attrs.get("amount")
 
@@ -50,6 +72,13 @@ class PaymentIntentSerializer(serializers.Serializer):
         if amount <= 0:
             raise serializers.ValidationError(
                 {"amount": "Amount must be greater than zero."}
+            )
+
+        fundraise_id = attrs.get("fundraise_id")
+        funding_pool_id = attrs.get("funding_pool_id")
+        if fundraise_id is not None and funding_pool_id is not None:
+            raise serializers.ValidationError(
+                "fundraise_id and funding_pool_id are mutually exclusive."
             )
 
         return attrs

--- a/src/purchase/services/funding_pool_service.py
+++ b/src/purchase/services/funding_pool_service.py
@@ -1,0 +1,178 @@
+import logging
+from decimal import Decimal
+
+from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
+
+from analytics.tasks import track_revenue_event
+from purchase.models import Balance, FundingPool, Grant, Purchase, RscExchangeRate
+from purchase.related_models.constants import (
+    MAXIMUM_FUNDRAISE_CONTRIBUTION_AMOUNT_RSC,
+    MINIMUM_FUNDRAISE_CONTRIBUTION_AMOUNT_RSC,
+)
+from purchase.related_models.constants.currency import RSC
+from purchase.services.fundraise_service import FundraiseService
+from reputation.models import BountyFee
+from reputation.utils import calculate_bounty_fees, deduct_bounty_fees
+from user.models import User
+
+logger = logging.getLogger(__name__)
+
+
+class FundingPoolService:
+    """Service for FundingPool contributions and pool lifecycle helpers."""
+
+    def create_pool_for_grant(self, grant: Grant) -> FundingPool:
+        """Create the community contribution pot for a grant (one pool per grant)."""
+        pool, _created = FundingPool.objects.get_or_create(
+            grant=grant,
+            defaults={"created_by": grant.created_by},
+        )
+        return pool
+
+    def validate_pool_for_contribution(
+        self, pool: FundingPool
+    ) -> tuple[bool, str | None]:
+        """Validate that a funding pool can accept contributions."""
+        if pool.status != FundingPool.OPEN:
+            return False, "Funding pool is not open"
+        return True, None
+
+    def create_contribution(
+        self,
+        user: User,
+        pool: FundingPool,
+        amount: Decimal,
+        currency: str = RSC,
+        use_credits: bool = True,
+    ) -> tuple[Purchase | None, str | None]:
+        """
+        Validate and create an RSC contribution to a funding pool.
+
+
+        Fees and balance debits follow the fundraise pattern;
+        net amount is credited to ``pool.amount_holding``.
+        """
+        is_valid, error = self.validate_pool_for_contribution(pool)
+        if not is_valid:
+            return None, error
+
+        if currency != RSC:
+            return None, "Only RSC contributions are supported for funding pools"
+
+        try:
+            amount = Decimal(amount)
+        except Exception:
+            return None, "Invalid amount"
+
+        min_rsc = MINIMUM_FUNDRAISE_CONTRIBUTION_AMOUNT_RSC
+        max_rsc = MAXIMUM_FUNDRAISE_CONTRIBUTION_AMOUNT_RSC
+        if amount < min_rsc or amount > max_rsc:
+            return None, f"Invalid amount. Minimum is {min_rsc}"
+
+        return self.create_rsc_contribution(user, pool, amount, use_credits=use_credits)
+
+    def create_rsc_contribution(
+        self,
+        user: User,
+        pool: FundingPool,
+        amount: Decimal,
+        use_credits: bool = True,
+    ) -> tuple[Purchase | None, str | None]:
+        """
+        Create an RSC contribution to a funding pool.
+
+        When ``use_credits`` is True, the full ``amount + fee`` must be covered
+        by funding credits. Otherwise, promotional RSC is consumed first and
+        available RSC covers any remainder.
+        """
+        try:
+            amount = Decimal(str(amount))
+        except (ArithmeticError, TypeError, ValueError):
+            return None, "Invalid amount"
+
+        if not amount.is_finite() or amount <= 0:
+            return None, "Invalid amount"
+
+        fee, rh_fee, dao_fee, fee_object = calculate_bounty_fees(amount)
+        total_cost = amount + fee
+
+        if any(
+            not value.is_finite() or value < 0
+            for value in (fee, rh_fee, dao_fee, total_cost)
+        ):
+            return None, "Invalid fee configuration"
+
+        with transaction.atomic():
+            pool = FundingPool.objects.select_for_update().get(id=pool.id)
+            if pool.status != FundingPool.OPEN:
+                return None, "Funding pool is not open"
+
+            user = User.objects.select_for_update().get(id=user.id)
+
+            try:
+                allocations = FundraiseService._allocate_contribution_spend(
+                    user, total_cost, use_credits
+                )
+            except ValueError as error:
+                return None, str(error)
+
+            purchase = Purchase.objects.create(
+                user=user,
+                content_type=ContentType.objects.get_for_model(FundingPool),
+                object_id=pool.id,
+                purchase_method=Purchase.OFF_CHAIN,
+                purchase_type=Purchase.FUNDING_POOL_CONTRIBUTION,
+                paid_status=Purchase.PAID,
+                amount=amount,
+                rsc_usd_rate=RscExchangeRate.get_latest(),
+            )
+
+            deduct_bounty_fees(user, fee, rh_fee, dao_fee, fee_object)
+
+            remaining_amount = amount
+
+            for alloc in allocations:
+                alloc_amount = alloc["amount"]
+                amount_used = min(alloc_amount, remaining_amount)
+                fee_used = alloc_amount - amount_used
+
+                if amount_used > 0:
+                    Balance.objects.create(
+                        user=user,
+                        content_type=ContentType.objects.get_for_model(Purchase),
+                        object_id=purchase.id,
+                        amount=f"-{amount_used.to_eng_string()}",
+                        is_locked=alloc["is_locked"],
+                        lock_type=alloc["lock_type"],
+                        purchase=purchase,
+                    )
+
+                if fee_used > 0:
+                    Balance.objects.create(
+                        user=user,
+                        content_type=ContentType.objects.get_for_model(BountyFee),
+                        object_id=fee_object.id,
+                        amount=f"-{fee_used.to_eng_string()}",
+                        is_locked=alloc["is_locked"],
+                        lock_type=alloc["lock_type"],
+                        purchase=purchase,
+                    )
+
+                remaining_amount -= amount_used
+
+            track_revenue_event.apply_async(
+                (
+                    user.id,
+                    "FUNDING_POOL_CONTRIBUTION_FEE",
+                    rh_fee.to_eng_string(),
+                    None,
+                    "OFF_CHAIN",
+                ),
+                priority=1,
+            )
+
+            pool.amount_holding += amount
+            pool.save(update_fields=["amount_holding", "updated_date"])
+
+        return purchase, None

--- a/src/purchase/services/payment_service.py
+++ b/src/purchase/services/payment_service.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from paper.related_models.paper_model import Paper
 from purchase.related_models.balance_model import Balance
 from purchase.related_models.constants.currency import RSC
+from purchase.related_models.funding_pool_model import FundingPool
 from purchase.related_models.fundraise_model import Fundraise
 from purchase.related_models.payment_model import (
     Payment,
@@ -247,6 +248,7 @@ class PaymentService:
         user_id: int,
         rsc_amount: Decimal,
         fundraise_id: int | None = None,
+        funding_pool_id: int | None = None,
     ) -> dict[str, Any]:
         """
         Create a Stripe payment intent for RSC purchase.
@@ -255,6 +257,8 @@ class PaymentService:
             user_id: ID of the user making the payment.
             rsc_amount: Amount of RSC to purchase (Decimal for precision).
             fundraise_id: Optional fundraise ID to auto-contribute to after purchase.
+            funding_pool_id: Optional funding pool ID to auto-contribute to after
+                purchase. Mutually exclusive with fundraise_id.
 
         Returns:
             Dict containing client_secret, payment_intent_id, and locked_rsc_amount
@@ -299,9 +303,11 @@ class PaymentService:
                 "stripe_fees": str(stripe_fee),
             }
 
-            # Add fundraise_id to metadata if provided
+            # Add fundraise_id / funding_pool_id to metadata if provided
             if fundraise_id is not None:
                 metadata["fundraise_id"] = str(fundraise_id)
+            if funding_pool_id is not None:
+                metadata["funding_pool_id"] = str(funding_pool_id)
 
             # Get user's email for receipt
             user = User.objects.get(id=user_id)
@@ -331,17 +337,18 @@ class PaymentService:
         """
         Process a confirmed payment intent and create a Payment record for RSC purchase.
 
-        If a fundraise_id is present in the payment intent metadata, the purchased RSC
-        will be automatically contributed to the fundraise in a separate transaction.
+        If a fundraise_id or funding_pool_id is present in the payment intent metadata,
+        the purchased RSC will be automatically contributed in a separate transaction.
 
         Args:
             payment_intent_id: ID of the confirmed payment intent
 
         Returns:
-            Tuple of (Payment, Purchase or None). Purchase is returned if a fundraise
+            Tuple of (Payment, Purchase or None). Purchase is returned if a
             contribution was created, otherwise None.
         """
         # Import here to avoid circular imports
+        from purchase.services.funding_pool_service import FundingPoolService
         from purchase.services.fundraise_service import FundraiseService
 
         try:
@@ -371,20 +378,28 @@ class PaymentService:
                 locked_rsc_amount=locked_rsc_amount,
             )
 
-            # Handle fundraise contribution in a separate transaction
+            # Handle auto-contribution in a separate transaction
             # This ensures payment succeeds even if contribution fails
-            fundraise_contribution = None
+            contribution = None
             fundraise_id_str = payment_intent.metadata.get("fundraise_id")
+            funding_pool_id_str = payment_intent.metadata.get("funding_pool_id")
 
             if fundraise_id_str:
-                fundraise_contribution = self._process_fundraise_contribution(
+                contribution = self._process_fundraise_contribution(
                     fundraise_id_str=fundraise_id_str,
                     user_id=user_id,
                     rsc_amount=rsc_amount,
                     fundraise_service=FundraiseService(),
                 )
+            elif funding_pool_id_str:
+                contribution = self._process_funding_pool_contribution(
+                    funding_pool_id_str=funding_pool_id_str,
+                    user_id=user_id,
+                    rsc_amount=rsc_amount,
+                    funding_pool_service=FundingPoolService(),
+                )
 
-            return payment, fundraise_contribution
+            return payment, contribution
 
         except Exception as e:
             logger.error("Error processing payment intent confirmation: %s", e)
@@ -519,6 +534,36 @@ class PaymentService:
             amount=rsc_amount,
             currency=RSC,
             check_self_contribution=False,
+            use_credits=True,
+        )
+
+        return contribution if not error else None
+
+    def _process_funding_pool_contribution(
+        self,
+        funding_pool_id_str: str,
+        user_id: int,
+        rsc_amount: Decimal,
+        funding_pool_service,
+    ) -> Purchase | None:
+        """
+        Process funding pool contribution in a separate transaction.
+        Failures here do not affect the payment processing.
+
+        Returns:
+            Purchase if contribution succeeded, None otherwise
+        """
+        try:
+            pool = FundingPool.objects.get(id=int(funding_pool_id_str))
+            user = User.objects.get(id=user_id)
+        except (FundingPool.DoesNotExist, User.DoesNotExist):
+            return None
+
+        contribution, error = funding_pool_service.create_contribution(
+            user=user,
+            pool=pool,
+            amount=rsc_amount,
+            currency=RSC,
             use_credits=True,
         )
 

--- a/src/purchase/tests/test_funding_pool_service.py
+++ b/src/purchase/tests/test_funding_pool_service.py
@@ -1,0 +1,159 @@
+from decimal import Decimal
+
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from purchase.models import Balance, FundingPool, Grant, Purchase, RscExchangeRate
+from purchase.services.funding_pool_service import FundingPoolService
+from reputation.models import BountyFee
+from researchhub_document.helpers import create_post
+from researchhub_document.related_models.constants.document_type import (
+    GRANT as GRANT_DOC,
+)
+from user.tests.helpers import create_random_authenticated_user, create_user
+
+
+class FundingPoolServiceTests(TestCase):
+    def setUp(self):
+        self.creator = create_random_authenticated_user("pool_creator")
+        self.post = create_post(created_by=self.creator, document_type=GRANT_DOC)
+        self.grant = Grant.objects.create(
+            created_by=self.creator,
+            unified_document=self.post.unified_document,
+            amount=Decimal("10000.00"),
+            currency="USD",
+            organization="Test Org",
+            description="Test grant",
+        )
+        self.service = FundingPoolService()
+        self.pool = self.service.create_pool_for_grant(self.grant)
+
+        self.bounty_fee = BountyFee.objects.create(rh_pct=0.07, dao_pct=0.02)
+        RscExchangeRate.objects.create(
+            rate=0.5,
+            real_rate=0.5,
+            target_currency="USD",
+        )
+        create_user(email="bank@researchhub.com")
+
+    def _give_available_balance(self, user, amount):
+        distribution_ct = ContentType.objects.get(model="distribution")
+        Balance.objects.create(amount=amount, user=user, content_type=distribution_ct)
+
+    def _give_funding_credits(self, user, amount):
+        distribution_ct = ContentType.objects.get(model="distribution")
+        Balance.objects.create(
+            amount=amount,
+            user=user,
+            content_type=distribution_ct,
+            is_locked=True,
+            lock_type=Balance.LockType.FUNDING_CREDIT,
+        )
+
+    def test_create_pool_for_grant_is_idempotent(self):
+        # Act
+        again = self.service.create_pool_for_grant(self.grant)
+
+        # Assert
+        self.assertEqual(again.id, self.pool.id)
+        self.assertEqual(FundingPool.objects.filter(grant=self.grant).count(), 1)
+
+    def test_create_rsc_contribution_with_available_balance(self):
+        # Arrange
+        contributor = create_random_authenticated_user("pool_contributor")
+        self._give_available_balance(contributor, 1000)
+
+        # Act
+        purchase, error = self.service.create_rsc_contribution(
+            contributor, self.pool, Decimal(100), use_credits=False
+        )
+
+        # Assert
+        self.assertIsNone(error)
+        self.assertIsNotNone(purchase)
+        self.assertEqual(purchase.purchase_type, Purchase.FUNDING_POOL_CONTRIBUTION)
+        self.assertEqual(purchase.object_id, self.pool.id)
+
+        self.pool.refresh_from_db()
+        self.assertEqual(self.pool.amount_holding, Decimal(100))
+        self.assertEqual(self.pool.amount_raised, Decimal(100))
+
+        amount_balance = Balance.objects.filter(
+            user=contributor, content_type=ContentType.objects.get_for_model(Purchase)
+        )
+        self.assertEqual(amount_balance.count(), 1)
+        self.assertEqual(float(amount_balance.first().amount), -100.0)
+
+        fee_balance = Balance.objects.filter(
+            user=contributor, content_type=ContentType.objects.get_for_model(BountyFee)
+        )
+        self.assertEqual(fee_balance.count(), 1)
+        self.assertEqual(float(fee_balance.first().amount), -9.0)
+
+    def test_create_rsc_contribution_with_funding_credits(self):
+        # Arrange
+        contributor = create_random_authenticated_user("credits_pool_contributor")
+        self._give_funding_credits(contributor, 200)
+        self._give_available_balance(contributor, 500)
+
+        # Act
+        purchase, error = self.service.create_rsc_contribution(
+            contributor, self.pool, Decimal(100), use_credits=True
+        )
+
+        # Assert
+        self.assertIsNone(error)
+        debits = Balance.objects.filter(purchase=purchase)
+        self.assertTrue(
+            all(
+                debit.is_locked and debit.lock_type == Balance.LockType.FUNDING_CREDIT
+                for debit in debits
+            )
+        )
+        self.assertEqual(contributor.get_available_balance(), Decimal(500))
+
+    def test_create_rsc_contribution_insufficient_credits(self):
+        # Arrange
+        contributor = create_random_authenticated_user("short_credits_pool")
+        self._give_funding_credits(contributor, 50)
+        self._give_available_balance(contributor, 1000)
+
+        # Act
+        purchase, error = self.service.create_rsc_contribution(
+            contributor, self.pool, Decimal(100), use_credits=True
+        )
+
+        # Assert
+        self.assertIsNone(purchase)
+        self.assertEqual(error, "Insufficient funding credit balance")
+        self.pool.refresh_from_db()
+        self.assertEqual(self.pool.amount_holding, Decimal(0))
+
+    def test_create_contribution_rejects_closed_pool(self):
+        # Arrange
+        self.pool.status = FundingPool.CLOSED
+        self.pool.save()
+        contributor = create_random_authenticated_user("closed_pool_contributor")
+        self._give_available_balance(contributor, 1000)
+
+        # Act
+        purchase, error = self.service.create_contribution(
+            contributor, self.pool, Decimal(100), use_credits=False
+        )
+
+        # Assert
+        self.assertIsNone(purchase)
+        self.assertEqual(error, "Funding pool is not open")
+
+    def test_create_contribution_rejects_usd(self):
+        # Arrange
+        contributor = create_random_authenticated_user("usd_pool_contributor")
+
+        # Act
+        purchase, error = self.service.create_contribution(
+            contributor, self.pool, Decimal(100), currency="USD"
+        )
+
+        # Assert
+        self.assertIsNone(purchase)
+        self.assertIn("Only RSC", error)

--- a/src/purchase/tests/test_funding_pool_view.py
+++ b/src/purchase/tests/test_funding_pool_view.py
@@ -1,0 +1,173 @@
+from decimal import Decimal
+
+from django.contrib.contenttypes.models import ContentType
+from rest_framework.test import APITestCase
+
+from purchase.models import Balance, FundingPool, Grant, Purchase, RscExchangeRate
+from purchase.services.funding_pool_service import FundingPoolService
+from reputation.models import BountyFee
+from researchhub_document.helpers import create_post
+from researchhub_document.related_models.constants.document_type import (
+    GRANT as GRANT_DOC,
+)
+from researchhub_document.related_models.researchhub_post_model import ResearchhubPost
+from user.related_models.follow_model import Follow
+from user.tests.helpers import create_random_authenticated_user, create_user
+
+
+class FundingPoolViewTests(APITestCase):
+    def setUp(self):
+        self.creator = create_random_authenticated_user("pool_view_creator")
+        self.post = create_post(created_by=self.creator, document_type=GRANT_DOC)
+        self.grant = Grant.objects.create(
+            created_by=self.creator,
+            unified_document=self.post.unified_document,
+            amount=Decimal("10000.00"),
+            currency="USD",
+            organization="Test Org",
+            description="Test grant",
+        )
+        self.pool = FundingPoolService().create_pool_for_grant(self.grant)
+
+        RscExchangeRate.objects.create(
+            rate=0.5,
+            real_rate=0.5,
+            price_source="COIN_GECKO",
+            target_currency="USD",
+        )
+        create_user(email="bank@researchhub.com")
+        BountyFee.objects.create(rh_pct=0.07, dao_pct=0.02)
+
+    def _give_user_balance(self, user, amount):
+        distribution_ct = ContentType.objects.get(model="distribution")
+        Balance.objects.create(amount=amount, user=user, content_type=distribution_ct)
+
+    def _give_funding_credits(self, user, amount):
+        distribution_ct = ContentType.objects.get(model="distribution")
+        Balance.objects.create(
+            amount=amount,
+            user=user,
+            content_type=distribution_ct,
+            is_locked=True,
+            lock_type=Balance.LockType.FUNDING_CREDIT,
+        )
+
+    def _create_contribution(self, pool_id, user, amount=100, use_credits=None):
+        self.client.force_authenticate(user)
+        payload = {"amount": amount, "amount_currency": "RSC"}
+        if use_credits is not None:
+            payload["use_credits"] = use_credits
+        return self.client.post(
+            f"/api/funding_pool/{pool_id}/create_contribution/",
+            payload,
+        )
+
+    def test_retrieve_funding_pool(self):
+        # Arrange
+        self.client.force_authenticate(self.creator)
+
+        # Act
+        response = self.client.get(f"/api/funding_pool/{self.pool.id}/")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["id"], self.pool.id)
+        self.assertEqual(response.data["status"], FundingPool.OPEN)
+        self.assertEqual(float(response.data["amount_holding"]["rsc"]), 0.0)
+
+    def test_create_contribution(self):
+        # Arrange
+        user = create_random_authenticated_user("pool_view_contributor")
+        self._give_user_balance(user, 1000)
+
+        # Act
+        response = self._create_contribution(self.pool.id, user, use_credits=False)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(float(response.data["amount_holding"]["rsc"]), 100.0)
+        self.assertEqual(float(response.data["amount_raised"]["rsc"]), 100.0)
+
+        amount_balance = Balance.objects.filter(
+            user=user, content_type=ContentType.objects.get_for_model(Purchase)
+        )
+        self.assertEqual(amount_balance.count(), 1)
+        self.assertEqual(float(amount_balance.first().amount), -100.0)
+
+        fee_balance = Balance.objects.filter(
+            user=user, content_type=ContentType.objects.get_for_model(BountyFee)
+        )
+        self.assertEqual(fee_balance.count(), 1)
+        self.assertEqual(float(fee_balance.first().amount), -9.0)
+
+        follow = Follow.objects.filter(
+            user=user,
+            object_id=self.post.id,
+            content_type=ContentType.objects.get_for_model(ResearchhubPost),
+        )
+        self.assertEqual(follow.count(), 1)
+
+    def test_create_contribution_with_funding_credits(self):
+        # Arrange
+        user = create_random_authenticated_user("pool_credits_view")
+        self._give_funding_credits(user, 200)
+
+        # Act
+        response = self._create_contribution(self.pool.id, user, use_credits=True)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(float(response.data["amount_holding"]["rsc"]), 100.0)
+
+    def test_create_contribution_not_enough_funds(self):
+        # Arrange
+        user = create_random_authenticated_user("pool_broke_view")
+        self._give_user_balance(user, 10)
+
+        # Act
+        response = self._create_contribution(
+            self.pool.id, user, amount=100, use_credits=False
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_contribution_rejects_usd(self):
+        # Arrange
+        user = create_random_authenticated_user("pool_usd_view")
+        self.client.force_authenticate(user)
+
+        # Act
+        response = self.client.post(
+            f"/api/funding_pool/{self.pool.id}/create_contribution/",
+            {"amount": 100, "amount_currency": "USD"},
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("amount_currency", response.data)
+
+    def test_grant_create_via_api_creates_funding_pool(self):
+        # Arrange
+        user = create_random_authenticated_user("grant_pool_api")
+        self.client.force_authenticate(user)
+        new_post = create_post(created_by=user, document_type=GRANT_DOC)
+
+        # Act
+        response = self.client.post(
+            "/api/grant/",
+            {
+                "unified_document_id": new_post.unified_document.id,
+                "amount": "25000.00",
+                "currency": "USD",
+                "organization": "Pool Foundation",
+                "description": "Grant that should create a pool",
+            },
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 201)
+        grant = Grant.objects.get(id=response.data["id"])
+        self.assertTrue(hasattr(grant, "funding_pool"))
+        self.assertEqual(grant.funding_pool.created_by_id, user.id)
+        self.assertEqual(grant.funding_pool.status, FundingPool.OPEN)

--- a/src/purchase/tests/test_payment_intent_serializer.py
+++ b/src/purchase/tests/test_payment_intent_serializer.py
@@ -4,9 +4,15 @@ from decimal import Decimal
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
+from purchase.related_models.funding_pool_model import FundingPool
 from purchase.related_models.fundraise_model import Fundraise
+from purchase.related_models.grant_model import Grant
 from purchase.serializers.payment_intent_serializer import PaymentIntentSerializer
 from reputation.models import Escrow
+from researchhub_document.helpers import create_post
+from researchhub_document.related_models.constants.document_type import (
+    GRANT as GRANT_DOC,
+)
 from researchhub_document.related_models.researchhub_unified_document_model import (
     ResearchhubUnifiedDocument,
 )
@@ -33,6 +39,20 @@ class PaymentIntentSerializerTest(TestCase):
         )
         self.fundraise.escrow = self.escrow
         self.fundraise.save()
+
+        grant_post = create_post(created_by=self.user, document_type=GRANT_DOC)
+        self.grant = Grant.objects.create(
+            created_by=self.user,
+            unified_document=grant_post.unified_document,
+            amount=Decimal("10000.00"),
+            currency="USD",
+            organization="Org",
+            description="Desc",
+        )
+        self.funding_pool = FundingPool.objects.create(
+            grant=self.grant,
+            created_by=self.user,
+        )
 
     def test_valid_data(self):
         # Arrange
@@ -171,3 +191,66 @@ class PaymentIntentSerializerTest(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("fundraise_id", serializer.errors)
         self.assertIn("expired", str(serializer.errors["fundraise_id"]))
+
+    def test_valid_data_with_funding_pool_id(self):
+        # Arrange
+        data = {
+            "amount": 100,
+            "funding_pool_id": self.funding_pool.id,
+        }
+
+        # Act
+        serializer = PaymentIntentSerializer(data=data)
+
+        # Assert
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(
+            serializer.validated_data["funding_pool_id"], self.funding_pool.id
+        )
+
+    def test_funding_pool_id_not_found(self):
+        # Arrange
+        data = {
+            "amount": 100,
+            "funding_pool_id": 99999,
+        }
+
+        # Act
+        serializer = PaymentIntentSerializer(data=data)
+
+        # Assert
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("funding_pool_id", serializer.errors)
+
+    def test_funding_pool_id_closed_pool(self):
+        # Arrange
+        self.funding_pool.status = FundingPool.CLOSED
+        self.funding_pool.save()
+
+        data = {
+            "amount": 100,
+            "funding_pool_id": self.funding_pool.id,
+        }
+
+        # Act
+        serializer = PaymentIntentSerializer(data=data)
+
+        # Assert
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("funding_pool_id", serializer.errors)
+        self.assertIn("not open", str(serializer.errors["funding_pool_id"]))
+
+    def test_fundraise_id_and_funding_pool_id_mutually_exclusive(self):
+        # Arrange
+        data = {
+            "amount": 100,
+            "fundraise_id": self.fundraise.id,
+            "funding_pool_id": self.funding_pool.id,
+        }
+
+        # Act
+        serializer = PaymentIntentSerializer(data=data)
+
+        # Assert
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("mutually exclusive", str(serializer.errors))

--- a/src/purchase/tests/test_payment_intent_view.py
+++ b/src/purchase/tests/test_payment_intent_view.py
@@ -73,6 +73,7 @@ class PaymentIntentViewTest(APITestCase):
             user_id=self.user.id,
             rsc_amount=Decimal(100),
             fundraise_id=None,
+            funding_pool_id=None,
         )
 
     def test_create_payment_intent_unauthenticated(self):
@@ -132,6 +133,7 @@ class PaymentIntentViewTest(APITestCase):
             user_id=self.user.id,
             rsc_amount=Decimal(100),
             fundraise_id=self.fundraise.id,
+            funding_pool_id=None,
         )
 
     def test_create_payment_intent_invalid_fundraise_id(self):
@@ -168,6 +170,64 @@ class PaymentIntentViewTest(APITestCase):
         # Assert
         self.assertEqual(response.status_code, 400)
         self.assertIn("fundraise_id", response.data)
+
+    @patch("purchase.views.payment_intent_view.PaymentService")
+    def test_create_payment_intent_with_funding_pool_id(
+        self, mock_payment_service_class
+    ):
+        # Arrange
+        from decimal import Decimal
+
+        from purchase.related_models.funding_pool_model import FundingPool
+        from purchase.related_models.grant_model import Grant
+        from researchhub_document.helpers import create_post
+        from researchhub_document.related_models.constants.document_type import (
+            GRANT as GRANT_DOC,
+        )
+
+        mock_payment_service = MagicMock()
+        mock_payment_service_class.return_value = mock_payment_service
+        mock_payment_service.create_payment_intent.return_value = {
+            "client_secret": "pi_secret_pool",
+            "payment_intent_id": "pi_pool_123",
+            "locked_rsc_amount": 100,
+            "stripe_amount_cents": 500,
+        }
+
+        grant_post = create_post(
+            created_by=self.fundraise_creator, document_type=GRANT_DOC
+        )
+        grant = Grant.objects.create(
+            created_by=self.fundraise_creator,
+            unified_document=grant_post.unified_document,
+            amount=Decimal("10000.00"),
+            currency="USD",
+            organization="Org",
+            description="Desc",
+        )
+        pool = FundingPool.objects.create(
+            grant=grant,
+            created_by=self.fundraise_creator,
+        )
+
+        data = {
+            "amount": 100,
+            "funding_pool_id": pool.id,
+        }
+
+        self.client.force_authenticate(user=self.user)
+
+        # Act
+        response = self.client.post(self.url, data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        mock_payment_service.create_payment_intent.assert_called_once_with(
+            user_id=self.user.id,
+            rsc_amount=Decimal(100),
+            fundraise_id=None,
+            funding_pool_id=pool.id,
+        )
 
     @patch("purchase.views.payment_intent_view.PaymentService")
     def test_create_payment_intent_service_error(self, mock_payment_service_class):

--- a/src/purchase/tests/test_payment_service.py
+++ b/src/purchase/tests/test_payment_service.py
@@ -8,16 +8,23 @@ from django.test import TestCase
 from paper.related_models.paper_model import Paper
 from purchase.related_models.balance_model import Balance
 from purchase.related_models.constants.currency import USD
+from purchase.related_models.funding_pool_model import FundingPool
+from purchase.related_models.grant_model import Grant
 from purchase.related_models.payment_model import (
     Payment,
     PaymentProcessor,
     PaymentPurpose,
 )
+from purchase.related_models.purchase_model import Purchase
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
 from purchase.related_models.rsc_purchase_fee import RscPurchaseFee
 from purchase.services.payment_service import PaymentService
 from reputation.related_models.bounty_fee import BountyFee
 from reputation.related_models.distribution import Distribution
+from researchhub_document.helpers import create_post
+from researchhub_document.related_models.constants.document_type import (
+    GRANT as GRANT_DOC,
+)
 from user.models import User
 from user.tests.helpers import create_user
 
@@ -735,6 +742,48 @@ class PaymentServiceTest(TestCase):
         expected_balance = locked_rsc_amount * Decimal("1.07")
         self.assertEqual(self.user.get_locked_balance(), expected_balance)
 
+    @patch("stripe.PaymentIntent.retrieve")
+    def test_process_payment_intent_confirmation_contributes_to_funding_pool(
+        self, mock_stripe_retrieve
+    ):
+        """Payment confirmation with funding_pool_id contributes RSC to the pool."""
+        grant_post = create_post(created_by=self.user, document_type=GRANT_DOC)
+        grant = Grant.objects.create(
+            created_by=self.user,
+            unified_document=grant_post.unified_document,
+            amount=Decimal("10000.00"),
+            currency="USD",
+            organization="Org",
+            description="Desc",
+        )
+        pool = FundingPool.objects.create(grant=grant, created_by=self.user)
+
+        locked_rsc_amount = Decimal("100.0")
+        mock_payment_intent = MagicMock()
+        mock_payment_intent.status = "succeeded"
+        mock_payment_intent.amount = 1000
+        mock_payment_intent.currency = "usd"
+        mock_payment_intent.id = "pi_pool_contribution"
+        mock_payment_intent.metadata = {
+            "user_id": str(self.user.id),
+            "purpose": PaymentPurpose.RSC_PURCHASE,
+            "locked_rsc_amount": str(locked_rsc_amount),
+            "funding_pool_id": str(pool.id),
+        }
+        mock_stripe_retrieve.return_value = mock_payment_intent
+
+        # Act
+        payment, contribution = self.service.process_payment_intent_confirmation(
+            "pi_pool_contribution"
+        )
+
+        # Assert
+        self.assertIsInstance(payment, Payment)
+        self.assertIsNotNone(contribution)
+        self.assertEqual(contribution.purchase_type, Purchase.FUNDING_POOL_CONTRIBUTION)
+        pool.refresh_from_db()
+        self.assertEqual(pool.amount_holding, locked_rsc_amount)
+
     @patch("stripe.PaymentIntent.create")
     def test_create_payment_intent_with_fundraise_id(
         self, mock_stripe_payment_intent_create
@@ -766,6 +815,32 @@ class PaymentServiceTest(TestCase):
         self.assertEqual(call_kwargs["metadata"]["fundraise_id"], "42")
 
     @patch("stripe.PaymentIntent.create")
+    def test_create_payment_intent_with_funding_pool_id(
+        self, mock_stripe_payment_intent_create
+    ):
+        """Test that create_payment_intent includes funding_pool_id in metadata."""
+        # Arrange
+        mock_payment_intent = MagicMock()
+        mock_payment_intent.client_secret = "pi_secret_pool"
+        mock_payment_intent.id = "pi_pool_123"
+        mock_stripe_payment_intent_create.return_value = mock_payment_intent
+
+        # Mock exchange rate (100 RSC = $5.00)
+        with patch.object(RscExchangeRate, "rsc_to_usd", return_value=5.0):
+            # Act
+            result = self.service.create_payment_intent(
+                user_id=self.user.id,
+                rsc_amount=Decimal(100),
+                funding_pool_id=77,
+            )
+
+        # Assert
+        self.assertEqual(result["client_secret"], "pi_secret_pool")
+        call_kwargs = mock_stripe_payment_intent_create.call_args[1]
+        self.assertEqual(call_kwargs["metadata"]["funding_pool_id"], "77")
+        self.assertNotIn("fundraise_id", call_kwargs["metadata"])
+
+    @patch("stripe.PaymentIntent.create")
     def test_create_payment_intent_without_fundraise_id(
         self, mock_stripe_payment_intent_create
     ):
@@ -788,6 +863,7 @@ class PaymentServiceTest(TestCase):
         # Assert
         call_kwargs = mock_stripe_payment_intent_create.call_args[1]
         self.assertNotIn("fundraise_id", call_kwargs["metadata"])
+        self.assertNotIn("funding_pool_id", call_kwargs["metadata"])
 
     @patch("stripe.PaymentIntent.retrieve")
     def test_user_receives_full_rsc_amount_plus_bounty_fee_after_paying_fees(

--- a/src/purchase/views/__init__.py
+++ b/src/purchase/views/__init__.py
@@ -11,6 +11,7 @@ from .endaoment_auth_views import (
 )
 from .endaoment_viewset import EndaomentViewSet
 from .funder_view import FunderViewSet
+from .funding_pool_view import FundingPoolViewSet
 from .fundraise_view import FundraiseViewSet
 from .grant_view import GrantViewSet
 from .payment_intent_view import PaymentIntentView
@@ -29,6 +30,7 @@ __all__ = [
     "EndaomentStatusView",
     "EndaomentViewSet",
     "FunderViewSet",
+    "FundingPoolViewSet",
     "FundraiseViewSet",
     "GrantViewSet",
     "PaymentIntentView",

--- a/src/purchase/views/funding_pool_view.py
+++ b/src/purchase/views/funding_pool_view.py
@@ -1,0 +1,92 @@
+from django.contrib.contenttypes.models import ContentType
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from analytics.amplitude import track_event
+from purchase.models import FundingPool
+from purchase.serializers.funding_pool_serializer import (
+    DynamicFundingPoolSerializer,
+    FundingPoolContributionSerializer,
+)
+from purchase.services.funding_pool_service import FundingPoolService
+from user.related_models.follow_model import Follow
+
+
+class FundingPoolViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = FundingPool.objects.all()
+    serializer_class = DynamicFundingPoolSerializer
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["get", "head", "options", "post"]
+
+    def dispatch(self, request, *args, **kwargs):
+        self.funding_pool_service = kwargs.pop(
+            "funding_pool_service", FundingPoolService()
+        )
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["pch_dfps_get_created_by"] = {
+            "_include_fields": (
+                "id",
+                "author_profile",
+                "first_name",
+                "last_name",
+            )
+        }
+        context["usr_dus_get_author_profile"] = {
+            "_include_fields": (
+                "id",
+                "first_name",
+                "last_name",
+                "created_date",
+                "updated_date",
+                "profile_image",
+                "is_verified",
+            )
+        }
+        return context
+
+    @track_event
+    @action(
+        methods=["POST"],
+        detail=True,
+        permission_classes=[IsAuthenticated],
+    )
+    def create_contribution(self, request, *args, **kwargs):
+        input_serializer = FundingPoolContributionSerializer(data=request.data)
+        input_serializer.is_valid(raise_exception=True)
+        validated = input_serializer.validated_data
+
+        try:
+            pool = FundingPool.objects.get(id=kwargs.get("pk"))
+        except FundingPool.DoesNotExist:
+            return Response({"message": "Funding pool does not exist"}, status=400)
+
+        _, error = self.funding_pool_service.create_contribution(
+            user=request.user,
+            pool=pool,
+            amount=validated["amount"],
+            currency=validated["amount_currency"],
+            use_credits=validated["use_credits"],
+        )
+
+        if error:
+            return Response({"message": error}, status=400)
+
+        # Let the contributor follow the grant document when present
+        grant = pool.grant
+        document = grant.unified_document.get_document()
+        if document is not None:
+            Follow.objects.get_or_create(
+                user=request.user,
+                object_id=document.id,
+                content_type=ContentType.objects.get_for_model(document),
+            )
+
+        pool.refresh_from_db()
+        context = self.get_serializer_context()
+        serializer = self.get_serializer(pool, context=context)
+        return Response(serializer.data)

--- a/src/purchase/views/payment_intent_view.py
+++ b/src/purchase/views/payment_intent_view.py
@@ -5,9 +5,10 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from purchase.models import Fundraise
+from purchase.models import FundingPool, Fundraise
 from purchase.related_models.payment_model import Payment
 from purchase.serializers.payment_intent_serializer import PaymentIntentSerializer
+from purchase.services.funding_pool_service import FundingPoolService
 from purchase.services.fundraise_service import FundraiseService
 from purchase.services.payment_service import PaymentService
 
@@ -26,11 +27,13 @@ class PaymentIntentView(APIView):
         self,
         payment_service: PaymentService = None,
         fundraise_service: FundraiseService = None,
+        funding_pool_service: FundingPoolService = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.payment_service = payment_service or PaymentService()
         self.fundraise_service = fundraise_service or FundraiseService()
+        self.funding_pool_service = funding_pool_service or FundingPoolService()
 
     def post(self, request, *args, **kwargs):
         user_id = request.user.id
@@ -40,6 +43,7 @@ class PaymentIntentView(APIView):
         data = serializer.validated_data
         rsc_amount = data.get("amount")
         fundraise_id = data.get("fundraise_id")
+        funding_pool_id = data.get("funding_pool_id")
 
         # Validate fundraise if provided
         if fundraise_id is not None:
@@ -62,11 +66,30 @@ class PaymentIntentView(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
+        if funding_pool_id is not None:
+            try:
+                pool = FundingPool.objects.get(id=funding_pool_id)
+            except FundingPool.DoesNotExist:
+                return Response(
+                    {"message": "Funding pool does not exist"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            is_valid, error = self.funding_pool_service.validate_pool_for_contribution(
+                pool
+            )
+            if not is_valid:
+                return Response(
+                    {"message": error},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
         try:
             payment_intent_data = self.payment_service.create_payment_intent(
                 user_id=user_id,
                 rsc_amount=rsc_amount,
                 fundraise_id=fundraise_id,
+                funding_pool_id=funding_pool_id,
             )
 
             return Response(payment_intent_data, status=status.HTTP_200_OK)

--- a/src/researchhub/urls.py
+++ b/src/researchhub/urls.py
@@ -172,6 +172,10 @@ router.register(r"fundraise", purchase.views.FundraiseViewSet, basename="fundrai
 
 router.register(r"funder", purchase.views.FunderViewSet, basename="funder")
 
+router.register(
+    r"funding_pool", purchase.views.FundingPoolViewSet, basename="funding_pool"
+)
+
 router.register(r"grant", purchase.views.GrantViewSet, basename="grant")
 
 router.register(r"activity_feed", ActivityFeedViewSet, basename="activity_feed")

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -24,6 +24,7 @@ from purchase.serializers.fundraise_create_serializer import FundraiseCreateSeri
 from purchase.serializers.fundraise_serializer import DynamicFundraiseSerializer
 from purchase.serializers.grant_create_serializer import GrantCreateSerializer
 from purchase.serializers.grant_serializer import DynamicGrantSerializer
+from purchase.services.funding_pool_service import FundingPoolService
 from purchase.services.fundraise_service import FundraiseService
 from purchase.services.grant_service import GrantModerationService
 from researchhub.settings import TESTING
@@ -490,6 +491,8 @@ class ResearchhubPostViewSet(
                         grant.contacts.set(contacts)
                     else:
                         grant.contacts.clear()
+
+                    FundingPoolService().create_pool_for_grant(grant)
 
                     # Trusted users skip the grant moderation queue.
                     if risk_score_service.is_trusted(created_by):


### PR DESCRIPTION
## Summary
- Add `FundingPoolService.create_contribution` and `FundingPoolViewSet` with `GET /api/funding_pool/{id}/` and `POST .../create_contribution/`
- Auto-create a `FundingPool` when a Grant is created
- Support optional `funding_pool_id` on payment intents (mutually exclusive with `fundraise_id`); on Stripe success, contribute to the pool via funding credits
