### PR TITLE
FundingPool - refund

### DIFF
--- a/src/purchase/services/fundraise_service.py
+++ b/src/purchase/services/fundraise_service.py
@@ -12,6 +12,8 @@ from purchase.endaoment import EndaomentService
 from purchase.models import (
     Balance,
     EndaomentAccount,
+    FundingDistribution,
+    FundingPool,
     Fundraise,
     Purchase,
     RscExchangeRate,
@@ -575,6 +577,75 @@ class FundraiseService:
         record = distributor.distribute()
         return record.distributed_status != "FAILED"
 
+    def _reverse_pool_sourced_contribution(
+        self,
+        fundraise: Fundraise,
+        distribution: FundingDistribution,
+    ) -> bool:
+        """
+        Return a pool-sourced escrow slice to the FundingPool.
+        """
+        try:
+            amount = Decimal(str(distribution.amount))
+        except (ArithmeticError, TypeError, ValueError):
+            logger.error(
+                "Invalid funding distribution amount for distribution %s",
+                distribution.id,
+            )
+            return False
+
+        if not amount.is_finite() or amount <= 0:
+            logger.error(
+                "Refusing to reverse non-positive funding distribution %s",
+                distribution.id,
+            )
+            return False
+
+        if not fundraise.escrow_id:
+            logger.error(
+                "Fundraise %s has no escrow for pool reverse of distribution %s",
+                fundraise.id,
+                distribution.id,
+            )
+            return False
+
+        escrow = Escrow.objects.select_for_update().get(id=fundraise.escrow_id)
+        pool = FundingPool.objects.select_for_update().get(id=distribution.pool_id)
+
+        if amount > escrow.amount_holding:
+            logger.error(
+                "Insufficient escrow holding to reverse distribution %s "
+                "(amount=%s, holding=%s)",
+                distribution.id,
+                amount,
+                escrow.amount_holding,
+            )
+            return False
+
+        if amount > pool.amount_distributed:
+            logger.error(
+                "Insufficient pool distributed to reverse distribution %s "
+                "(amount=%s, distributed=%s)",
+                distribution.id,
+                amount,
+                pool.amount_distributed,
+            )
+            return False
+
+        escrow.amount_holding -= amount
+        escrow.save(update_fields=["amount_holding", "updated_date"])
+
+        pool.amount_holding += amount
+        pool.amount_distributed -= amount
+        pool.save(
+            update_fields=["amount_holding", "amount_distributed", "updated_date"]
+        )
+
+        distribution.status = FundingDistribution.REVERSED
+        distribution.save(update_fields=["status", "updated_date"])
+
+        return True
+
     def refund_rsc_contributions(self, fundraise: Fundraise) -> bool:
         """
         Refund all RSC contributions from escrow back to contributors.
@@ -586,6 +657,21 @@ class FundraiseService:
         bounty_fee_ct = ContentType.objects.get_for_model(BountyFee)
 
         for contribution in fundraise.purchases.all():
+            pool_distribution = (
+                FundingDistribution.objects.filter(
+                    fundraise_purchase=contribution,
+                    status=FundingDistribution.APPLIED,
+                )
+                .select_related("pool")
+                .first()
+            )
+            if pool_distribution is not None:
+                if not self._reverse_pool_sourced_contribution(
+                    fundraise, pool_distribution
+                ):
+                    return False
+                continue
+
             for debit in Balance.objects.filter(purchase=contribution):
                 if not self._refund_contribution_debit(
                     fundraise, contribution.user, debit, purchase_ct, bounty_fee_ct
@@ -610,6 +696,7 @@ class FundraiseService:
         """
         Complete a fundraise and payout funds to the recipient.
         Only works if the fundraise is in OPEN status and has escrow funds.
+        Marks any APPLIED FundingDistribution rows as SETTLED after payout.
 
         Args:
             fundraise: The fundraise to complete
@@ -632,6 +719,14 @@ class FundraiseService:
 
             if not fundraise.payout_funds():
                 raise RuntimeError("Failed to payout funds")
+
+            FundingDistribution.objects.filter(
+                target_fundraise=fundraise,
+                status=FundingDistribution.APPLIED,
+            ).update(
+                status=FundingDistribution.SETTLED,
+                updated_date=timezone.now(),
+            )
 
             fundraise.status = Fundraise.COMPLETED
             fundraise.save()

--- a/src/purchase/tests/test_funding_pool_service.py
+++ b/src/purchase/tests/test_funding_pool_service.py
@@ -48,6 +48,7 @@ class FundingPoolServiceTests(TestCase):
             target_currency="USD",
         )
         create_user(email="bank@researchhub.com")
