### PR TITLE
Open assistant access with budget-only usage limits

### DIFF
--- a/src/research_ai/consumers.py
+++ b/src/research_ai/consumers.py
@@ -14,7 +14,7 @@ Admission mirrors the REST contract in ``notebook_chat_views`` and must be
 kept in sync with ``NOTEBOOK_CHAT_PERMISSIONS`` there: authentication
 (4401 -- including a deactivated account, which ``TokenAuthMiddleware``
 still resolves from its lingering token but DRF's ``TokenAuthentication``
-refuses), the editor-or-moderator rollout gate (4403, the REST 403), and
+refuses), the Research AI tier gate (4403, the REST 403), and
 owner-scoped resolution of the note and conversation (4404, the REST 404).
 Resolution failures close with the same code whether the chat does not
 exist, belongs to someone else, or sits on an invisible note -- the group is
@@ -41,10 +41,8 @@ CLOSE_NOT_FOUND = 4404
 
 
 def _gate_rejection_code(user) -> int | None:
-    """The Research AI tier and editor-or-moderator rollout gates."""
+    """Reject accounts whose Research AI tier is blocked."""
     if resolve_ai_tier(user).name == "blocked":
-        return CLOSE_FORBIDDEN
-    if not (user.moderator or user.is_hub_editor()):
         return CLOSE_FORBIDDEN
     return None
 

--- a/src/research_ai/services/usage_budget/config.py
+++ b/src/research_ai/services/usage_budget/config.py
@@ -5,11 +5,8 @@ from dataclasses import dataclass, replace
 DEFAULT_OPEN_WEIGHT_MODEL = "openrouter:deepseek/deepseek-v4-flash-0731"
 BUDGETS_ENFORCED = True
 DEFAULT_DAILY_BUDGET_MICROUSD = 250_000
-DEFAULT_DAILY_TURN_CAP = 10
 INVITED_DAILY_BUDGET_MICROUSD = 10_000_000
-INVITED_DAILY_TURN_CAP = 200
 PRIVILEGED_DAILY_BUDGET_MICROUSD = 100_000_000
-PRIVILEGED_DAILY_TURN_CAP = 2000
 
 
 @dataclass(frozen=True)
@@ -32,7 +29,7 @@ def tier_policies() -> dict[str, TierPolicy]:
     default = TierPolicy(
         name="default",
         daily_budget_microusd=DEFAULT_DAILY_BUDGET_MICROUSD,
-        daily_turn_cap=DEFAULT_DAILY_TURN_CAP,
+        daily_turn_cap=None,
         allowed_model_refs=(DEFAULT_OPEN_WEIGHT_MODEL,),
         default_model_ref=DEFAULT_OPEN_WEIGHT_MODEL,
         max_effort="none",
@@ -41,14 +38,14 @@ def tier_policies() -> dict[str, TierPolicy]:
     invited = TierPolicy(
         name="invited",
         daily_budget_microusd=INVITED_DAILY_BUDGET_MICROUSD,
-        daily_turn_cap=INVITED_DAILY_TURN_CAP,
+        daily_turn_cap=None,
         allowed_model_refs=None,
         default_model_ref=None,
     )
     privileged = TierPolicy(
         name="privileged",
         daily_budget_microusd=PRIVILEGED_DAILY_BUDGET_MICROUSD,
-        daily_turn_cap=PRIVILEGED_DAILY_TURN_CAP,
+        daily_turn_cap=None,
         allowed_model_refs=None,
         default_model_ref=None,
     )

--- a/src/research_ai/tests/assistant_chat/test_assistant_chat_consumer.py
+++ b/src/research_ai/tests/assistant_chat/test_assistant_chat_consumer.py
@@ -30,8 +30,6 @@ class AssistantChatConsumerTests(TransactionTestCase):
             password="password",
             email="owner@researchhub_test.com",
         )
