### PR TITLE
Expose funding pool on activity-feed serializer

### DIFF
--- a/src/feed/serializers.py
+++ b/src/feed/serializers.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
 
 from hub.models import Hub
@@ -9,6 +10,7 @@ from paper.models import Paper
 from purchase.related_models.constants.currency import RSC, USD
 from purchase.related_models.rsc_exchange_rate_model import RscExchangeRate
 from purchase.serializers import DynamicPurchaseSerializer
+from purchase.serializers.funding_pool_serializer import DynamicFundingPoolSerializer
 from purchase.serializers.fundraise_serializer import DynamicFundraiseSerializer
 from purchase.serializers.grant_serializer import DynamicGrantSerializer
 from researchhub_document.related_models.constants import document_type
@@ -1136,11 +1138,29 @@ class RelatedWorkSerializer(serializers.Serializer):
         if num_applicants is None:
             num_applicants = grant.applications.count()
 
+        try:
+            pool = grant.funding_pool
+        except ObjectDoesNotExist:
+            funding_pool = None
+        else:
+            funding_pool = DynamicFundingPoolSerializer(
+                pool,
+                context=self.context,
+                _include_fields=(
+                    "id",
+                    "amount_holding",
+                    "amount_distributed",
+                    "amount_raised",
+                    "status",
+                ),
+            ).data
+
         return {
             "status": grant.status,
             "amount": _grant_amount(grant),
             "organization": grant.organization,
             "application_count": num_applicants,
+            "funding_pool": funding_pool,
         }
 
     def get_fundraise(self, unified_document):

--- a/src/feed/tests/views/test_activity_feed_view.py
+++ b/src/feed/tests/views/test_activity_feed_view.py
@@ -191,6 +191,13 @@ class ActivityFeedRelatedWorkTests(ActivityFeedBaseTests):
             status=Grant.OPEN,
             organization="Test Org",
         )
+        self.funding_pool = FundingPool.objects.create(
+            grant=self.grant,
+            created_by=self.user,
+            amount_holding=Decimal("100.00"),
+            amount_distributed=Decimal("25.00"),
+            status=FundingPool.OPEN,
+        )
         self.fundraise = Fundraise.objects.create(
             unified_document=self.prereg_doc,
             created_by=self.user,
@@ -236,6 +243,14 @@ class ActivityFeedRelatedWorkTests(ActivityFeedBaseTests):
         self.assertIn("amount", related_work["grant"])
         self.assertEqual(related_work["grant"]["amount"]["usd"], 10000.0)
         self.assertIn("application_count", related_work["grant"])
+        self.assertIn("funding_pool", related_work["grant"])
+        funding_pool = related_work["grant"]["funding_pool"]
+        self.assertEqual(funding_pool["id"], self.funding_pool.id)
+        self.assertEqual(funding_pool["status"], FundingPool.OPEN)
+        self.assertEqual(float(funding_pool["amount_holding"]["rsc"]), 100.0)
+        self.assertEqual(float(funding_pool["amount_distributed"]["rsc"]), 25.0)
+        self.assertEqual(float(funding_pool["amount_raised"]["rsc"]), 125.0)
+        self.assertEqual(funding_pool["amount_holding"]["usd"], 300.0)
 
     def test_related_work_on_prereg_comment(self):
         # Act


### PR DESCRIPTION
## Summary
- Include slim `funding_pool` on activity-feed `related_work.grant`, matching grant feed / `DynamicGrantSerializer`
