### PR TITLE
Improve edit_note argument guidance and recovery

### DIFF
--- a/src/research_ai/services/note_block_edits.py
+++ b/src/research_ai/services/note_block_edits.py
@@ -39,6 +39,13 @@ def parse_block_edits(raw) -> list[BlockEdit]:
     can expand and schema-validate them, and index bounds wait for
     ``check_block_edits``.
     """
+    if isinstance(raw, str):
+        raise ValueError(
+            "edits must be a non-empty array of operations, not a JSON string. "
+            "Pass the array directly; do not quote or JSON-encode it. "
+            'Example: {"edits": [{"op": "insert", "at": 0, '
+            '"blocks": ["Paragraph text"]}]}'
+        )
     if not isinstance(raw, list) or not raw:
         raise ValueError(
             "edits must be a non-empty array of operations "

--- a/src/research_ai/services/note_tools.py
+++ b/src/research_ai/services/note_tools.py
@@ -187,6 +187,9 @@ class NoteToolset:
                     "delete one. Indices refer to the `blocks` map from "
                     "read_note; all edits in one call apply together against "
                     "that same numbering, so they never shift each other. "
+                    "Call edit_note directly, including retries; it is not "
+                    "available inside code_execution. Pass edits as an actual "
+                    "array of operation objects, never a JSON-encoded string. "
                     "Pass the version_id from your latest read_note or "
                     "edit_note result as expected_version_id; the edit is "
                     "rejected as stale if the note changed since. "
@@ -207,8 +210,10 @@ class NoteToolset:
                         "expected_version_id": {
                             "type": ["integer", "null"],
                             "description": (
-                                "version_id from read_note. Pass null only if "
-                                "read_note reported no version."
+                                "version_id from the latest read_note or "
+                                "edit_note result. Pass null for a freshly "
+                                "created note when create_note or read_note "
+                                "reported no version."
                             ),
                         },
                         "edits": {
@@ -216,7 +221,10 @@ class NoteToolset:
                             "minItems": 1,
                             "description": (
                                 "Operations on the block indices you read, "
-                                "applied as one batch."
+                                "applied as one batch. Supply an array, not a "
+                                "string containing JSON. Example: "
+                                '[{"op": "insert", "at": 0, '
+                                '"blocks": ["Paragraph text"]}]'
                             ),
                             "items": {
                                 "type": "object",
@@ -402,7 +410,14 @@ class NoteToolset:
                     except ValueError as exc:
                         raise ValueError(f"edits[{index}]: {exc}") from exc
         except ValueError as exc:
-            return {"error": str(exc)}
+            return {
+                "error": (
+                    f"{exc}. No edits were saved by this call. "
+                    "Correct the arguments and retry edit_note directly with "
+                    "the intended content and the same expected_version_id; "
+                    "edit_note is not available inside code_execution."
+                )
+            }
 
         expected = input.get("expected_version_id")
         try:

--- a/src/research_ai/tests/test_note_block_edits.py
+++ b/src/research_ai/tests/test_note_block_edits.py
@@ -51,6 +51,23 @@ class ParseBlockEditsTests(unittest.TestCase):
             with self.subTest(name), self.assertRaises(ValueError):
                 parse_block_edits(raw)
 
+    def test_rejects_encoded_edits_with_array_guidance(self):
+        # Arrange: both valid and malformed JSON must remain rejected strings.
+        inputs = [
+            '[{"op": "insert", "at": 0, "blocks": ["Paragraph"]}]',
+            '[{"op": "insert", "at": 0, "blocks": ["Unescaped "quote""]}]',
+        ]
+
+        # Act
+        for raw in inputs:
+            with self.subTest(raw=raw):
+                with self.assertRaises(ValueError) as caught:
+                    parse_block_edits(raw)
+
+                # Assert
+                self.assertIn("not a JSON string", str(caught.exception))
+                self.assertIn("Pass the array directly", str(caught.exception))
+
     def test_rejects_bad_operations_with_indexed_messages(self):
         # Arrange
         bad_ops = {

--- a/src/research_ai/tests/test_note_tools.py
+++ b/src/research_ai/tests/test_note_tools.py
@@ -442,6 +442,45 @@ class NoteToolsetTests(TestCase):
         self.note.refresh_from_db()
         self.assertEqual(self.note.latest_version_id, self.content.id)
 
+    def test_edit_note_recovers_from_encoded_edits_without_partial_save(self):
+        # Arrange
+        edits = _insert(["Intended paragraph"])
+        version_count = NoteContent.objects.filter(note=self.note).count()
+        args = {
+            "note_id": self.note.id,
+            "expected_version_id": self.content.id,
+            "edits": json.dumps(edits),
+        }
+
+        # Act
+        rejected, _ = self.toolset.dispatch(EDIT_NOTE, args)
+
+        # Assert: rejection preserves the version, so a corrected call can retry.
+        self.assertIn("not a JSON string", rejected["error"])
+        self.assertIn("No edits were saved", rejected["error"])
+        self.assertIn("retry edit_note directly", rejected["error"])
+        self.assertIn("not available inside code_execution", rejected["error"])
+        self.note.refresh_from_db()
+        self.assertEqual(self.note.latest_version_id, self.content.id)
+        self.assertEqual(
+            NoteContent.objects.filter(note=self.note).count(), version_count
+        )
+
+        # Act
+        saved, _ = self.toolset.dispatch(EDIT_NOTE, {**args, "edits": edits})
+
+        # Assert
+        self.assertTrue(saved["saved"])
+        self.note.refresh_from_db()
+        self.assertEqual(self.note.latest_version_id, saved["version_id"])
+        self.assertEqual(
+            NoteContent.objects.filter(note=self.note).count(), version_count + 1
+        )
+        document = json.loads(self.note.latest_version.json)
+        self.assertEqual(
+            document["content"][0]["content"][0]["text"], "Intended paragraph"
+        )
+
     def test_edit_note_rejects_stale_version(self):
         # Arrange: another writer saved a version after our read.
         newer, _ = self.toolset.dispatch(


### PR DESCRIPTION
When the agent passes `edit_note.edits` as a JSON string, the generic validation error can lead it to retry through `code_execution`, where `edit_note` is unavailable. This adds explicit array examples and direct-call guidance to the tool description, plus a specific error for string inputs. Validation failures now confirm that nothing was saved and explain how to retry with corrected arguments and the same expected version.

Also clarifies that a newly created note can use `expected_version_id: null`. Existing validation, permissions, and optimistic concurrency checks remain in place. This improves model guidance and recovery; it does not enable strict tool schemas or automatically repair malformed JSON.

Validation: all 40 note-tool and block-edit tests passed against an isolated local PostgreSQL test database with AWS clients mocked. Regression coverage verifies that encoded edits are rejected without creating a version and that a corrected array succeeds using the same expected version. Ruff lint, formatting, and `git diff --check` passed.