+        create_user(email="revenue@researchhub.com")
 
     def _give_available_balance(self, user, amount):
         distribution_ct = ContentType.objects.get(model="distribution")
@@ -321,3 +322,81 @@ class FundingPoolServiceTests(TestCase):
         # Assert
         self.assertIsNone(distribution)
         self.assertEqual(error, "Funding pool is not open")
+
+    def test_close_fundraise_restores_pool_and_refunds_user_slices(self):
+        # Arrange: pool top-up + direct user contribution on the same proposal
+        self._seed_pool_holding(Decimal(200))
+        _, application, fundraise = self._create_proposal_application_with_fundraise()
+        distribution, error = self.service.distribute(
+            self.pool, self.creator, Decimal(75), application.id
+        )
+        self.assertIsNone(error)
+
+        user_contributor = create_random_authenticated_user("mixed_close_user")
+        self._give_available_balance(user_contributor, 1000)
+        _, user_error = FundraiseService().create_rsc_contribution(
+            user_contributor, fundraise, Decimal(40), use_credits=False
+        )
+        self.assertIsNone(user_error)
+        creator_balance_before_close = self.creator.get_available_balance()
+
+        # Act
+        closed = FundraiseService().close_fundraise(fundraise)
+
+        # Assert
+        self.assertTrue(closed)
+        fundraise.refresh_from_db()
+        fundraise.escrow.refresh_from_db()
+        self.assertEqual(fundraise.status, Fundraise.CLOSED)
+        self.assertEqual(fundraise.escrow.amount_holding, Decimal(0))
+
+        distribution.refresh_from_db()
+        self.assertEqual(distribution.status, FundingDistribution.REVERSED)
+
+        self.pool.refresh_from_db()
+        self.assertEqual(self.pool.amount_holding, Decimal(200))
+        self.assertEqual(self.pool.amount_distributed, Decimal(0))
+
+        self.assertTrue(
+            Balance.objects.filter(user=user_contributor, amount=40).exists()
+        )
+        self.assertEqual(
+            self.creator.get_available_balance(), creator_balance_before_close
+        )
+        self.assertEqual(
+            Balance.objects.filter(purchase=distribution.fundraise_purchase).count(),
+            0,
+        )
+
+    def test_complete_fundraise_settles_distribution_and_pays_author(self):
+        # Arrange
+        self._seed_pool_holding(Decimal(150))
+        applicant, application, fundraise = (
+            self._create_proposal_application_with_fundraise()
+        )
+        distribution, error = self.service.distribute(
+            self.pool, self.creator, Decimal(90), application.id
+        )
+        self.assertIsNone(error)
+        author_balance_before = applicant.get_available_balance()
+
+        # Act
+        FundraiseService().complete_fundraise(fundraise)
+
+        # Assert
+        fundraise.refresh_from_db()
+        self.assertEqual(fundraise.status, Fundraise.COMPLETED)
+        fundraise.escrow.refresh_from_db()
+        self.assertEqual(fundraise.escrow.amount_holding, Decimal(0))
+
+        distribution.refresh_from_db()
+        self.assertEqual(distribution.status, FundingDistribution.SETTLED)
+
+        self.pool.refresh_from_db()
+        self.assertEqual(self.pool.amount_holding, Decimal(60))
+        self.assertEqual(self.pool.amount_distributed, Decimal(90))
+
+        self.assertEqual(
+            applicant.get_available_balance(),
+            author_balance_before + Decimal(90),
+        )


### PR DESCRIPTION
## Summary
- On `close_fundraise`, pool-sourced escrow slices return to the FundingPool counters (`holding +=`, `distributed -=`, status `REVERSED`)
- On `complete_fundraise`, related `APPLIED` distributions are marked `SETTLED` after payout to the proposal author.