-        self.user.moderator = True
-        self.user.save(update_fields=["moderator"])
         self.other_user = user_model.objects.create_user(
             username="other@researchhub_test.com",
             password="password",
@@ -60,11 +58,26 @@ class AssistantChatConsumerTests(TransactionTestCase):
         self.assertFalse(connected)
         self.assertEqual(code, CLOSE_UNAUTHENTICATED)
 
-    async def test_user_outside_the_rollout_gate_is_rejected(self):
-        # Act: authenticated, but neither editor nor moderator.
-        _communicator, connected, code = await self._connect(
-            self.other_user, conversation_id=self.other_conversation.id
+    async def test_regular_user_can_connect_to_own_conversation(self):
+        # Arrange: the user has no editor or moderator role.
+        user = self.other_user
+
+        # Act
+        communicator, connected, _detail = await self._connect(
+            user, conversation_id=self.other_conversation.id
         )
+
+        # Assert
+        self.assertTrue(connected)
+        await communicator.disconnect()
+
+    async def test_suspended_user_is_rejected(self):
+        # Arrange
+        self.user.is_suspended = True
+        await self.user.asave(update_fields=["is_suspended"])
+
+        # Act
+        _communicator, connected, code = await self._connect(self.user)
 
         # Assert
         self.assertFalse(connected)
@@ -82,7 +95,7 @@ class AssistantChatConsumerTests(TransactionTestCase):
         self.assertFalse(connected)
         self.assertEqual(code, CLOSE_NOT_FOUND)
 
-    async def test_hub_editor_passes_the_rollout_gate(self):
+    async def test_hub_editor_can_connect(self):
         # Arrange
         user_model = get_user_model()
 

--- a/src/research_ai/tests/assistant_chat/test_assistant_chat_views.py
+++ b/src/research_ai/tests/assistant_chat/test_assistant_chat_views.py
@@ -36,15 +36,12 @@ class AssistantChatViewTests(APITestCase):
             password="password",
             email="other@researchhub_test.com",
         )
-        # Neither editor nor moderator: exercises the rollout gate.
+        # Neither editor nor moderator: verifies regular user access.
         self.regular_user = user_model.objects.create_user(
             username="regular@researchhub_test.com",
             password="password",
             email="regular@researchhub_test.com",
         )
-        for user in (self.owner, self.other):
-            user.moderator = True
-            user.save(update_fields=["moderator"])
 
     def _chat_url(self, conversation_id):
         return f"{CHATS_URL}{conversation_id}/"
@@ -79,7 +76,7 @@ class AssistantChatViewTests(APITestCase):
         self.assertEqual(response.data["executions"], [])
         self.assertEqual(response.data["notes"], [])
 
-    def test_gate_blocks_regular_users(self):
+    def test_regular_users_can_create_chats(self):
         # Arrange
         self.client.force_authenticate(self.regular_user)
 
@@ -87,7 +84,7 @@ class AssistantChatViewTests(APITestCase):
         response = self.client.post(CHATS_URL, {}, format="json")
 
         # Assert
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 201)
 
     def test_requires_authentication(self):
         # Act

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_consumer.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_consumer.py
@@ -44,10 +44,6 @@ class NotebookChatConsumerTests(TransactionTestCase):
             password="password",
             email="owner@researchhub_test.com",
         )
