### PR TITLE
Expose funding_pool on DynamicGrantSerializer

### DIFF
--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -435,6 +435,7 @@ class PostSerializer(ContentObjectSerializer):
                     "created_by",
                     "contacts",
                     "applications",
+                    "funding_pool",
                 ],
             )
             return serializer.data
@@ -1373,6 +1374,7 @@ MODERATOR_GRANT_FEED_ITEM_FIELDS = (
     "created_by",
     "contacts",
     "post_id",
+    "funding_pool",
 )
 MODERATOR_GRANT_FEED_USER_FIELDS = (
     "id",

--- a/src/note/serializers/note_serializer.py
+++ b/src/note/serializers/note_serializer.py
@@ -356,6 +356,7 @@ class NoteSerializer(ModelSerializer):
                     "contacts",
                     "applications",
                     "application_visibility",
+                    "funding_pool",
                 ]
             },
             "pch_dgs_get_created_by": {
@@ -510,6 +511,7 @@ class DynamicNoteSerializer(DynamicModelFieldSerializer):
                     "contacts",
                     "applications",
                     "application_visibility",
+                    "funding_pool",
                 ]
             },
             "pch_dgs_get_created_by": {

--- a/src/purchase/serializers/grant_serializer.py
+++ b/src/purchase/serializers/grant_serializer.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 from ai_peer_review.serializers import ProposalKeyInsightSerializer
 from purchase.models import Grant
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
+from purchase.serializers.funding_pool_serializer import DynamicFundingPoolSerializer
 from researchhub.serializers import DynamicModelFieldSerializer
 from user.serializers import DynamicAuthorSerializer, DynamicUserSerializer
 
@@ -30,6 +31,7 @@ class DynamicGrantSerializer(DynamicModelFieldSerializer):
     is_active = serializers.SerializerMethodField()
     applications = serializers.SerializerMethodField()
     image_url = serializers.SerializerMethodField()
+    funding_pool = serializers.SerializerMethodField()
 
     class Meta:
         model = Grant
@@ -48,6 +50,31 @@ class DynamicGrantSerializer(DynamicModelFieldSerializer):
         _context_fields = context.get("pch_dgs_get_contacts", {})
         serializer = DynamicUserSerializer(
             grant.contacts.all(), context=context, many=True, **_context_fields
+        )
+        return serializer.data
+
+    def get_funding_pool(self, grant):
+        """Expose pool holding/distributed/raised on the grant payload."""
+        try:
+            pool = grant.funding_pool
+        except ObjectDoesNotExist:
+            return None
+
+        context = self.context
+        _context_fields = context.get(
+            "pch_dgs_get_funding_pool",
+            {
+                "_include_fields": (
+                    "id",
+                    "amount_holding",
+                    "amount_distributed",
+                    "amount_raised",
+                    "status",
+                )
+            },
+        )
+        serializer = DynamicFundingPoolSerializer(
+            pool, context=context, **_context_fields
         )
         return serializer.data
 

--- a/src/purchase/tests/test_grant_serializer_funding_pool.py
+++ b/src/purchase/tests/test_grant_serializer_funding_pool.py
@@ -1,0 +1,68 @@
+from purchase.related_models.constants.currency import USD
+from purchase.related_models.funding_pool_model import FundingPool
+from purchase.related_models.grant_model import Grant
+from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
+from purchase.serializers import DynamicGrantSerializer
+from researchhub_document.helpers import create_post
+from researchhub_document.related_models.constants.document_type import GRANT
+from user.tests.helpers import create_random_authenticated_user
+from utils.test_helpers import AWSMockTestCase
+
+
+class GrantSerializerFundingPoolTests(AWSMockTestCase):
+    """DynamicGrantSerializer exposes funding_pool holding/distributed/raised."""
+
+    def setUp(self):
+        super().setUp()
+        RscExchangeRate.objects.create(
+            rate=0.5,
+            real_rate=0.5,
+            target_currency="USD",
+        )
+        self.user = create_random_authenticated_user("grant_pool_ser")
+        grant_post = create_post(created_by=self.user, document_type=GRANT)
+        self.grant = Grant.objects.create(
+            created_by=self.user,
+            unified_document=grant_post.unified_document,
+            amount=1000,
+            currency=USD,
+            organization="Org",
+            description="desc",
+        )
+
+    def test_funding_pool_none_when_missing(self):
+        # Arrange / Act
+        data = DynamicGrantSerializer(
+            self.grant, _include_fields=["id", "funding_pool"]
+        ).data
+
+        # Assert
+        self.assertIsNone(data["funding_pool"])
+
+    def test_funding_pool_amounts_and_status(self):
+        # Arrange
+        pool = FundingPool.objects.create(
+            grant=self.grant,
+            created_by=self.user,
+            amount_holding=100,
+            amount_distributed=50,
+            status=FundingPool.OPEN,
+        )
+
+        # Act
+        data = DynamicGrantSerializer(
+            self.grant, _include_fields=["id", "funding_pool"]
+        ).data
+
+        # Assert
+        funding_pool = data["funding_pool"]
+        self.assertEqual(funding_pool["id"], pool.id)
+        self.assertEqual(funding_pool["status"], FundingPool.OPEN)
+        self.assertEqual(float(funding_pool["amount_holding"]["rsc"]), 100.0)
+        self.assertEqual(float(funding_pool["amount_distributed"]["rsc"]), 50.0)
+        self.assertEqual(float(funding_pool["amount_raised"]["rsc"]), 150.0)
+        self.assertIn("usd", funding_pool["amount_holding"])
+        self.assertIn("usd", funding_pool["amount_distributed"])
+        self.assertIn("usd", funding_pool["amount_raised"])
+        self.assertNotIn("created_by", funding_pool)
+        self.assertNotIn("grant", funding_pool)

--- a/src/reputation/views/bounty_view.py
+++ b/src/reputation/views/bounty_view.py
@@ -108,6 +108,7 @@ BOUNTY_DOCUMENT_GRANT_FIELDS = (
     "is_active",
     "created_by",
     "contacts",
+    "funding_pool",
 )
 
 BOUNTY_DOCUMENT_USER_FIELDS = (

--- a/src/researchhub_document/views/researchhub_post_views.py
+++ b/src/researchhub_document/views/researchhub_post_views.py
@@ -579,6 +579,7 @@ class ResearchhubPostViewSet(
                         "created_by",
                         "contacts",
                         "application_visibility",
+                        "funding_pool",
                     ],
                 ).data
                 if grant
@@ -757,6 +758,7 @@ class ResearchhubPostViewSet(
                         "created_by",
                         "contacts",
                         "application_visibility",
+                        "funding_pool",
                     ],
                 ).data
                 if grant

--- a/src/researchhub_document/views/researchhub_unified_document_views.py
+++ b/src/researchhub_document/views/researchhub_unified_document_views.py
@@ -151,6 +151,7 @@ class ResearchhubUnifiedDocumentViewSet(GenericViewSet):
                     "contacts",
                     "applications",
                     "application_visibility",
+                    "funding_pool",
                 ]
             },
             "pch_dfs_get_contributors": {
@@ -356,6 +357,7 @@ class ResearchhubUnifiedDocumentViewSet(GenericViewSet):
                     "contacts",
                     "applications",
                     "application_visibility",
+                    "funding_pool",
                 ]
             },
             "pch_dfs_get_contributors": {


### PR DESCRIPTION
## Summary
- Expose `funding_pool` (holding / distributed / raised + status) on `DynamicGrantSerializer` and grant API surfaces.
