### PR TITLE
Implement reliable throttling behind Cloudflare

### DIFF
--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -352,7 +352,7 @@ REST_FRAMEWORK = {
         "rest_framework.renderers.JSONRenderer",
     ],
     "DEFAULT_THROTTLE_CLASSES": [
-        "rest_framework.throttling.AnonRateThrottle",
+        "utils.throttles.CloudflareAnonRateThrottle",
     ],
     "DEFAULT_THROTTLE_RATES": {
         "anon": "50/minute",

--- a/src/utils/tests/test_throttles.py
+++ b/src/utils/tests/test_throttles.py
@@ -1,0 +1,83 @@
+from django.contrib.auth.models import AnonymousUser
+from django.core.cache import cache
+from django.test import SimpleTestCase
+from rest_framework.test import APIRequestFactory
+
+from utils.throttles import CloudflareAnonRateThrottle
+
+
+class TwoPerMinuteCloudflareAnonRateThrottle(CloudflareAnonRateThrottle):
+    rate = "2/minute"
+
+
+class CloudflareAnonRateThrottleTests(SimpleTestCase):
+    def setUp(self):
+        cache.clear()
+        self.factory = APIRequestFactory()
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_prefers_cloudflare_connecting_ip(self):
+        # Arrange
+        request = self.factory.get(
+            "/",
+            HTTP_CF_CONNECTING_IP="203.0.113.10",
+            HTTP_X_FORWARDED_FOR="198.51.100.20",
+            REMOTE_ADDR="10.0.0.1",
+        )
+
+        # Act
+        ident = CloudflareAnonRateThrottle().get_ident(request)
+
+        # Assert
+        self.assertEqual(ident, "203.0.113.10")
+
+    def test_falls_back_to_remote_addr_without_cloudflare_header(self):
+        # Arrange
+        request = self.factory.get(
+            "/",
+            HTTP_X_FORWARDED_FOR="198.51.100.20",
+            REMOTE_ADDR="10.0.0.1",
+        )
+
+        # Act
+        ident = CloudflareAnonRateThrottle().get_ident(request)
+
+        # Assert
+        self.assertEqual(ident, "10.0.0.1")
+
+    def test_falls_back_to_remote_addr_for_invalid_cloudflare_header(self):
+        # Arrange
+        request = self.factory.get(
+            "/",
+            HTTP_CF_CONNECTING_IP="not-an-ip",
+            HTTP_X_FORWARDED_FOR="198.51.100.20",
+            REMOTE_ADDR="10.0.0.1",
+        )
+
+        # Act
+        with self.assertLogs("utils.throttles", level="WARNING"):
+            ident = CloudflareAnonRateThrottle().get_ident(request)
+
+        # Assert
+        self.assertEqual(ident, "10.0.0.1")
+
+    def test_bucket_cannot_be_bypassed_by_varying_xff(self):
+        # Arrange
+        results = []
+
+        # Act
+        for request_number in range(3):
+            request = self.factory.get(
+                "/",
+                HTTP_CF_CONNECTING_IP="203.0.113.10",
+                HTTP_X_FORWARDED_FOR=f"198.51.100.{request_number + 1}",
+            )
+            request.user = AnonymousUser()
+            results.append(
+                TwoPerMinuteCloudflareAnonRateThrottle().allow_request(request, None)
+            )
+
+        # Assert
+        self.assertEqual(results, [True, True, False])

--- a/src/utils/throttles.py
+++ b/src/utils/throttles.py
@@ -1,4 +1,33 @@
-from rest_framework.throttling import UserRateThrottle
+import logging
+from ipaddress import ip_address
+from typing import override
+
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+
+logger = logging.getLogger(__name__)
+
+
+class CloudflareAnonRateThrottle(AnonRateThrottle):
+    """
+    Throttle class that uses the Cloudflare connecting IP address for identifying
+    anonymous users. This is safe since it cannot be spoofed by the client.
+    Falls back to the standard REMOTE_ADDR if the Cloudflare header is not present
+    or invalid.
+    """
+
+    @override
+    def get_ident(self, request):
+        value = request.META.get("HTTP_CF_CONNECTING_IP")
+
+        if value:
+            try:
+                return str(ip_address(value))
+            except ValueError:
+                logger.warning("Invalid IP address in HTTP_CF_CONNECTING_IP: %s", value)
+
+        # Fall back to the standard REMOTE_ADDR if the Cloudflare header is not present
+        # or invalid since X-Forwarded-For can be spoofed by the client.
+        return request.META.get("REMOTE_ADDR")
 
 
 class FeedRecommendationRefreshThrottle(UserRateThrottle):

--- a/src/utils/throttles.py
+++ b/src/utils/throttles.py
@@ -1,21 +1,20 @@
 import logging
 from ipaddress import ip_address
-from typing import override
 
 from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 
 logger = logging.getLogger(__name__)
 
 
-class CloudflareAnonRateThrottle(AnonRateThrottle):
+class CloudflareClientIPMixin:
     """
-    Throttle class that uses the Cloudflare connecting IP address for identifying
-    anonymous users. This is safe since it cannot be spoofed by the client.
+    Mixing class for throttle implementations that overrides the `get_ident` method to
+    use the Cloudflare connecting IP address (`HTTP_CF_CONNECTING_IP`).
+    This is safer than using `X-Forwarded-For` since it cannot be spoofed by the client.
     Falls back to the standard REMOTE_ADDR if the Cloudflare header is not present
     or invalid.
     """
 
-    @override
     def get_ident(self, request):
         value = request.META.get("HTTP_CF_CONNECTING_IP")
 
@@ -30,7 +29,14 @@ class CloudflareAnonRateThrottle(AnonRateThrottle):
         return request.META.get("REMOTE_ADDR")
 
 
-class FeedRecommendationRefreshThrottle(UserRateThrottle):
+class CloudflareAnonRateThrottle(CloudflareClientIPMixin, AnonRateThrottle):
+    """
+    Throttle class for anonymous users that uses the Cloudflare connecting IP address
+    for identification.
+    """
+
+
+class FeedRecommendationRefreshThrottle(CloudflareClientIPMixin, UserRateThrottle):
     scope = "force_refresh"
     rate = "5/min"
 


### PR DESCRIPTION
- Add throttle implementation that identifies clients using the `CF-CONNECTING-IP` header (falling back to `REMOTE_ADDR`).
- Configures the new throttle as DRF’s global anonymous throttle.
- Extract the throttle identification logic into a shared mixin, so it can be applied to other throttles as well.

Note: This change explicitly does not consider the `X-Forwarded-For` header since it can be spoofed by clients.