### PR TITLE
Show code execution details in assistant and notebook activity

### DIFF
--- a/src/research_ai/services/agent_persistence/activity.py
+++ b/src/research_ai/services/agent_persistence/activity.py
@@ -302,6 +302,13 @@ def _apply_server_block(
         is_error = isinstance(content, dict) and str(content.get("type", "")).endswith(
             "_error"
         )
+        if isinstance(content, dict) and data_type in {
+            "code_execution_tool_result",
+            "bash_code_execution_tool_result",
+        }:
+            return_code = content.get("return_code")
+            if type(return_code) is int and return_code != 0:
+                is_error = True
         walk.close(
             execution_id,
             data.get("tool_use_id"),

--- a/src/research_ai/services/notebook_chat/activity.py
+++ b/src/research_ai/services/notebook_chat/activity.py
@@ -13,9 +13,9 @@ spinner into a readable account of what the agent is doing. Thinking events
 carry readable reasoning text while dropping provider signatures and encrypted
 state.
 
-Raw tool arguments and results never pass through: tool traffic includes whole
-note documents, paper full texts, and provider payloads, and tool error strings
-are written for the model, not the user.
+Whole tool argument and result payloads never pass through. Code execution
+adds an explicitly selected, bounded code/stdout preview; provider error text,
+encrypted state, note documents, and paper full texts stay private.
 
 Alongside the feed, :func:`execution_phase` reduces the same events to a single
 coarse "what is it doing right now" for a live turn, so a client has something
@@ -31,6 +31,10 @@ from research_ai.services.agent_persistence.activity import (
     ToolCallEvent,
 )
 from research_ai.services.note_tools import CREATE_NOTE, EDIT_NOTE, READ_NOTE
+from research_ai.services.notebook_chat.code_execution import (
+    CODE_EXECUTION_TOOLS,
+    public_code_execution,
+)
 from research_ai.services.notebook_chat.grant_tools import (
     GET_GRANT_DETAILS,
     READ_SELECTED_RFP,
@@ -53,6 +57,7 @@ GET_AUTHOR = "get_author"
 GET_AUTHOR_WORKS = "get_author_works"
 
 _LABELS = {
+    **dict.fromkeys(CODE_EXECUTION_TOOLS, "Code finished"),
     CREATE_NOTE: "Created a note",
     READ_NOTE: "Read the note",
     EDIT_NOTE: "Edited the note",
@@ -73,6 +78,7 @@ _LABELS = {
 # What each tool is doing while the call is still open, for the live phase.
 # Distinct from _LABELS, which reads as a completed step.
 _ACTIVE_LABELS = {
+    **dict.fromkeys(CODE_EXECUTION_TOOLS, "Running code"),
     CREATE_NOTE: "Creating a note",
     READ_NOTE: "Reading the note",
     EDIT_NOTE: "Editing the note",
@@ -95,6 +101,7 @@ _ACTIVE_LABELS = {
 # distinct from the active label: an edit is drafted for seconds before the
 # call runs, whereas a search query is written in an instant.
 _DRAFTING_LABELS = {
+    **dict.fromkeys(CODE_EXECUTION_TOOLS, "Preparing code"),
     EDIT_NOTE: "Drafting an edit",
 }
 # The input field per tool whose value is the user's own kind of text -- safe
@@ -235,6 +242,19 @@ def _public_tool_call(event: ToolCallEvent, execution_active: bool) -> dict:
     detail = _detail(event)
     if detail:
         public["detail"] = detail
+    if event.server_side and event.tool in CODE_EXECUTION_TOOLS:
+        status = public["status"]
+        public["label"] = {
+            "in_progress": "Running code",
+            "succeeded": "Code finished",
+            "failed": "Code execution failed",
+            "interrupted": "Code execution interrupted",
+        }[status]
+        details, summary = public_code_execution(event)
+        if details:
+            public["code_execution"] = details
+        if summary:
+            public["detail"] = summary
     succeeded = event.completed and not event.is_error
     if succeeded and event.tool == EDIT_NOTE:
         version_id = (event.result or {}).get("version_id")

--- a/src/research_ai/services/notebook_chat/code_execution.py
+++ b/src/research_ai/services/notebook_chat/code_execution.py
@@ -1,0 +1,65 @@
+"""Bounded, explicit public fields for provider-managed code execution.
+
+Code and readable stdout are plain text for an expandable UI, never markup to
+execute. Opaque output, file identifiers, and raw provider errors stay private.
+"""
+
+from research_ai.services.agent_persistence.activity import ToolCallEvent
+
+CODE_EXECUTION_TOOLS = frozenset({"code_execution", "bash_code_execution"})
+MAX_CODE_CHARS = 12_000
+MAX_OUTPUT_CHARS = 2_000
+
+_ERROR_SUMMARIES = {
+    "execution_time_exceeded": "Execution timed out.",
+    "unavailable": "Code execution is temporarily unavailable.",
+    "container_expired": "The code execution session expired.",
+    "too_many_requests": "Code execution is temporarily busy.",
+}
+
+
+def public_code_execution(event: ToolCallEvent) -> tuple[dict, str | None]:
+    """Return selected execution fields and a short outcome summary, if known."""
+    details = {}
+    code_field = "command" if event.tool == "bash_code_execution" else "code"
+    code = event.input.get(code_field)
+    if isinstance(code, str) and code.strip():
+        details["code"] = code[:MAX_CODE_CHARS]
+        details["code_truncated"] = len(code) > MAX_CODE_CHARS
+
+    if not event.completed:
+        return details, None
+    result = (event.result or {}).get("content")
+    if not isinstance(result, dict):
+        return details, "Code execution failed." if event.is_error else None
+
+    return_code = result.get("return_code")
+    if type(return_code) is int:
+        details["return_code"] = return_code
+    outputs = result.get("content")
+    if isinstance(outputs, list):
+        details["output_count"] = len(outputs)
+    # An encrypted result must never be treated as readable, even if an
+    # unexpected stdout field accompanies it.
+    if result.get("type") != "encrypted_code_execution_result":
+        stdout = result.get("stdout")
+        if isinstance(stdout, str) and stdout.strip():
+            details["output"] = stdout[:MAX_OUTPUT_CHARS]
+            details["output_truncated"] = len(stdout) > MAX_OUTPUT_CHARS
+
+    if event.is_error:
+        error_code = result.get("error_code")
+        if isinstance(error_code, str) and error_code in _ERROR_SUMMARIES:
+            summary = _ERROR_SUMMARIES[error_code]
+        elif type(return_code) is int and return_code != 0:
+            summary = f"Code exited with error (exit code {return_code})."
+        else:
+            summary = "Code execution failed."
+    elif type(return_code) is int and return_code == 0:
+        summary = "Code finished successfully."
+        count = details.get("output_count", 0)
+        if count:
+            summary += f" Produced {count} output item{'s' if count != 1 else ''}."
+    else:
+        summary = None
+    return details, summary

--- a/src/research_ai/tests/notebook_chat/test_code_execution_activity.py
+++ b/src/research_ai/tests/notebook_chat/test_code_execution_activity.py
@@ -1,0 +1,222 @@
+import json
+from unittest.mock import Mock, patch
+
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from research_ai.models import AgentExecutionMessage
+from research_ai.services.agent_persistence.activity import conversation_activity_events
+from research_ai.services.notebook_chat.activity import execution_phase, public_activity
+from research_ai.services.notebook_chat.code_execution import (
+    MAX_CODE_CHARS,
+    MAX_OUTPUT_CHARS,
+)
+
+
+class CodeExecutionActivityTests(SimpleTestCase):
+    def _events(self, result=None, *, tool="code_execution", code="print(42)"):
+        code_field = "command" if tool == "bash_code_execution" else "code"
+        content = [
+            {
+                "type": "server_tool",
+                "data": {
+                    "type": "server_tool_use",
+                    "id": "s1",
+                    "name": tool,
+                    "input": {code_field: code, "private": "input-sentinel"},
+                },
+            }
+        ]
+        if result is not None:
+            content.append(
+                {
+                    "type": "server_tool",
+                    "data": {
+                        "type": f"{tool}_tool_result",
+                        "tool_use_id": "s1",
+                        "content": result,
+                    },
+                }
+            )
+        with patch.object(AgentExecutionMessage.objects, "filter") as query:
+            rows = query.return_value.exclude.return_value.order_by.return_value
+            rows.values_list.return_value = [(1, "assistant", content, timezone.now())]
+            return conversation_activity_events(Mock())[1]
+
+    def _public(self, events, *, active=False):
+        return public_activity(
+            events,
+            execution_active=active,
+            answer_published=False,
+            published_answer=None,
+        )[0]
+
+    def test_readable_result_exposes_code_output_and_summary(self):
+        # Arrange
+        events = self._events(
+            {
+                "type": "code_execution_result",
+                "return_code": 0,
+                "stdout": "42\n",
+                "stderr": "private-error-sentinel",
+                "content": [{"file_id": "private-file-sentinel"}],
+            }
+        )
+
+        # Act
+        event = self._public(events)
+
+        # Assert
+        self.assertEqual(event["label"], "Code finished")
+        self.assertEqual(event["status"], "succeeded")
+        self.assertEqual(
+            event["code_execution"],
+            {
+                "code": "print(42)",
+                "code_truncated": False,
+                "return_code": 0,
+                "output": "42\n",
+                "output_truncated": False,
+                "output_count": 1,
+            },
+        )
+        self.assertEqual(
+            event["detail"], "Code finished successfully. Produced 1 output item."
+        )
+        self.assertNotIn("sentinel", json.dumps(event, default=str))
+
+    def test_encrypted_output_is_never_exposed(self):
+        # Arrange
+        events = self._events(
+            {
+                "type": "encrypted_code_execution_result",
+                "return_code": 0,
+                "encrypted_stdout": "encrypted-sentinel",
+                "stdout": "unexpected-sentinel",
+                "content": [],
+            }
+        )
+
+        # Act
+        event = self._public(events)
+
+        # Assert
+        self.assertEqual(event["detail"], "Code finished successfully.")
+        self.assertNotIn("output", event["code_execution"])
+        self.assertNotIn("sentinel", json.dumps(event, default=str))
+
+    def test_nonzero_exit_codes_fail_for_python_and_shell(self):
+        for tool in ("code_execution", "bash_code_execution"):
+            with self.subTest(tool=tool):
+                # Arrange
+                events = self._events(
+                    {"return_code": 1, "stderr": "private-sentinel"}, tool=tool
+                )
+
+                # Act
+                event = self._public(events)
+
+                # Assert
+                self.assertEqual(event["status"], "failed")
+                self.assertEqual(event["label"], "Code execution failed")
+                self.assertEqual(
+                    event["detail"], "Code exited with error (exit code 1)."
+                )
+                self.assertEqual(event["code_execution"]["return_code"], 1)
+                self.assertNotIn("sentinel", json.dumps(event, default=str))
+
+    def test_provider_errors_have_public_explanations(self):
+        cases = (
+            ("execution_time_exceeded", "Execution timed out."),
+            ("unknown-private-sentinel", "Code execution failed."),
+        )
+        for error_code, summary in cases:
+            with self.subTest(error_code=error_code):
+                # Arrange
+                events = self._events(
+                    {
+                        "type": "code_execution_tool_result_error",
+                        "error_code": error_code,
+                    }
+                )
+
+                # Act
+                event = self._public(events)
+
+                # Assert
+                self.assertEqual(event["status"], "failed")
+                self.assertEqual(event["detail"], summary)
+                self.assertNotIn("sentinel", json.dumps(event, default=str))
+
+    def test_running_and_interrupted_calls_do_not_claim_completion(self):
+        # Arrange
+        events = self._events()
+
+        # Act
+        running = self._public(events, active=True)
+        interrupted = self._public(events)
+        phase = execution_phase(events, execution_active=True, execution_claimed=True)
+
+        # Assert
+        self.assertEqual(running["label"], "Running code")
+        self.assertEqual(running["status"], "in_progress")
+        self.assertEqual(running["code_execution"]["code"], "print(42)")
+        self.assertNotIn("detail", running)
+        self.assertEqual(interrupted["label"], "Code execution interrupted")
+        self.assertEqual(interrupted["status"], "interrupted")
+        self.assertEqual(phase["label"], "Running code")
+
+    def test_code_and_output_are_bounded_and_marked_when_truncated(self):
+        # Arrange
+        events = self._events(
+            {"return_code": 0, "stdout": "y" * (MAX_OUTPUT_CHARS + 1)},
+            code="x" * (MAX_CODE_CHARS + 1),
+        )
+
+        # Act
+        details = self._public(events)["code_execution"]
+
+        # Assert
+        self.assertEqual(len(details["code"]), MAX_CODE_CHARS)
+        self.assertTrue(details["code_truncated"])
+        self.assertEqual(len(details["output"]), MAX_OUTPUT_CHARS)
+        self.assertTrue(details["output_truncated"])
+
+    def test_shell_command_is_available_as_code(self):
+        # Arrange
+        events = self._events(tool="bash_code_execution", code="echo hello")
+
+        # Act
+        event = self._public(events, active=True)
+
+        # Assert
+        self.assertEqual(event["code_execution"]["code"], "echo hello")
+
+    def test_missing_or_malformed_fields_are_not_invented(self):
+        for result in ({}, {"return_code": True, "stdout": {}, "content": "bad"}):
+            with self.subTest(result=result):
+                # Arrange
+                events = self._events(result, code=None)
+
+                # Act
+                event = self._public(events)
+
+                # Assert
+                self.assertNotIn("code_execution", event)
+                self.assertNotIn("detail", event)
+
+    def test_other_tools_keep_their_existing_projection(self):
+        # Arrange: a return_code field on an unrelated tool has no execution
+        # semantics, and its inputs and output must not gain a code preview.
+        events = self._events(
+            {"return_code": 1, "stdout": "private-sentinel"}, tool="web_search"
+        )
+
+        # Act
+        event = self._public(events)
+
+        # Assert
+        self.assertEqual(event["label"], "Searched the web")
+        self.assertEqual(event["status"], "succeeded")
+        self.assertNotIn("code_execution", event)
+        self.assertNotIn("sentinel", json.dumps(event, default=str))

--- a/src/research_ai/tests/notebook_chat/test_notebook_chat_streaming.py
+++ b/src/research_ai/tests/notebook_chat/test_notebook_chat_streaming.py
@@ -148,6 +148,21 @@ class NotebookStreamBufferTests(SimpleTestCase):
         self.assertEqual(draft_item["label"], "Drafting an edit")
         self.assertEqual(draft_item["text"], "")
 
+    def test_code_execution_announces_label_without_raw_arguments(self):
+        # Arrange
+        self.buffer.append(1, ToolUseStreamStart(block_index=0, name="code_execution"))
+
+        # Act
+        self.buffer.append(
+            1, ToolInputStreamDelta(block_index=0, partial_json='{"code":"print(42)"}')
+        )
+        self.buffer.flush()
+
+        # Assert
+        item = self.store.get(9)["items"][0]
+        self.assertEqual(item["label"], "Preparing code")
+        self.assertEqual(item["text"], "")
+
     def test_edit_note_argument_json_streams_as_prose(self):
         # Arrange
         self.buffer.append(1, ToolUseStreamStart(block_index=0, name="edit_note"))


### PR DESCRIPTION
Assistant and notebook activity currently show generic code execution labels without useful execution details. Add readable running/completed/failed labels, bounded code and stdout previews, and short outcome summaries to their shared activity response. Treat nonzero process exit codes as failures, and keep encrypted output and raw provider errors out of the public response.

The new optional `code_execution` object provides the backend fields for an expandable code panel; frontend rendering is not included.

Validation: 76 focused activity, streaming, and Claude provider tests passed using an existing local dependency environment. Ruff lint and formatting checks passed for all changed Python files. The standard offline uv setup could not resolve an uncached dependency.
