### PR TITLE
Make assistant reference URLs clickable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "djangorestframework==3.18.0",
     "elastic-apm==6.24.0",
     "humanize>=4.12.2,<5.0.0",
+    "linkify-it-py>=2,<3",
     "flower>=2.0.1,<3.0.0",
     "lxml>=6.0.1",
     "mailchimp-marketing>=3.0.72,<4.0.0",

--- a/src/note/services/note_link_service.py
+++ b/src/note/services/note_link_service.py
@@ -1,40 +1,23 @@
-"""Make source URLs clickable in blocks written by note agents."""
+"""Make plain-text source URLs clickable in blocks written by note agents."""
 
-import re
-from urllib.parse import urlsplit
-
-_URL = re.compile(r"https?://[^\s<>\"']+", re.IGNORECASE)
-_MARKDOWN_START = re.compile(r"\[([^\[\]\n]+)\]\((https?://)", re.IGNORECASE)
-_CLOSING_BRACKETS = {")": "(", "]": "[", "}": "{"}
-
-
-def _trim_url(raw: str) -> str:
-    # Count once and move an end index, rather than repeatedly rescanning and
-    # copying a long URL with many trailing citation delimiters.
-    excess = {
-        closing: raw.count(closing) - raw.count(opening)
-        for closing, opening in _CLOSING_BRACKETS.items()
-    }
-    end = len(raw)
-    while end:
-        char = raw[end - 1]
-        if char in ".,;:!?":
-            end -= 1
-        elif excess.get(char, 0) > 0:
-            excess[char] -= 1
-            end -= 1
-        else:
-            break
-    return raw[:end]
+from linkify_it import LinkifyIt
 
 
 def link_note_urls(blocks: list[dict]) -> list[dict]:
-    """Link HTTP(S) URLs in new blocks, preserving existing marks and code.
+    """Add ProseMirror links to HTTP(S) URLs in inserted/replaced blocks.
 
