### PR TITLE
Prevent effort changes in notebook conversations

### DIFF
--- a/src/research_ai/services/agent/providers/registry.py
+++ b/src/research_ai/services/agent/providers/registry.py
@@ -13,6 +13,7 @@ configuration without constructing clients or requiring credentials.
 
 from django.conf import settings
 
+from research_ai.services.agent.model_capabilities import model_capabilities
 from research_ai.services.agent.providers import bedrock, claude_platform, openrouter
 from research_ai.services.agent.providers.base import LLMProvider
 from research_ai.services.agent.providers.bedrock import BedrockProvider
@@ -49,6 +50,16 @@ def generator_model_ref() -> str:
         OPENROUTER: openrouter.MODEL_ID,
     }
     return f"{name}:{model_ids[name]}"
+
+
+def default_effort(model_ref: str) -> str | None:
+    """Resolve the adapter's supported effort default without building a client."""
+    provider_name, model_id = split_model_ref(model_ref)
+    if provider_name == BEDROCK:
+        return None
+    adapter = openrouter if provider_name == OPENROUTER else claude_platform
+    capabilities = model_capabilities(provider_name, model_id or adapter.MODEL_ID)
+    return adapter.EFFORT if adapter.EFFORT in capabilities.effort else None
 
 
 def resolve_provider(

--- a/src/research_ai/services/notebook_chat/service.py
+++ b/src/research_ai/services/notebook_chat/service.py
@@ -64,6 +64,7 @@ from research_ai.services.agent import (
     validate_model_ref,
 )
 from research_ai.services.agent.model_capabilities import validate_generation_options
+from research_ai.services.agent.providers.registry import default_effort
 from research_ai.services.agent_persistence import (
     AgentChatService,
     AgentContextService,
@@ -489,8 +490,8 @@ class NotebookChatService:
         note-less assistant conversation, whose turn runs with ``create_note``
         against the notes attached to it. A chat still untitled takes its
         name from this message. ``model_ref`` selects the model for the first
-        turn. Later turns reuse that model; requesting a different provider or
-        model raises ``ValueError``.
+        turn. Later turns reuse that model and effort; requesting a different
+        provider, model, or effort raises ``ValueError``.
         Raises ``ValueError`` on an empty or oversized message or a model not
         in the selectable catalog, and lets ``AgentConversationBusyError``
         propagate when a turn is already running on this conversation (the
@@ -546,9 +547,28 @@ class NotebookChatService:
             model = (
                 conversation_model or selected_model or resolve_default_model(policy)
             )
+            previous_configuration = (
+                locked_conversation.executions.order_by("-attempt")
+                .values_list("configuration", flat=True)
+                .first()
+            )
+            if previous_configuration is not None:
+                # Preserve the latest setting for chats that predate effort
+                # locking. Older rows can omit the adapter's default.
+                conversation_effort = previous_configuration.get("effort")
+                if conversation_effort is None:
+                    conversation_effort = default_effort(model)
+                if effort is not None and effort != conversation_effort:
+                    raise ValueError(
+                        "effort cannot be changed after a conversation has started; "
+                        "start a new conversation to use a different effort"
+                    )
+                effort = conversation_effort
             effort, thinking = effective_generation_options(
                 policy, effort=effort, thinking=thinking
             )
+            if effort is None:
+                effort = default_effort(model)
             with atomic_turn_admission(
                 locked_conversation.user,
                 model,

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_service.py
@@ -17,6 +17,7 @@ from research_ai.models import (
     ProposalDraft,
     SearchExpert,
 )
+from research_ai.services.agent.providers import claude_platform, openrouter
 from research_ai.services.agent.types import StopReason, TurnUsage
 from research_ai.services.agent_persistence import (
     AgentConversationBusyError,
@@ -172,6 +173,101 @@ class NotebookChatServiceTests(TestCase):
         self.assertEqual(execution.configuration["effort"], "high")
         self.assertEqual(execution.configuration["thinking"], "disabled")
 
+    def test_later_messages_inherit_or_repeat_the_effort(self):
+        # Arrange
+        first, _delay = self._submit(effort="high")
+        first.status = AgentExecution.Status.SUCCEEDED
+        first.save(update_fields=["status"])
+
+        for options in ({}, {"effort": "high"}):
+            with self.subTest(options=options):
+                # Act
+                execution, _delay = self._submit("Continue", **options)
+
+                # Assert
+                self.assertEqual(execution.configuration["effort"], "high")
+                execution.status = AgentExecution.Status.SUCCEEDED
+                execution.save(update_fields=["status"])
+
+    def test_later_messages_cannot_change_effort(self):
+        # Arrange
+        first, _delay = self._submit(effort="low")
+        first.status = AgentExecution.Status.SUCCEEDED
+        first.save(update_fields=["status"])
+
+        # Act / Assert
+        with self.assertRaisesRegex(ValueError, "effort cannot be changed"):
+            self._submit("Think harder", effort="high")
+        self.assertEqual(self.conversation.executions.count(), 1)
+        self.assertEqual(self.conversation.chat_messages.count(), 1)
+
+    def test_new_conversation_can_choose_a_different_effort(self):
+        # Arrange
+        first, _delay = self._submit(effort="low")
+        first.status = AgentExecution.Status.SUCCEEDED
+        first.save(update_fields=["status"])
+        conversation = self.service.create_conversation(self.note, self.user)
+
+        # Act
+        second, _delay = self._submit(conversation=conversation, effort="high")
+
+        # Assert
+        self.assertEqual(second.configuration["effort"], "high")
+        self.assertNotEqual(second.conversation_id, first.conversation_id)
+
+    def test_default_effort_is_pinned_across_adapter_default_changes(self):
+        for adapter, model_ref in (
+            (claude_platform, "claude_platform:claude-opus-5"),
+            (openrouter, "openrouter:openai/gpt-5.6-sol"),
+        ):
+            with self.subTest(model=model_ref):
+                # Arrange
+                conversation = self.service.create_conversation(self.note, self.user)
+                first, _delay = self._submit(
+                    conversation=conversation, model_ref=model_ref
+                )
+                first.status = AgentExecution.Status.SUCCEEDED
+                first.save(update_fields=["status"])
+
+                # Act
+                with patch.object(adapter, "EFFORT", "high"):
+                    second, _delay = self._submit(conversation=conversation)
+
+                # Assert
+                self.assertEqual(first.configuration["effort"], "low")
+                self.assertEqual(second.configuration["effort"], "low")
+                second.status = AgentExecution.Status.SUCCEEDED
+                second.save(update_fields=["status"])
+
+    def test_legacy_conversation_without_effort_uses_adapter_default(self):
+        # Arrange
+        first, _delay = self._submit()
+        first.configuration.pop("effort")
+        first.status = AgentExecution.Status.SUCCEEDED
+        first.save(update_fields=["configuration", "status"])
+
+        # Act / Assert
+        with self.assertRaisesRegex(ValueError, "effort cannot be changed"):
+            self._submit(effort="high")
+        second, _delay = self._submit()
+        self.assertEqual(second.configuration["effort"], "low")
+
+    def test_legacy_conversation_keeps_its_latest_effort(self):
+        # Arrange: before locking, an existing chat could change effort.
+        first, _delay = self._submit(effort="low")
+        first.status = AgentExecution.Status.SUCCEEDED
+        first.save(update_fields=["status"])
+        second, _delay = self._submit()
+        second.configuration["effort"] = "high"
+        second.status = AgentExecution.Status.SUCCEEDED
+        second.save(update_fields=["configuration", "status"])
+
+        # Act
+        third, _delay = self._submit()
+
+        # Assert
+        self.assertEqual(third.configuration["effort"], "high")
+
     def test_submit_message_accepts_temperature_for_gemini(self):
         # Act
         execution, _delay = self._submit(
@@ -215,6 +311,7 @@ class NotebookChatServiceTests(TestCase):
         resolve.assert_called_once_with(
             "claude_platform:claude-sonnet-5",
             native_tools=frozenset({"web_search"}),
+            effort="low",
         )
 
     def test_second_message_continues_the_same_conversation(self):
@@ -516,7 +613,9 @@ class NotebookChatServiceTests(TestCase):
 
         # Assert
         resolver.assert_called_once_with(
-            "claude_platform:claude-sonnet-5", native_tools=frozenset({"web_search"})
+            "claude_platform:claude-sonnet-5",
+            native_tools=frozenset({"web_search"}),
+            effort="low",
         )
         self.assertEqual(result["final_text"], "Done.")
 

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_views.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_views.py
@@ -211,6 +211,25 @@ class NotebookChatViewTests(APITestCase):
         self.assertIn("model", response.data)
         self.assertFalse(AgentExecution.objects.exists())
 
+    def test_post_message_cannot_switch_the_conversation_effort(self):
+        # Arrange
+        self.client.force_authenticate(self.owner)
+        chat_id = self._create_chat_id()
+        first_response, _delay = self._post_message(chat_id, effort="low")
+        first = AgentExecution.objects.get(id=first_response.data["execution_id"])
+        first.status = AgentExecution.Status.SUCCEEDED
+        first.save(update_fields=["status"])
+
+        # Act
+        response, delay = self._post_message(chat_id, effort="high")
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("effort cannot be changed", response.data["detail"])
+        self.assertEqual(first.conversation.executions.count(), 1)
+        self.assertEqual(first.conversation.chat_messages.count(), 1)
+        delay.assert_not_called()
+
     @override_settings(
         ANTHROPIC_AWS_WORKSPACE_ID="ws-test", AWS_REGION_NAME="us-east-1"
     )


### PR DESCRIPTION
Changing effort between notebook chat turns invalidates the provider's prompt cache. Keep effort fixed per conversation: later turns inherit it when omitted, accept the same value, and return HTTP 400 before recording or queuing work if a different value is requested.

Snapshot the adapter's supported default on new turns so default changes do not alter existing chats. Preserve the latest recorded effort for older chats, falling back to the adapter default when it was not recorded. The shared assistant chat engine uses the same rule; a new conversation can choose a different effort.

Validation: all 118 notebook and assistant service/API tests pass against an isolated PostgreSQL database after rebasing onto main. Ruff lint, formatting, and diff whitespace checks pass.