### PR TITLE
Return effort alongside model in chat responses

### DIFF
--- a/src/research_ai/services/agent_persistence/chat_service.py
+++ b/src/research_ai/services/agent_persistence/chat_service.py
@@ -348,6 +348,11 @@ class AgentChatService:
                 # The model ref this turn was submitted with, so a client can
                 # label which model produced each answer.
                 "model": execution.model,
+                "effort": (
+                    execution.configuration.get("effort")
+                    if isinstance(execution.configuration, dict)
+                    else None
+                ),
                 "trigger_message_id": execution.trigger_message_id,
                 "retry_of_id": execution.retry_of_id,
                 "context_parent_id": execution.context_parent_id,

--- a/src/research_ai/tests/agent/test_persistence_chat.py
+++ b/src/research_ai/tests/agent/test_persistence_chat.py
@@ -260,7 +260,7 @@ class AgentChatPersistenceTests(AgentPersistenceTestCase):
         prepared = chat.prepare_turn(
             self.conversation,
             "Question",
-            configuration={"max_iterations": 12},
+            configuration={"max_iterations": 12, "effort": "high"},
         )
 
         # Act
@@ -273,6 +273,7 @@ class AgentChatPersistenceTests(AgentPersistenceTestCase):
         self.assertIsNotNone(entry["last_activity_at"])
         self.assertEqual(entry["iterations"], 1)
         self.assertEqual(entry["max_iterations"], 12)
+        self.assertEqual(entry["effort"], "high")
 
     def test_max_iterations_is_absent_when_the_attempt_recorded_none(self):
         # Arrange: max_iterations is read from the attempt's own configuration
@@ -287,6 +288,7 @@ class AgentChatPersistenceTests(AgentPersistenceTestCase):
 
         # Assert
         self.assertIsNone(entry["max_iterations"])
+        self.assertIsNone(entry["effort"])
 
     def test_a_running_turn_reports_a_heartbeat_and_no_finish(self):
         # Arrange: a turn in flight, no terminal hook called.

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_views.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_views.py
@@ -197,6 +197,8 @@ class NotebookChatViewTests(APITestCase):
         execution = AgentExecution.objects.get(id=response.data["execution_id"])
         self.assertEqual(execution.configuration["effort"], "high")
         self.assertEqual(execution.configuration["thinking"], "disabled")
+        chat = self.client.get(self._chat_url(chat_id))
+        self.assertEqual(chat.data["executions"][0]["effort"], "high")
 
     def test_post_message_with_unknown_model_is_rejected(self):
         # Arrange
@@ -493,6 +495,7 @@ class NotebookChatViewTests(APITestCase):
         )
         self.assertIsNotNone(response.data["messages"][0]["created_date"])
         self.assertEqual(len(response.data["executions"]), 1)
+        self.assertEqual(response.data["executions"][0]["effort"], "low")
         self.assertEqual(
             response.data["executions"][0]["status"],
             AgentExecution.Status.PENDING,


### PR DESCRIPTION
Notebook and assistant chat responses now include `executions[].effort` alongside `model`, allowing clients to restore the locked effort setting when reopening a conversation. The value comes from the execution's saved configuration; older executions without a recorded effort return `null`.

Validation: all 156 targeted chat persistence, notebook, and assistant service/API tests pass. Coverage checks explicit and default effort values and missing historical values. Ruff lint, formatting, and whitespace checks pass.