-        # The rollout gate admits editors or moderators; the flag is the
-        # cheapest way through it for tests.
-        self.user.moderator = True
-        self.user.save(update_fields=["moderator"])
         self.other_user = user_model.objects.create_user(
             username="other@researchhub_test.com",
             password="password",
@@ -111,9 +107,26 @@ class NotebookChatConsumerTests(TransactionTestCase):
         self.assertFalse(connected)
         self.assertEqual(code, CLOSE_UNAUTHENTICATED)
 
-    async def test_user_outside_the_rollout_gate_is_rejected(self):
-        # Act: authenticated, but neither editor nor moderator.
-        _communicator, connected, code = await self._connect(self.other_user)
+    async def test_regular_user_can_connect_to_own_conversation(self):
+        # Arrange: the user has no editor or moderator role.
+        user = self.other_user
+
+        # Act
+        communicator, connected, _detail = await self._connect(
+            user, conversation_id=self.other_conversation.id
+        )
+
+        # Assert
+        self.assertTrue(connected)
+        await communicator.disconnect()
+
+    async def test_suspended_user_is_rejected(self):
+        # Arrange
+        self.user.is_suspended = True
+        await self.user.asave(update_fields=["is_suspended"])
+
+        # Act
+        _communicator, connected, code = await self._connect(self.user)
 
         # Assert
         self.assertFalse(connected)
@@ -154,8 +167,8 @@ class NotebookChatConsumerTests(TransactionTestCase):
         self.assertFalse(connected)
         self.assertEqual(code, CLOSE_NOT_FOUND)
 
-    async def test_hub_editor_passes_the_rollout_gate(self):
-        # Arrange: not a moderator; the gate's other branch admits editors.
+    async def test_hub_editor_can_connect(self):
+        # Arrange
         user_model = get_user_model()
 
         # Act

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_views.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_views.py
@@ -161,6 +161,8 @@ class NotebookChatViewTests(APITestCase):
     )
     def test_post_message_records_a_selected_model(self):
         # Arrange
+        self.owner.moderator = True
+        self.owner.save(update_fields=["moderator"])
         self.client.force_authenticate(self.owner)
         chat_id = self._create_chat_id()
 
@@ -176,6 +178,8 @@ class NotebookChatViewTests(APITestCase):
 
     def test_post_message_records_effort_and_thinking(self):
         # Arrange
+        self.owner.moderator = True
+        self.owner.save(update_fields=["moderator"])
         self.client.force_authenticate(self.owner)
         chat_id = self._create_chat_id()
 
@@ -209,6 +213,8 @@ class NotebookChatViewTests(APITestCase):
 
     def test_post_message_cannot_switch_the_conversation_effort(self):
         # Arrange
+        self.owner.moderator = True
+        self.owner.save(update_fields=["moderator"])
         self.client.force_authenticate(self.owner)
         chat_id = self._create_chat_id()
         first_response, _delay = self._post_message(chat_id, effort="low")
@@ -231,6 +237,8 @@ class NotebookChatViewTests(APITestCase):
     )
     def test_post_message_cannot_switch_the_conversation_model(self):
         # Arrange
+        self.owner.moderator = True
+        self.owner.save(update_fields=["moderator"])
         self.client.force_authenticate(self.owner)
         chat_id = self._create_chat_id()
         first_response, _delay = self._post_message(
@@ -489,7 +497,7 @@ class NotebookChatViewTests(APITestCase):
         )
         self.assertIsNotNone(response.data["messages"][0]["created_date"])
         self.assertEqual(len(response.data["executions"]), 1)
-        self.assertEqual(response.data["executions"][0]["effort"], "low")
+        self.assertEqual(response.data["executions"][0]["effort"], "none")
         self.assertEqual(
             response.data["executions"][0]["status"],
             AgentExecution.Status.PENDING,

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_views.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_views.py
@@ -38,18 +38,12 @@ class NotebookChatViewTests(APITestCase):
             email="outsider@researchhub_test.com",
         )
         # A collaborator on the note who is neither a hub editor nor a
-        # moderator, to exercise the rollout gate.
+        # moderator, to verify access for regular users.
         self.regular_user = user_model.objects.create_user(
             username="regular@researchhub_test.com",
             password="password",
             email="regular@researchhub_test.com",
         )