-    Accept expanded editor nodes. Only call on inserted/replaced blocks so
-    untouched content is not rewritten. Existing link labels and destinations
-    are authoritative, even when their visible text is another URL.
+    Preserve existing links, formatting, code, and all visible text. This is
+    URL detection only; the document is not parsed as Markdown. Use a detector
+    per operation because LinkifyIt keeps mutable match state.
     """
+    detector = LinkifyIt(
+        schemas={"ftp:": None, "mailto:": None, "//": None},
+        options={"fuzzy_link": False, "fuzzy_email": False, "fuzzy_ip": False},
+    )
+    return _link_nodes(blocks, detector)
+
+
+def _link_nodes(blocks: list[dict], detector: LinkifyIt) -> list[dict]:
     result = []
     for node in blocks:
         marks = node.get("marks", [])
@@ -43,86 +26,34 @@ def link_note_urls(blocks: list[dict]) -> list[dict]:
         ):
             result.append(node)
         elif node.get("type") == "text":
-            result.extend(_link_text(node))
+            result.extend(_link_text(node, detector))
         elif "content" in node:
-            result.append({**node, "content": link_note_urls(node["content"])})
+            result.append({**node, "content": _link_nodes(node["content"], detector)})
         else:
             result.append(node)
     return result
 
 
-def _is_web_url(url: str) -> bool:
-    try:
-        return bool(urlsplit(url).hostname)
-    except ValueError:
-        return False
-
-
-def _destination_end(text: str, start: int) -> tuple[int, bool]:
-    """Read a Markdown destination, keeping balanced URL parentheses.
-
-    Return the scan endpoint even on failure so callers never rescan a long
-    malformed destination for every apparent link nested inside it.
-    """
-    depth = 1
-    for index in range(start, len(text)):
-        char = text[index]
-        if char.isspace() or char in "<>\"'":
-            return index + 1, False
-        if char == "(":
-            depth += 1
-        elif char == ")":
-            depth -= 1
-            if depth == 0:
-                return index + 1, True
-    return len(text), False
-
-
-def _markdown_links(text: str):
-    """Yield complete Markdown links before considering bare URLs."""
-    cursor = 0
-    while match := _MARKDOWN_START.search(text, cursor):
-        start = match.start(2)
-        cursor, complete = _destination_end(text, start)
-        url = text[start : cursor - 1]
-        if complete and _is_web_url(url):
-            yield match.start(), cursor, match.group(1), url
-
-
-def _linked_node(node: dict, label: str, url: str) -> dict:
-    return {
-        **node,
-        "text": label,
-        "marks": [
-            *node.get("marks", []),
-            {"type": "link", "attrs": {"href": url}},
-        ],
-    }
-
-
-def _link_bare_urls(node: dict, text: str) -> list[dict]:
+def _link_text(node: dict, detector: LinkifyIt) -> list[dict]:
+    text = node["text"]
+    if "http" not in text.lower():
+        return [node]
     result = []
     cursor = 0
-    for match in _URL.finditer(text):
-        url = _trim_url(match.group())
-        if not _is_web_url(url):
-            continue
-        if match.start() > cursor:
-            result.append({**node, "text": text[cursor : match.start()]})
-        result.append(_linked_node(node, url, url))
-        cursor = match.start() + len(url)
+    for match in detector.match(text) or []:
+        if match.index > cursor:
+            result.append({**node, "text": text[cursor : match.index]})
+        result.append(
+            {
+                **node,
+                "text": match.raw,
+                "marks": [
+                    *node.get("marks", []),
+                    {"type": "link", "attrs": {"href": match.url}},
+                ],
+            }
+        )
+        cursor = match.last_index
     if cursor < len(text):
         result.append({**node, "text": text[cursor:]})
-    return result
-
-
-def _link_text(node: dict) -> list[dict]:
-    text = node["text"]
-    result = []
-    cursor = 0
-    for start, end, label, url in _markdown_links(text):
-        result.extend(_link_bare_urls(node, text[cursor:start]))
-        result.append(_linked_node(node, label, url))
-        cursor = end
-    result.extend(_link_bare_urls(node, text[cursor:]))
     return result

--- a/src/note/services/note_link_service.py
+++ b/src/note/services/note_link_service.py
@@ -4,6 +4,7 @@ import re
 from urllib.parse import urlsplit
 
 _URL = re.compile(r"https?://[^\s<>\"']+", re.IGNORECASE)
+_MARKDOWN_START = re.compile(r"\[([^\[\]\n]+)\]\((https?://)", re.IGNORECASE)
 _CLOSING_BRACKETS = {")": "(", "]": "[", "}": "{"}
 
 
@@ -50,45 +51,78 @@ def link_note_urls(blocks: list[dict]) -> list[dict]:
     return result
 
 
+def _is_web_url(url: str) -> bool:
+    try:
+        return bool(urlsplit(url).hostname)
+    except ValueError:
+        return False
+
+
+def _destination_end(text: str, start: int) -> tuple[int, bool]:
+    """Read a Markdown destination, keeping balanced URL parentheses.
+
+    Return the scan endpoint even on failure so callers never rescan a long
+    malformed destination for every apparent link nested inside it.
+    """
+    depth = 1
+    for index in range(start, len(text)):
+        char = text[index]
+        if char.isspace() or char in "<>\"'":
+            return index + 1, False
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return index + 1, True
+    return len(text), False
+
+
+def _markdown_links(text: str):
+    """Yield complete Markdown links before considering bare URLs."""
+    cursor = 0
+    while match := _MARKDOWN_START.search(text, cursor):
+        start = match.start(2)
+        cursor, complete = _destination_end(text, start)
+        url = text[start : cursor - 1]
+        if complete and _is_web_url(url):
+            yield match.start(), cursor, match.group(1), url
+
+
+def _linked_node(node: dict, label: str, url: str) -> dict:
+    return {
+        **node,
+        "text": label,
+        "marks": [
+            *node.get("marks", []),
+            {"type": "link", "attrs": {"href": url}},
+        ],
+    }
+
+
+def _link_bare_urls(node: dict, text: str) -> list[dict]:
+    result = []
+    cursor = 0
+    for match in _URL.finditer(text):
+        url = _trim_url(match.group())
+        if not _is_web_url(url):
+            continue
+        if match.start() > cursor:
+            result.append({**node, "text": text[cursor : match.start()]})
+        result.append(_linked_node(node, url, url))
+        cursor = match.start() + len(url)
+    if cursor < len(text):
+        result.append({**node, "text": text[cursor:]})
+    return result
+
+
 def _link_text(node: dict) -> list[dict]:
     text = node["text"]
     result = []
     cursor = 0
-    previous_match_end = 0
-    for match in _URL.finditer(text):
-        label_boundary = previous_match_end
-        previous_match_end = match.end()
-        url = _trim_url(match.group())
-        try:
-            if not urlsplit(url).hostname:
-                continue
-        except ValueError:
-            continue
-        start, end = match.start(), match.start() + len(url)
-        label = url
-        if text.endswith("](", label_boundary, start) and text[end : end + 1] == ")":
-            # Search only the gap since the preceding URL, even if that URL
-            # was invalid. This avoids repeatedly scanning a growing prefix.
-            opening = text.rfind("[", label_boundary, start - 2)
-            if opening >= 0:
-                candidate = text[opening + 1 : start - 2]
-                if candidate and "]" not in candidate and "\n" not in candidate:
-                    start = opening
-                    end += 1
-                    label = candidate
-        if start > cursor:
-            result.append({**node, "text": text[cursor:start]})
-        result.append(
-            {
-                **node,
-                "text": label,
-                "marks": [
-                    *node.get("marks", []),
-                    {"type": "link", "attrs": {"href": url}},
-                ],
-            }
-        )
+    for start, end, label, url in _markdown_links(text):
+        result.extend(_link_bare_urls(node, text[cursor:start]))
+        result.append(_linked_node(node, label, url))
         cursor = end
-    if cursor < len(text):
-        result.append({**node, "text": text[cursor:]})
+    result.extend(_link_bare_urls(node, text[cursor:]))
     return result

--- a/src/note/services/note_link_service.py
+++ b/src/note/services/note_link_service.py
@@ -1,0 +1,94 @@
+"""Make source URLs clickable in blocks written by note agents."""
+
+import re
+from urllib.parse import urlsplit
+
+_URL = re.compile(r"https?://[^\s<>\"']+", re.IGNORECASE)
+_CLOSING_BRACKETS = {")": "(", "]": "[", "}": "{"}
+
+
+def _trim_url(raw: str) -> str:
+    # Count once and move an end index, rather than repeatedly rescanning and
+    # copying a long URL with many trailing citation delimiters.
+    excess = {
+        closing: raw.count(closing) - raw.count(opening)
+        for closing, opening in _CLOSING_BRACKETS.items()
+    }
+    end = len(raw)
+    while end:
+        char = raw[end - 1]
+        if char in ".,;:!?":
+            end -= 1
+        elif excess.get(char, 0) > 0:
+            excess[char] -= 1
+            end -= 1
+        else:
+            break
+    return raw[:end]
+
+
+def link_note_urls(blocks: list[dict]) -> list[dict]:
+    """Link HTTP(S) URLs in new blocks, preserving existing marks and code.
+
+    Accept expanded editor nodes. Only call on inserted/replaced blocks so
+    untouched content is not rewritten. Existing link labels and destinations
+    are authoritative, even when their visible text is another URL.
+    """
+    result = []
+    for node in blocks:
+        marks = node.get("marks", [])
+        if node.get("type") == "codeBlock" or any(
+            mark["type"] in ("code", "link") for mark in marks
+        ):
+            result.append(node)
+        elif node.get("type") == "text":
+            result.extend(_link_text(node))
+        elif "content" in node:
+            result.append({**node, "content": link_note_urls(node["content"])})
+        else:
+            result.append(node)
+    return result
+
+
+def _link_text(node: dict) -> list[dict]:
+    text = node["text"]
+    result = []
+    cursor = 0
+    previous_match_end = 0
+    for match in _URL.finditer(text):
+        label_boundary = previous_match_end
+        previous_match_end = match.end()
+        url = _trim_url(match.group())
+        try:
+            if not urlsplit(url).hostname:
+                continue
+        except ValueError:
+            continue
+        start, end = match.start(), match.start() + len(url)
+        label = url
+        if text.endswith("](", label_boundary, start) and text[end : end + 1] == ")":
+            # Search only the gap since the preceding URL, even if that URL
+            # was invalid. This avoids repeatedly scanning a growing prefix.
+            opening = text.rfind("[", label_boundary, start - 2)
+            if opening >= 0:
+                candidate = text[opening + 1 : start - 2]
+                if candidate and "]" not in candidate and "\n" not in candidate:
+                    start = opening
+                    end += 1
+                    label = candidate
+        if start > cursor:
+            result.append({**node, "text": text[cursor:start]})
+        result.append(
+            {
+                **node,
+                "text": label,
+                "marks": [
+                    *node.get("marks", []),
+                    {"type": "link", "attrs": {"href": url}},
+                ],
+            }
+        )
+        cursor = end
+    if cursor < len(text):
+        result.append({**node, "text": text[cursor:]})
+    return result

--- a/src/note/tests/test_note_link_service.py
+++ b/src/note/tests/test_note_link_service.py
@@ -6,72 +6,35 @@ from utils.prosemirror import BLOCK_EDITOR, compact_blocks, parse_blocks
 
 
 class NoteLinkServiceTests(TestCase):
-    def test_url_label_links_to_markdown_destination(self):
+    def test_only_explicit_http_urls_are_linked(self):
         # Arrange
-        blocks = [
-            {
-                "type": "text",
-                "text": "[https://example.com/label](https://example.com/target)",
-            }
-        ]
-
-        # Act
-        result = link_note_urls(blocks)
-
-        # Assert
-        self.assertEqual(
-            result,
-            [
-                {
-                    "type": "text",
-                    "text": "https://example.com/label",
-                    "marks": [
-                        {
-                            "type": "link",
-                            "attrs": {"href": "https://example.com/target"},
-                        }
-                    ],
-                }
-            ],
+        prefix = (
+            "example.com user@example.com //example.com/path "
+            "ftp://example.com/file mailto:user@example.com "
         )
-
-    def test_mixed_and_adjacent_markdown_links_keep_separate_destinations(self):
-        # Arrange
-        text = (
-            "https://example.org/first "
-            "[https://example.org/label](https://doi.org/a(b))"
-            "[Second](https://example.org/second?x=1&y=2). "
-            "https://example.org/last."
-        )
+        text = prefix + "http://example.com/paper"
 
         # Act
         result = link_note_urls([{"type": "text", "text": text}])
 
         # Assert
-        links = [node for node in result if node.get("marks")]
+        self.assertEqual(result[0], {"type": "text", "text": prefix})
         self.assertEqual(
-            [node["marks"][0]["attrs"]["href"] for node in links],
-            [
-                "https://example.org/first",
-                "https://doi.org/a(b)",
-                "https://example.org/second?x=1&y=2",
-                "https://example.org/last",
-            ],
+            result[1]["marks"][0]["attrs"]["href"], "http://example.com/paper"
         )
-        self.assertEqual(links[1]["text"], "https://example.org/label")
-        self.assertEqual(links[2]["text"], "Second")
 
-    def test_markdown_destination_keeps_nested_parentheses_and_final_punctuation(self):
+    def test_preserves_literal_text_without_markdown_interpretation(self):
         # Arrange
-        url = "https://example.org/a(b(c))."
-        blocks = [{"type": "text", "text": f"[Paper]({url})"}]
+        text = "**Source** [Paper](https://example.com/paper)"
 
         # Act
-        result = link_note_urls(blocks)
+        result = link_note_urls([{"type": "text", "text": text}])
 
         # Assert
-        self.assertEqual(result[0]["text"], "Paper")
-        self.assertEqual(result[0]["marks"][0]["attrs"]["href"], url)
+        self.assertEqual("".join(node["text"] for node in result), text)
+        linked = [node for node in result if node.get("marks")]
+        self.assertEqual(len(linked), 1)
+        self.assertEqual(linked[0]["text"], "https://example.com/paper")
 
     def test_links_survive_editor_schema_round_trip(self):
         # Arrange
@@ -119,18 +82,6 @@ class NoteLinkServiceTests(TestCase):
         )
         self.assertTrue(all({"type": "italic"} in node["marks"] for node in nodes))
         self.assertEqual(blocks, original)
-
-    def test_converts_markdown_reference_to_a_link_label(self):
-        # Arrange
-        blocks = [{"type": "text", "text": "Read [Paper](https://doi.org/a(b))."}]
-
-        # Act
-        result = link_note_urls(blocks)
-
-        # Assert
-        self.assertEqual("".join(node["text"] for node in result), "Read Paper.")
-        self.assertEqual(result[1]["text"], "Paper")
-        self.assertEqual(result[1]["marks"][0]["attrs"]["href"], "https://doi.org/a(b)")
 
     def test_preserves_existing_links_and_code(self):
         # Arrange
@@ -227,23 +178,3 @@ class NoteLinkServiceTests(TestCase):
         # Assert
         self.assertEqual(result[0]["marks"][0]["attrs"]["href"], url)
         self.assertEqual(result[1]["text"], suffix)
-
-    def test_invalid_url_does_not_disrupt_later_markdown_reference(self):
-        # Arrange
-        prefix = "https://[bad "
-        blocks = [
-            {
-                "type": "text",
-                "text": prefix + "[Paper](https://example.org/paper)",
-            }
-        ]
-
-        # Act
-        result = link_note_urls(blocks)
-
-        # Assert
-        self.assertEqual(result[0]["text"], prefix)
-        self.assertEqual(result[1]["text"], "Paper")
-        self.assertEqual(
-            result[1]["marks"][0]["attrs"]["href"], "https://example.org/paper"
-        )

--- a/src/note/tests/test_note_link_service.py
+++ b/src/note/tests/test_note_link_service.py
@@ -6,6 +6,73 @@ from utils.prosemirror import BLOCK_EDITOR, compact_blocks, parse_blocks
 
 
 class NoteLinkServiceTests(TestCase):
+    def test_url_label_links_to_markdown_destination(self):
+        # Arrange
+        blocks = [
+            {
+                "type": "text",
+                "text": "[https://example.com/label](https://example.com/target)",
+            }
+        ]
+
+        # Act
+        result = link_note_urls(blocks)
+
+        # Assert
+        self.assertEqual(
+            result,
+            [
+                {
+                    "type": "text",
+                    "text": "https://example.com/label",
+                    "marks": [
+                        {
+                            "type": "link",
+                            "attrs": {"href": "https://example.com/target"},
+                        }
+                    ],
+                }
+            ],
+        )
+
+    def test_mixed_and_adjacent_markdown_links_keep_separate_destinations(self):
+        # Arrange
+        text = (
+            "https://example.org/first "
+            "[https://example.org/label](https://doi.org/a(b))"
+            "[Second](https://example.org/second?x=1&y=2). "
+            "https://example.org/last."
+        )
+
+        # Act
+        result = link_note_urls([{"type": "text", "text": text}])
+
+        # Assert
+        links = [node for node in result if node.get("marks")]
+        self.assertEqual(
+            [node["marks"][0]["attrs"]["href"] for node in links],
+            [
+                "https://example.org/first",
+                "https://doi.org/a(b)",
+                "https://example.org/second?x=1&y=2",
+                "https://example.org/last",
+            ],
+        )
+        self.assertEqual(links[1]["text"], "https://example.org/label")
+        self.assertEqual(links[2]["text"], "Second")
+
+    def test_markdown_destination_keeps_nested_parentheses_and_final_punctuation(self):
+        # Arrange
+        url = "https://example.org/a(b(c))."
+        blocks = [{"type": "text", "text": f"[Paper]({url})"}]
+
+        # Act
+        result = link_note_urls(blocks)
+
+        # Assert
+        self.assertEqual(result[0]["text"], "Paper")
+        self.assertEqual(result[0]["marks"][0]["attrs"]["href"], url)
+
     def test_links_survive_editor_schema_round_trip(self):
         # Arrange
         blocks = parse_blocks(BLOCK_EDITOR, ["See https://doi.org/10.1234/paper."])

--- a/src/note/tests/test_note_link_service.py
+++ b/src/note/tests/test_note_link_service.py
@@ -1,0 +1,182 @@
+from copy import deepcopy
+from unittest import TestCase
+
+from note.services.note_link_service import link_note_urls
+from utils.prosemirror import BLOCK_EDITOR, compact_blocks, parse_blocks
+
+
+class NoteLinkServiceTests(TestCase):
+    def test_links_survive_editor_schema_round_trip(self):
+        # Arrange
+        blocks = parse_blocks(BLOCK_EDITOR, ["See https://doi.org/10.1234/paper."])
+
+        # Act
+        result = parse_blocks(BLOCK_EDITOR, link_note_urls(blocks))
+        compact = compact_blocks(BLOCK_EDITOR, {"type": "doc", "content": result})
+
+        # Assert
+        linked = compact[0]["content"][1]
+        self.assertEqual(linked["text"], "https://doi.org/10.1234/paper")
+        self.assertEqual(
+            linked["marks"],
+            [{"type": "link", "attrs": {"href": "https://doi.org/10.1234/paper"}}],
+        )
+
+    def test_links_reference_urls_and_preserves_punctuation_and_marks(self):
+        # Arrange
+        text = "See https://doi.org/10.1234/a(b), and https://example.org/paper."
+        blocks = [
+            {
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": text, "marks": [{"type": "italic"}]}
+                ],
+            }
+        ]
+        original = deepcopy(blocks)
+
+        # Act
+        result = link_note_urls(blocks)
+
+        # Assert
+        nodes = result[0]["content"]
+        self.assertEqual("".join(node["text"] for node in nodes), text)
+        self.assertEqual(
+            [
+                mark["attrs"]["href"]
+                for node in nodes
+                for mark in node["marks"]
+                if mark["type"] == "link"
+            ],
+            ["https://doi.org/10.1234/a(b)", "https://example.org/paper"],
+        )
+        self.assertTrue(all({"type": "italic"} in node["marks"] for node in nodes))
+        self.assertEqual(blocks, original)
+
+    def test_converts_markdown_reference_to_a_link_label(self):
+        # Arrange
+        blocks = [{"type": "text", "text": "Read [Paper](https://doi.org/a(b))."}]
+
+        # Act
+        result = link_note_urls(blocks)
+
+        # Assert
+        self.assertEqual("".join(node["text"] for node in result), "Read Paper.")
+        self.assertEqual(result[1]["text"], "Paper")
+        self.assertEqual(result[1]["marks"][0]["attrs"]["href"], "https://doi.org/a(b)")
+
+    def test_preserves_existing_links_and_code(self):
+        # Arrange
+        blocks = [
+            {
+                "type": "codeBlock",
+                "content": [{"type": "text", "text": "https://example.org/code"}],
+            },
+            {
+                "type": "text",
+                "text": "https://example.org/inline",
+                "marks": [{"type": "code"}],
+            },
+            {
+                "type": "text",
+                "text": "https://example.org/label",
+                "marks": [
+                    {"type": "link", "attrs": {"href": "https://example.org/target"}}
+                ],
+            },
+        ]
+        original = deepcopy(blocks)
+
+        # Act
+        result = link_note_urls(blocks)
+
+        # Assert
+        self.assertEqual(result, original)
+
+    def test_handles_urls_in_nested_list_items(self):
+        # Arrange
+        blocks = [
+            {
+                "type": "bulletList",
+                "content": [
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": "(https://example.org/paper).",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+
+        # Act
+        result = link_note_urls(blocks)
+
+        # Assert
+        nodes = result[0]["content"][0]["content"][0]["content"]
+        self.assertEqual(
+            nodes[1]["marks"][0]["attrs"]["href"], "https://example.org/paper"
+        )
+        self.assertEqual(nodes[2]["text"], ").")
+
+    def test_leaves_non_web_schemes_and_invalid_urls_unlinked(self):
+        # Arrange
+        blocks = [{"type": "text", "text": "javascript:alert(1) https:// https://[bad"}]
+
+        # Act
+        result = link_note_urls(blocks)
+
+        # Assert
+        self.assertEqual(result, blocks)
+
+    def test_linking_is_idempotent(self):
+        # Arrange
+        blocks = [{"type": "text", "text": "https://example.org/paper."}]
+        linked = link_note_urls(blocks)
+
+        # Act
+        result = link_note_urls(linked)
+
+        # Assert
+        self.assertEqual(result, linked)
+
+    def test_preserves_long_trailing_delimiters_outside_link(self):
+        # Arrange
+        url = "https://doi.org/10.1234/a(b)"
+        suffix = ")" * 10000 + "."
+        blocks = [{"type": "text", "text": url + suffix}]
+
+        # Act
+        result = link_note_urls(blocks)
+
+        # Assert
+        self.assertEqual(result[0]["marks"][0]["attrs"]["href"], url)
+        self.assertEqual(result[1]["text"], suffix)
+
+    def test_invalid_url_does_not_disrupt_later_markdown_reference(self):
+        # Arrange
+        prefix = "https://[bad "
+        blocks = [
+            {
+                "type": "text",
+                "text": prefix + "[Paper](https://example.org/paper)",
+            }
+        ]
+
+        # Act
+        result = link_note_urls(blocks)
+
+        # Assert
+        self.assertEqual(result[0]["text"], prefix)
+        self.assertEqual(result[1]["text"], "Paper")
+        self.assertEqual(
+            result[1]["marks"][0]["attrs"]["href"], "https://example.org/paper"
+        )

--- a/src/research_ai/services/note_tools.py
+++ b/src/research_ai/services/note_tools.py
@@ -34,6 +34,7 @@ from django.db import transaction
 
 from note.related_models.note_model import Note, NoteContent, parse_note_json
 from note.services.note_content_service import NoteContentService
+from note.services.note_link_service import link_note_urls
 from research_ai.services.agent import Tool, Toolset
 from research_ai.services.note_block_edits import (
     apply_block_edits,
@@ -398,7 +399,10 @@ class NoteToolset:
             for index, edit in enumerate(edits):
                 if edit.blocks is not None:
                     try:
-                        edit.blocks = parse_blocks(BLOCK_EDITOR, edit.blocks)
+                        edit.blocks = parse_blocks(
+                            BLOCK_EDITOR,
+                            link_note_urls(parse_blocks(BLOCK_EDITOR, edit.blocks)),
+                        )
                     except ValueError as exc:
                         raise ValueError(f"edits[{index}]: {exc}") from exc
         except ValueError as exc:

--- a/src/research_ai/tests/test_note_tools.py
+++ b/src/research_ai/tests/test_note_tools.py
@@ -308,6 +308,36 @@ class NoteToolsetTests(TestCase):
         self.assertEqual(read["blocks"], {"0": "Written by the agent"})
         self.assertEqual(read["version_id"], result["version_id"])
 
+    def test_edit_note_saves_clickable_references_only_in_changed_blocks(self):
+        # Arrange
+        untouched = {
+            "type": "paragraph",
+            "content": [{"type": "text", "text": "https://example.org/unchanged"}],
+        }
+        seeded = self._seed_version({"type": "doc", "content": [untouched]})
+
+        # Act
+        result, _ = self.toolset.dispatch(
+            EDIT_NOTE,
+            {
+                "note_id": self.note.id,
+                "expected_version_id": seeded.id,
+                "edits": _insert(["Reference: https://doi.org/10.1234/paper."], at=1),
+            },
+        )
+
+        # Assert
+        self.assertTrue(result["saved"])
+        self.note.refresh_from_db()
+        stored = json.loads(self.note.latest_version.json)
+        self.assertEqual(stored["content"][0], untouched)
+        linked = stored["content"][1]["content"][1]
+        self.assertEqual(linked["text"], "https://doi.org/10.1234/paper")
+        self.assertEqual(linked["marks"][0]["type"], "link")
+        self.assertEqual(
+            linked["marks"][0]["attrs"]["href"], "https://doi.org/10.1234/paper"
+        )
+
     def test_edit_note_touches_only_the_addressed_blocks(self):
         # Arrange
         seeded = self._seed_version(EDITOR_DOC)

--- a/uv.lock
+++ b/uv.lock
@@ -1602,6 +1602,15 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/98/7a1a5f31fd5c7ba93e963b168e244b8e3dd705b3d2a718e3c3307583bf57/linkify_it_py-2.2.0.tar.gz", hash = "sha256:907acd2d17ac1fbb9ddb62c8957ccbd6158cac602231a15c3b0cd1e215f03cee", size = 32939, upload-time = "2026-08-29T07:07:08.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/d4/1152d1c7ab42d8b908be64fd200ddc870dc9d4925e951198702084aa1a7d/linkify_it_py-2.2.0-py3-none-any.whl", hash = "sha256:3adc40eb5af300b2605fcfdb968c24e1d780a90f1f2221af7c15e5111e94d443", size = 21971, upload-time = "2026-08-29T07:07:07.164Z" },
+]
+
+[[package]]
 name = "lru-dict"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2496,6 +2505,7 @@ dependencies = [
     { name = "elastic-apm" },
     { name = "flower" },
     { name = "humanize" },
+    { name = "linkify-it-py" },
     { name = "lxml" },
     { name = "mailchimp-marketing" },
     { name = "openai" },
@@ -2564,6 +2574,7 @@ requires-dist = [
     { name = "elastic-apm", specifier = "==6.24.0" },
     { name = "flower", specifier = ">=2.0.1,<3.0.0" },
     { name = "humanize", specifier = ">=4.12.2,<5.0.0" },
+    { name = "linkify-it-py", specifier = ">=2,<3" },
     { name = "lxml", specifier = ">=6.0.1" },
     { name = "mailchimp-marketing", specifier = ">=3.0.72,<4.0.0" },
     { name = "openai", specifier = ">=1.45.0" },


### PR DESCRIPTION
Assistant and notebook edits can save reference URLs as plain text when the model misses the ProseMirror link-formatting instructions. Use `linkify-it-py` to recognize explicit HTTP(S) URLs in inserted or replaced blocks and add ProseMirror link marks before saving.

The adapter preserves all visible text, existing links and formatting, code, and untouched blocks. Bare domains, email addresses, protocol-relative URLs, and non-HTTP schemes are not linked. It does not parse Markdown or repair Markdown references; prompts continue to require native ProseMirror links. Existing notes are not backfilled.

Validation:
- 35 focused URL-linking and editor-schema tests pass, covering schema round trips, punctuation, nested blocks, text preservation, existing links/code, allowed URL schemes, and long delimiter input.
- Added a database-backed regression test for saving clickable references without rewriting untouched blocks. Database-backed Django tests remain blocked by the missing local Django setup.
- New service/tests pass Ruff lint and formatting; whitespace checks and lockfile consistency checks pass.
- Local Python 3.13 conversion-only benchmark (median of 7 batches of 10 calls): 100 references: 0.877 ms; 100 KB prose without URLs: 0.111 ms; 100,000 trailing closing brackets: 1.647 ms. These measurements exclude schema validation and database writes and are not production latency guarantees.

Follow-up to #4112.