-        # The feature is gated to hub editors and moderators for now; note
-        # access is still checked separately, so the outsider is a moderator
-        # too (they must clear the gate to exercise the 404 path).
-        for user in (self.owner, self.viewer, self.outsider):
-            user.moderator = True
-            user.save(update_fields=["moderator"])
         self.note, self.content = create_note(self.owner, organization=None)
         unified_doc_ct = ContentType.objects.get_for_model(ResearchhubUnifiedDocument)
         Permission.objects.create(
@@ -311,7 +305,7 @@ class NotebookChatViewTests(APITestCase):
         self.assertEqual(get_response.status_code, 404)
         self.assertEqual(post_response.status_code, 404)
 
-    def test_gate_blocks_regular_users_even_with_note_access(self):
+    def test_regular_users_can_create_and_list_chats_with_note_access(self):
         # Arrange: full note access, but neither hub editor nor moderator.
         self.client.force_authenticate(self.regular_user)
 
@@ -320,8 +314,8 @@ class NotebookChatViewTests(APITestCase):
         list_response = self.client.get(self.chats_url)
 
         # Assert
-        self.assertEqual(create_response.status_code, 403)
-        self.assertEqual(list_response.status_code, 403)
+        self.assertEqual(create_response.status_code, 201)
+        self.assertEqual(list_response.status_code, 200)
 
     def test_post_message_requires_authentication(self):
         # Act

--- a/src/research_ai/tests/test_usage_budget.py
+++ b/src/research_ai/tests/test_usage_budget.py
@@ -128,19 +128,50 @@ class UsageBudgetTests(TestCase):
             {"daily_limit": "250", "used": "1.65", "remaining": "248.35"},
         )
 
-    def test_admission_raises_when_daily_turn_cap_is_spent(self):
-        # Arrange
+    def test_admission_allows_many_cheap_calls_for_each_tier(self):
+        # Arrange: exceed even the former privileged-tier cap for little cost.
         LLMUsageEvent.objects.bulk_create(
             [
                 LLMUsageEvent(
                     user=self.user,
                     feature="notebook_chat",
                     provider="openrouter",
-                    model="deepseek/deepseek-v4-pro-0813",
+                    model="deepseek/deepseek-v4-flash-0731",
                     cost_microusd=1,
                 )
-                for _ in range(10)
+                for _ in range(2001)
             ]
+        )
+        for tier in ("default", "invited", "privileged"):
+            with self.subTest(tier=tier):
+                # Arrange
+                if tier == "invited":
+                    Expert.objects.create(
+                        email=self.user.email, registered_user=self.user
+                    )
+                elif tier == "privileged":
+                    self.user.moderator = True
+                    self.user.save(update_fields=["moderator"])
+
+                # Act
+                status = check_turn_admission(
+                    self.user, self.MODEL, effort="none", thinking="disabled"
+                )
+
+                # Assert
+                self.assertEqual(status.tier, tier)
+                self.assertEqual(status.turns_used, 2001)
+                self.assertIsNone(status.turn_cap)
+                self.assertFalse(status.exhausted)
+
+    def test_admission_rejects_exhausted_budget_without_turn_cap(self):
+        # Arrange
+        LLMUsageEvent.objects.create(
+            user=self.user,
+            feature="notebook_chat",
+            provider="openrouter",
+            model="deepseek/deepseek-v4-flash-0731",
+            cost_microusd=250_000,
         )
 
         # Act / Assert
@@ -148,7 +179,8 @@ class UsageBudgetTests(TestCase):
             check_turn_admission(
                 self.user, self.MODEL, effort="none", thinking="disabled"
             )
-        self.assertEqual(raised.exception.status.turns_used, 10)
+        self.assertIsNone(raised.exception.status.turn_cap)
+        self.assertEqual(raised.exception.status.remaining_microusd, 0)
 
     def test_default_tier_rejects_locked_model(self):
         with self.assertRaisesRegex(ValueError, "not allowed"):

--- a/src/research_ai/tests/test_usage_budget.py
+++ b/src/research_ai/tests/test_usage_budget.py
@@ -279,18 +279,13 @@ class AgentLoopBudgetRecorderTests(TestCase):
         self.assertGreater(execution.usage_reservation_expires_at, old_expiry)
 
     def test_discarded_attempt_is_charged_before_retry_admission(self):
-        # Arrange: nine earlier calls leave one turn in the default tier.
-        LLMUsageEvent.objects.bulk_create(
-            [
-                LLMUsageEvent(
-                    user=self.user,
-                    feature="notebook_chat",
-                    provider="openrouter",
-                    model="deepseek/deepseek-v4-pro-0813",
-                    cost_microusd=1,
-                )
-                for _ in range(9)
-            ]
+        # Arrange: prior usage leaves one microdollar in the daily budget.
+        LLMUsageEvent.objects.create(
+            user=self.user,
+            feature="notebook_chat",
+            provider="openrouter",
+            model="deepseek/deepseek-v4-pro-0813",
+            cost_microusd=249_999,
         )
         execution = self._execution(
             status=AgentExecution.Status.RUNNING,
@@ -298,14 +293,14 @@ class AgentLoopBudgetRecorderTests(TestCase):
         )
         recorder = self._recorder(execution)
 
-        # Act: the completed first attempt consumes the last turn before the
+        # Act: the completed first attempt consumes the remaining budget before the
         # provider asks whether it may make its internal retry.
         recorder.record_usage(TurnUsage(input_tokens=10, output_tokens=2))
 
         # Assert
         with self.assertRaises(BudgetExceededError):
             recorder.before_model_call()
-        self.assertEqual(LLMUsageEvent.objects.filter(user=self.user).count(), 10)
+        self.assertEqual(LLMUsageEvent.objects.filter(user=self.user).count(), 2)
 
     def test_stream_activity_leaves_the_lease_to_the_heartbeat(self):
         # Arrange: liveness is the worker heartbeat's job, so a burst of stream

--- a/src/research_ai/views/assistant_chat_views.py
+++ b/src/research_ai/views/assistant_chat_views.py
@@ -4,7 +4,7 @@ The assistant is the notebook chat without a note: the collection lives at
 ``assistant/chats/`` and every other route addresses one chat by id. Chats
 are private to their creator, so another user's chat id is a 404. Access is
 gated exactly as the notebook chat: authentication, a non-blocked Research AI
-tier, and the editor-or-moderator rollout gate.
+tier.
 """
 
 import logging
@@ -29,14 +29,12 @@ from research_ai.services.usage_budget import (
     UsageLimitExceededError,
     UsageWorkInProgressError,
 )
-from user.permissions import IsModerator, UserIsEditor
 
 logger = logging.getLogger(__name__)
 
 ASSISTANT_CHAT_PERMISSIONS = [
     IsAuthenticated,
     ResearchAIBudgetPermission,
-    UserIsEditor | IsModerator,
 ]
 
 

--- a/src/research_ai/views/notebook_chat_views.py
+++ b/src/research_ai/views/notebook_chat_views.py
@@ -40,14 +40,12 @@ from research_ai.services.usage_budget import (
     UsageLimitExceededError,
     UsageWorkInProgressError,
 )
-from user.permissions import IsModerator, UserIsEditor
 
 logger = logging.getLogger(__name__)
 
 NOTEBOOK_CHAT_PERMISSIONS = [
     IsAuthenticated,
     ResearchAIBudgetPermission,
-    UserIsEditor | IsModerator,
 ]
 
 

--- a/src/researchhub/settings.py
+++ b/src/researchhub/settings.py
@@ -741,6 +741,8 @@ REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
 REDIS_PORT = int(os.environ.get("REDIS_PORT", "6379"))
 
 # Cache Settings
+TEST_RUNNER = "utils.test_runner.IsolatedCacheRunner"
+
 if TESTING:
     CACHES = {
         "default": {

--- a/src/user/tests/test_leaderboard_views.py
+++ b/src/user/tests/test_leaderboard_views.py
@@ -2,8 +2,6 @@ from datetime import timedelta
 from decimal import Decimal
 
 from django.contrib.contenttypes.models import ContentType
-from django.core.cache import cache
-from django.test import override_settings
 from django.utils import timezone
 from rest_framework.test import APITestCase
 
@@ -30,20 +28,6 @@ from user.tests.helpers import create_user
 
 class LeaderboardApiTests(APITestCase):
     def setUp(self):
-        # Isolate anonymous throttles and cached responses from other tests.
-        cache_settings = override_settings(
-            CACHES={
-                "default": {
-                    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-                    "LOCATION": self.id(),
-                }
-            }
-        )
-        cache_settings.enable()
-        self.addCleanup(cache_settings.disable)
-        cache.clear()
-        self.addCleanup(cache.clear)
-
         # Create test users
         self.reviewer1 = create_user(
             email="reviewer1@researchhub.com", first_name="First", last_name="Reviewer"

--- a/src/user/tests/test_leaderboard_views.py
+++ b/src/user/tests/test_leaderboard_views.py
@@ -2,6 +2,8 @@ from datetime import timedelta
 from decimal import Decimal
 
 from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+from django.test import override_settings
 from django.utils import timezone
 from rest_framework.test import APITestCase
 
@@ -28,6 +30,20 @@ from user.tests.helpers import create_user
 
 class LeaderboardApiTests(APITestCase):
     def setUp(self):
+        # Isolate anonymous throttles and cached responses from other tests.
+        cache_settings = override_settings(
+            CACHES={
+                "default": {
+                    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                    "LOCATION": self.id(),
+                }
+            }
+        )
+        cache_settings.enable()
+        self.addCleanup(cache_settings.disable)
+        cache.clear()
+        self.addCleanup(cache.clear)
+
         # Create test users
         self.reviewer1 = create_user(
             email="reviewer1@researchhub.com", first_name="First", last_name="Reviewer"

--- a/src/utils/test_runner.py
+++ b/src/utils/test_runner.py
@@ -1,0 +1,47 @@
+"""Isolate the in-memory test cache between tests, including parallel workers."""
+
+import unittest
+
+from django.core.cache import cache
+from django.test.runner import (
+    DiscoverRunner,
+    ParallelTestSuite,
+    RemoteTestResult,
+    RemoteTestRunner,
+)
+
+
+class CacheIsolationMixin:
+    def startTest(self, test):  # noqa: N802 - unittest hook
+        cache.clear()
+        super().startTest(test)
+
+    def stopTest(self, test):  # noqa: N802 - unittest hook
+        try:
+            super().stopTest(test)
+        finally:
+            cache.clear()
+
+
+class IsolatedRemoteResult(CacheIsolationMixin, RemoteTestResult):
+    pass
+
+
+class IsolatedRemoteRunner(RemoteTestRunner):
+    resultclass = IsolatedRemoteResult
+
+
+class IsolatedParallelSuite(ParallelTestSuite):
+    runner_class = IsolatedRemoteRunner
+
+
+class IsolatedCacheRunner(DiscoverRunner):
+    parallel_test_suite = IsolatedParallelSuite
+
+    def get_resultclass(self):
+        base = super().get_resultclass() or unittest.TextTestResult
+
+        class IsolatedResult(CacheIsolationMixin, base):
+            pass
+
+        return IsolatedResult

--- a/src/utils/tests/test_test_runner.py
+++ b/src/utils/tests/test_test_runner.py
@@ -1,0 +1,82 @@
+import io
+import unittest
+from types import SimpleNamespace
+
+from django.core.cache import cache
+from django.test import RequestFactory
+from rest_framework.throttling import AnonRateThrottle
+
+from utils.test_runner import IsolatedCacheRunner, IsolatedRemoteRunner
+
+
+class CacheIsolationRunnerTests(unittest.TestCase):
+    def _runners(self):
+        yield unittest.TextTestRunner(
+            stream=io.StringIO(),
+            resultclass=IsolatedCacheRunner().get_resultclass(),
+        )
+        yield IsolatedRemoteRunner()
+
+    def test_cache_and_throttles_work_within_tests_but_do_not_leak(self):
+        # Arrange: both tests use the same IP and cache keys.
+        class RequestTest(unittest.TestCase):
+            def test_request(self):
+                self.assertIsNone(cache.get("runner-isolation"))
+                cache.set("runner-isolation", "present")
+                self.assertEqual(cache.get("runner-isolation"), "present")
+                request = RequestFactory().get("/api/leaderboard/reviewers/")
+                request.user = SimpleNamespace(is_authenticated=False)
+                for _ in range(50):
+                    self.assertTrue(AnonRateThrottle().allow_request(request, None))
+                self.assertFalse(AnonRateThrottle().allow_request(request, None))
+
+        for runner in self._runners():
+            with self.subTest(runner=type(runner).__name__):
+                cache.set("runner-isolation", "left by an earlier test")
+
+                # Act
+                result = runner.run(
+                    unittest.TestSuite(
+                        [RequestTest("test_request"), RequestTest("test_request")]
+                    )
+                )
+
+                # Assert
+                if hasattr(result, "events"):
+                    failures = [
+                        event
+                        for event in result.events
+                        if event[0] in ("addError", "addFailure")
+                    ]
+                    self.assertEqual(failures, [])
+                else:
+                    self.assertTrue(result.wasSuccessful(), str(result))
+                self.assertEqual(result.testsRun, 2)
+                self.assertIsNone(cache.get("runner-isolation"))
+
+    def test_cache_is_cleared_after_setup_failure(self):
+        # Arrange
+        class BrokenSetupTest(unittest.TestCase):
+            def setUp(self):
+                cache.set("runner-isolation", "left by failed setup")
+                raise RuntimeError("setup failed")
+
+            def test_request(self):
+                pass
+
+        for runner in self._runners():
+            with self.subTest(runner=type(runner).__name__):
+                # Act
+                result = runner.run(
+                    unittest.TestSuite([BrokenSetupTest("test_request")])
+                )
+
+                # Assert: remote results store errors as events.
+                self.assertEqual(result.testsRun, 1)
+                if hasattr(result, "events"):
+                    self.assertTrue(
+                        any(event[0] == "addError" for event in result.events)
+                    )
+                else:
+                    self.assertEqual(len(result.errors), 1)
+                self.assertIsNone(cache.get("runner-isolation"))


### PR DESCRIPTION
Ordinary signed-in users currently receive a permission denial when using notebook or standalone assistant chats. Remove the editor-or-moderator requirement from REST endpoints and WebSocket admission so those users can create chats and receive live responses. Authentication, blocked-account checks, note access, and conversation ownership still apply.

Use daily AI spending budgets as the usage limit, removing daily model-call caps for default, invited, and privileged users. Preserve the $0.25 / $10 / $100 budgets, the default-tier single-model restriction, one in-flight job per user, and between-call budget checks. Retain the API turn counter and return a null turn cap for these tiers for compatibility.

Update regression coverage for regular-user access, suspended-account rejection, admission beyond the former call caps in every tier, and rejection when the dollar budget is spent.

Add a shared test runner that clears the default in-memory cache before and after each test in serial and parallel execution. This prevents unrelated anonymous requests and cached responses from leaking between tests while preserving real caching and throttling within each test.

Validation: Ruff lint and formatting and diff whitespace checks pass. Runner regression tests pass with minimal Django settings, including cleanup after setup failure. A real two-worker run also passes cache and throttle isolation checks. Full Django tests could not run locally because no development containers are running and the existing Python environment is unusable on this Mac.

Companion frontend PR: https://github.com/ResearchHub/web/pull/1102
